### PR TITLE
Fix prime prompt pasting but not submitting on session start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to TangleClaw are documented in this file.
 
+## [3.11.5] - 2026-04-03
+
+### Fixed
+
+- **Prime prompt pastes but doesn't submit on session start** — `sendKeys()` in tmux.js was sending text and Enter in a single command, which broke with larger payloads (especially after playbook injection made prompts longer); split into two separate tmux commands and added `-l` (literal) flag so text is sent verbatim without tmux interpreting key names within it
+
 ## [3.11.4] - 2026-04-03
 
 ### Fixed

--- a/lib/tmux.js
+++ b/lib/tmux.js
@@ -159,12 +159,11 @@ function sendKeys(session, text, options = {}) {
 
   const enter = options.enter !== false;
   const escaped = text.replace(/'/g, "'\\''");
-  let cmd = `tmux send-keys -t ${_escapeArg(session)} '${escaped}'`;
+  _exec(`tmux send-keys -t ${_escapeArg(session)} -l '${escaped}'`);
   if (enter) {
-    cmd += ' Enter';
+    _exec(`tmux send-keys -t ${_escapeArg(session)} Enter`);
   }
 
-  _exec(cmd);
   log.debug('Sent keys to session', { session, length: text.length });
 }
 


### PR DESCRIPTION
## Summary

- `sendKeys()` in `tmux.js` was sending text and Enter as a single tmux command
- With the larger prime prompts (after playbook injection in 3.11.0/3.11.3), this broke — text was pasted but Enter was never sent
- Split into two separate tmux commands: literal text send (`-l` flag), then Enter
- Added `-l` flag to prevent tmux from interpreting key names within the prompt text

## Test plan

- [x] 57 session/server tests pass
- [ ] Manual: start a session → prime prompt should paste AND submit automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)