### PR TITLE
Refresh README — launch modes, shared docs, session memory, HTTPS wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ TangleClaw was built to fix that. It wraps AI coding sessions in persistent tmux
 
 What started as session persistence grew into a full orchestration platform. Once you have persistent sessions, you start wanting a dashboard to manage them. Then you want your development methodology enforced as structural rules, not suggestions the agent can ignore. Then you want engine-native config generated automatically so Claude Code, Codex, Gemini CLI, and Aider all get the same instructions without you maintaining four different config files. Then you want port conflict management across projects, mobile access, idle detection, session wrap protocols.
 
-TangleClaw is all of that — a local platform that sits between you and your AI coding agents, accessible from any browser or phone on your network.
+TangleClaw is all of that — a local platform that sits between you and your AI coding agents, accessible from any browser or phone on your network. Project groups with shared markdown docs, per-session launch-mode selection (from fully interactive to full-autonomy sandboxed), file-based session memory that persists across restarts, a one-click mkcert HTTPS wizard, and a universal project-version detection chain are all wired in.
 
 ## Screenshots
 
@@ -43,24 +43,41 @@ TangleClaw is all of that — a local platform that sits between you and your AI
   <br><em>PortHub registry — all port leases grouped by project with conflict detection</em>
 </p>
 
+<p align="center">
+  <img src="https://github.com/Jason-Vaughan/project-assets/blob/main/tangleclaw-screenshots/launch%20mode%20selector%20modal.png?raw=true" alt="Launch mode selector" width="480">
+  <br><em>Launch mode selector — pick per-session permission mode (Interactive / Accept Edits / Plan Only / Auto / Bypass)</em>
+</p>
+
+<p align="center">
+  <img src="https://github.com/Jason-Vaughan/project-assets/blob/main/tangleclaw-screenshots/shared%20directories%20and%20files%20between%20groups%20modal.png?raw=true" alt="Shared directories between groups" width="800">
+  <br><em>Project groups & shared docs — link related projects and share markdown across them with doc locking</em>
+</p>
+
 ## Features
 
 - **Persistent sessions** — AI engine sessions run in tmux, surviving network drops, device switches, and reconnects. Close your laptop, switch devices, pick up where you left off
 - **Five built-in engines** — [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Codex](https://github.com/openai/codex), [Gemini CLI](https://github.com/google-gemini/gemini-cli), [Aider](https://aider.chat), and [OpenClaw](https://github.com/Jason-Vaughan/OpenClaw). Write rules once — TangleClaw generates engine-native config so every agent gets the same instructions
+- **Launch mode selector** — pick a permission mode when you start a session: Interactive (prompt on every action), Accept Edits (auto-accept file reads and edits), Plan Only (read-only, no code changes), Auto (full autonomy with safety classifier), or Bypass (accepts everything — containers/VMs only). Engines without `launchModes` launch as before; Claude Code ships with all five wired in
+- **Project groups & shared docs** — link related projects into a group, then share markdown documents across them (architecture notes, network diagrams, runbooks) with per-doc locking so two sessions can't step on each other. Shared directories auto-sync `.md` files on session launch
+- **Session memory** — file-based, per-project memory system at `.tangleclaw/memories/` that persists context across AI sessions. The guide is injected into every engine config so Claude, Codex, Gemini, and Aider all read and update it the same way
 - **Methodology enforcement** — pluggable JSON templates define phases, rules, and session behavior. Rules are structural gates, not suggestions. First-class [Prawduct](https://github.com/brookstalley/prawduct) integration for governed workflows with independent Critic review
 - **[PortHub](https://github.com/Jason-Vaughan/PortHub) built in** — central port registry preventing conflicts across all projects. Originally a [standalone CLI](https://github.com/Jason-Vaughan/PortHub), now fully integrated into TangleClaw with permanent and TTL leases, heartbeat support, and system-wide conflict detection via lsof
-- **Dashboard & mobile PWA** — manage projects, launch sessions, and interact with AI agents from any browser or phone on your network. Installable on iOS and Android
+- **HTTPS via mkcert, one click** — first-run wizard detects mkcert, generates localhost certs into `~/.tangleclaw/certs/`, and hot-swaps the server to HTTPS with a restart overlay. Required for OpenClaw Web UI device pairing; optional manual-cert and skip paths also supported
+- **Dashboard & mobile PWA** — manage projects, launch sessions, and interact with AI agents from any browser or phone on your network. Installable on iOS and Android. Archive projects you're not touching, get an update-available pill when a new TangleClaw ships, and see model status for Claude/OpenAI/Google in the session banner
 - **OpenClaw integration** — connect to remote [OpenClaw](https://github.com/Jason-Vaughan/OpenClaw) instances via SSH or Web UI mode with automatic SSH tunnel management, and live background process visibility via [ClawBridge](https://github.com/Jason-Vaughan/ClawBridge)
+- **Universal project version detection** — every project's current version is resolved through a layered chain: `.tangleclaw/project-version.txt` (AI-recorded) → `CHANGELOG.md` → `version.json` → `package.json`. The session wrap re-records it, so the dashboard badge stays honest across any project convention
 - **Zero dependencies** — Node.js 22+ stdlib only. No npm install, no build step, no bundler
 
 <details>
 <summary>All features</summary>
 
 ### Sessions
+- **Launch modes** — Interactive / Accept Edits / Plan Only / Auto / Bypass picker on session start for engines that declare `launchModes`. The selected mode is appended to the engine's launch args and recorded in the session DB
 - **Session briefings** — auto-generated context from methodology state, active learnings, and last session summary, injected on session start
 - **Structured session wrap** — configurable close-out with version bumps, changelog updates, learnings capture, and next-session priming
+- **Session memory** — per-project `.tangleclaw/memories/` directory with a `MEMORY.md` index. Auto-scaffolded on project init; engine configs include the read/update instructions so every AI follows the same memory convention
 - **Command bar** — inject commands into running sessions without touching the terminal. Quick command pills for common operations and engine-specific slash commands
-- **Peek** — slide-up drawer showing the last lines of terminal output — check progress without scrolling
+- **Peek** — slide-up drawer showing full terminal scrollback (up to 50,000 lines), with search (Cmd/Ctrl+F), live match highlighting, and alternate-screen-aware capture for TUI engines like Codex
 - **File upload** — send files into the project directory from the session wrapper (images, docs, configs up to 15 MB)
 - **Idle chime** — audio notification when the terminal goes idle, so you know the agent has finished
 - **Session history** — start time, duration, engine, wrap status, and wrap summary per project
@@ -77,11 +94,14 @@ TangleClaw is all of that — a local platform that sits between you and your AI
 - **Methodology switching** — switch methodologies on any project with automatic state archival and rollback support
 
 ### Dashboard
-- **Project management** — create, attach, filter, tag, and delete projects from a central landing page
-- **Setup wizard** — first-run guided setup scans for existing projects, detects engines, configures preferences
-- **Project groups & shared documents** — group related projects, share markdown documents across groups with document locking
+- **Project management** — create, attach, archive/unarchive, filter, tag, and delete projects from a central landing page. Attaching an unregistered project shows a confirmation dialog explaining what scaffolding will be generated before it registers
+- **Setup wizard** — first-run guided setup scans for existing projects (including plain folders with `package.json`, `Cargo.toml`, `pyproject.toml`, `go.mod`, `Makefile`, etc.), detects engines, configures preferences, and walks through HTTPS setup
+- **Project groups & shared documents** — group related projects, share markdown documents across groups with document locking, and auto-sync `.md` files from a group's shared directory on session launch
+- **Universal project version detection** — every project's version is resolved from a layered chain (`.tangleclaw/project-version.txt` → `CHANGELOG.md` → `version.json` → `package.json`) and shown on the project card and session banner
+- **Update notification pill** — landing page shows a pill when a newer TangleClaw version is available, with dismiss-per-version persistence
+- **Startup project sync** — on every server boot, all engine configs regenerate and memory/scaffolding backfills for existing projects, so code changes land immediately without a session relaunch
 - **PortHub** — central port registry preventing conflicts across all projects. Permanent and TTL leases with heartbeat support
-- **HTTPS/TLS** — optional TLS via mkcert for secure remote access
+- **HTTPS/TLS** — one-click mkcert setup wizard that generates `cert.pem`/`key.pem` into `~/.tangleclaw/certs/` with correct perms, plus manual-cert and skip paths. Server hot-switches between HTTP and HTTPS on save with a restart overlay
 
 ### Integrations
 - **[OpenClaw](https://github.com/Jason-Vaughan/OpenClaw)** — SSH or Web UI mode, connection registry, health checks, auto SSH tunnels, reverse proxy, auto device pairing


### PR DESCRIPTION
## Summary

The README was last touched at v3.10.1; project is now at v3.12.7 with more in `[Unreleased]`. Expands the top section to cover features shipped in the meantime — origin story paragraphs are intact, only the closing summary paragraph and feature lists grew.

- **Narrative** — single-sentence addition at the end of the intro mentioning groups/shared docs, per-session launch modes, session memory, the HTTPS wizard, and the version detection chain. Origin story untouched.
- **Screenshots** — added two new shots (both already pushed to `Jason-Vaughan/project-assets`):
  - `launch mode selector modal.png` — per-session permission picker
  - `shared directories and files between groups modal.png` — the groups/shared-docs UI that was only in the hidden details before
- **Features (main bullets)** — promoted `Project groups & shared docs` and `Session memory` out of the hidden details; added `Launch mode selector`, `HTTPS via mkcert`, and `Universal project version detection`.
- **All features / Sessions** — added Launch modes and Session memory; updated the Peek entry to reflect full-scrollback + search + alternate-screen awareness.
- **All features / Dashboard** — added archive/unarchive, broader setup-wizard scan, shared-directory `.md` auto-sync, project version chain, update-notification pill, startup project sync, and the HTTPS mkcert wizard.

No functional changes; text/image only. `Technical` block (test count, endpoint count) intentionally left alone — out of scope for this pass.

## Test plan

- [ ] Render `README.md` on the GitHub PR preview and confirm the two new `<p align="center">` screenshot blocks load (raw URLs on `project-assets` main).
- [ ] Confirm the launch mode + shared directories images resolve (they were pushed to `Jason-Vaughan/project-assets` in commit `696d4ce`).
- [ ] Skim the main Features bullets to confirm the promoted items read well in order and don't duplicate anything in the `<details>` block.
- [ ] Verify origin story paragraphs (VPN → SSH → session-gone → TangleClaw was built to fix that) are unchanged.