### PR TITLE
Fix prime prompt not submitting with paste-buffer approach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to TangleClaw are documented in this file.
 
 ### Fixed
 
-- **Prime prompt pastes but doesn't submit on session start** — `sendKeys()` in tmux.js was sending text and Enter in a single command, which broke with larger payloads (especially after playbook injection made prompts longer); split into two separate tmux commands and added `-l` (literal) flag so text is sent verbatim without tmux interpreting key names within it
+- **Prime prompt pastes but doesn't submit on session start** — `sendKeys()` now uses tmux `load-buffer`/`paste-buffer` for reliable delivery of large text (properly triggers bracketed paste mode), with a 500ms delay before sending Enter to let the terminal process the paste; the previous `send-keys -l` approach sent characters too fast for Claude Code to process before Enter arrived
 
 ## [3.11.4] - 2026-04-03
 

--- a/lib/tmux.js
+++ b/lib/tmux.js
@@ -1,5 +1,8 @@
 'use strict';
 
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 const { execSync } = require('node:child_process');
 const { createLogger } = require('./logger');
 
@@ -158,9 +161,22 @@ function sendKeys(session, text, options = {}) {
   }
 
   const enter = options.enter !== false;
-  const escaped = text.replace(/'/g, "'\\''");
-  _exec(`tmux send-keys -t ${_escapeArg(session)} -l '${escaped}'`);
+  const enterDelay = options.enterDelay || 500;
+
+  // Use tmux load-buffer + paste-buffer for reliable delivery of large text.
+  // This properly triggers bracketed paste mode in the target terminal.
+  const tmpFile = path.join(os.tmpdir(), `tangleclaw-paste-${process.pid}.tmp`);
+  try {
+    fs.writeFileSync(tmpFile, text);
+    _exec(`tmux load-buffer ${_escapeArg(tmpFile)}`);
+    _exec(`tmux paste-buffer -t ${_escapeArg(session)}`);
+  } finally {
+    try { fs.unlinkSync(tmpFile); } catch (_e) { /* ignore cleanup errors */ }
+  }
+
   if (enter) {
+    // Delay to let the terminal process the pasted content before sending Enter
+    execSync(`sleep ${enterDelay / 1000}`);
     _exec(`tmux send-keys -t ${_escapeArg(session)} Enter`);
   }
 


### PR DESCRIPTION
## Summary

- Previous `send-keys -l` approach sent characters individually, which Claude Code detected as a paste but couldn't finish processing before Enter arrived
- Switched to `load-buffer` / `paste-buffer` which properly triggers bracketed paste mode in the terminal
- Added 500ms delay between paste and Enter to let the terminal finish processing
- Temp file is cleaned up in a `finally` block

## Test plan

- [x] 46 session tests pass
- [ ] Manual: start a session → prime prompt should paste AND auto-submit

🤖 Generated with [Claude Code](https://claude.com/claude-code)