### PR TITLE
Fix status pill missing short-lived incidents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to TangleClaw are documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- **Status pill misses short incidents** — `_parseAtlassian()` only checked component status, which can revert to `operational` before the next poll; now also parses the `incidents[]` array from the Atlassian summary response and checks for unresolved incidents affecting the target component; uses the worse of component status vs. active incident impact; new `_parseAtlassianIncidents()` and `_incidentAffectsComponent()` helpers with component matching by ID and name; 7 new tests
+
 ## [3.12.7] - 2026-04-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to TangleClaw are documented in this file.
 
 ### Fixed
 
-- **Status pill misses short incidents** — `_parseAtlassian()` only checked component status, which can revert to `operational` before the next poll; now also parses the `incidents[]` array from the Atlassian summary response and checks for unresolved incidents affecting the target component; uses the worse of component status vs. active incident impact; new `_parseAtlassianIncidents()` and `_incidentAffectsComponent()` helpers with component matching by ID and name; 7 new tests
+- **Status pill misses short incidents** — `_parseAtlassian()` only checked component status, which can revert to `operational` before the next poll; now also parses the `incidents[]` array from the Atlassian summary response and checks for unresolved incidents affecting the target component; uses the worse of component status vs. active incident impact; new `_parseAtlassianIncidents()` and `_incidentAffectsComponent()` helpers with component matching by ID and name; 10 new tests
 
 ## [3.12.7] - 2026-04-05
 

