### PR TITLE
Fix kill button showing generic error instead of actual message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to TangleClaw are documented in this file.
 
+## [3.11.4] - 2026-04-03
+
+### Fixed
+
+- **Kill button shows generic "Check password" instead of actual error** — session view's `confirmKill()` used `apiMutate()` which swallowed server error messages and showed a hardcoded string; now uses direct `fetch` (matching the landing page pattern) to display the actual error from the server (e.g. "Password required" vs "Incorrect password")
+
 ## [3.11.3] - 2026-04-03
 
 ### Fixed

--- a/public/session.js
+++ b/public/session.js
@@ -1168,14 +1168,15 @@ async function confirmKill() {
   const body = { reason: 'Manual kill from UI' };
   if (pw) body.password = pw;
 
-  const data = await apiMutate(
-    `/api/sessions/${encodeURIComponent(projectName)}`,
-    'DELETE',
-    body
-  );
+  const res = await fetch(`/api/sessions/${encodeURIComponent(projectName)}`, {
+    method: 'DELETE',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  });
 
-  if (!data) {
-    document.getElementById('killError').textContent = 'Kill failed. Check password.';
+  if (!res.ok) {
+    const errData = await res.json().catch(() => ({}));
+    document.getElementById('killError').textContent = errData.error || 'Kill failed.';
     document.getElementById('killError').classList.remove('hidden');
     return;
   }


### PR DESCRIPTION
## Summary

- Session view's `confirmKill()` used `apiMutate()` → `api()` which caught errors and returned `null`, losing the server's actual error message
- Showed hardcoded "Kill failed. Check password." regardless of the real issue
- Switched to direct `fetch` (matching the landing page's working pattern in `ui.js`) so the actual server error is displayed (e.g. "Password required for this operation" or "Incorrect password")

## Test plan

- [x] Server tests pass (11/11)
- [ ] Manual: trigger kill with wrong password → should show "Incorrect password"
- [ ] Manual: trigger kill without password when required → should show "Password required for this operation"

🤖 Generated with [Claude Code](https://claude.com/claude-code)