### PR TITLE
Add CHANGELOG structural-invariants test (#168)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **CHANGELOG.md structural-invariants test (#168)** — `test/changelog-structure.test.js` asserts four structural invariants on `CHANGELOG.md`: every release banner (`> 🛟` / `> 🚀`) is inside a `## [X.Y.Z] - YYYY-MM-DD` section (catches the PR #166-class regression where a heading was silently consumed); released-version headings appear in descending semver order (catches cherry-pick / backport misorderings); no released-version heading appears twice (catches bad merge resolutions); the top released-version heading agrees with `version.json` (the load-bearing invariant — would have caught PR #166 directly, where the cache self-heal then propagated `3.16.0` to dashboards on every install). Invariant detectors are factored as pure functions so a second describe block exercises them against a synthesized post-#166 / pre-#167 file shape, proving the regression is detected. ~180 lines, 9 tests, runs in < 40ms inside the standard `node --test 'test/*.test.js'` sweep — no new tooling. Structural-only; lints body content of release entries is intentionally out of scope (style / completeness remains Critic territory).
+
 ## [3.16.2] - 2026-05-13
 
 > 🛟 **Recommended bug-fix release.** Two patch-class fixes since v3.16.1: **ttyd-watcher actually fires on macOS** (#144) — closes a 6+-month silent regression where the watcher's `pgrep -c` proxy exited 2 on every BSD invocation, leaving #94's session-killing PTY-exhaustion bug unprotected since #95 merged; users had been manually `launchctl kickstart`-ing ttyd on every incident. The replacement measures `kern.tty.ptmx_max` vs `/dev/ttys*` directly and trips at 85% pool saturation. **Dashboard project-version label self-heals on enrichment** (#165) — closes the stale-label gap where external version bumps (release-PR merges, manual `version.json` edits) didn't reach the dashboard until the next TC-managed session launch or wrap on the same project. Anyone on v3.16.1 will get the update-pill notification with a clickable link to this release page.

--- a/test/changelog-structure.test.js
+++ b/test/changelog-structure.test.js
@@ -1,0 +1,183 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const CHANGELOG_PATH = path.join(REPO_ROOT, 'CHANGELOG.md');
+const VERSION_JSON_PATH = path.join(REPO_ROOT, 'version.json');
+
+const RELEASE_HEADING_RE = /^## \[(\d+)\.(\d+)\.(\d+)\] - \d{4}-\d{2}-\d{2}\s*$/;
+const UNRELEASED_HEADING_RE = /^## \[Unreleased\]\s*$/;
+const BANNER_RE = /^> (🛟|🚀)/u;
+
+function parseReleaseHeadings(text) {
+  const headings = [];
+  text.split('\n').forEach((line, i) => {
+    const m = line.match(RELEASE_HEADING_RE);
+    if (m) {
+      headings.push({
+        line: i + 1,
+        version: [Number(m[1]), Number(m[2]), Number(m[3])],
+        versionString: `${m[1]}.${m[2]}.${m[3]}`,
+      });
+    }
+  });
+  return headings;
+}
+
+function compareSemver(a, b) {
+  for (let i = 0; i < 3; i += 1) {
+    if (a[i] !== b[i]) return a[i] - b[i];
+  }
+  return 0;
+}
+
+function findOrphanBanners(text) {
+  let currentSection = null;
+  const orphans = [];
+  text.split('\n').forEach((line, i) => {
+    if (UNRELEASED_HEADING_RE.test(line)) {
+      currentSection = 'unreleased';
+      return;
+    }
+    if (RELEASE_HEADING_RE.test(line)) {
+      currentSection = 'released';
+      return;
+    }
+    if (BANNER_RE.test(line) && currentSection !== 'released') {
+      orphans.push({ line: i + 1, raw: line });
+    }
+  });
+  return orphans;
+}
+
+function findDuplicateHeadings(headings) {
+  const seen = new Map();
+  const dupes = [];
+  for (const h of headings) {
+    const prev = seen.get(h.versionString);
+    if (prev) dupes.push({ versionString: h.versionString, lines: [prev.line, h.line] });
+    else seen.set(h.versionString, h);
+  }
+  return dupes;
+}
+
+function findOutOfOrderPairs(headings) {
+  const violations = [];
+  for (let i = 1; i < headings.length; i += 1) {
+    if (compareSemver(headings[i - 1].version, headings[i].version) <= 0) {
+      violations.push({ prev: headings[i - 1], curr: headings[i] });
+    }
+  }
+  return violations;
+}
+
+describe('CHANGELOG.md structural invariants (#168)', () => {
+  const changelog = fs.readFileSync(CHANGELOG_PATH, 'utf8');
+  const versionJson = JSON.parse(fs.readFileSync(VERSION_JSON_PATH, 'utf8'));
+  const headings = parseReleaseHeadings(changelog);
+
+  it('has at least one released-version heading', () => {
+    assert.ok(headings.length > 0, 'CHANGELOG.md must contain at least one "## [X.Y.Z] - YYYY-MM-DD" heading');
+  });
+
+  it('released-version headings appear in descending semver order (invariant #2)', () => {
+    const violations = findOutOfOrderPairs(headings);
+    assert.equal(
+      violations.length,
+      0,
+      violations.length === 0
+        ? undefined
+        : `CHANGELOG.md release headings out of order: ${violations
+            .map((v) => `[${v.prev.versionString}] (line ${v.prev.line}) before [${v.curr.versionString}] (line ${v.curr.line})`)
+            .join('; ')}`,
+    );
+  });
+
+  it('no released-version heading appears twice (invariant #3)', () => {
+    const dupes = findDuplicateHeadings(headings);
+    assert.equal(
+      dupes.length,
+      0,
+      dupes.length === 0
+        ? undefined
+        : `CHANGELOG.md duplicate release headings: ${dupes.map((d) => `[${d.versionString}] at lines ${d.lines.join(' and ')}`).join('; ')}`,
+    );
+  });
+
+  it('top released-version heading agrees with version.json (invariant #4 — load-bearing)', () => {
+    const top = headings[0];
+    assert.equal(
+      top.versionString,
+      versionJson.version,
+      `version.json says ${versionJson.version} but the top released CHANGELOG heading is [${top.versionString}] (line ${top.line}). PR #166-class regression: a release-version heading was deleted while its content remained.`,
+    );
+  });
+
+  it('no release banner (> 🛟 / > 🚀) floats outside a released-version section (invariant #1)', () => {
+    const orphans = findOrphanBanners(changelog);
+    assert.equal(
+      orphans.length,
+      0,
+      orphans.length === 0
+        ? undefined
+        : `Release banner(s) found outside a released-version section: ${orphans
+            .map((o) => `line ${o.line}: ${o.raw.slice(0, 80)}`)
+            .join('; ')}. Likely cause: the parent "## [X.Y.Z]" heading was deleted.`,
+    );
+  });
+});
+
+describe('CHANGELOG.md invariant detectors flag the post-#166 / pre-#167 regression shape', () => {
+  // Synthesized minimal reproduction of the PR #166 state: the [3.16.1]
+  // heading is gone, its banner + content remain under [Unreleased], and
+  // version.json still says 3.16.1.
+  const BROKEN = [
+    '# Changelog',
+    '',
+    '## [Unreleased]',
+    '',
+    '> 🛟 **Recommended bug-fix release.** Three fixes since v3.16.0…',
+    '',
+    '### Fixed',
+    '',
+    '- Some fix.',
+    '',
+    '## [3.16.0] - 2026-05-12',
+    '',
+    '### Added',
+    '',
+    '- Something.',
+    '',
+  ].join('\n');
+
+  it('top released-version heading mismatch is detected (invariant #4)', () => {
+    const headings = parseReleaseHeadings(BROKEN);
+    assert.equal(headings[0].versionString, '3.16.0');
+    assert.notEqual(headings[0].versionString, '3.16.1');
+  });
+
+  it('orphan release banner under [Unreleased] is detected (invariant #1)', () => {
+    const orphans = findOrphanBanners(BROKEN);
+    assert.equal(orphans.length, 1);
+    assert.match(orphans[0].raw, /🛟/u);
+  });
+
+  it('out-of-order headings are detected (invariant #2)', () => {
+    const SCRAMBLED = '## [3.15.0] - 2026-05-10\n\n## [3.16.0] - 2026-05-12\n';
+    const violations = findOutOfOrderPairs(parseReleaseHeadings(SCRAMBLED));
+    assert.equal(violations.length, 1);
+    assert.equal(violations[0].prev.versionString, '3.15.0');
+    assert.equal(violations[0].curr.versionString, '3.16.0');
+  });
+
+  it('duplicate headings are detected (invariant #3)', () => {
+    const DUPED = '## [3.16.0] - 2026-05-12\n\n## [3.16.0] - 2026-05-12\n';
+    const dupes = findDuplicateHeadings(parseReleaseHeadings(DUPED));
+    assert.equal(dupes.length, 1);
+    assert.equal(dupes[0].versionString, '3.16.0');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #168. Adds `test/changelog-structure.test.js` — a small structural test that asserts CHANGELOG.md invariants so a future regex-edit (LLM-driven or human) can't silently drop a release-version heading without CI catching it.

Direct follow-up to PR #166's silent regression: the `## [3.16.1] - 2026-05-13` heading was consumed during an `[Unreleased]`-boundary edit, the release banner and content stayed in place, and `lib/projects.js:_readChangelogVersion` then walked past `[Unreleased]` and landed on `[3.16.0]`, propagating the wrong version to dashboards on every install (fixed live in PR #167).

## What

Four invariants, asserted against the real `CHANGELOG.md` + `version.json`:

1. **No release banner (\`> 🛟\` / \`> 🚀\`) floats outside a \`## [X.Y.Z]\` section** — directly catches the PR #166 shape (banner orphaned under \`[Unreleased]\`).
2. **Released-version headings appear in descending semver order** — catches cherry-pick / backport misorderings.
3. **No released-version heading appears twice** — catches bad merge resolutions.
4. **Top released-version heading agrees with \`version.json\`** — the load-bearing invariant; would have caught PR #166 directly.

Detector functions are factored as pure functions so a second describe block exercises them against a synthesized post-#166 / pre-#167 file shape, proving the regression is detected (not just that the current file is currently healthy).

Invariant #5 (orphan subsections) and content-linting of release entries are explicitly out of scope per the issue body — style / completeness remains Critic territory.

## Why

PR #166's regression went undetected because the existing Critic checked doc *parity* (does the entry describe what shipped?) but not doc *structure* (does the file still have all the released-version headings it had before?). A structural test closes that gap mechanically.

## Test plan

- [x] `node --test test/changelog-structure.test.js` — 9 tests pass in ~35ms against current CHANGELOG.md + version.json.
- [x] Synthesized post-#166 / pre-#167 shape is detected by the pure detector functions (invariant #4 mismatch, invariant #1 orphan banner).
- [x] No false positives — current release-section banners (\`> 🛟\` for v3.16.2, v3.16.1, v3.16.0, etc.) are correctly classified as "inside a released section".
- [x] Independent Critic review run before commit (1 BLOCKER on doc-parity line count in CHANGELOG entry; addressed in-chunk before commit).
- [x] CHANGELOG \`[Unreleased]\` entry added under \`### Added\`; post-edit \`grep -E "^## \[" CHANGELOG.md | head -5\` confirms heading structure preserved.

Fixes #168