### PR TITLE
Fix setup wizard scan missing unmarked directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to TangleClaw are documented in this file.
 
 ### Fixed
 
+- **Setup wizard scan includes all directories** — `POST /api/setup/scan` previously required at least one project marker (methodology, git, or TangleClaw config) to include a directory; plain folders were silently skipped, causing new users to miss legitimate projects; scan now returns all top-level directories with a `detected` flag — directories with recognized markers (including new common project files: `package.json`, `Cargo.toml`, `pyproject.toml`, `go.mod`, `Makefile`, etc.) are pre-selected; unrecognized directories appear in a collapsed "Other directories" section that users can expand and opt into; 2 new tests, 1426 total passing (fixes #63)
 - **Fix setup wizard logo SVG not rendering** — Welcome step inline SVG used `var(--primary)` CSS custom properties which aren't resolved when the setup page loads before the theme stylesheet is applied; replaced with hardcoded `#8BC34A` hex values (fixes #60)
 - **Fix OpenClaw falsely detected as available in setup wizard** — `openclaw.json` used `"strategy": "which", "target": "ssh"` which matched on every machine since ssh is ubiquitous; OpenClaw is a remote engine requiring explicit configuration, so detection is now `null` — the base profile correctly shows as unavailable, while configured OpenClaw connections still appear as virtual engines with `available: true` (fixes #60)
 

--- a/public/setup.js
+++ b/public/setup.js
@@ -195,18 +195,20 @@ async function wizardValidateDir() {
   }
 
   wizard.scannedProjects = data.projects || [];
-  wizard.selectedProjects = new Set(wizard.scannedProjects.map(p => p.name));
+  wizard.selectedProjects = new Set(wizard.scannedProjects.filter(p => p.detected).map(p => p.name));
   wizardNext();
 }
 
 function renderDetectProjects(body) {
-  const projects = wizard.scannedProjects;
+  const allDirs = wizard.scannedProjects;
+  const detected = allDirs.filter(p => p.detected);
+  const other = allDirs.filter(p => !p.detected);
 
-  if (projects.length === 0) {
+  if (allDirs.length === 0) {
     body.innerHTML = `
       <div class="setup-step">
         <h2 class="setup-heading">Detect Projects</h2>
-        <p class="setup-text-muted">No existing projects found in <strong>${esc(wizard.projectsDir)}</strong>.</p>
+        <p class="setup-text-muted">No directories found in <strong>${esc(wizard.projectsDir)}</strong>.</p>
         <p class="setup-text-muted">That's fine — you can create projects after setup.</p>
         <div class="setup-nav">
           <button class="btn" onclick="wizardBack()">Back</button>
@@ -216,28 +218,60 @@ function renderDetectProjects(body) {
     return;
   }
 
-  let listHtml = '';
-  for (const p of projects) {
-    const checked = wizard.selectedProjects.has(p.name) ? 'checked' : '';
-    const methLabel = p.methodology ? p.methodology : 'No methodology';
-    const gitLabel = p.git ? `${p.git.branch}${p.git.dirty ? ' (dirty)' : ''}` : '';
+  /**
+   * Build a checkbox list HTML for an array of scanned projects.
+   * @param {object[]} items - Scanned project entries
+   * @returns {string} HTML string
+   */
+  function buildProjectList(items) {
+    let html = '';
+    for (const p of items) {
+      const checked = wizard.selectedProjects.has(p.name) ? 'checked' : '';
+      const methLabel = p.methodology ? p.methodology : 'No methodology';
+      const gitLabel = p.git ? `${p.git.branch}${p.git.dirty ? ' (dirty)' : ''}` : '';
 
-    listHtml += `
-      <label class="setup-project-item">
-        <input type="checkbox" ${checked}
-               onchange="wizardToggleProject('${esc(p.name)}', this.checked)">
-        <div class="setup-project-info">
-          <span class="setup-project-name">${esc(p.name)}</span>
-          <span class="setup-project-meta">${esc(methLabel)}${gitLabel ? ' &middot; ' + esc(gitLabel) : ''}</span>
-        </div>
-      </label>`;
+      html += `
+        <label class="setup-project-item">
+          <input type="checkbox" ${checked}
+                 onchange="wizardToggleProject('${esc(p.name)}', this.checked)">
+          <div class="setup-project-info">
+            <span class="setup-project-name">${esc(p.name)}</span>
+            <span class="setup-project-meta">${esc(methLabel)}${gitLabel ? ' &middot; ' + esc(gitLabel) : ''}</span>
+          </div>
+        </label>`;
+    }
+    return html;
   }
+
+  let listHtml = '';
+
+  if (detected.length > 0) {
+    listHtml += `<div class="setup-project-list">${buildProjectList(detected)}</div>`;
+  }
+
+  if (other.length > 0) {
+    const detectedNote = detected.length > 0
+      ? 'These directories don\'t have recognized project markers but can still be attached:'
+      : 'No projects with recognized markers were found, but you can attach any directory:';
+    listHtml += `
+      <details class="setup-other-dirs">
+        <summary class="setup-other-dirs-summary">Other directories (${other.length})</summary>
+        <p class="setup-text-muted" style="margin:4px 0 8px">${detectedNote}</p>
+        <div class="setup-project-list">${buildProjectList(other)}</div>
+      </details>`;
+  }
+
+  const detectedCount = detected.length;
+  const totalCount = allDirs.length;
+  const summary = detectedCount > 0
+    ? `Found ${detectedCount} project${detectedCount !== 1 ? 's' : ''} in <strong>${esc(wizard.projectsDir)}</strong>. Select which to attach:`
+    : `Found ${totalCount} director${totalCount !== 1 ? 'ies' : 'y'} in <strong>${esc(wizard.projectsDir)}</strong>:`;
 
   body.innerHTML = `
     <div class="setup-step">
       <h2 class="setup-heading">Detect Projects</h2>
-      <p class="setup-text-muted">Found ${projects.length} project${projects.length !== 1 ? 's' : ''} in <strong>${esc(wizard.projectsDir)}</strong>. Select which to attach:</p>
-      <div class="setup-project-list">${listHtml}</div>
+      <p class="setup-text-muted">${summary}</p>
+      ${listHtml}
       <div class="setup-nav">
         <button class="btn" onclick="wizardBack()">Back</button>
         <button class="btn btn-primary" onclick="wizardNext()">Next</button>

--- a/public/style.css
+++ b/public/style.css
@@ -1826,6 +1826,20 @@ body.setup-active { overflow: hidden; }
   color: var(--text-muted);
 }
 
+/* Wizard other-directories disclosure */
+.setup-other-dirs {
+  margin-top: 12px;
+}
+.setup-other-dirs-summary {
+  font-size: 13px;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 6px 0;
+}
+.setup-other-dirs .setup-project-list {
+  max-height: 30vh;
+}
+
 /* Wizard engine list */
 .setup-engine-list {
   display: flex;

--- a/server.js
+++ b/server.js
@@ -446,16 +446,24 @@ route('POST', '/api/setup/scan', (_req, res, _params, body) => {
     // Check for TangleClaw config
     const hasTangleclawConfig = fs.existsSync(path.join(dirPath, '.tangleclaw', 'project.json'));
 
-    // Include if it has any project markers (methodology, git, or tangleclaw config)
-    if (detectedMethodology || (gitInfo && gitInfo.branch) || hasTangleclawConfig) {
-      detected.push({
-        name: entry.name,
-        path: dirPath,
-        methodology: detectedMethodology ? detectedMethodology.id : null,
-        hasTangleclawConfig,
-        git: gitInfo ? { branch: gitInfo.branch, dirty: gitInfo.dirty } : null
-      });
-    }
+    // Check for common project manifest files
+    const PROJECT_MARKERS = [
+      'package.json', 'Cargo.toml', 'pyproject.toml', 'go.mod',
+      'Makefile', 'Gemfile', 'pom.xml', 'build.gradle',
+      'CMakeLists.txt', 'setup.py', 'composer.json', 'mix.exs'
+    ];
+    const hasProjectMarker = PROJECT_MARKERS.some(m => fs.existsSync(path.join(dirPath, m)));
+
+    const isDetected = !!(detectedMethodology || (gitInfo && gitInfo.branch) || hasTangleclawConfig || hasProjectMarker);
+
+    detected.push({
+      name: entry.name,
+      path: dirPath,
+      methodology: detectedMethodology ? detectedMethodology.id : null,
+      hasTangleclawConfig,
+      git: gitInfo ? { branch: gitInfo.branch, dirty: gitInfo.dirty } : null,
+      detected: isDetected
+    });
   }
 
   jsonResponse(res, 200, { projects: detected });

--- a/test/setup-wizard.test.js
+++ b/test/setup-wizard.test.js
@@ -181,6 +181,44 @@ describe('Setup Wizard', () => {
       const found = data.projects.find(p => p.name === 'test-git-project');
       assert.ok(found, 'Should find the git project');
       assert.ok(found.git, 'Should include git info');
+      assert.equal(found.detected, true, 'Git project should be detected');
+    });
+
+    it('should include directories without markers as detected: false', async () => {
+      const plainDir = path.join(projectsDir, 'test-plain-folder');
+      fs.mkdirSync(plainDir, { recursive: true });
+
+      const { status, data } = await request(server, 'POST', '/api/setup/scan', {
+        directory: projectsDir
+      });
+      assert.equal(status, 200);
+
+      const found = data.projects.find(p => p.name === 'test-plain-folder');
+      assert.ok(found, 'Should include the plain directory');
+      assert.equal(found.detected, false, 'Should be marked as not detected');
+    });
+
+    it('should detect directories with common project markers', async () => {
+      const pyDir = path.join(projectsDir, 'test-python-project');
+      fs.mkdirSync(pyDir, { recursive: true });
+      fs.writeFileSync(path.join(pyDir, 'pyproject.toml'), '[project]\nname = "test"\n');
+
+      const goDir = path.join(projectsDir, 'test-go-project');
+      fs.mkdirSync(goDir, { recursive: true });
+      fs.writeFileSync(path.join(goDir, 'go.mod'), 'module example.com/test\n');
+
+      const { status, data } = await request(server, 'POST', '/api/setup/scan', {
+        directory: projectsDir
+      });
+      assert.equal(status, 200);
+
+      const pyFound = data.projects.find(p => p.name === 'test-python-project');
+      assert.ok(pyFound, 'Should find the Python project');
+      assert.equal(pyFound.detected, true, 'pyproject.toml should trigger detection');
+
+      const goFound = data.projects.find(p => p.name === 'test-go-project');
+      assert.ok(goFound, 'Should find the Go project');
+      assert.equal(goFound.detected, true, 'go.mod should trigger detection');
     });
 
     it('should detect projects with methodology markers', async () => {
@@ -197,6 +235,7 @@ describe('Setup Wizard', () => {
       const found = data.projects.find(p => p.name === 'test-meth-project');
       assert.ok(found, 'Should find the methodology project');
       assert.equal(found.methodology, 'prawduct');
+      assert.equal(found.detected, true, 'Methodology project should be detected');
     });
   });
 


### PR DESCRIPTION
## Summary
- Scan now returns **all** top-level directories, each with a `detected` boolean flag
- Added common project manifest markers to detection: `package.json`, `Cargo.toml`, `pyproject.toml`, `go.mod`, `Makefile`, `Gemfile`, `pom.xml`, `build.gradle`, `CMakeLists.txt`, `setup.py`, `composer.json`, `mix.exs`
- Only detected projects are pre-selected; unrecognized directories appear in a collapsed "Other directories" `<details>` section
- 2 new tests + existing tests updated with `detected` flag assertions (1426 total passing)

## Test plan
- [ ] Fresh install: projects dir with mixed content (git repos, package.json projects, plain folders) — all should appear, only recognized ones pre-selected
- [ ] Empty projects dir — shows "No directories found" message
- [ ] Expand "Other directories" and check some — they should be included in the attach step
- [ ] All 1426 tests passing

Fixes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)