### PR TITLE
Fix main page banner scrolling with content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to TangleClaw are documented in this file.
 
+## [3.10.1] - 2026-03-31
+
+### Fixed
+
+- **Main page banner now stays fixed while content scrolls** — matches behavior of session and OpenClaw pages (body flex layout + scrollable content wrapper)
+
 ## [3.10.0] - 2026-03-30
 
 ### Changed

--- a/public/index.html
+++ b/public/index.html
@@ -53,6 +53,7 @@
     </div>
   </header>
 
+  <div class="main-scroll">
   <!-- Ports Grid (expandable panel) -->
   <div id="portsGrid" class="ports-grid" aria-label="Port leases"></div>
 
@@ -291,6 +292,7 @@
   <main id="projectsContainer" aria-label="Projects">
     <div class="cards-grid" id="cardsGrid"></div>
   </main>
+  </div>
 
   <!-- Create Project Drawer -->
   <div class="drawer-backdrop" id="createBackdrop"></div>

--- a/public/style.css
+++ b/public/style.css
@@ -60,20 +60,29 @@ body {
   font-family: -apple-system, BlinkMacSystemFont, 'SF Pro', system-ui, sans-serif;
   background: var(--bg);
   color: var(--text);
-  min-height: 100dvh;
+  height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
   -webkit-tap-highlight-color: transparent;
-  overflow-x: hidden;
 }
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after { transition: none !important; animation: none !important; }
 }
 
 /* ── Dashboard Bar ── */
+.main-scroll {
+  flex: 1;
+  overflow-y: auto;
+  min-height: 0;
+  -webkit-overflow-scrolling: touch;
+}
 .dash-bar {
   display: flex;
   align-items: center;
   gap: 16px;
   padding: calc(env(safe-area-inset-top, 0px) + 8px) 16px 8px;
+  flex-shrink: 0;
 }
 .dash-brand {
   display: flex;


### PR DESCRIPTION
## Summary
- Main page banner (`.dash-bar`) now stays fixed at top while content scrolls underneath, matching session and OpenClaw pages
- Applied same flex column layout from `session.css` to `style.css` body
- Added `.main-scroll` wrapper for scrollable content area

Fixes #9

## Test plan
- [ ] Open main dashboard — banner stays fixed, project cards scroll underneath
- [ ] Expand panels (Ports, Groups, OpenClaw, Audit, Rules) — content still scrollable
- [ ] Navigate to a session page — verify no regression, banner still fixed
- [ ] Test on mobile viewport — scroll behavior consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/CSS layout change that only affects landing page scrolling behavior; primary risk is unintended overflow/height quirks on mobile browsers.
> 
> **Overview**
> Fixes the landing page layout so the header banner (the `.dash-bar`) stays fixed while the dashboard content scrolls.
> 
> This switches `body` to a full-viewport flex column with `overflow: hidden`, wraps the page content in a new scroll container (`.main-scroll`), and prevents the header from shrinking. The change is documented as `v3.10.1` in `CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34e8ed1be420ca0e305d469130ebad28d65ac6fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->