### PR TITLE
fix: stats workflow push to project-assets

### DIFF
--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -5,9 +5,6 @@ on:
     branches: [main]
   workflow_dispatch:
 
-permissions:
-  contents: write
-
 jobs:
   stats:
     runs-on: ubuntu-latest
@@ -43,9 +40,14 @@ jobs:
 
           cat stats.json
 
-      - name: Commit stats
+      - name: Push stats to project-assets
+        env:
+          PAT_TOKEN: ${{ secrets.PROJECT_ASSETS_TOKEN }}
         run: |
+          git clone https://x-access-token:${PAT_TOKEN}@github.com/Jason-Vaughan/project-assets.git /tmp/project-assets
+          cp stats.json /tmp/project-assets/tangleclaw-stats.json
+          cd /tmp/project-assets
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add stats.json
-          git diff --cached --quiet && echo "No changes" || git commit -m "chore: update project stats [skip ci]" && git push
+          git add tangleclaw-stats.json
+          git diff --cached --quiet && echo "No changes" || (git commit -m "chore: update TangleClaw stats [skip ci]" && git push)

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -1,0 +1,51 @@
+name: Update project stats
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  stats:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Count stats
+        run: |
+          # Lines of code (JS/MJS files, excluding node_modules and min files)
+          LOC=$(find . -name '*.js' -o -name '*.mjs' | grep -v node_modules | grep -v '.min.' | xargs wc -l 2>/dev/null | tail -1 | awk '{print $1}')
+
+          # Test cases (it() and test() calls in test files)
+          TESTS=$(find . -name '*.test.*' -o -name '*.spec.*' | grep -v node_modules | xargs grep -c 'it(\|test(' 2>/dev/null | awk -F: '{s+=$2} END {print s+0}')
+
+          # Test files
+          TEST_FILES=$(find . -name '*.test.*' -o -name '*.spec.*' | grep -v node_modules | wc -l | awk '{print $1}')
+
+          # AI engines supported (count unique engine references)
+          ENGINES=$(grep -rio 'claude code\|aider\|codex\|cursor' lib/ server.js 2>/dev/null | grep -io 'claude code\|aider\|codex\|cursor' | sort -uf | wc -l | awk '{print $1}')
+
+          # API routes
+          ROUTES=$(grep -rE '(method|req\.method)' lib/ server.js 2>/dev/null | wc -l | awk '{print $1}')
+
+          echo "{" > stats.json
+          echo "  \"loc\": $LOC," >> stats.json
+          echo "  \"tests\": $TESTS," >> stats.json
+          echo "  \"testFiles\": $TEST_FILES," >> stats.json
+          echo "  \"engines\": $ENGINES," >> stats.json
+          echo "  \"routes\": $ROUTES," >> stats.json
+          echo "  \"npmDeps\": 0," >> stats.json
+          echo "  \"updatedAt\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"" >> stats.json
+          echo "}" >> stats.json
+
+          cat stats.json
+
+      - name: Commit stats
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add stats.json
+          git diff --cached --quiet && echo "No changes" || git commit -m "chore: update project stats [skip ci]" && git push

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -50,4 +50,4 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add tangleclaw-stats.json
-          git diff --cached --quiet && echo "No changes" || (git commit -m "chore: update TangleClaw stats [skip ci]" && git push)
+          git diff --cached --quiet && echo "No changes" || (git commit -m "chore: update TangleClaw stats [skip ci]" && git pull --rebase && git push)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Remove misleading PortHub warning from installer** — `deploy/install.sh` previously checked for standalone `porthub` and printed a yellow warning when not found, causing new users to think it was a missing dependency; PortHub was fully absorbed into TangleClaw — the standalone CLI check and its associated messages have been removed (fixes #59)
+
 ### Added
 
 - **Document project version convention (#55, chunk 3)** — Added "Project Version Recording" section to CLAUDE.md global rules documenting the `.tangleclaw/project-version.txt` convention: file format, when to write (session start + wrap), detection order, and how TangleClaw reads it. Doc parity sweep confirmed no stale references in README or user-guide — existing "version badge" references are generic and still accurate. Completes #55.

--- a/data/default-global-rules.md
+++ b/data/default-global-rules.md
@@ -9,3 +9,23 @@ Edit them from the TangleClaw landing page or via the API.
 - Prefer small, focused commits over large monolithic ones
 - Keep functions short and single-purpose
 - Write clear commit messages that explain why, not just what
+
+## Project Stats Workflow
+
+Every project managed by TangleClaw must include a GitHub Actions workflow (`.github/workflows/stats.yml`) that auto-generates project metrics on every push to `main`. This enables the portfolio site to display live stats.
+
+### What the workflow does
+- Counts lines of code (JS/TS/JSX/TSX/MJS, excluding node_modules, .next, dist, .min files)
+- Counts test cases (`it()` and `test()` calls in test/spec files)
+- Counts test files
+- Writes results to `stats.json` with an `updatedAt` timestamp
+
+### Public vs private repos
+- **Public repos**: Commit `stats.json` directly to the repo root. The portfolio fetches from the raw GitHub URL.
+- **Private repos**: Push `<project>-stats.json` to the `project-assets` repo using the `PROJECT_ASSETS_TOKEN` secret. This secret must be added to each private repo (Settings → Secrets → Actions).
+
+### When setting up a new project
+1. Add `.github/workflows/stats.yml` (use the public or private template as appropriate)
+2. For private repos: add the `PROJECT_ASSETS_TOKEN` secret
+3. Push to main to trigger the first stats generation
+4. If the project has a portfolio card, update the card to fetch from the stats URL

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -56,13 +56,6 @@ fi
 TMUX_PATH="$(which tmux)"
 green "  tmux ($TMUX_PATH)"
 
-# PortHub (optional — TangleClaw manages ports directly)
-if command -v porthub &>/dev/null; then
-  green "  porthub ($(which porthub)) — existing leases will be imported"
-else
-  yellow "  porthub not found (optional — TangleClaw manages ports directly)"
-fi
-
 # Build PATH for launchd plists — start from the user's current PATH so that
 # engine binaries installed in non-standard locations (e.g. ~/.local/bin,
 # ~/.npm-global/bin) are discoverable at runtime for engine detection.


### PR DESCRIPTION
Fixes branch protection blocking stats.json push. Now pushes to project-assets like the private repos.