### PR TITLE
Widen silentPrime SessionStart matcher to startup|clear|resume (#130)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- **Silent prime SessionStart hook now re-fires on `/clear` and `/resume` (#130)** — Chunk-1 set the matcher to `'startup'` only, leaving an unintended gap: when the user ran `/clear` or `/resume` mid-session, the model's context reset but the SessionStart hook didn't re-inject the prime, so methodology + last-session summary + active learnings disappeared until the next fresh session launch — the same regression class the original silent-prime feature was designed to prevent. Widened the matcher in `lib/engines.js:_buildBaselineHooks` from `'startup'` to `'startup|clear|resume'` (matching Prawduct's existing governance hook precedent for the same conceptual flag — symmetric matchers across coexisting hooks). `'compact'` is intentionally excluded because compaction summarizes context internally and a fresh prime would conflict with that summary. Three test updates (the existing `_buildBaselineHooks` matcher assertion + two `syncEngineHooks` integration tests that hardcoded the old matcher) plus 1 new test (`matcher includes startup, clear, and resume but not compact`) — total 1683 passing (was 1682). The prime file written at `launchSession` time is reused on every re-injection, which is correct: the AI sees the same launch-time prime context whether the session is fresh or post-`/clear`.
+
 ## [3.14.0] - 2026-05-01
 
 ### Added

--- a/lib/engines.js
+++ b/lib/engines.js
@@ -938,9 +938,11 @@ function _buildBaselineHooks(projConfig, engineProfile) {
     && engineProfile.capabilities
     && engineProfile.capabilities.supportsSilentPrime === true);
   if (projConfig && projConfig.silentPrime === true && supportsSilentPrime) {
+    // 'compact' is intentionally excluded — it summarizes context internally,
+    // and re-feeding the prime would conflict with the compaction summary.
     hooks.SessionStart = [
       {
-        matcher: 'startup',
+        matcher: 'startup|clear|resume',
         hooks: [
           {
             type: 'command',

--- a/test/engines.test.js
+++ b/test/engines.test.js
@@ -1245,7 +1245,17 @@ describe('engines', () => {
       const result = engines._buildBaselineHooks({ silentPrime: true }, supportingProfile);
       assert.ok(result.SessionStart, 'SessionStart should be present');
       assert.equal(result.SessionStart.length, 1);
-      assert.equal(result.SessionStart[0].matcher, 'startup');
+      assert.equal(result.SessionStart[0].matcher, 'startup|clear|resume');
+    });
+
+    it('matcher includes startup, clear, and resume but not compact (#130)', () => {
+      const result = engines._buildBaselineHooks({ silentPrime: true }, supportingProfile);
+      const matcher = result.SessionStart[0].matcher;
+      const sources = matcher.split('|');
+      assert.ok(sources.includes('startup'), 'must fire on fresh sessions');
+      assert.ok(sources.includes('clear'), 'must re-fire after /clear so AI keeps methodology');
+      assert.ok(sources.includes('resume'), 'must re-fire after /resume');
+      assert.ok(!sources.includes('compact'), 'must NOT include compact source — would conflict with compaction summary');
     });
 
     it('returns empty object when silentPrime is true but engine lacks supportsSilentPrime (Critic M1)', () => {
@@ -1348,7 +1358,7 @@ describe('engines', () => {
       const settings = readSettings();
       assert.equal(settings.hooks.SessionStart.length, 2, 'methodology + baseline coexist');
       assert.equal(settings.hooks.SessionStart[0].matcher, 'startup|clear|resume', 'methodology entry first');
-      assert.equal(settings.hooks.SessionStart[1].matcher, 'startup', 'baseline entry second');
+      assert.equal(settings.hooks.SessionStart[1].matcher, 'startup|clear|resume', 'baseline entry second (#130 widened from startup)');
       assert.ok(settings.hooks.Stop, 'Stop hook still present');
     });
 
@@ -1358,7 +1368,7 @@ describe('engines', () => {
 
       const settings = readSettings();
       assert.equal(settings.hooks.SessionStart.length, 1);
-      assert.equal(settings.hooks.SessionStart[0].matcher, 'startup');
+      assert.equal(settings.hooks.SessionStart[0].matcher, 'startup|clear|resume');
       assert.ok(settings.hooks.SessionStart[0].hooks[0].command.endsWith('sessionstart-prime.sh'));
     });
 


### PR DESCRIPTION
## Summary

- Chunk-1 set the silentPrime SessionStart hook matcher to `'startup'` only. After the user ran `/clear` or `/resume` mid-session, the model's context reset but the hook didn't re-inject the prime — the AI lost methodology + last-session summary + active learnings until the next fresh launch. Same regression class the original silent-prime feature was designed to prevent.
- Widened the matcher in `lib/engines.js:_buildBaselineHooks` from `'startup'` to `'startup|clear|resume'`, matching Prawduct's existing governance hook precedent (symmetric matchers across coexisting SessionStart entries).
- `'compact'` is intentionally excluded — compaction summarizes context internally, and re-feeding the prime would conflict with the compaction summary.

## Why

- Closes #130. Direct follow-up to #103 chunk 3 (open follow-ups list called this out).
- Prime file written at `launchSession` time is reused on every re-injection — the AI sees the same launch-time prime context whether the session is fresh or post-`/clear`. No race with the chunk-3 `_removePrimeFile` cleanup, which only fires on the silentPrime=OFF launch branch.

## Test plan

- [x] `node --test 'test/*.test.js'` passes (1683/1683, +1 over `main`'s 1682).
- [x] Updated 3 assertions that hardcoded the old matcher (1 unit + 2 integration in `test/engines.test.js`).
- [x] Added new lock-in test: `matcher includes startup, clear, and resume but not compact` — explicit enumeration so a future refactor can't silently narrow the scope OR add `compact`.
- [x] Independent Critic ran against the diff. Two findings addressed: superseded note added to chunk-1 plan's Decision #9, and a test message wording polish. CHANGELOG test count verified via runtime (Critic's static count was off — `node --test` is authoritative).
- [ ] Manual: enable silentPrime on a project, launch, run `/clear`, ask a methodology-aware question — confirm AI still has methodology context after `/clear`.

Closes #130