### PR TITLE
ci: add stats workflow for portfolio live stats

### DIFF
--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -1,0 +1,51 @@
+name: Update project stats
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  stats:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Count stats
+        run: |
+          # Lines of code (JS/MJS files, excluding node_modules and min files)
+          LOC=$(find . -name '*.js' -o -name '*.mjs' | grep -v node_modules | grep -v '.min.' | xargs wc -l 2>/dev/null | tail -1 | awk '{print $1}')
+
+          # Test cases (it() and test() calls in test files)
+          TESTS=$(find . -name '*.test.*' -o -name '*.spec.*' | grep -v node_modules | xargs grep -c 'it(\|test(' 2>/dev/null | awk -F: '{s+=$2} END {print s+0}')
+
+          # Test files
+          TEST_FILES=$(find . -name '*.test.*' -o -name '*.spec.*' | grep -v node_modules | wc -l | awk '{print $1}')
+
+          # AI engines supported (count unique engine references)
+          ENGINES=$(grep -rio 'claude code\|aider\|codex\|cursor' lib/ server.js 2>/dev/null | grep -io 'claude code\|aider\|codex\|cursor' | sort -uf | wc -l | awk '{print $1}')
+
+          # API routes
+          ROUTES=$(grep -rE '(method|req\.method)' lib/ server.js 2>/dev/null | wc -l | awk '{print $1}')
+
+          echo "{" > stats.json
+          echo "  \"loc\": $LOC," >> stats.json
+          echo "  \"tests\": $TESTS," >> stats.json
+          echo "  \"testFiles\": $TEST_FILES," >> stats.json
+          echo "  \"engines\": $ENGINES," >> stats.json
+          echo "  \"routes\": $ROUTES," >> stats.json
+          echo "  \"npmDeps\": 0," >> stats.json
+          echo "  \"updatedAt\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"" >> stats.json
+          echo "}" >> stats.json
+
+          cat stats.json
+
+      - name: Commit stats
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add stats.json
+          git diff --cached --quiet && echo "No changes" || git commit -m "chore: update project stats [skip ci]" && git push


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow that counts LOC, tests, AI engines, and routes on every push to main
- Generates `stats.json` in the repo root
- Portfolio site fetches this file to display live project stats

## Test plan
- [ ] Merge and verify workflow runs successfully
- [ ] Confirm stats.json is committed to repo
- [ ] Verify portfolio hero card picks up the live data

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>