### PR TITLE
Fix peek for alternate-screen engines (Codex)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to TangleClaw are documented in this file.
 
+## [3.12.6] - 2026-04-05
+
+### Fixed
+
+- **Peek not working for alternate-screen engines (Codex, etc.)** — TUI-based engines like Codex run in tmux's alternate screen buffer, which has no scrollback history; `capture-pane -S - -E -` could fail or return empty content for these panes; `capturePane()` now detects alternate screen mode via `#{alternate_on}` and falls back to visible-only capture; new `isAlternateScreen()` helper in `tmux.js`; peek API response includes `alternateScreen` flag; frontend shows informational notice when peek content is screen-only (no scrollback); 4 new tests (fixes #44)
+
 ## [3.12.5] - 2026-04-05
 
 ### Added

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -532,8 +532,8 @@ function getSessionStatus(projectName) {
 
       // Cache pane output while wrapping (for capture when tmux dies)
       try {
-        const lines = tmux.capturePane(wrapping.tmuxSession, { lines: 100 });
-        _wrapPaneCache.set(wrapping.id, lines.join('\n'));
+        const capture = tmux.capturePane(wrapping.tmuxSession, { lines: 100 });
+        _wrapPaneCache.set(wrapping.id, capture.lines.join('\n'));
       } catch {
         // tmux may have just died — ignore
       }
@@ -629,8 +629,8 @@ const WRAP_TIMEOUT_MS = 120_000;
  */
 function detectIdle(tmuxSession) {
   try {
-    const lines = tmux.capturePane(tmuxSession, { lines: 3 });
-    const currentOutput = lines.join('\n');
+    const capture = tmux.capturePane(tmuxSession, { lines: 3 });
+    const currentOutput = capture.lines.join('\n');
 
     const cached = _lastOutput.get(tmuxSession);
     const now = Date.now();
@@ -728,14 +728,14 @@ function peek(projectName, options = {}) {
   }
 
   if (options.full) {
-    const output = tmux.capturePane(active.tmuxSession, { full: true });
-    return { lines: output, tmuxSession: active.tmuxSession, error: null };
+    const capture = tmux.capturePane(active.tmuxSession, { full: true });
+    return { lines: capture.lines, tmuxSession: active.tmuxSession, alternateScreen: capture.alternateScreen, error: null };
   }
 
   const lineCount = Math.max(options.lines || 5, 1);
-  const output = tmux.capturePane(active.tmuxSession, { lines: lineCount });
+  const capture = tmux.capturePane(active.tmuxSession, { lines: lineCount });
 
-  return { lines: output, tmuxSession: active.tmuxSession, error: null };
+  return { lines: capture.lines, tmuxSession: active.tmuxSession, alternateScreen: capture.alternateScreen, error: null };
 }
 
 // ── Wrap ──

--- a/lib/tmux.js
+++ b/lib/tmux.js
@@ -205,16 +205,53 @@ function sendRawKey(session, key) {
 }
 
 /**
+ * Check if a tmux pane is in alternate screen mode.
+ * TUI applications (Codex, vim, etc.) switch to the alternate screen buffer,
+ * which has no scrollback history and requires different capture handling.
+ * @param {string} session - Session name
+ * @returns {boolean}
+ */
+function isAlternateScreen(session) {
+  try {
+    const result = _exec(
+      `tmux display-message -t ${_escapeArg(session)} -p '#{alternate_on}'`
+    );
+    return result.trim() === '1';
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Capture the current pane output.
+ * For panes in alternate screen mode (TUI engines like Codex), the full
+ * scrollback range flags (-S - -E -) may fail or return empty content.
+ * In that case, falls back to capturing just the visible pane content.
  * @param {string} session - Session name
  * @param {object} [options] - Options
  * @param {number} [options.lines] - Number of lines to capture (default 5)
  * @param {boolean} [options.full] - Capture full scrollback buffer
- * @returns {string[]}
+ * @returns {{ lines: string[], alternateScreen: boolean }}
  */
 function capturePane(session, options = {}) {
   if (!hasSession(session)) {
     throw new Error(`tmux session "${session}" does not exist`);
+  }
+
+  const altScreen = isAlternateScreen(session);
+
+  // Alternate screen panes have no scrollback history — skip range flags
+  // and capture only the visible content.
+  if (altScreen) {
+    try {
+      const output = _exec(
+        `tmux capture-pane -t ${_escapeArg(session)} -p`
+      );
+      return { lines: output.split('\n'), alternateScreen: true };
+    } catch (err) {
+      log.error('Failed to capture alternate screen pane', { session, error: err.message });
+      return { lines: [], alternateScreen: true };
+    }
   }
 
   let rangeFlag;
@@ -229,10 +266,10 @@ function capturePane(session, options = {}) {
     const output = _exec(
       `tmux capture-pane -t ${_escapeArg(session)} -p ${rangeFlag}`
     );
-    return output.split('\n');
+    return { lines: output.split('\n'), alternateScreen: false };
   } catch (err) {
     log.error('Failed to capture pane', { session, error: err.message });
-    return [];
+    return { lines: [], alternateScreen: false };
   }
 }
 
@@ -329,6 +366,7 @@ module.exports = {
   killSession,
   sendKeys,
   sendRawKey,
+  isAlternateScreen,
   capturePane,
   setMouse,
   getMouse,

--- a/public/session.js
+++ b/public/session.js
@@ -938,6 +938,10 @@ async function refreshPeek() {
   const content = document.getElementById('peekContent');
   content.textContent = 'Loading\u2026';
 
+  // Remove previous alternate-screen notice if any
+  const oldNotice = document.getElementById('peekAltScreenNotice');
+  if (oldNotice) oldNotice.remove();
+
   const data = await api(`/api/sessions/${encodeURIComponent(projectName)}/peek?full=true`);
   if (data && data.lines) {
     peekRawText = stripAnsi(data.lines.join('\n'));
@@ -948,6 +952,14 @@ async function refreshPeek() {
     }
     if (peekStickyScroll) {
       content.scrollTop = content.scrollHeight;
+    }
+    // Show notice for alternate screen (TUI engines with no scrollback)
+    if (data.alternateScreen) {
+      const notice = document.createElement('div');
+      notice.id = 'peekAltScreenNotice';
+      notice.style.cssText = 'padding:6px 12px;background:#2a2a1a;color:#b8a830;font-size:12px;border-bottom:1px solid #444;';
+      notice.textContent = 'Showing visible screen only \u2014 this engine uses a fullscreen TUI (no scrollback history)';
+      content.parentNode.insertBefore(notice, content);
     }
   } else {
     peekRawText = '';

--- a/server.js
+++ b/server.js
@@ -1129,7 +1129,8 @@ route('GET', '/api/sessions/:project/peek', (req, res, params) => {
   jsonResponse(res, 200, {
     lines: result.lines,
     project: params.project,
-    tmuxSession: result.tmuxSession
+    tmuxSession: result.tmuxSession,
+    alternateScreen: result.alternateScreen || false
   });
 });
 

--- a/test/tmux.test.js
+++ b/test/tmux.test.js
@@ -187,9 +187,10 @@ describe('tmux', () => {
         // Small delay for output
         const { execSync } = require('node:child_process');
         execSync('sleep 0.5');
-        const lines = tmux.capturePane(testSession, { full: true });
-        assert.ok(Array.isArray(lines));
-        assert.ok(lines.length > 0, 'Expected at least some output');
+        const capture = tmux.capturePane(testSession, { full: true });
+        assert.ok(Array.isArray(capture.lines));
+        assert.ok(capture.lines.length > 0, 'Expected at least some output');
+        assert.equal(typeof capture.alternateScreen, 'boolean');
       } finally {
         try { tmux.killSession(testSession); } catch (_) {}
       }
@@ -206,8 +207,58 @@ describe('tmux', () => {
         execSync('sleep 1');
         const limited = tmux.capturePane(testSession, { lines: 3 });
         const full = tmux.capturePane(testSession, { full: true });
-        assert.ok(full.length >= limited.length,
-          `Full (${full.length}) should be >= limited (${limited.length})`);
+        assert.ok(full.lines.length >= limited.lines.length,
+          `Full (${full.lines.length}) should be >= limited (${limited.lines.length})`);
+      } finally {
+        try { tmux.killSession(testSession); } catch (_) {}
+      }
+    });
+  });
+
+  describe('isAlternateScreen', () => {
+    it('should return false for non-existent session', () => {
+      assert.equal(tmux.isAlternateScreen('__nonexistent_test_session__'), false);
+    });
+
+    it('should return false for a normal bash session (not in alternate screen)', () => {
+      const testSession = '__tc_test_altscreen__';
+      try {
+        tmux.createSession(testSession, { command: 'exec bash' });
+        assert.equal(tmux.isAlternateScreen(testSession), false);
+      } finally {
+        try { tmux.killSession(testSession); } catch (_) {}
+      }
+    });
+  });
+
+  describe('capturePane - alternate screen handling', () => {
+    const testSession = '__tc_test_altcap__';
+
+    it('should return alternateScreen false for normal bash pane', () => {
+      try {
+        tmux.createSession(testSession, { command: 'exec bash' });
+        const capture = tmux.capturePane(testSession, { full: true });
+        assert.equal(capture.alternateScreen, false);
+        assert.ok(Array.isArray(capture.lines));
+      } finally {
+        try { tmux.killSession(testSession); } catch (_) {}
+      }
+    });
+
+    it('should return alternateScreen true and visible content for TUI pane', () => {
+      try {
+        // Use `less` as a controlled alternate screen app
+        tmux.createSession(testSession, { command: 'exec bash' });
+        tmux.sendKeys(testSession, 'echo hello-alt-test | less');
+        const { execSync } = require('node:child_process');
+        execSync('sleep 0.5');
+        const capture = tmux.capturePane(testSession, { full: true });
+        assert.equal(capture.alternateScreen, true);
+        assert.ok(Array.isArray(capture.lines));
+        // less should show our content on the visible screen
+        const joined = capture.lines.join('\n');
+        assert.ok(joined.includes('hello-alt-test'),
+          `Expected visible content to include "hello-alt-test", got: ${joined.slice(0, 200)}`);
       } finally {
         try { tmux.killSession(testSession); } catch (_) {}
       }


### PR DESCRIPTION
## Summary

- TUI-based engines like Codex run in tmux's alternate screen buffer, which has no scrollback history
- `capture-pane -S - -E -` (full scrollback) could fail or return empty content for these panes, causing peek to show blank
- `capturePane()` now detects alternate screen via `#{alternate_on}` and falls back to visible-only capture
- New `isAlternateScreen()` helper in `tmux.js`
- Peek API response includes `alternateScreen` flag; frontend shows informational notice when content is screen-only

## Test plan

- [x] All 1363 existing tests pass
- [x] 4 new tests: `isAlternateScreen` (non-existent session, normal bash), `capturePane` alternate screen handling (normal pane returns false, TUI pane via `less` returns true with visible content)
- [ ] Manual: launch a Codex session, open peek, verify content displays with alternate-screen notice
- [ ] Manual: launch a Claude session, verify peek still shows full scrollback without notice

Fixes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)