--- a/lib/model-status.js
+++ b/lib/model-status.js
@@ -15,6 +15,8 @@ let _engines = [];
  * @returns {{ status: string, message: string|null }}
  */
 function _parseAtlassian(json, config) {
+  const statusRank = { operational: 0, degraded: 1, partial_outage: 2, major_outage: 3 };
+
   // Try to find the specific component
   const components = json.components || [];
   let component = null;
@@ -26,31 +28,120 @@ function _parseAtlassian(json, config) {
     component = components.find(c => c.name === config.componentName);
   }
 
+  const componentStatusMap = {
+    operational: 'operational',
+    degraded_performance: 'degraded',
+    partial_outage: 'partial_outage',
+    major_outage: 'major_outage'
+  };
+
+  let compResult;
   if (component) {
-    const statusMap = {
-      operational: 'operational',
-      degraded_performance: 'degraded',
-      partial_outage: 'partial_outage',
-      major_outage: 'major_outage'
-    };
-    return {
-      status: statusMap[component.status] || 'unknown',
+    compResult = {
+      status: componentStatusMap[component.status] || 'unknown',
       message: component.status === 'operational' ? null : component.status.replace(/_/g, ' ')
+    };
+  } else {
+    // Fall back to page-level indicator
+    const indicator = json.status && json.status.indicator;
+    const indicatorMap = {
+      none: 'operational',
+      minor: 'degraded',
+      major: 'partial_outage',
+      critical: 'major_outage'
+    };
+    compResult = {
+      status: indicatorMap[indicator] || 'unknown',
+      message: json.status && json.status.description || null
     };
   }
 
-  // Fall back to page-level indicator
-  const indicator = json.status && json.status.indicator;
-  const indicatorMap = {
+  // Check unresolved incidents affecting our component
+  const incidentResult = _parseAtlassianIncidents(json.incidents || [], config);
+
+  // Return the worse of component status vs active incidents
+  if (incidentResult.status !== 'operational') {
+    const compRank = statusRank[compResult.status] ?? -1;
+    const incRank = statusRank[incidentResult.status] ?? -1;
+    if (incRank > compRank) {
+      return incidentResult;
+    }
+  }
+
+  return compResult;
+}
+
+/**
+ * Parse unresolved Atlassian Statuspage incidents for a specific component.
+ * Returns the worst active incident status affecting the target component.
+ * @param {Array} incidents - Incidents array from summary.json
+ * @param {object} config - Engine statusPage config ({ componentId, componentName })
+ * @returns {{ status: string, message: string|null }}
+ */
+function _parseAtlassianIncidents(incidents, config) {
+  if (!Array.isArray(incidents) || incidents.length === 0) {
+    return { status: 'operational', message: null };
+  }
+
+  const impactMap = {
     none: 'operational',
     minor: 'degraded',
     major: 'partial_outage',
     critical: 'major_outage'
   };
-  return {
-    status: indicatorMap[indicator] || 'unknown',
-    message: json.status && json.status.description || null
-  };
+  const statusRank = { operational: 0, degraded: 1, partial_outage: 2, major_outage: 3 };
+
+  let worstStatus = 'operational';
+  let worstMessage = null;
+
+  for (const incident of incidents) {
+    // Skip resolved/postmortem incidents
+    if (incident.status === 'resolved' || incident.status === 'postmortem') continue;
+
+    // Check if this incident affects our component
+    const affectsComponent = _incidentAffectsComponent(incident, config);
+    if (!affectsComponent) continue;
+
+    const mapped = impactMap[incident.impact] || 'degraded';
+    if ((statusRank[mapped] || 0) > (statusRank[worstStatus] || 0)) {
+      worstStatus = mapped;
+      worstMessage = incident.name || null;
+    }
+  }
+
+  return { status: worstStatus, message: worstMessage };
+}
+
+/**
+ * Check whether an Atlassian incident affects the target component.
+ * Looks at the most recent update's affected_components list.
+ * @param {object} incident - Atlassian incident object
+ * @param {object} config - Engine statusPage config ({ componentId, componentName })
+ * @returns {boolean}
+ */
+function _incidentAffectsComponent(incident, config) {
+  // Check affected_components in the most recent update
+  const updates = incident.incident_updates || [];
+  if (updates.length > 0) {
+    const latestAffected = updates[0].affected_components || [];
+    for (const ac of latestAffected) {
+      if (config.componentId && ac.code === config.componentId) return true;
+      if (config.componentName && ac.name === config.componentName) return true;
+    }
+  }
+
+  // Also check top-level components array if present
+  const topComponents = incident.components || [];
+  for (const c of topComponents) {
+    if (config.componentId && c.id === config.componentId) return true;
+    if (config.componentName && c.name === config.componentName) return true;
+  }
+
+  // If no component info at all, treat as affecting all components
+  const updates0 = updates.length > 0 ? (updates[0].affected_components || []) : [];
+  if (updates0.length === 0 && topComponents.length === 0) return true;
+
+  return false;
 }
 
 /**
@@ -256,6 +347,8 @@ module.exports = {
   getStatus,
   getEngineStatus,
   _parseAtlassian,
+  _parseAtlassianIncidents,
+  _incidentAffectsComponent,
   _parseGoogleIncidents,
   _pollEngine,
   _reset

--- a/lib/model-status.js
+++ b/lib/model-status.js
@@ -8,6 +8,8 @@ let _statusCache = {};
 let _pollTimer = null;
 let _engines = [];
 
+const STATUS_RANK = { operational: 0, degraded: 1, partial_outage: 2, major_outage: 3 };
+
 /**
  * Parse Atlassian Statuspage summary.json response into normalized status.
  * @param {object} json - Parsed summary.json response
@@ -15,7 +17,6 @@ let _engines = [];
  * @returns {{ status: string, message: string|null }}
  */
 function _parseAtlassian(json, config) {
-  const statusRank = { operational: 0, degraded: 1, partial_outage: 2, major_outage: 3 };
 
   // Try to find the specific component
   const components = json.components || [];
@@ -61,8 +62,8 @@ function _parseAtlassian(json, config) {
 
   // Return the worse of component status vs active incidents
   if (incidentResult.status !== 'operational') {
-    const compRank = statusRank[compResult.status] ?? -1;
-    const incRank = statusRank[incidentResult.status] ?? -1;
+    const compRank = STATUS_RANK[compResult.status] ?? -1;
+    const incRank = STATUS_RANK[incidentResult.status] ?? -1;
     if (incRank > compRank) {
       return incidentResult;
     }
@@ -89,8 +90,6 @@ function _parseAtlassianIncidents(incidents, config) {
     major: 'partial_outage',
     critical: 'major_outage'
   };
-  const statusRank = { operational: 0, degraded: 1, partial_outage: 2, major_outage: 3 };
-
   let worstStatus = 'operational';
   let worstMessage = null;
 
@@ -103,7 +102,7 @@ function _parseAtlassianIncidents(incidents, config) {
     if (!affectsComponent) continue;
 
     const mapped = impactMap[incident.impact] || 'degraded';
-    if ((statusRank[mapped] || 0) > (statusRank[worstStatus] || 0)) {
+    if ((STATUS_RANK[mapped] || 0) > (STATUS_RANK[worstStatus] || 0)) {
       worstStatus = mapped;
       worstMessage = incident.name || null;
     }
@@ -121,6 +120,7 @@ function _parseAtlassianIncidents(incidents, config) {
  */
 function _incidentAffectsComponent(incident, config) {
   // Check affected_components in the most recent update
+  // Atlassian returns incident_updates in reverse chronological order (newest first)
   const updates = incident.incident_updates || [];
   if (updates.length > 0) {
     const latestAffected = updates[0].affected_components || [];

--- a/test/model-status.test.js
+++ b/test/model-status.test.js
@@ -231,6 +231,75 @@ describe('model-status', () => {
       assert.equal(result.status, 'partial_outage');
     });
 
+    it('ignores postmortem incidents', () => {
+      const json = {
+        components: [
+          { id: 'abc', name: 'Claude Code', status: 'operational' }
+        ],
+        incidents: [
+          {
+            status: 'postmortem',
+            impact: 'critical',
+            name: 'Post-incident review',
+            incident_updates: [{
+              affected_components: [
+                { code: 'abc', name: 'Claude Code', old_status: 'major_outage', new_status: 'operational' }
+              ]
+            }]
+          }
+        ],
+        status: { indicator: 'none' }
+      };
+      const result = modelStatus._parseAtlassian(json, { componentId: 'abc', componentName: 'Claude Code' });
+      assert.equal(result.status, 'operational');
+    });
+
+    it('matches via top-level incident.components when no incident_updates', () => {
+      const json = {
+        components: [
+          { id: 'abc', name: 'Claude Code', status: 'operational' }
+        ],
+        incidents: [
+          {
+            status: 'investigating',
+            impact: 'major',
+            name: 'Service disruption',
+            incident_updates: [],
+            components: [
+              { id: 'abc', name: 'Claude Code' }
+            ]
+          }
+        ],
+        status: { indicator: 'none' }
+      };
+      const result = modelStatus._parseAtlassian(json, { componentId: 'abc', componentName: 'Claude Code' });
+      assert.equal(result.status, 'partial_outage');
+      assert.equal(result.message, 'Service disruption');
+    });
+
+    it('does not escalate for impact none (informational incidents)', () => {
+      const json = {
+        components: [
+          { id: 'abc', name: 'Claude Code', status: 'operational' }
+        ],
+        incidents: [
+          {
+            status: 'investigating',
+            impact: 'none',
+            name: 'Informational notice',
+            incident_updates: [{
+              affected_components: [
+                { code: 'abc', name: 'Claude Code', old_status: 'operational', new_status: 'operational' }
+              ]
+            }]
+          }
+        ],
+        status: { indicator: 'none' }
+      };
+      const result = modelStatus._parseAtlassian(json, { componentId: 'abc', componentName: 'Claude Code' });
+      assert.equal(result.status, 'operational');
+    });
+
     it('uses worst incident when multiple unresolved incidents exist', () => {
       const json = {
         components: [

--- a/test/model-status.test.js
+++ b/test/model-status.test.js
@@ -94,6 +94,176 @@ describe('model-status', () => {
       const result = modelStatus._parseAtlassian({}, { componentId: 'x' });
       assert.equal(result.status, 'unknown');
     });
+
+    it('escalates status when unresolved incident is worse than component status', () => {
+      const json = {
+        components: [
+          { id: 'abc', name: 'Claude Code', status: 'operational' }
+        ],
+        incidents: [
+          {
+            status: 'investigating',
+            impact: 'major',
+            name: 'Elevated errors on Claude Code',
+            incident_updates: [{
+              affected_components: [
+                { code: 'abc', name: 'Claude Code', old_status: 'operational', new_status: 'partial_outage' }
+              ]
+            }]
+          }
+        ],
+        status: { indicator: 'none' }
+      };
+      const result = modelStatus._parseAtlassian(json, { componentId: 'abc', componentName: 'Claude Code' });
+      assert.equal(result.status, 'partial_outage');
+      assert.equal(result.message, 'Elevated errors on Claude Code');
+    });
+
+    it('keeps component status when it is worse than incident impact', () => {
+      const json = {
+        components: [
+          { id: 'abc', name: 'Claude Code', status: 'major_outage' }
+        ],
+        incidents: [
+          {
+            status: 'investigating',
+            impact: 'minor',
+            name: 'Minor issue',
+            incident_updates: [{
+              affected_components: [
+                { code: 'abc', name: 'Claude Code', old_status: 'operational', new_status: 'degraded_performance' }
+              ]
+            }]
+          }
+        ],
+        status: { indicator: 'critical' }
+      };
+      const result = modelStatus._parseAtlassian(json, { componentId: 'abc', componentName: 'Claude Code' });
+      assert.equal(result.status, 'major_outage');
+    });
+
+    it('ignores resolved incidents', () => {
+      const json = {
+        components: [
+          { id: 'abc', name: 'Claude Code', status: 'operational' }
+        ],
+        incidents: [
+          {
+            status: 'resolved',
+            impact: 'critical',
+            name: 'Past outage',
+            incident_updates: [{
+              affected_components: [
+                { code: 'abc', name: 'Claude Code', old_status: 'partial_outage', new_status: 'operational' }
+              ]
+            }]
+          }
+        ],
+        status: { indicator: 'none' }
+      };
+      const result = modelStatus._parseAtlassian(json, { componentId: 'abc', componentName: 'Claude Code' });
+      assert.equal(result.status, 'operational');
+    });
+
+    it('ignores incidents affecting other components', () => {
+      const json = {
+        components: [
+          { id: 'abc', name: 'Claude Code', status: 'operational' }
+        ],
+        incidents: [
+          {
+            status: 'investigating',
+            impact: 'critical',
+            name: 'API is down',
+            incident_updates: [{
+              affected_components: [
+                { code: 'xyz', name: 'Claude API', old_status: 'operational', new_status: 'major_outage' }
+              ]
+            }]
+          }
+        ],
+        status: { indicator: 'none' }
+      };
+      const result = modelStatus._parseAtlassian(json, { componentId: 'abc', componentName: 'Claude Code' });
+      assert.equal(result.status, 'operational');
+    });
+
+    it('treats incidents with no component info as affecting all components', () => {
+      const json = {
+        components: [
+          { id: 'abc', name: 'Claude Code', status: 'operational' }
+        ],
+        incidents: [
+          {
+            status: 'investigating',
+            impact: 'minor',
+            name: 'Something is wrong',
+            incident_updates: [{ affected_components: [] }]
+          }
+        ],
+        status: { indicator: 'none' }
+      };
+      const result = modelStatus._parseAtlassian(json, { componentId: 'abc', componentName: 'Claude Code' });
+      assert.equal(result.status, 'degraded');
+      assert.equal(result.message, 'Something is wrong');
+    });
+
+    it('matches component by name in incident affected_components', () => {
+      const json = {
+        components: [
+          { id: 'abc', name: 'Claude Code', status: 'operational' }
+        ],
+        incidents: [
+          {
+            status: 'identified',
+            impact: 'major',
+            name: 'Auth errors',
+            incident_updates: [{
+              affected_components: [
+                { code: 'different-id', name: 'Claude Code', old_status: 'operational', new_status: 'partial_outage' }
+              ]
+            }]
+          }
+        ],
+        status: { indicator: 'none' }
+      };
+      const result = modelStatus._parseAtlassian(json, { componentId: 'abc', componentName: 'Claude Code' });
+      assert.equal(result.status, 'partial_outage');
+    });
+
+    it('uses worst incident when multiple unresolved incidents exist', () => {
+      const json = {
+        components: [
+          { id: 'abc', name: 'Claude Code', status: 'operational' }
+        ],
+        incidents: [
+          {
+            status: 'monitoring',
+            impact: 'minor',
+            name: 'Minor degradation',
+            incident_updates: [{
+              affected_components: [
+                { code: 'abc', name: 'Claude Code', old_status: 'operational', new_status: 'degraded_performance' }
+              ]
+            }]
+          },
+          {
+            status: 'investigating',
+            impact: 'critical',
+            name: 'Major outage',
+            incident_updates: [{
+              affected_components: [
+                { code: 'abc', name: 'Claude Code', old_status: 'degraded_performance', new_status: 'major_outage' }
+              ]
+            }]
+          }
+        ],
+        status: { indicator: 'none' }
+      };
+      const result = modelStatus._parseAtlassian(json, { componentId: 'abc', componentName: 'Claude Code' });
+      assert.equal(result.status, 'major_outage');
+      assert.equal(result.message, 'Major outage');
+    });
   });
 
   describe('_parseGoogleIncidents', () => {


### PR DESCRIPTION
## Summary

- `_parseAtlassian()` now checks the `incidents[]` array from the Atlassian `summary.json` response for unresolved incidents affecting the target component
- Returns the worse of component status vs active incident impact — so even if the component says `operational`, an active `major` incident will show `partial_outage`
- New `_parseAtlassianIncidents()` and `_incidentAffectsComponent()` helpers handle filtering by component ID/name, skipping resolved/postmortem incidents, and worst-case multi-incident logic

## Test plan

- [x] 7 new tests: escalation, resolved filtering, other-component filtering, no-component-info fallback, name matching, multi-incident worst-case
- [x] All 1376 tests pass
- [ ] Live verification: wait for next status.claude.com incident and confirm pill changes

Fixes #49