### PR TITLE
Fix setup wizard logo SVG + false OpenClaw detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Fix setup wizard logo SVG not rendering** — Welcome step inline SVG used `var(--primary)` CSS custom properties which aren't resolved when the setup page loads before the theme stylesheet is applied; replaced with hardcoded `#8BC34A` hex values (fixes #60)
+- **Fix OpenClaw falsely detected as available in setup wizard** — `openclaw.json` used `"strategy": "which", "target": "ssh"` which matched on every machine since ssh is ubiquitous; OpenClaw is a remote engine requiring explicit configuration, so detection is now `null` — the base profile correctly shows as unavailable, while configured OpenClaw connections still appear as virtual engines with `available: true` (fixes #60)
+
 ### Added
 
 - **Document project version convention (#55, chunk 3)** — Added "Project Version Recording" section to CLAUDE.md global rules documenting the `.tangleclaw/project-version.txt` convention: file format, when to write (session start + wrap), detection order, and how TangleClaw reads it. Doc parity sweep confirmed no stale references in README or user-guide — existing "version badge" references are generic and still accurate. Completes #55.

--- a/data/engines/openclaw.json
+++ b/data/engines/openclaw.json
@@ -6,7 +6,7 @@
   "configFormat": { "filename": null, "syntax": null, "generator": null },
   "coAuthorFormat": null,
   "commands": [],
-  "detection": { "strategy": "which", "target": "ssh" },
+  "detection": null,
   "launch": {
     "shellCommand": "ssh",
     "args": [],

--- a/public/setup.js
+++ b/public/setup.js
@@ -131,10 +131,10 @@ function renderWelcome(body) {
     <div class="setup-step">
       <div class="setup-icon">
         <svg viewBox="0 0 96 96" width="80" height="80" aria-hidden="true">
-          <circle cx="48" cy="48" r="44" fill="none" stroke="var(--primary)" stroke-width="2"/>
+          <circle cx="48" cy="48" r="44" fill="none" stroke="#8BC34A" stroke-width="2"/>
           <path d="M30 60 Q38 28 48 36 Q58 44 52 56 Q46 68 58 62 Q70 56 66 44 Q62 32 48 28"
-                fill="none" stroke="var(--primary)" stroke-width="3" stroke-linecap="round"/>
-          <circle cx="42" cy="34" r="2.5" fill="var(--primary)"/>
+                fill="none" stroke="#8BC34A" stroke-width="3" stroke-linecap="round"/>
+          <circle cx="42" cy="34" r="2.5" fill="#8BC34A"/>
         </svg>
       </div>
       <h2 class="setup-heading">Welcome to TangleClaw</h2>

--- a/test/openclaw-engine.test.js
+++ b/test/openclaw-engine.test.js
@@ -65,10 +65,9 @@ describe('OpenClaw engine integration', () => {
       assert.equal(profile.statusPage, null);
     });
 
-    it('should detect via ssh', () => {
+    it('should have null detection (requires manual configuration)', () => {
       const profile = store.engines.get('openclaw');
-      assert.equal(profile.detection.strategy, 'which');
-      assert.equal(profile.detection.target, 'ssh');
+      assert.equal(profile.detection, null);
     });
   });
 


### PR DESCRIPTION
## Summary
- **SVG fix**: Replaced `var(--primary)` CSS custom properties with hardcoded `#8BC34A` hex in the welcome step SVG — properties weren't resolved before the theme stylesheet loaded
- **OpenClaw detection fix**: Changed `openclaw.json` detection from `{"strategy": "which", "target": "ssh"}` to `null` — ssh exists on every machine, making OpenClaw falsely appear as "Detected". Configured OpenClaw connections still show as available virtual engines via `listWithAvailability()`
- Updated test assertion to match new null detection

## Test plan
- [ ] Fresh install: setup wizard welcome step should show the logo SVG with green strokes
- [ ] Fresh install: OpenClaw should show as "Not found" in the engines step (not "Detected")
- [ ] Existing OpenClaw connections should still appear as available virtual engines
- [ ] All 1424 tests passing

Fixes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)