### PR TITLE
Feature Index Chunk 4: dogfood on TC-v3 (#207)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Feature Index dogfooded on TC-v3 (#207 Chunk 4)** — closes out the four-chunk Feature Index build. `featureIndexEnabled` is now `true` on TC-v3's own project config, and `FEATURES.md` ships at the repo root with hand-authored pointer entries across UI / Web, Server / API, Methodologies / Engines, and CLI / Tooling. The Chunk-1 stub-seeding helper was verified end-to-end via a `PATCH /api/projects/TangleClaw-v3 {"featureIndexEnabled": true}` API call: the seed template lands when the toggle flips, and the hand-authored content replaces the placeholder sections. **Verification deferred.** Two parts of the plan's verification matrix can only run in *future* sessions and are intentionally not part of this PR: (1) starting a fresh Claude Code session on TC-v3 to confirm the Chunk-2 SessionStart injection actually pastes `## Feature Index` into the prime context, and (2) producing a PR that touches a brand-new file to confirm Chunk-3's `features-toc` wrap-step appends a TBD stub. Both will happen organically as the project continues; if either misbehaves, the regression is captured in a follow-up issue rather than blocking the dogfood landing. **Cross-references.** `MEMORY.md` gains a `reference_features_index.md` entry pointing at `FEATURES.md` as the canonical "where does feature X live?" lookup, so future sessions know to consult it before spawning Explore agents.
+
 ## [3.18.0] - 2026-05-23
 
 ### Fixed

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -5,45 +5,50 @@ Maintained automatically: the wrap-step handler appends
 stubs when PRs touch new files. Fill in descriptions before
 next wrap.
 
-Format: - **Name** — short description. file.js:line, file2.js:line.
+Format: - **Name** — short description. file.js:line[, file2.js:line, ...].
+Sub-pointer prefixes ("Backend:", "Handler:", "Core:") are allowed for
+entries that span multiple co-equal locations.
 -->
 
 ## UI / Web
 
-- **Landing page** — project list, port stats, system stats, group rendering. `public/landing.html`, `public/landing.js`.
-- **Session view** — per-project app shell, banner, settings, wrap controls. `public/index.html`, `public/session.js`.
+- **Landing + session shells** — `public/index.html` is the single HTML host; it loads `/landing.js` (project list, port stats, system stats) and `/session.js` (per-project app shell) via the same document. `public/index.html`, `public/landing.js`, `public/session.js`.
 - **Settings modal** — per-project config editor (engine, methodology, silentPrime, featureIndexEnabled, rules). `public/ui.js:697`.
 - **Silent-prime toggle** — engine-gated capability toggle. `public/ui.js:779`.
 - **Feature Index toggle** (#207) — opt-in flag that seeds `FEATURES.md` on first enable. `public/ui.js:808`.
 - **Banner group pills** — group membership chips on the session banner. `public/session.js:302`.
 - **Methodology action buttons** — `actions[]` from `template.json` (e.g. "Run Critic"). `public/session.js:212`. Handler: `lib/actions/invoke-critic.js`. Toast: `public/session.js:281`.
 - **Stale-server banner** (#199) — runtime-vs-disk SHA delta; no dismiss UI today. `public/landing.js:131`, `public/index.html:287`. Backend: `lib/server-info.js`.
-- **Orphan-hooks repair banner** (#145) — scans projects for hook config drift. `public/landing.js:354`, `public/index.html:290`.
+- **Orphan-hooks repair banner** (#145) — scans projects for hook config drift. Section banner: `public/landing.js:364`. HTML: `public/index.html:290`.
 - **Update-available pill** — GitHub release check with localStorage dismiss-per-version. `public/landing.js:160`.
 - **Session Wrap drawer** — step-by-step wrap status, BLOCKED/SKIPPED/DONE rendering. `public/wrap-drawer.js`.
 - **OpenClaw view** — remote-engine project cache + view. `public/openclaw-view.js`, `public/openclaw-cache.js`.
 
 ## Server / API
 
-- **HTTP entrypoint + route table** — `server.js` (single-file router; `route(method, path, handler)` registrations throughout).
-- **`GET /api/projects`** — project list with enrichment. `server.js:854`. Enrichment: `lib/projects.js:559` (`enrichProject`).
-- **`POST /api/projects/attach`** — register an existing directory as a project. `server.js:868`. `lib/projects.js:1111`.
-- **`PATCH /api/projects/:name`** — update fields (silentPrime, featureIndexEnabled, methodology, engine, rules…). `lib/projects.js:1224` (`updateProject`).
-- **`POST /api/projects/repair-orphan-hooks`** — strip orphan hook entries. `server.js:907`.
-- **`GET /api/server-info`** (#199) — startup SHA, current disk SHA, isStale, uptimeSeconds. `server.js:324`. `lib/server-info.js`.
-- **PortHub leasing** — `POST /api/ports/lease` `server.js:805`, `POST /api/ports/release` `:834`, `POST /api/ports/heartbeat` `:843`, `GET /api/ports` `:781`. Backend: `lib/porthub.js`.
-- **Session lifecycle** — `POST /api/sessions/:project` (launch) `server.js:1162`, `DELETE` (kill) `:1232`, `GET /status` `:1265`, `POST /command` `:1274`. Core: `lib/sessions.js:51` (`launchSession`).
-- **Session prime prompt builder** — assembles SessionStart prime text (last-session summary, eval-audit, Feature Index, etc.). `lib/sessions.js:340` (`generatePrimePrompt`).
-- **Session Wrap pipeline** — `POST /api/sessions/:project/wrap` `server.js:1304`. Runner: `lib/wrap-pipeline.js:135` (`runWrapPipeline`).
-- **Methodology-action dispatcher** — invokes declared template actions (write side of "Run Critic"). `lib/actions.js:68` (`runAction`).
-- **Skills / wrap-shape registry** — looks up the wrap skill for a methodology. `lib/skills.js:108` (`getWrapSkill`).
-- **Eval Audit** — Tier-1 exchange scoring + watchdog. `lib/eval-audit.js:55` (`runTier1`), `:238` (`watchSession`).
+- **HTTP entrypoint + route table** — `server.js` (single-file router; `route(method, path, handler)` registrations throughout). API families summarized below; line numbers point at the first route in each family.
+- **Projects family** — `GET /api/projects` `server.js:855`, `POST /api/projects` `:932`, `GET /api/projects/:name` `:923`, `PATCH` `:1079`, `DELETE` `:1031`, `POST .../archive` `:1057`, `POST .../unarchive` `:1068`, `POST /api/projects/attach` `:869`, `POST /api/projects/import` `:962`, orphan-hooks scan `:902` / repair `:910`. Enrichment: `lib/projects.js:559` (`enrichProject`). Updates: `lib/projects.js:1224` (`updateProject`).
+- **Methodology-action invocation** — `POST /api/projects/:name/actions/:command` `server.js:1138`. Dispatcher: `lib/actions.js:68` (`runAction`).
+- **Methodologies registry** — `GET /api/methodologies` `server.js:1119`, `GET /api/methodologies/:id` `:1125`. Backend: `lib/methodologies.js:235` (`initialize`), `:614` (`listTemplates`).
+- **Sessions family** — `POST /api/sessions/:project` (launch) `:1162`, `DELETE` (kill) `:1232`, `GET /status` `:1265`, `POST /command` `:1274`, `POST /wrap` `:1304`, `POST /wrap/complete` `:1338`, `GET /peek` `:1354`, `GET /history` `:1374`. Core: `lib/sessions.js:51` (`launchSession`), `:335` (`generatePrimePrompt` docstring).
+- **Wrap pipeline runner** — `lib/wrap-pipeline.js:135` (`runWrapPipeline`).
+- **Server-info endpoint** (#199) — `GET /api/server-info` `server.js:324`. Backend: `lib/server-info.js`.
+- **PortHub leasing** — `POST /api/ports/lease` `:805`, `POST /api/ports/release` `:834`, `POST /api/ports/heartbeat` `:843`, `GET /api/ports` `:781`, `POST /api/ports/sync` `:828`. Backend: `lib/porthub.js`.
+- **Groups family** — `GET /api/groups` `server.js:1493`, `POST` `:1505`, `GET/PUT/DELETE /:id` `:1521`/`:1536`/`:1555`, `POST /:id/sync` `:1568`, `GET/POST/DELETE /:id/members` `:1583`/`:1598`/`:1615`.
+- **Shared-docs family** — `GET /api/shared-docs` `server.js:1627`, `POST` `:1637`, `GET/PUT/DELETE /:id` `:1659`/`:1670`/`:1689`, lock CRUD `:1704`/`:1723`/`:1733`.
+- **OpenClaw connections family** — `GET /api/openclaw/connections` `server.js:1745`, `POST` `:1751`, `GET/PUT/DELETE /:id` `:1777`/`:1786`/`:1818`, `POST /api/openclaw/test` `:1839`, tunnel CRUD `:1887`/`:1921`/`:1941`, approve-pending `:1980`.
+- **Eval Audit ingest** — `POST /api/audit/ingest` `server.js:2504`, `POST /api/audit/heartbeat` `:2770`. Backend: `lib/eval-audit.js:55` (`runTier1`), `:238` (`watchSession`).
+- **Activity feed** — `GET /api/activity` `server.js:1394`.
+- **Uploads** — `POST /api/upload` `server.js:1435`, `GET /api/uploads` `:1462`. Backend: `lib/uploads.js`.
+- **Tmux mouse mode** — `GET /api/tmux/mouse/:session` `server.js:1480`.
+- **Sidecar processes** — `GET /api/sidecar/:project/processes` `server.js:2724`, `GET /api/sidecar/connection/:connId/processes` `:2747`. Backend: `lib/sidecar.js`.
+- **Skills / wrap-shape registry** — `lib/skills.js:108` (`getWrapSkill`).
 - **Project store / DB** — SQLite-backed project records, project-config persistence. `lib/store.js` (`DEFAULT_PROJECT_CONFIG`, `store.projects.*`).
-- **Engine profiles + config generation** — detect installed engines, generate per-engine config files (`CLAUDE.md`, `.gemini/`, `.aider.conf.yml`, etc.). `lib/engines.js:16` (`detect`), `:214` (`generateConfig`).
+- **Engine profiles + config generation** — detect installed engines, generate per-engine config files (`CLAUDE.md`, `.gemini/`, `.aider.conf.yml`, etc.). `lib/engines.js:16` (`detect`), `:214` (`generateConfig`), `:935` (`_buildBaselineHooks`).
 
 ## Methodologies / Engines
 
-- **Methodology registry** — loads `data/templates/<id>/template.json` + `playbook.md`. `lib/methodologies.js`.
+- **Methodology registry** — loads `data/templates/<id>/template.json` + `playbook.md`. `lib/methodologies.js:235` (`initialize`).
 - **Prawduct template** — methodology shipped in repo. `data/templates/prawduct/template.json`, `data/templates/prawduct/playbook.md`.
 - **Engine profiles** — claude, codex, gemini, aider, genesis, openclaw. `data/engines/<id>.json`. Capability gates (`supportsSilentPrime`, `supportsPrimePrompt`, etc.) consumed throughout `lib/sessions.js`, `lib/engines.js`.
 - **SessionStart hook (Claude Code)** — shell script Claude Code runs on session start; reads `<project>/.tangleclaw/session-prime.md` and emits it as the prime context. `data/hooks/sessionstart-prime.sh`. Hook plumbing: `lib/engines.js:935` (`_buildBaselineHooks`).
@@ -57,9 +62,13 @@ Format: - **Name** — short description. file.js:line, file2.js:line.
 - **Wrap step: `ai-content`** — prompts injected into the AI session for changelog / learnings / memory updates. `lib/wrap-steps/ai-content.js`.
 - **Wrap step: `test`** / **`lint`** — test + lint hooks. `lib/wrap-steps/test.js`, `lib/wrap-steps/lint.js`.
 - **Run Critic action handler** — appends entry to `.tangleclaw/critic-runs.json`; **does not run a Critic** (the review is out-of-band). `lib/actions/invoke-critic.js`. UX clarification tracked in issue #230.
+- **Project version reader** — surfaces `version.json` semver to the UI. `lib/project-version.js`.
+- **Model status monitor** — polls engine providers (Atlassian / Google status pages) for outage detection. `lib/model-status.js:202` (`_pollEngine`), `:303` (`startMonitor`).
 
 ## CLI / Tooling
 
+- **Git helpers** — repo detection, branch/dirty/tag/commit-age info, commits, internal cache. `lib/git.js:33` (`isGitRepo`), `:47` (`getInfo`), `:171` (`commit`).
+- **Tmux helpers** — session create/kill/list, send-keys, capture-pane, mouse mode. `lib/tmux.js:100` (`createSession`), `:177` (`sendKeys`), `:251` (`capturePane`), `:298` (`setMouse`).
 - **TTYD watcher** — keeps the shared ttyd alive; restart hook on PTY exhaustion (#94). `lib/ttyd-watcher.js`.
 - **Tunnel** — Cloudflare tunnel lifecycle for remote access. `lib/tunnel.js`.
 - **Sidecar** — supplementary process supervisor. `lib/sidecar.js`.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,0 +1,73 @@
+# Feature Index
+
+<!--
+Maintained automatically: the wrap-step handler appends
+stubs when PRs touch new files. Fill in descriptions before
+next wrap.
+
+Format: - **Name** — short description. file.js:line, file2.js:line.
+-->
+
+## UI / Web
+
+- **Landing page** — project list, port stats, system stats, group rendering. `public/landing.html`, `public/landing.js`.
+- **Session view** — per-project app shell, banner, settings, wrap controls. `public/index.html`, `public/session.js`.
+- **Settings modal** — per-project config editor (engine, methodology, silentPrime, featureIndexEnabled, rules). `public/ui.js:697`.
+- **Silent-prime toggle** — engine-gated capability toggle. `public/ui.js:779`.
+- **Feature Index toggle** (#207) — opt-in flag that seeds `FEATURES.md` on first enable. `public/ui.js:808`.
+- **Banner group pills** — group membership chips on the session banner. `public/session.js:302`.
+- **Methodology action buttons** — `actions[]` from `template.json` (e.g. "Run Critic"). `public/session.js:212`. Handler: `lib/actions/invoke-critic.js`. Toast: `public/session.js:281`.
+- **Stale-server banner** (#199) — runtime-vs-disk SHA delta; no dismiss UI today. `public/landing.js:131`, `public/index.html:287`. Backend: `lib/server-info.js`.
+- **Orphan-hooks repair banner** (#145) — scans projects for hook config drift. `public/landing.js:354`, `public/index.html:290`.
+- **Update-available pill** — GitHub release check with localStorage dismiss-per-version. `public/landing.js:160`.
+- **Session Wrap drawer** — step-by-step wrap status, BLOCKED/SKIPPED/DONE rendering. `public/wrap-drawer.js`.
+- **OpenClaw view** — remote-engine project cache + view. `public/openclaw-view.js`, `public/openclaw-cache.js`.
+
+## Server / API
+
+- **HTTP entrypoint + route table** — `server.js` (single-file router; `route(method, path, handler)` registrations throughout).
+- **`GET /api/projects`** — project list with enrichment. `server.js:854`. Enrichment: `lib/projects.js:559` (`enrichProject`).
+- **`POST /api/projects/attach`** — register an existing directory as a project. `server.js:868`. `lib/projects.js:1111`.
+- **`PATCH /api/projects/:name`** — update fields (silentPrime, featureIndexEnabled, methodology, engine, rules…). `lib/projects.js:1224` (`updateProject`).
+- **`POST /api/projects/repair-orphan-hooks`** — strip orphan hook entries. `server.js:907`.
+- **`GET /api/server-info`** (#199) — startup SHA, current disk SHA, isStale, uptimeSeconds. `server.js:324`. `lib/server-info.js`.
+- **PortHub leasing** — `POST /api/ports/lease` `server.js:805`, `POST /api/ports/release` `:834`, `POST /api/ports/heartbeat` `:843`, `GET /api/ports` `:781`. Backend: `lib/porthub.js`.
+- **Session lifecycle** — `POST /api/sessions/:project` (launch) `server.js:1162`, `DELETE` (kill) `:1232`, `GET /status` `:1265`, `POST /command` `:1274`. Core: `lib/sessions.js:51` (`launchSession`).
+- **Session prime prompt builder** — assembles SessionStart prime text (last-session summary, eval-audit, Feature Index, etc.). `lib/sessions.js:340` (`generatePrimePrompt`).
+- **Session Wrap pipeline** — `POST /api/sessions/:project/wrap` `server.js:1304`. Runner: `lib/wrap-pipeline.js:135` (`runWrapPipeline`).
+- **Methodology-action dispatcher** — invokes declared template actions (write side of "Run Critic"). `lib/actions.js:68` (`runAction`).
+- **Skills / wrap-shape registry** — looks up the wrap skill for a methodology. `lib/skills.js:108` (`getWrapSkill`).
+- **Eval Audit** — Tier-1 exchange scoring + watchdog. `lib/eval-audit.js:55` (`runTier1`), `:238` (`watchSession`).
+- **Project store / DB** — SQLite-backed project records, project-config persistence. `lib/store.js` (`DEFAULT_PROJECT_CONFIG`, `store.projects.*`).
+- **Engine profiles + config generation** — detect installed engines, generate per-engine config files (`CLAUDE.md`, `.gemini/`, `.aider.conf.yml`, etc.). `lib/engines.js:16` (`detect`), `:214` (`generateConfig`).
+
+## Methodologies / Engines
+
+- **Methodology registry** — loads `data/templates/<id>/template.json` + `playbook.md`. `lib/methodologies.js`.
+- **Prawduct template** — methodology shipped in repo. `data/templates/prawduct/template.json`, `data/templates/prawduct/playbook.md`.
+- **Engine profiles** — claude, codex, gemini, aider, genesis, openclaw. `data/engines/<id>.json`. Capability gates (`supportsSilentPrime`, `supportsPrimePrompt`, etc.) consumed throughout `lib/sessions.js`, `lib/engines.js`.
+- **SessionStart hook (Claude Code)** — shell script Claude Code runs on session start; reads `<project>/.tangleclaw/session-prime.md` and emits it as the prime context. `data/hooks/sessionstart-prime.sh`. Hook plumbing: `lib/engines.js:935` (`_buildBaselineHooks`).
+- **Wrap pipeline runner** — orchestrates the wrap step sequence declared in `template.json#wrap_pipeline.steps[]`. `lib/wrap-pipeline.js:135`.
+- **Wrap step: `version-bump`** — semver bump on `[Unreleased]` promotion. `lib/wrap-steps/version-bump.js`.
+- **Wrap step: `critic-check`** — surfaces medium+ work without Critic dispatch. `lib/wrap-steps/critic-check.js`.
+- **Wrap step: `commit`** — flushes staged writes, makes the wrap commit. `lib/wrap-steps/commit.js`.
+- **Wrap step: `features-toc`** (#207 Chunk 3) — append-stub for files touched in PR not yet in FEATURES.md. `lib/wrap-steps/features-toc.js`.
+- **Wrap step: `priming-roll`** — roll the next-session priming pointer. `lib/wrap-steps/priming-roll.js`.
+- **Wrap step: `pr-check`** — surfaces open PRs. `lib/wrap-steps/pr-check.js`.
+- **Wrap step: `ai-content`** — prompts injected into the AI session for changelog / learnings / memory updates. `lib/wrap-steps/ai-content.js`.
+- **Wrap step: `test`** / **`lint`** — test + lint hooks. `lib/wrap-steps/test.js`, `lib/wrap-steps/lint.js`.
+- **Run Critic action handler** — appends entry to `.tangleclaw/critic-runs.json`; **does not run a Critic** (the review is out-of-band). `lib/actions/invoke-critic.js`. UX clarification tracked in issue #230.
+
+## CLI / Tooling
+
+- **TTYD watcher** — keeps the shared ttyd alive; restart hook on PTY exhaustion (#94). `lib/ttyd-watcher.js`.
+- **Tunnel** — Cloudflare tunnel lifecycle for remote access. `lib/tunnel.js`.
+- **Sidecar** — supplementary process supervisor. `lib/sidecar.js`.
+- **HTTPS setup** — mkcert-backed cert discovery + HTTPS listener. `lib/https-setup.js`.
+- **Update checker** — GitHub release-tag polling. `lib/update-checker.js`.
+- **Uploads** — file-upload handling for the in-browser drop zone. `lib/uploads.js`.
+- **System stats** — CPU / mem / disk for the landing page. `lib/system.js`.
+- **Port scanner** — local-port introspection for the PortHub UI. `lib/port-scanner.js`.
+- **PID file** — single-instance guard. `lib/pidfile.js`.
+- **Installer** — bootstrap script for fresh hosts. `deploy/install.sh`.
+- **Detached ttyd attach** — helper for reconnecting to the shared ttyd. `deploy/ttyd-attach.sh`.


### PR DESCRIPTION
## What

Closes the four-chunk Feature Index build (#207) by **activating it on TC-v3 itself**.

- Hand-authored `FEATURES.md` at repo root with pointer entries (feature name → `file.js:line`) across **UI / Web**, **Server / API**, **Methodologies / Engines**, and **CLI / Tooling** sections.
- `CHANGELOG.md` `[Unreleased]` gains an `### Added` entry describing the dogfood landing + deferred verification.
- `MEMORY.md` (not committed — lives outside the repo) gains a `reference_features_index.md` entry pointing at `FEATURES.md` as the canonical "where does feature X live?" lookup.

## Why

Chunks 1–3 (#208, #214, #215) built the toggle, the SessionStart injection, and the `features-toc` wrap-step handler. The feature was inert until a real project turned it on with real content. TC-v3 dogfoods its own infrastructure, so this PR is also the "real" first user of the loop.

The intended payoff: a session asked *"where does the group pill live?"* answers in zero token-seconds by reading the injected `FEATURES.md` index, rather than spawning an Explore agent.

## Verification

### In-PR (done)

- `PATCH /api/projects/TangleClaw-v3 {"featureIndexEnabled": true}` returned the project record and persisted `featureIndexEnabled: true` to `.tangleclaw/project.json`.
- The Chunk-1 `_seedFeatureIndexFile` helper auto-created `FEATURES.md` with the template stub (the stub was then replaced with hand-authored content in the same PR).
- `grep -E "^## \[" CHANGELOG.md | head -5` confirms `[Unreleased]` and `[3.18.0]` headings both intact post-edit (per `feedback_verify_changelog_structure_post_edit`).
- **Independent Critic pass run on this PR; findings addressed in a follow-up commit.** Highlights from Critic: a hallucinated `public/landing.html` reference was corrected to `public/index.html` (which serves both landing + session shells via `/landing.js` and `/session.js`); the Server / API section was expanded from ~12 routes to cover the full family set (groups, shared-docs, openclaw/connections, audit ingest, activity, uploads, tmux/mouse, sidecar); four missing `lib/` modules (`git.js`, `tmux.js`, `model-status.js`, `project-version.js`) added; `landing.js:354` corrected to `:364`; `lib/methodologies.js` and `lib/sessions.js` line-anchored.

### Deferred to subsequent sessions (NOT in this PR, by design)

Two parts of the plan's verification matrix can only be exercised in *future* sessions and would be misleading to claim "done" here. Both tracked in follow-up issue **#233**:

1. **Chunk-2 SessionStart injection smoke test.** A fresh Claude Code session on TC-v3 must show `## Feature Index` injected into the prime context. This can't be reproduced from within the current session that's running the dogfood; the session itself wouldn't see its own injection in time. It'll happen organically next session.

2. **Chunk-3 `features-toc` auto-append smoke test.** Requires a wrap-bearing PR that touches a brand-new file whose path isn't already mentioned in `FEATURES.md`. This PR's own diff (`FEATURES.md` + `CHANGELOG.md`) is intentionally excluded from `features-toc`'s scan — both files are in the handler's exclusion list per `lib/wrap-steps/features-toc.js` docstring lines 51-55 (`CHANGELOG.md`, `README.md`, `LICENSE`, `FEATURES.md` itself). So a meaningful smoke test waits for the next non-doc PR.

If either deferred check fails, regression goes through a fresh issue rather than reopening this one.

## Test plan

- [x] Read CHANGELOG `[Unreleased]` section, confirm new entry sits under `### Added` and `[3.18.0]` heading is unmoved.
- [x] Read `FEATURES.md`, confirm sections populated, formatting matches the template's documented convention.
- [x] Confirm `.tangleclaw/project.json` shows `featureIndexEnabled: true` (gitignored, so verified locally — not in diff).
- [x] Independent Critic pass; MAJOR + MEDIUM findings addressed in this PR.
- [ ] *(next session, tracked in #233)* Open a fresh Claude Code session on TC-v3 → confirm SessionStart prime contains `## Feature Index` section.
- [ ] *(future wrap-bearing PR, tracked in #233)* Touch a brand-new non-excluded file → wrap → confirm `features-toc` appends a TBD stub under a `## TODO (auto-stubbed YYYY-MM-DD)` section.

Closes #207