### PR TITLE
chore(sync): bump Prawduct framework to v1.6.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,18 @@ docs/screenshots/
 # Node
 node_modules/
 __pycache__/
+
+# Prawduct session files
+.claude/settings.local.json
+.prawduct/.critic-findings.json
+.prawduct/.test-evidence.json
+.prawduct/.pr-reviews/
+.prawduct/.session-git-baseline
+.prawduct/.session-handoff.md
+.prawduct/.session-reflected
+.prawduct/.session-start
+.prawduct/.subagent-briefing.md
+.prawduct/.gates-waived
+.prawduct/reflections.md
+.prawduct/sync-manifest.json
+.prawduct/artifacts/build-plan.md

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@ __pycache__/
 .prawduct/reflections.md
 .prawduct/sync-manifest.json
 .prawduct/artifacts/build-plan.md
+
+# Prawduct session files
+.prawduct/.sync-pending
+.prawduct/.advisories.json

--- a/tools/product-hook
+++ b/tools/product-hook
@@ -39,19 +39,15 @@ def get_prawduct_dir(project_dir: Path) -> Path:
 # =============================================================================
 
 
-def try_sync(
-    project_dir: Path, *, quiet: bool = False
-) -> tuple[dict | None, list[dict], dict | None]:
+def try_sync(project_dir: Path, *, quiet: bool = False) -> tuple[dict | None, list[dict]]:
     """Attempt to run framework sync. Silently does nothing on any failure.
 
     When quiet=False (default), prints sync actions for Claude's context.
     When quiet=True, runs silently.
 
-    Returns a tuple of (upgrade_info, advisories, freshness):
+    Returns a tuple of (upgrade_info, advisories):
     - upgrade_info: dict with 'previous_version' and 'new_version' if version changed, else None
     - advisories: list of template drift advisory dicts from sync
-    - freshness: dict of framework freshness facts for the briefing, or None
-      when not derivable (no manifest, etc.). See _compute_framework_freshness.
     """
     try:
         manifest_path = project_dir / ".prawduct" / "sync-manifest.json"
@@ -63,7 +59,7 @@ def try_sync(
             # Prawduct repo without manifest — sync will bootstrap one
             fw_source = os.environ.get("PRAWDUCT_FRAMEWORK_DIR") or ""
         else:
-            return None, [], None  # Not a prawduct repo
+            return None, []  # Not a prawduct repo
 
         # Fall back to sibling ../prawduct if configured source not found
         if not fw_source or not Path(fw_source).is_dir():
@@ -72,14 +68,14 @@ def try_sync(
                 fw_source = str(sibling)
 
         if not fw_source:
-            return None, [], None
+            return None, []
 
         sync_script = Path(fw_source) / "tools" / "prawduct-setup.py"
         if not sync_script.is_file():
             # Backward compat: fall back to old script name
             sync_script = Path(fw_source) / "tools" / "prawduct-sync.py"
         if not sync_script.is_file():
-            return None, [], None
+            return None, []
 
         result = subprocess.run(
             [sys.executable, str(sync_script), "sync", str(project_dir), "--framework-dir", fw_source, "--json"],
@@ -126,97 +122,11 @@ def try_sync(
                 pass
         # Check if the framework is stale relative to this product's last sync
         _check_framework_version(project_dir, fw_source, quiet)
-        # Compute freshness AFTER sync so the manifest reflects any just-applied updates
-        freshness = _compute_framework_freshness(project_dir, fw_source)
-        return upgrade_info, advisories, freshness
+        return upgrade_info, advisories
 
     except Exception as e:  # prawduct:ok-broad-except — sync must never block session start
         print(f"NOTE: Framework sync failed: {e}", file=sys.stderr)
-        return None, [], None
-
-
-def _compute_framework_freshness(project_dir: Path, fw_source: str) -> dict | None:
-    """Compute structured framework freshness facts for the session briefing.
-
-    Returns a dict with the fields below, or None if no sync-manifest exists.
-    Individual fields may be None when their source is unavailable (framework
-    dir not a git repo, manifest predates a schema addition, etc.):
-
-    - framework_head: short SHA of fw_source HEAD, or None if not git
-    - framework_head_date: YYYY-MM-DD of HEAD commit, or None
-    - framework_version: contents of fw_source/VERSION, or None
-    - last_sync_date: YYYY-MM-DD parsed from manifest.last_sync, or None
-    - last_sync_version: manifest.framework_version, or None
-    - last_sync_commit: manifest.framework_commit (recorded at sync time;
-      not present in manifests written before that field was added — those
-      will populate on next sync)
-    - commits_behind: int — commits in fw_source ahead of last_sync_commit,
-      or None when either commit is unavailable
-
-    The three drift dimensions (version, commit, template content) are
-    independent. Callers should not synthesize them into a single answer.
-    """
-    manifest_path = project_dir / ".prawduct" / "sync-manifest.json"
-    if not manifest_path.is_file():
-        return None
-    try:
-        manifest = json.loads(manifest_path.read_text())
-    except (json.JSONDecodeError, OSError):
-        return None
-
-    out: dict[str, object] = {
-        "framework_head": None,
-        "framework_head_date": None,
-        "framework_version": None,
-        "last_sync_date": None,
-        "last_sync_version": manifest.get("framework_version") or None,
-        "last_sync_commit": manifest.get("framework_commit") or None,
-        "commits_behind": None,
-    }
-
-    last_sync = manifest.get("last_sync", "")
-    if last_sync:
-        out["last_sync_date"] = last_sync.split("T", 1)[0]
-
-    fw_dir = Path(fw_source) if fw_source else None
-    if not fw_dir or not fw_dir.is_dir():
-        return out
-
-    version_file = fw_dir / "VERSION"
-    if version_file.is_file():
-        try:
-            out["framework_version"] = version_file.read_text().strip() or None
-        except OSError:
-            pass
-
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(fw_dir), "log", "-1", "--format=%h|%ai", "HEAD"],
-            capture_output=True, text=True, timeout=10,
-        )
-        if result.returncode == 0 and result.stdout.strip():
-            parts = result.stdout.strip().split("|", 1)
-            if len(parts) == 2:
-                out["framework_head"] = parts[0]
-                out["framework_head_date"] = parts[1].split(" ", 1)[0]
-    except Exception:  # prawduct:ok-broad-except — best-effort git lookup
-        pass
-
-    if out["last_sync_commit"] and out["framework_head"]:
-        try:
-            result = subprocess.run(
-                ["git", "-C", str(fw_dir), "rev-list", "--count",
-                 f"{out['last_sync_commit']}..HEAD"],
-                capture_output=True, text=True, timeout=10,
-            )
-            if result.returncode == 0:
-                count = result.stdout.strip()
-                if count.isdigit():
-                    out["commits_behind"] = int(count)
-        except Exception:  # prawduct:ok-broad-except — best-effort
-            pass
-
-    return out
+        return None, []
 
 
 def _check_framework_version(project_dir: Path, fw_source: str, quiet: bool) -> None:
@@ -425,7 +335,6 @@ _SESSION_GITIGNORED_PATHS = (
     ".prawduct/.session-start",
     ".prawduct/.subagent-briefing.md",
     ".prawduct/.gates-waived",
-    ".prawduct/.sync-pending",
     ".prawduct/reflections.md",
     ".prawduct/sync-manifest.json",
     ".prawduct/artifacts/build-plan.md",
@@ -506,10 +415,8 @@ def tests_are_current(project_dir: Path) -> tuple[bool, str]:
 
     Uses a "trust the cycle" model: evidence is current if it was written
     during this session (timestamp >= session start) and all tests passed.
-    No tree-hashing or content fingerprinting (those mechanisms were
-    removed pre-v1.4 after chronic false positives from metadata churn) —
-    the build cycle (write code → run tests → Critic reviews) is the
-    trust boundary.
+    No fingerprinting or content hashing — the build cycle (write code →
+    run tests → Critic reviews) is the trust boundary.
 
     Falls back to timestamp-only comparison when no session-start marker
     exists (e.g., running outside a governed session).
@@ -529,15 +436,6 @@ def tests_are_current(project_dir: Path) -> tuple[bool, str]:
 
     if not isinstance(evidence, dict):
         return False, "evidence is not a JSON object"
-
-    # Schema check — catches writer typos like ``ran_at`` for ``timestamp`` or
-    # ``num_passed`` for ``passed``. Without this, missing fields silently fall
-    # through ``.get()`` calls and the evidence parses as "no failures, no
-    # timestamp" which the freshness check below would reject for the wrong
-    # reason. Loud failure makes the writer bug obvious.
-    schema_ok, schema_err = _validate_evidence_schema(evidence)
-    if not schema_ok:
-        return False, schema_err
 
     # Test pass/fail check — fail counts make evidence stale regardless of timing.
     failed = evidence.get("failed")
@@ -564,112 +462,6 @@ def tests_are_current(project_dir: Path) -> tuple[bool, str]:
     # Evidence exists with passing tests and a timestamp, but we can't verify
     # it's from this session. Accept it with a note.
     return True, f"evidence has passing tests ({evidence_ts}, no session marker to verify)"
-
-
-_EVIDENCE_REQUIRED_FIELDS: dict[str, tuple[type, ...]] = {
-    "timestamp": (str,),
-    "passed": (int,),
-    "failed": (int,),
-    "skipped": (int,),
-    "duration_seconds": (int, float),
-    "command": (str,),
-}
-
-# v1.4 F4a — coverage-evidence fields. Presence of ``verifier`` is the
-# discriminator: legacy evidence without ``verifier`` validates exactly as
-# before (compat). When ``verifier`` IS present, the writer has opted into
-# the new schema and the other three fields become conditionally required —
-# so writer typos (``coverage`` vs. ``coverage_level``, ``tests_ran`` vs.
-# ``tests_executed``) fail loud instead of silently dropping coverage data.
-_EVIDENCE_COVERAGE_FIELDS: dict[str, tuple[type, ...]] = {
-    "verifier": (str,),
-    "tests_executed": (list,),
-    "changes_referenced": (list,),
-    "coverage_level": (str,),
-}
-_EVIDENCE_COVERAGE_LEVELS = frozenset({"referenced", "executed"})
-
-
-# Critic mode values persisted in .prawduct/.critic-findings.json's `mode` field.
-# Verbose strings are intentional: the JSON is read by humans during session
-# briefings and gate WARNINGs, so the value itself communicates the implication.
-# The bare short tokens ("chunk" / "final") that callers pass via $ARGUMENTS
-# are NOT accepted in the persisted form — `validate_critic_findings` rejects them
-# so writer drift surfaces immediately.
-_CRITIC_MODE_CHUNK = "chunk (lighter pass, not ready for push)"
-_CRITIC_MODE_FINAL = "final (full review, ready for push)"
-_CRITIC_MODE_CUMULATIVE = "cumulative (bundle review, ready for merge)"
-# v1.5 Chunk 02 — verify-resolutions: delta review against prior findings'
-# scope. Cheaper than chunk/final for the common case of "Critic flagged 1-2
-# BLOCKING findings, builder fixed them, re-review pays full latency to
-# confirm the fix." Scope = prior files_reviewed ∪ files changed since
-# `commit_reviewed` (Chunk 01's anchor). Demotes to /critic final when scope
-# widens past `len(delta) > 2 * len(prior) + 5` or when prior findings lack
-# the anchor.
-_CRITIC_MODE_VERIFY_RESOLUTIONS = (
-    "verify-resolutions (delta review, prior findings only)"
-)
-_CRITIC_MODE_VALUES = frozenset({
-    _CRITIC_MODE_CHUNK,
-    _CRITIC_MODE_FINAL,
-    _CRITIC_MODE_CUMULATIVE,
-    _CRITIC_MODE_VERIFY_RESOLUTIONS,
-})
-
-
-def _validate_evidence_schema(evidence: dict) -> tuple[bool, str]:
-    """Reject ``.test-evidence.json`` with missing or wrong-typed fields.
-
-    Catches writer typos that would otherwise silently parse via ``.get()``.
-    Examples this catches: ``ran_at`` instead of ``timestamp``; ``num_passed``
-    instead of ``passed``; passed/failed/skipped emitted as strings.
-
-    v1.4 F4a: when ``verifier`` is present, the writer has opted into the
-    coverage-evidence schema and ``tests_executed`` / ``changes_referenced``
-    / ``coverage_level`` are also required. Legacy evidence (pre-F4a shape:
-    no ``verifier`` field — historically called "fingerprint" though the
-    tree-hash mechanism it referred to was removed pre-v1.4) is accepted
-    unchanged; v1.5 will drop the compat path (see Chunk 10's migration
-    NOTE — `prawduct-setup migrate --enable-coverage` surfaces the
-    deprecation).
-
-    Returns ``(True, "")`` on success, ``(False, reason)`` on failure. Missing
-    fields are reported before wrong-typed fields, so a single fix-it pass
-    addresses the highest-priority violations first.
-    """
-    required = dict(_EVIDENCE_REQUIRED_FIELDS)
-    if "verifier" in evidence:
-        required.update(_EVIDENCE_COVERAGE_FIELDS)
-
-    missing: list[str] = []
-    wrong_type: list[str] = []
-    for field, allowed_types in required.items():
-        if field not in evidence:
-            missing.append(field)
-            continue
-        if not isinstance(evidence[field], allowed_types):
-            wrong_type.append(
-                f"{field} must be {' | '.join(t.__name__ for t in allowed_types)}, "
-                f"got {type(evidence[field]).__name__}"
-            )
-    if missing:
-        return False, f"evidence missing required field(s): {', '.join(sorted(missing))}"
-    if wrong_type:
-        return False, f"evidence schema violation: {'; '.join(wrong_type)}"
-
-    # Enum check for coverage_level — only when the coverage schema is in use
-    # AND the field's type is already known good (str). Bad-type errors are
-    # surfaced by the loop above; here we just refuse out-of-set values.
-    if "verifier" in evidence:
-        level = evidence.get("coverage_level")
-        if isinstance(level, str) and level not in _EVIDENCE_COVERAGE_LEVELS:
-            allowed = ", ".join(sorted(_EVIDENCE_COVERAGE_LEVELS))
-            return False, (
-                f"evidence schema violation: coverage_level must be one of "
-                f"{{{allowed}}}, got {level!r}"
-            )
-
-    return True, ""
 
 
 def _read_gates_waived(prawduct_dir: Path) -> dict[str, str]:
@@ -1263,7 +1055,6 @@ def assemble_session_briefing(
     *,
     upgrade_info: dict | None = None,
     advisories: list[dict] | None = None,
-    freshness: dict | None = None,
 ) -> str:
     """Assemble session briefing text. Target: <400 tokens (excluding handoff pointer)."""
     prawduct_dir = get_prawduct_dir(project_dir)
@@ -1327,79 +1118,12 @@ def assemble_session_briefing(
         for s in staleness:
             lines.append(f"Stale: {s}")
 
-    # Framework freshness — surface only when there's actual drift to reason about.
-    # The three drift dimensions (version, commit, template content) are tracked
-    # separately so the agent doesn't have to derive deltas from raw timestamps.
-    has_commit_delta = bool(freshness and freshness.get("commits_behind"))
-    has_version_delta = bool(
-        freshness
-        and freshness.get("framework_version")
-        and freshness.get("last_sync_version")
-        and freshness["framework_version"] != freshness["last_sync_version"]
-    )
-    if freshness and (has_commit_delta or has_version_delta or advisories):
-        lines.append("Framework freshness:")
-        head = freshness.get("framework_head") or "?"
-        head_date = freshness.get("framework_head_date") or "?"
-        fw_v = freshness.get("framework_version") or "?"
-        sync_commit = freshness.get("last_sync_commit") or "(not recorded)"
-        sync_date = freshness.get("last_sync_date") or "?"
-        sync_v = freshness.get("last_sync_version") or "?"
-        behind = freshness.get("commits_behind")
-        lines.append(f"  Framework HEAD:    {head}  ({head_date})  v{fw_v}")
-        lines.append(f"  Last sync:         {sync_commit}  ({sync_date})  v{sync_v}")
-        if behind is None:
-            if not freshness.get("last_sync_commit"):
-                lines.append("  Commit delta:      unknown — manifest predates commit tracking; will populate on next sync")
-            else:
-                lines.append("  Commit delta:      unknown")
-        elif behind == 0:
-            lines.append("  Commit delta:      in sync")
-        else:
-            lines.append(f"  Commit delta:      {behind} commit(s) since sync")
-        if has_version_delta:
-            lines.append(f"  Version delta:     v{sync_v} → v{fw_v}")
-        if advisories:
-            lines.append(f"  Place-once template advisories: {len(advisories)}")
-            for adv in advisories:
-                short = adv.get("file", "?").rsplit("/", 1)[-1]
-                commit = adv.get("last_changed_commit", "")
-                date = adv.get("last_changed_date", "")
-                subject = adv.get("last_changed_subject", "")
-                if commit:
-                    subject_str = f" — \"{subject}\"" if subject else ""
-                    lines.append(f"    - {short}: changed in {commit} ({date}){subject_str}")
-                else:
-                    lines.append(f"    - {short}: changed since last sync (commit info unavailable)")
-    elif advisories:
-        # Manifest exists but freshness couldn't be computed (e.g., no fw_dir
-        # access). Fall back to the simple advisory list rather than dropping it.
-        lines.append(f"Place-once template advisories: {len(advisories)} template(s) have new content since project setup")
+    # Template drift advisories from sync
+    if advisories:
+        lines.append(f"Advisories: {len(advisories)} template(s) have new content since project setup")
         for adv in advisories:
             msg = adv.get("message", "template drift detected")
             lines.append(f"  - {msg}")
-
-    # F5a sync-pending marker — surfaces when sync couldn't auto-commit
-    # framework drift because a precondition (WIP, protected branch,
-    # in-progress git op) blocked it. Surface so the user/Claude know there
-    # is uncommitted framework drift that should be resolved.
-    sync_pending_path = prawduct_dir / ".sync-pending"
-    if sync_pending_path.is_file():
-        try:
-            pending = json.loads(sync_pending_path.read_text())
-            reason = pending.get("reason", "unknown")
-            version = pending.get("version", "")
-            v_suffix = f" (v{version})" if version else ""
-            lines.append(
-                f"Framework sync pending{v_suffix}: {reason}. "
-                f"Resolve and commit `.prawduct/`/`CLAUDE.md`/etc. drift, "
-                f"or rerun sync once the blocker clears."
-            )
-        except (json.JSONDecodeError, OSError):
-            lines.append(
-                "Framework sync pending: marker file present but unreadable; "
-                "inspect `.prawduct/.sync-pending`."
-            )
 
     # CLAUDE.md size check
     claude_md_path = project_dir / "CLAUDE.md"
@@ -1428,7 +1152,7 @@ def assemble_session_briefing(
         except Exception:  # prawduct:ok-broad-except — briefing must never block session start
             pass
 
-    # Test count — informational only; .test-evidence.json is the canonical count
+    # Test count (computed, not tracked)
     try:
         test_count = _count_test_functions(project_dir)
         if test_count > 0:
@@ -2023,6 +1747,19 @@ def cmd_clear(project_dir: Path) -> int:
     # Agent-facing messages go to stdout (SessionStart hooks show stdout to the model).
     # stderr is only visible to the user in the terminal, not to the agent.
 
+    # Warn if learnings.md is oversized
+    learnings_path = prawduct_dir / "learnings.md"
+    if learnings_path.is_file():
+        try:
+            size = learnings_path.stat().st_size
+            if size > 8000:  # ~3000 tokens ≈ ~8KB
+                print(
+                    f"NOTE: .prawduct/learnings.md is {size // 1024}KB — recommend pruning to ~3,000 tokens.\n"
+                    f"  Keep concise rules in learnings.md; move detailed root cause analysis to learnings-detail.md."
+                )
+        except Exception:  # prawduct:ok-broad-except — size check must not block session start
+            pass
+
     # Warn if project-state.yaml is oversized
     state_path = prawduct_dir / "project-state.yaml"
     if state_path.is_file():
@@ -2070,7 +1807,7 @@ def cmd_clear(project_dir: Path) -> int:
             )
 
     # Trigger framework sync (best-effort)
-    upgrade_info, sync_advisories, freshness = try_sync(project_dir)
+    upgrade_info, sync_advisories = try_sync(project_dir)
 
     # Capture git status baseline AFTER sync so sync-modified files
     # (settings.json, product-hook, etc.) don't trigger spurious stop-hook gates
@@ -2084,11 +1821,7 @@ def cmd_clear(project_dir: Path) -> int:
         try:
             staleness = staleness_scan(project_dir)
             briefing = assemble_session_briefing(
-                project_dir,
-                staleness,
-                upgrade_info=upgrade_info,
-                advisories=sync_advisories,
-                freshness=freshness,
+                project_dir, staleness, upgrade_info=upgrade_info, advisories=sync_advisories
             )
             print(briefing)
         except Exception as e:  # prawduct:ok-broad-except — briefing must never block session start
@@ -2111,11 +1844,7 @@ def validate_critic_findings(findings_path: Path) -> bool:
     """Validate that critic findings JSON has required structure.
 
     Requires: non-empty files_reviewed list, findings list where each entry
-    has goal/severity/summary, and a non-empty summary string. The `mode`
-    field is optional (legacy hooks pre-v1.3.13 omit it) but, when present,
-    must be one of the verbose strings in ``_CRITIC_MODE_VALUES``. The bare
-    short tokens (``"chunk"`` / ``"final"``) are rejected — those are the
-    caller-side input form, not the persistence form.
+    has goal/severity/summary, and a non-empty summary string.
     """
     try:
         data = json.loads(findings_path.read_text())
@@ -2139,358 +1868,9 @@ def validate_critic_findings(findings_path: Path) -> bool:
         summary = data.get("summary")
         if not isinstance(summary, str) or not summary.strip():
             return False
-        # Mode field is optional (back-compat). If present, must be exactly one
-        # of the verbose strings — bare tokens, unknown strings, and non-string
-        # values are all rejected so writer drift surfaces here, not later.
-        if "mode" in data:
-            mode = data["mode"]
-            if not isinstance(mode, str) or mode not in _CRITIC_MODE_VALUES:
-                return False
-        # v1.5 Chunk 01 — commit_reviewed / base_reviewed anchor the delta
-        # computation for the verify-resolutions mode (Chunk 02). Optional
-        # for back-compat with pre-v1.5 findings files (which simply cannot
-        # serve as a verify-resolutions baseline). When present, must be a
-        # NON-EMPTY string SHA or None — wrong types and empty strings are
-        # writer drift (empty string would silently anchor at no commit,
-        # breaking Chunk 02's delta computation), surfaced here.
-        for sha_field in ("commit_reviewed", "base_reviewed"):
-            if sha_field in data:
-                val = data[sha_field]
-                if val is None:
-                    continue
-                if not isinstance(val, str) or not val.strip():
-                    return False
-        # v1.5 Chunk 03 — mode_chosen_by records which rule fired in the
-        # inference helper, or the literal "explicit-args" when the
-        # builder overrode inference. Optional for back-compat. When
-        # present, must be a non-empty string — empty strings and wrong
-        # types are writer drift (the field's whole purpose is post-hoc
-        # introspection of mode selection; empty defeats that).
-        if "mode_chosen_by" in data:
-            val = data["mode_chosen_by"]
-            if not isinstance(val, str) or not val.strip():
-                return False
         return True
     except Exception:  # prawduct:ok-broad-except — validation must not crash gate check
         return False
-
-
-def _compute_verify_resolutions_scope(
-    prawduct_dir: Path, project_dir: Path
-) -> tuple[list[str], str]:
-    """Compute the file scope a ``/critic verify-resolutions`` pass should review.
-
-    Reads the *prior* ``.prawduct/.critic-findings.json`` (the record the
-    builder is about to re-verify) and returns the union of:
-
-      1. ``files_reviewed`` from the prior record — files the Critic already
-         examined — but only when actionable findings (BLOCKING or WARNING)
-         exist. NOTE-only and clean records have nothing to verify.
-      2. Files changed since ``commit_reviewed`` — anchor recorded in Chunk
-         01 — computed as ``git diff --name-only <commit_reviewed>`` plus
-         untracked files. Mirrors ``_coverage_changed_files``'s diff +
-         ls-files-others union so the verify pass sees the same shape the
-         cumulative-Critic flow does.
-
-    Returns ``(scope, reason)``. ``scope`` is sorted; ``reason`` is human-
-    readable. Successful computations return a non-empty scope and a reason
-    prefixed ``ok:``. All other cases return an empty scope and a categorized
-    reason so the caller (Critic agent or stop-hook gate) can fall safely
-    through to ``/critic chunk`` or ``/critic final``:
-
-      - ``no-findings:`` — prior findings file missing.
-      - ``unreadable-findings:`` — JSON parse or I/O failure.
-      - ``no-commit-reviewed:`` — anchor absent / null / empty. Pre-v1.5
-        records are valid for the schema but cannot serve as a verify
-        baseline; the helper fails closed.
-      - ``no-actionable-findings:`` — only NOTEs (or empty findings). Verify-
-        resolutions has nothing to re-check.
-      - ``invalid-files-reviewed:`` — schema-permitted but unusable
-        (non-list or empty list).
-      - ``unresolved-commit:`` — ``commit_reviewed`` does not resolve in
-        the current repo (rebase, force-push, or simply never on this
-        branch). Cannot compute a delta.
-      - ``git-diff-failed:`` — the diff invocation itself failed.
-      - ``scope-widened:`` — demotion criterion ``len(delta) > 2 * len(prior)
-        + 5`` tripped. The prior surface no longer covers what changed; a
-        partial review would mislead. Fall through to ``/critic final``.
-
-    Fail-closed throughout — when the helper cannot anchor a delta it
-    refuses to compute one rather than silently shrinking the review.
-    """
-    findings_path = prawduct_dir / ".critic-findings.json"
-    if not findings_path.is_file():
-        return [], (
-            "no-findings: .prawduct/.critic-findings.json is missing — "
-            "run /critic chunk or /critic final first"
-        )
-    try:
-        data = json.loads(findings_path.read_text())
-    except (json.JSONDecodeError, OSError) as exc:
-        return [], f"unreadable-findings: {exc}"
-
-    commit_reviewed = data.get("commit_reviewed")
-    if not isinstance(commit_reviewed, str) or not commit_reviewed.strip():
-        return [], (
-            "no-commit-reviewed: prior findings lack commit_reviewed — "
-            "cannot anchor delta. Run /critic chunk or /critic final."
-        )
-
-    findings = data.get("findings")
-    if not isinstance(findings, list):
-        return [], "invalid-findings: prior findings.findings is not a list"
-    actionable = [
-        f for f in findings
-        if isinstance(f, dict) and f.get("severity") in ("blocking", "warning")
-    ]
-    if not actionable:
-        return [], (
-            "no-actionable-findings: prior review had no blocking/warning "
-            "findings — verify-resolutions has nothing to verify. "
-            "Run /critic chunk or /critic final."
-        )
-
-    prior_files = data.get("files_reviewed")
-    if not isinstance(prior_files, list) or not prior_files:
-        return [], (
-            "invalid-files-reviewed: prior findings.files_reviewed is "
-            "missing or empty"
-        )
-    prior_files_set = {f for f in prior_files if isinstance(f, str) and f.strip()}
-
-    # rev-parse with the `^{commit}` peel rejects non-commit refs and SHAs
-    # that don't resolve. fail-closed: any non-0 → no delta computable.
-    proc = subprocess.run(
-        ["git", "rev-parse", "--verify", f"{commit_reviewed}^{{commit}}"],
-        cwd=str(project_dir),
-        capture_output=True,
-        text=True,
-        timeout=10,
-    )
-    if proc.returncode != 0:
-        return [], (
-            f"unresolved-commit: commit_reviewed {commit_reviewed[:12]} "
-            "does not resolve in the current repo — cannot compute delta. "
-            "Run /critic chunk or /critic final."
-        )
-
-    diff_proc = subprocess.run(
-        ["git", "diff", "--name-only", commit_reviewed],
-        cwd=str(project_dir),
-        capture_output=True,
-        text=True,
-        timeout=30,
-    )
-    if diff_proc.returncode != 0:
-        return [], f"git-diff-failed: {diff_proc.stderr.strip()}"
-    delta_files = {
-        line.strip() for line in diff_proc.stdout.splitlines() if line.strip()
-    }
-
-    ls_proc = subprocess.run(
-        ["git", "ls-files", "--others", "--exclude-standard"],
-        cwd=str(project_dir),
-        capture_output=True,
-        text=True,
-        timeout=30,
-    )
-    if ls_proc.returncode == 0:
-        delta_files.update(
-            line.strip() for line in ls_proc.stdout.splitlines() if line.strip()
-        )
-
-    # Filter metadata before threshold and scope union. The session-end
-    # gate already ignores ``_is_metadata_path`` files (``.prawduct/``,
-    # ``.claude/settings.json``, etc.) when computing the chunk diff;
-    # counting them here would inflate ``delta_files`` against the
-    # widening threshold and falsely demote a legitimate fix flow whose
-    # only delta beyond the prior surface is incidental state churn
-    # (the very ``.critic-findings.json`` the prior review wrote,
-    # ``.session-reflected``, ``.session-git-baseline``, etc.). Symmetric
-    # with ``_verify_resolutions_gate_check`` — both sides of "what
-    # counts as a chunk file" agree.
-    delta_files = {f for f in delta_files if not _is_metadata_path(f)}
-
-    # Demotion: when the delta has grown well past the prior review's
-    # surface, a verify pass would mislead — most of what changed wasn't
-    # part of the prior review's scope at all. Threshold mirrors the build
-    # plan (Chunk 02): linear factor 2 plus floor 5 so small priors don't
-    # demote on a single unrelated edit.
-    if len(delta_files) > 2 * len(prior_files_set) + 5:
-        return [], (
-            f"scope-widened: {len(delta_files)} files changed since "
-            f"commit_reviewed (prior surface {len(prior_files_set)} files; "
-            f"demotion threshold len(delta) > 2 * prior + 5). Fall through "
-            "to /critic chunk or /critic final."
-        )
-
-    scope = sorted(prior_files_set | delta_files)
-    return scope, (
-        f"ok: scope = {len(scope)} files "
-        f"(prior surface {len(prior_files_set)} + delta {len(delta_files)} "
-        f"since {commit_reviewed[:12]})"
-    )
-
-
-def _verify_resolutions_gate_check(
-    prawduct_dir: Path, project_dir: Path, findings_path: Path
-) -> tuple[bool, str]:
-    """Stop-hook gate helper: when the Critic findings file is in
-    ``verify-resolutions`` mode, accept only when the current chunk diff is
-    a subset of the verify pass's declared scope.
-
-    Returns ``(True, "")`` for any other mode — the standard gate logic
-    applies. For ``verify-resolutions``:
-
-      - ``(True, "")`` — current session-changed files (excluding metadata
-        paths the regular Critic gate also ignores) are all within the
-        findings' ``files_reviewed`` set.
-      - ``(False, reason)`` — at least one chunk-diff file is outside the
-        declared scope. The verify pass is stale relative to the current
-        diff; the gate keeps the block in place and surfaces the reason so
-        the builder runs ``/critic chunk`` or ``/critic final`` instead.
-
-    Fail-closed: a JSON read failure or schema gap returns ``(False, reason)``
-    rather than silently clearing the gate (see learnings: "Escape hatches
-    in classification create silent failures").
-    """
-    try:
-        data = json.loads(findings_path.read_text())
-    except (json.JSONDecodeError, OSError) as exc:
-        return False, (
-            f"verify-resolutions findings unreadable ({exc}). Run /critic "
-            "chunk or /critic final."
-        )
-
-    if data.get("mode") != _CRITIC_MODE_VERIFY_RESOLUTIONS:
-        return True, ""
-
-    files_reviewed = data.get("files_reviewed")
-    if not isinstance(files_reviewed, list):
-        return False, (
-            "verify-resolutions findings have no files_reviewed list. "
-            "Run /critic chunk or /critic final."
-        )
-    scope = {f for f in files_reviewed if isinstance(f, str) and f.strip()}
-
-    session_changed = {
-        f for f in _get_session_changed_files(project_dir)
-        if not _is_metadata_path(f)
-    }
-
-    out_of_scope = sorted(session_changed - scope)
-    if not out_of_scope:
-        return True, ""
-
-    sample = ", ".join(out_of_scope[:3])
-    more = f" (+{len(out_of_scope) - 3} more)" if len(out_of_scope) > 3 else ""
-    return False, (
-        f"verify-resolutions findings declare {len(scope)} file(s) in scope "
-        f"but the current chunk diff includes {len(out_of_scope)} file(s) "
-        f"outside scope ({sample}{more}). Run /critic chunk or /critic final."
-    )
-
-
-def _count_build_plan_chunks(prawduct_dir: Path) -> tuple[int, int]:
-    """Count chunks in build-plan.md's Status section.
-
-    Returns ``(total, complete)``: total chunks declared, and how many are
-    marked ``[x]``. Returns ``(0, 0)`` if the plan is missing, has no Status
-    section, or has no chunk items. Mirrors the parsing rules in
-    ``_parse_build_plan_status`` (skip HTML comments; exit on next ``## ``).
-    """
-    plan_path = prawduct_dir / "artifacts" / "build-plan.md"
-    if not plan_path.is_file():
-        return 0, 0
-    try:
-        content = plan_path.read_text()
-        in_status = False
-        in_comment = False
-        total = 0
-        complete = 0
-        for line in content.splitlines():
-            stripped = line.strip()
-            if stripped == "## Status":
-                in_status = True
-                continue
-            if not in_status:
-                continue
-            if stripped.startswith("## ") and stripped != "## Status":
-                break
-            if "<!--" in stripped:
-                in_comment = True
-            if "-->" in stripped:
-                in_comment = False
-                continue
-            if in_comment:
-                continue
-            if stripped.startswith("- [ ]"):
-                total += 1
-            elif stripped.startswith("- [x]") or stripped.startswith("- [X]"):
-                total += 1
-                complete += 1
-        return total, complete
-    except Exception:  # prawduct:ok-broad-except — gate check must not crash session end
-        return 0, 0
-
-
-_CRITIC_MODE_GOALS_1_3_ONLY = frozenset({
-    _CRITIC_MODE_CHUNK,
-    _CRITIC_MODE_VERIFY_RESOLUTIONS,
-})
-
-
-def _critic_session_satisfies_gate(prawduct_dir: Path) -> tuple[bool, str]:
-    """Check whether the latest Critic findings satisfy end-of-cycle synthesis.
-
-    Returns ``(True, "")`` when the gate is satisfied, ``(False, reason)``
-    otherwise. The gate is advisory: it fires when a multi-chunk build plan
-    has all chunks marked ``[x]`` but the most recent Critic review ran
-    Goals 1-3 only — ``chunk`` and ``verify-resolutions`` modes both skip
-    end-of-cycle goals (Coherence, Design, Learnings Cross-Check, Backlog
-    Reconciliation, Framework-Specific Checks). v1.5 Chunk 02 extended the
-    case-4 trigger to verify-resolutions so a plan that closes with a delta
-    re-review doesn't silently bypass final-mode synthesis.
-
-    Specific cases (in order):
-    1. No build plan, or no chunks declared → satisfied (non-chunked work).
-    2. Single-chunk plan → satisfied (the one Critic run is the final).
-    3. Multi-chunk plan with incomplete chunks → satisfied (mid-cycle).
-    4. Multi-chunk plan, all chunks ``[x]``, latest mode is in
-       ``_CRITIC_MODE_GOALS_1_3_ONLY`` (chunk or verify-resolutions)
-       → unsatisfied. Run ``/critic final`` for end-of-cycle synthesis.
-    5. Multi-chunk plan, all chunks ``[x]``, latest mode is ``_CRITIC_MODE_FINAL``
-       (or absent — legacy records default to final), or ``_CRITIC_MODE_CUMULATIVE``
-       → satisfied (full goal set ran).
-
-    Caller is expected to invoke this only after the existing critic-required
-    blocker has cleared (i.e. findings exist and ``validate_critic_findings``
-    returned True). Defensive checks here keep the helper standalone-safe.
-    """
-    total, complete = _count_build_plan_chunks(prawduct_dir)
-    if total == 0:
-        return True, ""
-    if total == 1:
-        return True, ""
-    if complete < total:
-        return True, ""
-
-    findings_path = prawduct_dir / ".critic-findings.json"
-    if not findings_path.is_file():
-        return True, ""
-    try:
-        data = json.loads(findings_path.read_text())
-    except (json.JSONDecodeError, OSError):
-        return True, ""
-    mode = data.get("mode", _CRITIC_MODE_FINAL)
-    if mode in _CRITIC_MODE_GOALS_1_3_ONLY:
-        return False, (
-            f"All {total} chunks complete; last Critic review was "
-            f"'{mode}'. Run /critic final for end-of-cycle "
-            "synthesis (Coherence, Design, Learnings Cross-Check, Backlog "
-            "Reconciliation) before pushing."
-        )
-    return True, ""
 
 
 def _has_build_plan_in_state(prawduct_dir: Path) -> bool:
@@ -2614,12 +1994,6 @@ def cmd_stop(project_dir: Path) -> int:
                 "  If this session produced a durable lesson (a rule future sessions should follow),\n"
                 "  also add it to .prawduct/learnings.md. Learnings are concise standing rules;\n"
                 "  the session reflection is the story behind them.\n"
-                "\n"
-                "  Escape hatch: if this gate cannot be satisfied this session (rare for reflection —\n"
-                "  it is meant to be cheap), declare a waiver so this gate stops re-firing:\n"
-                "    echo '{\"reflection\": \"reason — be specific\"}' > .prawduct/.gates-waived\n"
-                "  Empty reasons are rejected; the file auto-clears next session. See\n"
-                "  .prawduct/build-governance.md \"Gate Waivers\" for when this is appropriate.\n"
             )
     elif (
         has_changes
@@ -2641,64 +2015,8 @@ def cmd_stop(project_dir: Path) -> int:
     # noted when the gate would have actually blocked (valid findings absent).
     # `has_changes` already reflects baseline-aware diff via git_has_session_changes,
     # so no extra "code changes" check is needed beyond `not doc_only`.
-    #
-    # v1.4 F6 — Type: designer-handoff also skips the gate (formalizes the
-    # prior user-memory carveout into a framework rule). Other declared types
-    # (code, doc-only, cleanup, cumulative-final) leave the gate behavior
-    # unchanged — only Critic's *protocol* adjusts inside the agent.
-    designer_handoff_skip = False
-    # v1.5 Chunk 04 — Type: trivial fileset + rationale enforcement. The
-    # checks fire BEFORE the Critic gate and emit BLOCKING for any
-    # violation, but the chunk is still treated as `code` for gate
-    # purposes (so the Critic gate still applies on top). Fail-closed:
-    # over-declaring `trivial` produces a named blocker pointing at the
-    # specific bound violated, never a silent carveout. The trivial
-    # check does NOT honor the doc-only skip — bounds like
-    # "no edits under agents/" matter even when the diff is empirically
-    # all-.md (the agents/ tree itself is pure prose). Doc-only only
-    # carves out the Critic protocol (which has no code to review); the
-    # trivial-declaration contract is independent.
-    trivial_block_reason = ""
-    if has_changes and has_build_plan:
-        current_chunk_id = _current_chunk_id_from_status(prawduct_dir)
-        if current_chunk_id is not None:
-            chunk_type, type_error = _parse_build_plan_chunk_type(prawduct_dir, current_chunk_id)
-            # v1.5.1 Chunk 04(a): surface typo'd Type values. Pre-fix, the
-            # parser's "unknown type: ..." message was discarded so the author
-            # never saw it. Surfacing in waiver_notes makes the typo visible
-            # at session-end and in the next stop-hook briefing without
-            # changing fail-closed semantics (chunk still runs as `code` per
-            # parser default). Restricted to "unknown type:" errors only —
-            # "chunk not found" / "missing build-plan" errors indicate a
-            # structural fixture issue, not actionable user feedback.
-            if type_error and type_error.startswith("unknown type:"):
-                waiver_notes.append(f"chunk-type-parse-error: {type_error}")
-            if chunk_type == "designer-handoff" and not doc_only:
-                designer_handoff_skip = True
-                waiver_notes.append(
-                    f"critic: skipped (Chunk {current_chunk_id} declares Type: designer-handoff — v1.4 F6 carveout)"
-                )
-            elif chunk_type == "trivial":
-                fileset_ok, fileset_reason = _is_trivial_fileset_eligible(project_dir)
-                if not fileset_ok:
-                    trivial_block_reason = fileset_reason
-                else:
-                    _, rationale_error = _parse_build_plan_chunk_trivial_rationale(
-                        prawduct_dir, current_chunk_id
-                    )
-                    if rationale_error:
-                        trivial_block_reason = rationale_error
-
     critic_would_block = False
-    # v1.5 Chunk 02: when the fresh, schema-valid findings file is in
-    # verify-resolutions mode, the gate must also confirm that the current
-    # chunk diff is a subset of the verify pass's declared scope. Out-of-
-    # scope means the builder added work after the verify pass — the
-    # findings are stale relative to the current diff. The reason string is
-    # surfaced verbatim in the blocker so the builder knows which files
-    # widened the scope.
-    verify_resolutions_block_reason = ""
-    if has_changes and has_build_plan and not doc_only and not designer_handoff_skip:
+    if has_changes and has_build_plan and not doc_only:
         critic_would_block = True
         critic_findings = prawduct_dir / ".critic-findings.json"
         session_start_file = prawduct_dir / ".session-start"
@@ -2709,76 +2027,20 @@ def cmd_stop(project_dir: Path) -> int:
                     critic_findings.stat().st_mtime, tz=timezone.utc
                 ).strftime("%Y-%m-%dT%H:%M:%SZ")
                 if findings_mtime > session_start and validate_critic_findings(critic_findings):
-                    in_scope, scope_reason = _verify_resolutions_gate_check(
-                        prawduct_dir, project_dir, critic_findings
-                    )
-                    if in_scope:
-                        critic_would_block = False
-                    else:
-                        verify_resolutions_block_reason = scope_reason
+                    critic_would_block = False
             except Exception:  # prawduct:ok-broad-except — gate check must not crash session end
                 pass
 
     if critic_would_block:
         if "critic" in waivers:
             waiver_notes.append(f"critic: waived ({waivers['critic']})")
-        elif verify_resolutions_block_reason:
-            blockers.append(
-                "CRITIC REVIEW (verify-resolutions stale): "
-                f"{verify_resolutions_block_reason}\n"
-                "  Verify-resolutions findings clear the gate only when the current chunk\n"
-                "  diff is within the verify pass's declared scope. The chunk has grown\n"
-                "  beyond that surface, so the prior review's conclusions no longer cover\n"
-                "  what changed. Re-run with a wider mode before ending the session.\n"
-                "\n"
-                "  Escape hatch: if Critic cannot run this session (e.g., wider mode is\n"
-                "  blocked by an external dependency), declare a waiver so this gate stops\n"
-                "  re-firing every turn:\n"
-                "    echo '{\"critic\": \"reason — be specific\"}' > .prawduct/.gates-waived\n"
-                "  Empty reasons are rejected; the file auto-clears next session. See\n"
-                "  .prawduct/build-governance.md \"Gate Waivers\" for when this is appropriate.\n"
-            )
         else:
             blockers.append(
                 "CRITIC REVIEW: The build plan includes Critic review in each chunk's \"Done when\" steps,\n"
                 "  but no Critic findings were recorded this session. If you have completed a chunk,\n"
                 "  run `/critic` now. The Critic reads .prawduct/critic-review.md for instructions\n"
                 "  and records findings to .prawduct/.critic-findings.json\n"
-                "\n"
-                "  Escape hatch: if Critic legitimately cannot run this session — e.g., the chunk\n"
-                "  is in a designer-handoff phase (mark `Type: designer-handoff` in the build plan\n"
-                "  to skip this gate automatically), or the GO/NO-GO is not yet verifiable because\n"
-                "  it depends on a human authoring step or external system — declare a waiver so\n"
-                "  this gate stops re-firing every turn:\n"
-                "    echo '{\"critic\": \"reason — be specific\"}' > .prawduct/.gates-waived\n"
-                "  Empty reasons are rejected; the file auto-clears next session. See\n"
-                "  .prawduct/build-governance.md \"Gate Waivers\" for when this is appropriate.\n"
             )
-
-    # v1.5 Chunk 04: Type: trivial enforcement runs alongside the Critic
-    # gate (not in place of it). The chunk is still treated as `code`
-    # for gate purposes; this block adds a separate BLOCKING if either
-    # the file-set bound or rationale presence failed.
-    if trivial_block_reason:
-        blockers.append(
-            f"TYPE: TRIVIAL — declared but {trivial_block_reason}.\n"
-            "  Either fix the violation or change Type to `code`.\n"
-        )
-
-    # Gate 2.5: Advisory mode gate — fires only when Gate 2 passed, which
-    # already enforces this-session freshness on the findings file. So if we
-    # reach this branch, the findings represent a real review the agent ran
-    # this session; the gate doesn't need to re-check freshness. When all
-    # chunks of a multi-chunk plan are complete but the latest review was
-    # chunk-mode, end-of-cycle synthesis (Coherence, Design, Learnings
-    # Cross-Check, Backlog Reconciliation) hasn't run. Advisory NOT blocking —
-    # chunk-mode reviews are valid mid-cycle, and the builder may legitimately
-    # defer the final review (e.g., next session).
-    if has_changes and not doc_only and not critic_would_block:
-        mode_satisfied, mode_reason = _critic_session_satisfies_gate(prawduct_dir)
-        if not mode_satisfied:
-            print("", file=sys.stderr)
-            print(f"NOTE: {mode_reason}", file=sys.stderr)
 
     # Gate 3: PR review evidence (when a PR exists for the current branch).
     # Skipped for doc-only changes. The waiver is only noted when the gate
@@ -2808,37 +2070,20 @@ def cmd_stop(project_dir: Path) -> int:
                         pass
 
                 if has_pr:
-                    # Symmetry with `/pr create` Steps 1b/1c: when the PR diff
-                    # is doc-only (all .md) or trivial (every commit fileset-
-                    # eligible per Chunk 04 bounds), the cumulative-Critic and
-                    # PR-reviewer gates were legitimately skipped at create-
-                    # time and no evidence file was written. Gate 3 would
-                    # otherwise block session end with a misleading "no review
-                    # evidence" error for a PR that doesn't need one. If a
-                    # later session adds non-.md or fileset-violating commits,
-                    # both checks return False and the gate fires as intended
-                    # — matching the create-flow contract.
-                    pr_is_doc_only, _ = _pr_diff_is_doc_only(project_dir)
-                    pr_is_trivial, _ = (
-                        (False, "") if pr_is_doc_only else _pr_diff_is_trivial(project_dir)
-                    )
-                    if pr_is_doc_only or pr_is_trivial:
-                        pass  # Fast-path eligible — no evidence required
-                    else:
-                        # Check for review evidence with content validation
-                        branch_file = current_branch.replace("/", "--") + ".json"
-                        evidence_path = pr_reviews_dir / branch_file
-                        pr_review_valid = False
-                        if evidence_path.is_file():
-                            try:
-                                data = json.loads(evidence_path.read_text())
-                                if isinstance(data.get("findings"), list) and data.get("summary"):
-                                    pr_review_valid = True
-                            except (json.JSONDecodeError, OSError):
-                                pass
-                        if not pr_review_valid:
-                            pr_would_block = True
-                            pr_block_branch = current_branch
+                    # Check for review evidence with content validation
+                    branch_file = current_branch.replace("/", "--") + ".json"
+                    evidence_path = pr_reviews_dir / branch_file
+                    pr_review_valid = False
+                    if evidence_path.is_file():
+                        try:
+                            data = json.loads(evidence_path.read_text())
+                            if isinstance(data.get("findings"), list) and data.get("summary"):
+                                pr_review_valid = True
+                        except (json.JSONDecodeError, OSError):
+                            pass
+                    if not pr_review_valid:
+                        pr_would_block = True
+                        pr_block_branch = current_branch
         except Exception:  # prawduct:ok-broad-except — gate check must not crash session end
             pass
 
@@ -2850,14 +2095,6 @@ def cmd_stop(project_dir: Path) -> int:
                 f"PR REVIEW: PR exists for branch '{pr_block_branch}' but no valid review evidence found.\n"
                 "  Run /pr to invoke the PR reviewer before merging.\n"
                 "  The reviewer writes evidence to .prawduct/.pr-reviews/<branch>.json\n"
-                "\n"
-                "  Escape hatch: if PR review cannot run this session (e.g., reviewer agent is\n"
-                "  unavailable and merge is not imminent), declare a waiver so this gate stops\n"
-                "  re-firing every turn:\n"
-                "    echo '{\"pr\": \"reason — be specific\"}' > .prawduct/.gates-waived\n"
-                "  Empty reasons are rejected; the file auto-clears next session. PR review is\n"
-                "  the release-readiness gate — waive only when merge will not happen this\n"
-                "  session. See .prawduct/build-governance.md \"Gate Waivers\".\n"
             )
 
     # Surface any waivers so the agent (and reviewer) can see what was skipped.
@@ -2919,1224 +2156,13 @@ def cmd_test_status(project_dir: Path) -> int:
 
 
 # =============================================================================
-# validate-evidence command
-# =============================================================================
-
-
-def cmd_validate_evidence(project_dir: Path) -> int:
-    """Schema-only check on ``.test-evidence.json``.
-
-    Useful for CI / pre-commit hooks that want a fast schema sanity check
-    without the freshness comparison ``test-status`` performs. Returns
-    exit 0 only when the file exists, parses, and matches the required
-    schema; exit 1 otherwise.
-    """
-    evidence_path = get_prawduct_dir(project_dir) / ".test-evidence.json"
-    if not evidence_path.is_file():
-        print(f"missing: {evidence_path}", file=sys.stderr)
-        return 1
-    try:
-        evidence = json.loads(evidence_path.read_text())
-    except (json.JSONDecodeError, OSError) as exc:
-        print(f"unreadable: {exc}", file=sys.stderr)
-        return 1
-    if not isinstance(evidence, dict):
-        print("evidence is not a JSON object", file=sys.stderr)
-        return 1
-    ok, err = _validate_evidence_schema(evidence)
-    if not ok:
-        print(f"invalid: {err}", file=sys.stderr)
-        return 1
-    print("valid")
-    return 0
-
-
-# =============================================================================
-# check-cumulative-critic command (v1.4 F2 — PR gate)
-# =============================================================================
-
-
-_BUILD_PLAN_PATH_RE = re.compile(r"`([^`\s]+)`")
-_BUILD_PLAN_NEW_QUALIFIER_RE = re.compile(r"\bnew\s+`([^`\s]+)`")
-# Per-chunk Type declaration (v1.4 F6 — proportional Critic via chunk type).
-# Matches `- **Type:** <token>` or `**Type:** <token>` as a list item; trailing
-# parenthetical prose is allowed and ignored.
-_BUILD_PLAN_TYPE_RE = re.compile(r"^[\s\-\*]*\*\*Type:\*\*\s*([A-Za-z][\w\-]*)")
-# v1.5 Chunk 04 — `trivial` joins the allowed set. File-set bounds (no
-# edits under agents/, methodology/, templates/; no CLAUDE.md edit; no
-# test deletion; no new files) + required `**Trivial because:**`
-# rationale are enforced structurally; semantic-fit is Critic Goal 3 in
-# Chunk 05. Size is unbounded — trivial is a semantic claim, not a LOC
-# metric.
-_BUILD_PLAN_ALLOWED_TYPES = frozenset(
-    {"code", "doc-only", "cleanup", "designer-handoff", "cumulative-final", "trivial"}
-)
-# `**Trivial because:** <rationale>` — first line; continuation lines (no
-# list-item / heading prefix) are joined onto the rationale until the next
-# field. Empty after the colon → missing-rationale.
-_BUILD_PLAN_TRIVIAL_RATIONALE_RE = re.compile(
-    r"^[\s\-\*]*\*\*Trivial because:\*\*\s*(.*)$"
-)
-
-
-def _looks_like_file_path(token: str) -> bool:
-    """A backticked token is a precise file-path reference only when it
-    contains ``/`` — i.e. the chunk author wrote a specific relative path.
-    Bare filenames in prose (e.g. ``backlog.md``, ``SKILL.md``) are usually
-    conceptual references whose actual location varies, so they're not
-    verifiable in a useful way.
-
-    Slash-commands (``/pr``, ``/learnings``, ``/critic``) also contain
-    ``/`` but are not file paths. Exclude tokens that start with ``/``,
-    have no further ``/``, and contain no ``.`` — that shape is a single
-    slash-command identifier, not a path."""
-    if "/" not in token:
-        return False
-    if token.startswith("/") and "/" not in token[1:] and "." not in token:
-        return False
-    return True
-
-
-def _parse_build_plan_chunk_refs(prawduct_dir: Path, chunk_id: str) -> dict:
-    """Extract backticked file-path references from a single chunk's section
-    in ``.prawduct/artifacts/build-plan.md``.
-
-    The section is located by name (``### Chunk <chunk_id>:`` prefix, leading
-    zeros tolerant), and parsing stops at the next ``### `` or ``## `` heading
-    — sibling chunks' refs are NOT returned. Fenced code blocks (```...```)
-    are skipped because project-structure diagrams aren't load-bearing prose.
-    Paths preceded by the word ``new`` on the same line are skipped as
-    intra-chunk forward references (files the chunk creates rather than
-    modifies).
-
-    Returns ``{"file_paths": [{"line_num": int, "ref": str}, ...],
-    "error": str | None}``. Symbol and backlog-ID extraction are deferred —
-    see Chunk 02 plan-vs-execution divergence (commit message).
-    """
-    result: dict = {"file_paths": [], "error": None}
-    plan_path = prawduct_dir / "artifacts" / "build-plan.md"
-    if not plan_path.is_file():
-        result["error"] = f"missing build-plan: {plan_path}"
-        return result
-    try:
-        content = plan_path.read_text()
-    except OSError as exc:
-        result["error"] = f"unreadable build-plan: {exc}"
-        return result
-
-    # Normalize chunk_id: strip leading zeros for matching ("02" matches
-    # "### Chunk 2:" and vice versa) but report the original in errors.
-    target = chunk_id.lstrip("0") or "0"
-
-    in_section = False
-    in_fence = False
-    section_lines: list[tuple[int, str]] = []
-    for line_num, line in enumerate(content.splitlines(), start=1):
-        stripped = line.strip()
-        if stripped.startswith("### Chunk "):
-            # Heading format: "### Chunk NN: Name"
-            rest = stripped[len("### Chunk "):]
-            head = rest.split(":", 1)[0].strip()
-            head_norm = head.lstrip("0") or "0"
-            if in_section:
-                # Entered a sibling chunk; stop accumulating.
-                break
-            if head_norm == target:
-                in_section = True
-            continue
-        if not in_section:
-            continue
-        if stripped.startswith("## "):
-            # Left the Build Chunks section entirely.
-            break
-        if stripped.startswith("```"):
-            in_fence = not in_fence
-            continue
-        if in_fence:
-            continue
-        section_lines.append((line_num, line))
-
-    if not in_section and not section_lines:
-        result["error"] = f"chunk {chunk_id!r} not found in build-plan"
-        return result
-
-    seen: set[tuple[str, int]] = set()
-    for line_num, line in section_lines:
-        # Collect spans preceded by "new " — these get filtered out.
-        excluded_spans: list[tuple[int, int]] = [
-            m.span(1) for m in _BUILD_PLAN_NEW_QUALIFIER_RE.finditer(line)
-        ]
-        for match in _BUILD_PLAN_PATH_RE.finditer(line):
-            token = match.group(1)
-            if not _looks_like_file_path(token):
-                continue
-            if any(start == match.start(1) for start, _ in excluded_spans):
-                continue
-            key = (token, line_num)
-            if key in seen:
-                continue
-            seen.add(key)
-            result["file_paths"].append({"line_num": line_num, "ref": token})
-    return result
-
-
-def _parse_build_plan_chunk_type(
-    prawduct_dir: Path, chunk_id: str
-) -> tuple[str | None, str | None]:
-    """Extract the `Type:` declaration from a chunk's build-plan section.
-
-    Returns ``(chunk_type, error)``. ``chunk_type`` is one of
-    ``code | doc-only | cleanup | designer-handoff | cumulative-final | trivial``.
-    Default (field absent) is ``code`` — fail-closed so a missing declaration
-    runs the full Critic protocol rather than silently triggering a carveout
-    (learnings: "escape hatches in classification create silent failures").
-    Unknown values surface as ``(None, "unknown type: <value>")`` so the
-    author fixes the typo instead of getting silent fall-through.
-
-    Section discovery mirrors ``_parse_build_plan_chunk_refs`` — name-anchored
-    on ``### Chunk <chunk_id>:`` with leading-zero tolerance; fenced code
-    blocks are skipped.
-    """
-    plan_path = prawduct_dir / "artifacts" / "build-plan.md"
-    if not plan_path.is_file():
-        return None, f"missing build-plan: {plan_path}"
-    try:
-        content = plan_path.read_text()
-    except OSError as exc:
-        return None, f"unreadable build-plan: {exc}"
-
-    target = chunk_id.lstrip("0") or "0"
-
-    in_section = False
-    in_fence = False
-    section_found = False
-    declared: str | None = None
-    for line in content.splitlines():
-        stripped = line.strip()
-        if stripped.startswith("### Chunk "):
-            rest = stripped[len("### Chunk "):]
-            head = rest.split(":", 1)[0].strip()
-            head_norm = head.lstrip("0") or "0"
-            if in_section:
-                break  # hit sibling chunk
-            if head_norm == target:
-                in_section = True
-                section_found = True
-            continue
-        if not in_section:
-            continue
-        if stripped.startswith("## "):
-            break
-        if stripped.startswith("```"):
-            in_fence = not in_fence
-            continue
-        if in_fence:
-            continue
-        m = _BUILD_PLAN_TYPE_RE.match(line)
-        if m:
-            declared = m.group(1)
-            break
-
-    if not section_found:
-        return None, f"chunk {chunk_id!r} not found in build-plan"
-
-    if declared is None:
-        return "code", None  # fail-closed default
-    if declared not in _BUILD_PLAN_ALLOWED_TYPES:
-        allowed = ", ".join(sorted(_BUILD_PLAN_ALLOWED_TYPES))
-        return None, f"unknown type: {declared!r} (allowed: {allowed})"
-    return declared, None
-
-
-def _parse_build_plan_chunk_trivial_rationale(
-    prawduct_dir: Path, chunk_id: str
-) -> tuple[str | None, str | None]:
-    """Extract the ``**Trivial because:**`` rationale from a chunk's section.
-
-    Returns ``(rationale, error)``. Empty or absent field → ``(None,
-    "missing-rationale: Type: trivial requires non-empty **Trivial
-    because:** field")``. Multi-line rationale (continuation lines without
-    a list-item / heading prefix) is joined into a single string until the
-    next field.
-
-    Section discovery mirrors ``_parse_build_plan_chunk_type`` —
-    name-anchored on ``### Chunk <chunk_id>:`` with leading-zero
-    tolerance; fenced code blocks are skipped.
-    """
-    plan_path = prawduct_dir / "artifacts" / "build-plan.md"
-    if not plan_path.is_file():
-        return None, f"missing build-plan: {plan_path}"
-    try:
-        content = plan_path.read_text()
-    except OSError as exc:
-        return None, f"unreadable build-plan: {exc}"
-
-    target = chunk_id.lstrip("0") or "0"
-
-    in_section = False
-    in_fence = False
-    section_found = False
-    capturing = False
-    rationale_lines: list[str] = []
-    for line in content.splitlines():
-        stripped = line.strip()
-        if stripped.startswith("### Chunk "):
-            rest = stripped[len("### Chunk "):]
-            head = rest.split(":", 1)[0].strip()
-            head_norm = head.lstrip("0") or "0"
-            if in_section:
-                break  # hit sibling chunk
-            if head_norm == target:
-                in_section = True
-                section_found = True
-            continue
-        if not in_section:
-            continue
-        if stripped.startswith("## "):
-            break
-        if stripped.startswith("```"):
-            in_fence = not in_fence
-            continue
-        if in_fence:
-            continue
-        m = _BUILD_PLAN_TRIVIAL_RATIONALE_RE.match(line)
-        if m:
-            capturing = True
-            first = m.group(1).strip()
-            if first:
-                rationale_lines.append(first)
-            continue
-        if capturing:
-            # Stop at the next list-item field, bolded label, or sub-heading.
-            if (
-                stripped.startswith("- **")
-                or stripped.startswith("* **")
-                or stripped.startswith("**")
-                or stripped.startswith("#")
-            ):
-                break
-            if stripped:
-                rationale_lines.append(stripped)
-
-    if not section_found:
-        return None, f"chunk {chunk_id!r} not found in build-plan"
-    if not capturing:
-        return None, (
-            "missing-rationale: Type: trivial requires non-empty "
-            "**Trivial because:** field"
-        )
-    rationale = " ".join(rationale_lines).strip()
-    if not rationale:
-        return None, (
-            "missing-rationale: Type: trivial requires non-empty "
-            "**Trivial because:** field"
-        )
-    return rationale, None
-
-
-def _classify_trivial_change(
-    *,
-    path: str,
-    src_path: str | None,
-    is_addition: bool,
-    is_deletion: bool,
-) -> str | None:
-    """Single-file path-rule check for the ``Type: trivial`` file-set
-    bounds. Returns the violation reason or ``None`` when the change
-    is eligible. Shared by ``_is_trivial_fileset_eligible`` (Chunk 04 —
-    working-tree porcelain) and ``_pr_diff_is_trivial`` (Chunk 05 —
-    per-commit name-status diff). Centralizing the rule set prevents
-    the stop-hook gate and the PR-boundary gate from drifting apart
-    silently.
-
-    Metadata paths (``.prawduct/``, ``.claude/settings.json``, etc. —
-    see ``_is_metadata_path``) are treated as out-of-scope and return
-    ``None``. The check applies to BOTH ``path`` (rename dst / single-
-    file change) AND ``src_path`` (rename src) — without that
-    symmetry, a rename FROM a metadata path that landed somewhere
-    interesting would silently be classified, and a rename TO a
-    metadata path would be classified differently depending on which
-    gate ran (the callers previously did dst-only filtering before
-    calling this helper — v1.5.1 Chunk 04(b) consolidates).
-
-    The caller translates its status format into the boolean inputs
-    (porcelain handles 2-char codes; name-status handles single-char).
-    Path bounds are catastrophic-blast-radius classes regardless of
-    size — size is intentionally not a bound.
-    """
-    if _is_metadata_path(path):
-        return None
-    if src_path is not None and _is_metadata_path(src_path):
-        return None
-    if path == "CLAUDE.md":
-        return f"claude-md-edited: {path}"
-    if path.startswith("agents/"):
-        return f"agent-file-edited: {path}"
-    if path.startswith("methodology/"):
-        return f"methodology-edited: {path}"
-    if path.startswith("templates/"):
-        return f"template-edited: {path}"
-    if is_deletion and path.startswith("tests/"):
-        return f"test-file-deleted: {path}"
-    if src_path is not None and src_path.startswith("tests/"):
-        return f"test-file-deleted: {src_path} (renamed out)"
-    if is_addition:
-        return f"new-file: {path}"
-    return None
-
-
-def _is_trivial_fileset_eligible(project_dir: Path) -> tuple[bool, str]:
-    """Check the current session's diff against the ``Type: trivial``
-    file-set bounds. Returns ``(eligible, reason)``.
-
-    Bounds (catastrophic-blast-radius classes, regardless of size):
-    no edits under ``agents/``, ``methodology/``, or ``templates/``; no
-    edits to ``CLAUDE.md``; no test-file removals (porcelain ``D`` under
-    ``tests/`` OR rename whose source path is under ``tests/`` — a
-    ``git mv`` out of the test directory is semantically a deletion);
-    no newly-tracked files (porcelain ``A`` or ``??``).
-
-    Size is intentionally NOT a bound — trivial is a semantic judgment.
-    An 80-LOC project-wide rename can qualify; a 5-line state-machine
-    change cannot. The semantic claim lives in
-    ``**Trivial because:**``; Critic Goal 3 validates rationale-vs-diff
-    fit (Chunk 05).
-
-    Reason strings name the specific bound that failed for actionable
-    stop-hook messaging — e.g. ``"agent-file-edited: agents/critic/SKILL.md"``.
-    The first violating file wins (deterministic order: porcelain
-    output ordering); the user fixes one violation at a time.
-
-    Uses session-baseline filtering so pre-session dirt doesn't count
-    against the chunk (mirrors ``git_has_session_changes``).
-
-    Path-bound rules are delegated to ``_classify_trivial_change`` so
-    the PR-boundary helper (``_pr_diff_is_trivial``) applies an
-    identical rule set — same bounds checked at session-end and at
-    PR creation.
-    """
-    output = git_status_output(project_dir)
-    if output is None:
-        # No git or git error — defer to other gates; treat as eligible
-        # so the trivial check doesn't fail the build when git itself is
-        # the problem.
-        return True, ""
-
-    prawduct_dir = get_prawduct_dir(project_dir)
-    baseline_path = prawduct_dir / ".session-git-baseline"
-    baseline_lines: set[str] = set()
-    if baseline_path.is_file():
-        try:
-            baseline_lines = set(baseline_path.read_text().splitlines())
-        except (UnicodeDecodeError, OSError):
-            pass
-
-    for line in output.splitlines():
-        if not line or line in baseline_lines:
-            continue
-        if len(line) < 4:
-            continue
-        status = line[:2]
-        raw = line[3:].strip()
-        src_path: str | None = None
-        if " -> " in raw:
-            src_raw, dst_raw = raw.split(" -> ", 1)
-            src_path = src_raw.strip()
-            if src_path.startswith('"') and src_path.endswith('"'):
-                src_path = src_path[1:-1]
-            path = dst_raw.strip()
-        else:
-            path = raw
-        if path.startswith('"') and path.endswith('"'):
-            path = path[1:-1]
-        if not path:
-            continue
-
-        # v1.5.1 Chunk 04(b): metadata-path filtering lives inside
-        # `_classify_trivial_change` (returns None for both src and dst
-        # metadata paths). Single check site = no drift between this gate
-        # and `_pr_diff_is_trivial`.
-        is_addition = status[0] == "A" or status == "??"
-        is_deletion = "D" in status
-        violation = _classify_trivial_change(
-            path=path,
-            src_path=src_path,
-            is_addition=is_addition,
-            is_deletion=is_deletion,
-        )
-        if violation is not None:
-            return False, violation
-
-    return True, ""
-
-
-def _current_chunk_id_from_status(prawduct_dir: Path) -> str | None:
-    """Extract the chunk id of the first `- [ ]` item in the build-plan Status
-    section, e.g. ``"03"`` for ``- [ ] Chunk 03: Foo``. Returns ``None`` if
-    Status is missing, has no current chunk (all complete), or the chunk text
-    isn't in the expected ``Chunk NN:`` form.
-
-    Mirrors the resolution logic in ``cmd_verify_chunk_refs`` so the stop
-    hook and the Critic helper agree on "which chunk is current."
-    """
-    status = _parse_build_plan_status(prawduct_dir)
-    current = status.get("current_chunk", "")
-    if not current.startswith("Chunk "):
-        return None
-    rest = current[len("Chunk "):]
-    chunk_id = rest.split(":", 1)[0].strip()
-    return chunk_id or None
-
-
-def _verify_chunk_refs(project_dir: Path, refs: dict) -> list[dict]:
-    """Verify each file-path ref exists relative to ``project_dir``.
-    Returns a list of ``{"kind", "ref", "line_num", "reason"}`` for missing
-    entries. Empty list = all refs resolved.
-    """
-    missing: list[dict] = []
-    for entry in refs.get("file_paths", []):
-        ref = entry["ref"]
-        target = project_dir / ref
-        if not target.exists():
-            missing.append({
-                "kind": "file_path",
-                "ref": ref,
-                "line_num": entry["line_num"],
-                "reason": "file does not exist",
-            })
-    return missing
-
-
-def cmd_verify_chunk_refs(project_dir: Path, chunk_id: str | None) -> int:
-    """Critic Goal-2 helper: verify symbols/paths referenced in the current
-    chunk's build-plan section actually exist on the filesystem.
-
-    Exit 0 = all refs resolved (or nothing to check). Exit 1 = at least one
-    ref is missing, or the gate cannot be evaluated. stderr lists each
-    missing ref so the Critic can quote it in findings.
-
-    With no ``chunk_id``, reads the current chunk from Status (first unchecked
-    ``- [ ]`` item). If Status has no current chunk (all complete or no
-    Status section), exits 0 — there is nothing to verify.
-    """
-    prawduct_dir = get_prawduct_dir(project_dir)
-    if chunk_id is None:
-        chunk_id = os.environ.get("PRAWDUCT_VERIFY_CHUNK_ID")
-    if chunk_id is None:
-        status = _parse_build_plan_status(prawduct_dir)
-        current = status.get("current_chunk", "")
-        # current is e.g. "Chunk 02: F3 — …"
-        if not current.startswith("Chunk "):
-            print("ok: no current chunk in Status; nothing to verify")
-            return 0
-        rest = current[len("Chunk "):]
-        chunk_id = rest.split(":", 1)[0].strip()
-
-    refs = _parse_build_plan_chunk_refs(prawduct_dir, chunk_id)
-    if refs["error"]:
-        print(f"error: {refs['error']}", file=sys.stderr)
-        return 1
-    missing = _verify_chunk_refs(project_dir, refs)
-    if missing:
-        for m in missing:
-            print(
-                f"missing-ref: {m['ref']} (line {m['line_num']}, {m['kind']}): {m['reason']}",
-                file=sys.stderr,
-            )
-        return 1
-    count = len(refs["file_paths"])
-    print(f"ok: chunk {chunk_id} — {count} file ref(s) verified")
-    return 0
-
-
-# v1.4 F4b — coverage-required gate inputs.
-# Helper kept parallel to ``is_views_enabled`` in tools/lib/views.py: column-0
-# key scan, fail-closed default of False. Inline rather than imported to keep
-# the product-hook surface flat (no new lib dependency just for a 10-line
-# scanner). Same idiom = same drift discipline as views_enabled.
-def _read_bool_yaml_key(state_path: Path, key: str) -> bool:
-    if not state_path.exists():
-        return False
-    try:
-        content = state_path.read_text(encoding="utf-8")
-    except OSError:
-        return False
-    needle = f"{key}:"
-    for raw in content.splitlines():
-        if raw[:1] in (" ", "\t"):
-            continue
-        line = raw.split("#", 1)[0].rstrip()
-        if not line.startswith(needle):
-            continue
-        value = line.split(":", 1)[1].strip().lower()
-        return value == "true"
-    return False
-
-
-def _coverage_resolve_base(project_dir: Path) -> tuple[str | None, str]:
-    """Pick the git diff base for coverage verification. Mirrors
-    ``_resolve_base`` in ``tools/test-reference-verify`` so writer (verifier)
-    and reader (verify-coverage) examine the same set of changes. If the
-    bases diverge, every chunk's verify-coverage would emit spurious
-    missing-coverage findings on files outside the verifier's base.
-    """
-    for candidate in ("origin/main", "main", "HEAD~1"):
-        proc = subprocess.run(
-            ["git", "rev-parse", "--verify", candidate],
-            cwd=str(project_dir),
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
-        if proc.returncode == 0:
-            return candidate, candidate
-    return None, "no base candidate resolved (origin/main, main, HEAD~1 all absent)"
-
-
-def _coverage_changed_files(project_dir: Path, base: str) -> list[str]:
-    """Files changed between ``base`` and the working tree, union untracked.
-    Mirrors ``_changed_files`` in ``tools/test-reference-verify`` — same
-    union over ``git diff`` + ``git ls-files --others --exclude-standard``
-    so verify-coverage sees exactly the file set the verifier scored.
-    """
-    proc = subprocess.run(
-        ["git", "diff", "--name-only", base],
-        cwd=str(project_dir),
-        capture_output=True,
-        text=True,
-        timeout=30,
-    )
-    if proc.returncode != 0:
-        raise RuntimeError(f"git diff failed: {proc.stderr.strip()}")
-    files = {line.strip() for line in proc.stdout.splitlines() if line.strip()}
-
-    proc2 = subprocess.run(
-        ["git", "ls-files", "--others", "--exclude-standard"],
-        cwd=str(project_dir),
-        capture_output=True,
-        text=True,
-        timeout=30,
-    )
-    if proc2.returncode == 0:
-        files.update(line.strip() for line in proc2.stdout.splitlines() if line.strip())
-    return sorted(files)
-
-
-def cmd_verify_coverage(project_dir: Path) -> int:
-    """Critic Goal-1 helper (v1.4 F4b): when ``coverage_required: true`` in
-    project-state.yaml, verify every changed file in the diff appears in
-    ``.test-evidence.json``'s ``changes_referenced`` list.
-
-    Exit codes:
-      0 — check passed, or skipped (``coverage_required: false`` — the v1.4
-          default; opt-in by design).
-      1 — at least one changed file is missing from ``changes_referenced``,
-          or a precondition failed (evidence missing/invalid, schema lacks
-          F4a fields, git base unresolved).
-
-    stderr lists each missing file with language scaled to the declared
-    ``coverage_level`` — ``referenced`` (floor) vs ``executed`` (real
-    coverage tool) — so the Critic can quote it directly in BLOCKING
-    findings without re-deriving the wording.
-    """
-    prawduct_dir = get_prawduct_dir(project_dir)
-    state_path = prawduct_dir / "project-state.yaml"
-
-    if not _read_bool_yaml_key(state_path, "coverage_required"):
-        print("skipped: coverage_required is false (default in v1.4)")
-        return 0
-
-    evidence_path = prawduct_dir / ".test-evidence.json"
-    if not evidence_path.is_file():
-        print(
-            f"error: coverage_required=true but {evidence_path} is missing — "
-            "run the test suite + verifier first.",
-            file=sys.stderr,
-        )
-        return 1
-
-    try:
-        evidence = json.loads(evidence_path.read_text())
-    except (json.JSONDecodeError, OSError) as exc:
-        print(f"error: cannot read evidence: {exc}", file=sys.stderr)
-        return 1
-
-    if "verifier" not in evidence:
-        print(
-            "error: coverage_required=true but evidence lacks F4a schema "
-            "(no `verifier` field) — emit coverage fields with "
-            "`tools/test-reference-verify` (or a stronger product-specific "
-            "verifier) before re-running.",
-            file=sys.stderr,
-        )
-        return 1
-
-    ok, reason = _validate_evidence_schema(evidence)
-    if not ok:
-        print(f"error: {reason}", file=sys.stderr)
-        return 1
-
-    coverage_level = evidence["coverage_level"]
-    referenced = set(evidence.get("changes_referenced", []))
-
-    base, base_reason = _coverage_resolve_base(project_dir)
-    if base is None:
-        print(f"error: cannot resolve diff base — {base_reason}", file=sys.stderr)
-        return 1
-
-    try:
-        changed = _coverage_changed_files(project_dir, base)
-    except RuntimeError as exc:
-        print(f"error: {exc}", file=sys.stderr)
-        return 1
-
-    missing = [f for f in changed if f not in referenced]
-    if not missing:
-        print(
-            f"ok: {len(changed)} changed file(s) covered "
-            f"(level: {coverage_level})"
-        )
-        return 0
-
-    # Severity wording is per the F4a spec — the floor (``referenced``)
-    # explicitly disclaims execution, the real-coverage level
-    # (``executed``) asserts it. Critic quotes these lines verbatim.
-    if coverage_level == "executed":
-        suffix = "has no executing test."
-    else:
-        suffix = (
-            "is not referenced by any executed test "
-            "(floor check — does not prove execution)."
-        )
-
-    for m in missing:
-        print(
-            f"missing-coverage: {m} (coverage_level: {coverage_level}) — {suffix}",
-            file=sys.stderr,
-        )
-    return 1
-
-
-def cmd_check_cumulative_critic(project_dir: Path) -> int:
-    """Structural gate for `/pr create`: require a fresh cumulative-Critic record.
-
-    Exit 0 only when the Critic findings file:
-      - exists and parses,
-      - is schema-valid (``validate_critic_findings``),
-      - has ``mode == _CRITIC_MODE_CUMULATIVE`` (chunk/final do not satisfy
-        this gate — cumulative is specifically the ``merge-base...HEAD``
-        bundle review),
-      - is fresh (mtime later than the current session's ``.session-start``
-        marker; stale evidence from a prior session is rejected),
-      - contains no unresolved BLOCKING severity findings (WARNING and NOTE
-        are advisory at the PR gate, matching the PR reviewer's semantics).
-
-    Exit 1 otherwise. stderr names the specific check that failed so the
-    caller (`/pr` skill) can present an actionable message to the user.
-    """
-    prawduct_dir = get_prawduct_dir(project_dir)
-    findings_path = prawduct_dir / ".critic-findings.json"
-
-    if not findings_path.is_file():
-        print(
-            "missing: no cumulative-Critic findings at "
-            f"{findings_path}. Run /critic cumulative before opening a PR.",
-            file=sys.stderr,
-        )
-        return 1
-
-    if not validate_critic_findings(findings_path):
-        print(
-            f"invalid: {findings_path} did not pass schema validation",
-            file=sys.stderr,
-        )
-        return 1
-
-    try:
-        data = json.loads(findings_path.read_text())
-    except (json.JSONDecodeError, OSError) as exc:
-        print(f"unreadable: {exc}", file=sys.stderr)
-        return 1
-
-    mode = data.get("mode")
-    if mode != _CRITIC_MODE_CUMULATIVE:
-        print(
-            f"wrong-mode: findings mode is {mode!r}, expected cumulative "
-            f"({_CRITIC_MODE_CUMULATIVE!r}). The cumulative review covers "
-            "`merge-base...HEAD` — re-run /critic cumulative.",
-            file=sys.stderr,
-        )
-        return 1
-
-    # Freshness check — fail closed if the marker is missing or the check
-    # itself crashes. Mirrors the `needs_review = True` default in
-    # `_check_previous_session_gates` around line 1872; the cumulative gate
-    # cannot vouch for freshness it can't verify. (See "Escape hatches in
-    # classification create silent failures" in learnings.md.)
-    session_start_path = prawduct_dir / ".session-start"
-    if not session_start_path.is_file():
-        print(
-            "no-session-start: missing .prawduct/.session-start — cannot "
-            "validate cumulative-Critic freshness. Run /clear to start a "
-            "session, then re-run /critic cumulative.",
-            file=sys.stderr,
-        )
-        return 1
-    try:
-        session_start = session_start_path.read_text().strip()
-        findings_mtime = datetime.fromtimestamp(
-            findings_path.stat().st_mtime, tz=timezone.utc
-        ).strftime("%Y-%m-%dT%H:%M:%SZ")
-    except Exception as exc:  # prawduct:ok-broad-except — fail closed if freshness inputs are unreadable
-        print(
-            f"freshness-check-failed: could not compare cumulative-Critic "
-            f"findings vs session-start ({exc!r}). Re-run /critic cumulative.",
-            file=sys.stderr,
-        )
-        return 1
-    # Lexicographic compare on whole-second %Y-%m-%dT%H:%M:%SZ strings is
-    # order-preserving — same convention as cmd_clear's gate check around
-    # line 1874. Adding fractional seconds to the format would break both
-    # sides; keep them in lockstep.
-    if findings_mtime <= session_start:
-        print(
-            f"stale: cumulative findings ({findings_mtime}) "
-            f"predate session-start ({session_start}). Re-run "
-            "/critic cumulative in the current session before opening a PR.",
-            file=sys.stderr,
-        )
-        return 1
-
-    findings = data.get("findings", [])
-    blocking = [f for f in findings if isinstance(f, dict) and f.get("severity") == "blocking"]
-    if blocking:
-        first = blocking[0].get("summary", "<no summary>")
-        print(
-            f"blocking: cumulative-Critic recorded {len(blocking)} BLOCKING "
-            f"finding(s). First: {first}. Resolve before opening a PR.",
-            file=sys.stderr,
-        )
-        return 1
-
-    print(f"satisfied: cumulative-Critic record is fresh and clean ({findings_path})")
-    return 0
-
-
-# =============================================================================
 # main
 # =============================================================================
 
 
-def cmd_regen_views(project_dir: Path) -> int:
-    """Regenerate derived views from the change-log canonical store.
-
-    Three views are produced in one pass when `views_enabled: true`:
-
-      1. Build-plan `## Status` block — checkbox flips from `status=shipped` tags
-      2. Release-notes view — `.prawduct/release-notes.md` from `release=` tags
-      3. Scope-rollup view — `scope_rollups:` block in `project-state.yaml`
-         from `scope=` tags
-
-    No-op when `views_enabled: true` is absent (enabled by default in v1.4;
-    sync auto-enables for existing repos and `false` is the explicit opt-out).
-
-    Exit codes:
-      0 - success (views disabled, no changes needed, or regen applied cleanly)
-      2 - I/O or schema error (missing change-log or build-plan)
-    """
-    # Ensure tools/ is on sys.path so `from lib import views` resolves both
-    # when invoked as a script and when imported via SourceFileLoader in tests.
-    tools_dir = str(Path(__file__).resolve().parent)
-    if tools_dir not in sys.path:
-        sys.path.insert(0, tools_dir)
-    from lib import views  # noqa: PLC0415 — lazy import keeps top-level cheap
-
-    prawduct_dir = get_prawduct_dir(project_dir)
-    try:
-        enabled, results = views.plan_regen(prawduct_dir)
-    except FileNotFoundError as e:
-        msg = str(e)
-        if "change-log" in msg:
-            print(f"ERROR: {msg}", file=sys.stderr)
-        elif "build-plan" in msg:
-            print(f"ERROR: {msg}", file=sys.stderr)
-        else:
-            print(f"ERROR: {msg}", file=sys.stderr)
-        return 2
-    except OSError as e:
-        print(f"ERROR reading view inputs: {e}", file=sys.stderr)
-        return 2
-
-    if not enabled:
-        print("Views disabled (set views_enabled: true in project-state.yaml).")
-        return 0
-
-    try:
-        views.apply_regen(prawduct_dir, results)
-    except OSError as e:
-        print(f"ERROR writing view output: {e}", file=sys.stderr)
-        return 2
-
-    for r in results:
-        print(r.summary)
-    return 0
-
-
-def cmd_check_operator_verification(project_dir: Path) -> int:
-    """Structural gate for `/pr create`: refuse open when queue has pending entries.
-
-    Mirrors :func:`cmd_check_cumulative_critic` semantics — exit 0 only
-    when the gate is satisfied, exit 1 with stderr describing the
-    blocker. The gate is only active when ``operator_verification_required:
-    true`` is set in ``project-state.yaml``; otherwise the command is a
-    no-op exit 0.
-    """
-    tools_dir = str(Path(__file__).resolve().parent)
-    if tools_dir not in sys.path:
-        sys.path.insert(0, tools_dir)
-    from lib import operator_verification as ov  # noqa: PLC0415 — lazy import
-
-    result = ov.run_check_operator_verification(project_dir)
-    if not result["required"]:
-        return 0
-    if result["pending"] == 0:
-        print(result["message"])
-        return 0
-    print(result["message"], file=sys.stderr)
-    return 1
-
-
-def cmd_accept_operator_verification(
-    project_dir: Path, rationale: str | None
-) -> int:
-    """Flip all pending entries to ``accepted`` with the supplied rationale.
-
-    Invoked by ``/pr create --accept-pending-verification "rationale"``.
-    Refuses an empty or missing rationale — the work-log capture is the
-    whole point of the override.
-    """
-    tools_dir = str(Path(__file__).resolve().parent)
-    if tools_dir not in sys.path:
-        sys.path.insert(0, tools_dir)
-    from lib import operator_verification as ov  # noqa: PLC0415 — lazy import
-
-    if rationale is None or not rationale.strip():
-        print(
-            "error: accept-operator-verification requires a non-empty "
-            "rationale argument — `/pr create --accept-pending-verification "
-            '"rationale"`. The override is recorded in operator-verification.md '
-            "as the work-log entry.",
-            file=sys.stderr,
-        )
-        return 1
-
-    result = ov.run_accept_pending(project_dir, rationale)
-    if "error" in result:
-        print(f"error: {result['error']}", file=sys.stderr)
-        return 1
-
-    for action in result["actions"]:
-        print(action)
-    for note in result["notes"]:
-        print(f"  * {note}")
-    return 0
-
-
-def _pr_diff_is_doc_only(project_dir: Path) -> tuple[bool, str]:
-    """Shared helper: is the PR diff (``merge-base...HEAD``) all ``.md``?
-
-    Returns ``(is_doc_only, status_message)``. ``is_doc_only`` is True only
-    when the diff is non-empty AND every file ends in ``.md``. The status
-    message names the specific reason for False (``no-base``, ``git-failed``,
-    ``empty-diff``, ``not-doc-only: <files>``) so both the CLI gate and the
-    stop-hook Gate 3 can surface actionable detail without re-implementing
-    the diff inspection. Base resolution mirrors ``_coverage_resolve_base``
-    so the helper sees the same diff surface as the cumulative-Critic flow.
-    """
-    base, base_note = _coverage_resolve_base(project_dir)
-    if base is None:
-        return False, f"no-base: {base_note}"
-
-    proc = subprocess.run(
-        ["git", "diff", "--name-only", f"{base}...HEAD"],
-        cwd=str(project_dir),
-        capture_output=True,
-        text=True,
-        timeout=30,
-    )
-    if proc.returncode != 0:
-        return False, f"git-failed: git diff {base}...HEAD failed: {proc.stderr.strip()}"
-
-    files = [line.strip() for line in proc.stdout.splitlines() if line.strip()]
-    if not files:
-        return False, f"empty-diff: no files changed in {base}...HEAD"
-
-    non_md = [f for f in files if not f.endswith(".md")]
-    if non_md:
-        sample = ", ".join(non_md[:3])
-        more = f" (+{len(non_md) - 3} more)" if len(non_md) > 3 else ""
-        return False, f"not-doc-only: PR includes non-.md files: {sample}{more}"
-
-    return True, f"doc-only: {len(files)} file(s) in {base}...HEAD all .md"
-
-
-def cmd_check_pr_doc_only(project_dir: Path) -> int:
-    """Fast-path gate for `/pr create`: report whether the PR diff is doc-only.
-
-    Exit 0 when every file in ``merge-base...HEAD`` ends in ``.md`` and the
-    diff is non-empty — the `/pr` skill uses this to skip the cumulative-
-    Critic and PR-reviewer gates, mirroring the session-end stop-hook
-    behavior (`_session_changes_are_doc_only`) at the PR boundary. The
-    stop hook's PR-review evidence gate (Gate 3) consults the same helper
-    so a doc-only PR doesn't get blocked at session end for missing
-    evidence — symmetric behavior across both gates.
-
-    Exit 1 otherwise (any non-``.md`` file, empty diff, no resolvable base
-    branch, or git failure). Fails closed: when the gate cannot be evaluated,
-    fall through to the full review path rather than silently skipping it.
-    """
-    is_doc_only, status = _pr_diff_is_doc_only(project_dir)
-    if is_doc_only:
-        print(
-            f"{status} — cumulative-Critic and PR-reviewer gates may be skipped."
-        )
-        return 0
-    suffix = (
-        ". Doc-only fast-path is not applicable."
-        if status.startswith("empty-diff")
-        else ". Falling back to full review path."
-        if status.startswith(("no-base", "git-failed"))
-        else ". Full review required."
-    )
-    print(f"{status}{suffix}", file=sys.stderr)
-    return 1
-
-
-def _pr_diff_is_trivial(project_dir: Path) -> tuple[bool, str]:
-    """Shared helper: is every commit on ``merge-base...HEAD`` fileset-
-    eligible per Chunk 04's ``Type: trivial`` path bounds?
-
-    Returns ``(is_trivial, status_message)``. ``is_trivial`` is True only
-    when at least one commit exists ahead of base AND every commit's
-    file changes satisfy ``_classify_trivial_change``. The first
-    violating commit short-circuits with a reason naming the SHA and
-    the specific bound (e.g.
-    ``"not-trivial: commit a1b2c3d agent-file-edited: agents/foo.md"``).
-
-    Mirrors ``_pr_diff_is_doc_only`` at the PR boundary — same base
-    resolution via ``_coverage_resolve_base``, same fail-closed posture
-    on missing base / git failure / empty diff. Does NOT re-validate
-    rationale fit; that's the per-chunk Critic's job at chunk-mode
-    review time. This helper trusts that every chunk's rationale was
-    Critic-passed and only checks the structural file-set bounds.
-
-    Per-commit (not cumulative) walk: a PR that adds an ``agents/``
-    file in commit 1 and removes it in commit 2 has an empty cumulative
-    diff but is NOT fast-path eligible — the commit 1 violation is
-    real signal that the work crossed a catastrophic-blast-radius
-    boundary at least once during the build.
-    """
-    base, base_note = _coverage_resolve_base(project_dir)
-    if base is None:
-        return False, f"no-base: {base_note}"
-
-    # `git log --name-status --format=%H` emits one commit SHA per line
-    # followed by one tab-separated <status>\t<path> (or
-    # <status>\t<src>\t<dst> for renames) line per changed file, with
-    # a blank line between commits. Reverse order is irrelevant — we
-    # short-circuit on first violation regardless.
-    proc = subprocess.run(
-        [
-            "git",
-            "log",
-            "--name-status",
-            "-M",  # enable rename detection so test-renamed-out-of-tests/ trips
-            "--format=%H",
-            f"{base}..HEAD",
-        ],
-        cwd=str(project_dir),
-        capture_output=True,
-        text=True,
-        timeout=30,
-    )
-    if proc.returncode != 0:
-        return False, f"git-failed: git log {base}..HEAD failed: {proc.stderr.strip()}"
-
-    lines = proc.stdout.splitlines()
-    if not any(line.strip() for line in lines):
-        return False, f"empty-diff: no commits ahead of {base}"
-
-    current_sha: str | None = None
-    commits_seen = 0
-    for raw in lines:
-        line = raw.rstrip()
-        if not line:
-            continue
-        # A bare 40-hex line is a commit header.
-        if len(line) == 40 and all(c in "0123456789abcdef" for c in line):
-            current_sha = line
-            commits_seen += 1
-            continue
-        # Otherwise it's a name-status entry for the current commit.
-        if current_sha is None:
-            continue
-        parts = line.split("\t")
-        if len(parts) < 2:
-            continue
-        status = parts[0].strip()
-        if not status:
-            continue
-        # R<score> / C<score> rows are: <status>\t<src>\t<dst>
-        src_path: str | None = None
-        if status[0] in ("R", "C") and len(parts) >= 3:
-            src_path = parts[1].strip()
-            path = parts[2].strip()
-        else:
-            path = parts[-1].strip()
-        if not path:
-            continue
-        # v1.5.1 Chunk 04(b): metadata-path filtering lives inside
-        # `_classify_trivial_change` (handles both src and dst). Single
-        # check site = no drift between this PR-boundary gate and the
-        # stop-hook gate in `_is_trivial_fileset_eligible`.
-        is_addition = status == "A"
-        is_deletion = status == "D"
-        violation = _classify_trivial_change(
-            path=path,
-            src_path=src_path,
-            is_addition=is_addition,
-            is_deletion=is_deletion,
-        )
-        if violation is not None:
-            return False, f"not-trivial: commit {current_sha[:7]} {violation}"
-
-    return True, (
-        f"trivial: {commits_seen} commit(s) ahead of {base} all fileset-eligible"
-    )
-
-
-def cmd_check_pr_trivial(project_dir: Path) -> int:
-    """Fast-path gate for `/pr create`: report whether every commit in
-    ``merge-base...HEAD`` is fileset-eligible per Chunk 04's
-    ``Type: trivial`` path bounds.
-
-    Exit 0 when at least one commit exists ahead of base AND every
-    commit clears the bounds — the `/pr` skill skips the cumulative-
-    Critic and PR-reviewer gates in this case. This is the PR-boundary
-    parallel to the doc-only fast-path: same fail-closed shape, same
-    Gate-3 alignment at session end.
-
-    Exit 1 otherwise (any commit touches ``agents/``/``methodology/``/
-    ``templates/``/``CLAUDE.md``, adds a new file, removes a test
-    file, empty diff, no resolvable base, or git failure). Fails
-    closed: when the gate cannot be evaluated, fall through to the
-    full review path rather than silently skipping it.
-    """
-    is_trivial, status = _pr_diff_is_trivial(project_dir)
-    if is_trivial:
-        print(
-            f"{status} — cumulative-Critic and PR-reviewer gates may be skipped."
-        )
-        return 0
-    suffix = (
-        ". Trivial fast-path is not applicable."
-        if status.startswith("empty-diff")
-        else ". Falling back to full review path."
-        if status.startswith(("no-base", "git-failed"))
-        else ". Full review required."
-    )
-    print(f"{status}{suffix}", file=sys.stderr)
-    return 1
-
-
-def cmd_compute_verify_resolutions_scope(project_dir: Path) -> int:
-    """Print the file scope a ``/critic verify-resolutions`` pass should review.
-
-    Thin CLI wrapper around ``_compute_verify_resolutions_scope`` (v1.5
-    Chunk 02) so the Critic SKILL can call the canonical helper instead
-    of reimplementing the widening-threshold prose. Defense-in-depth: the
-    Critic's verify-resolutions invocation now computes the same scope
-    the stop-hook gate enforces; drift between the two is no longer
-    possible (v1.5.1 Chunk 03 — backlog 2026-05-21).
-
-    Output format:
-      stdout: one file path per line (the union of prior ``files_reviewed``
-              and files-changed-since-``commit_reviewed``, sorted).
-              Empty stdout when the helper returns no scope.
-      stderr: one line with the helper's reason string.
-
-    Exit codes:
-      0 - scope computed; stdout lists files; stderr reason starts ``ok:``.
-      1 - cannot compute (no prior findings, no ``commit_reviewed``,
-          unreadable findings, no actionable findings, unresolved commit,
-          git failure, invalid files_reviewed). The Critic should fall
-          back to ``/critic chunk`` or ``/critic final`` and record
-          ``mode_chosen_by: "fallback-no-prior-findings"`` (or similar).
-      2 - scope widened past the demotion threshold
-          (``len(delta) > 2 * len(prior) + 5``). The Critic should fall
-          back to ``/critic final`` and record
-          ``mode_chosen_by: "fallback-scope-widened"``.
-    """
-    prawduct_dir = get_prawduct_dir(project_dir)
-    scope, reason = _compute_verify_resolutions_scope(prawduct_dir, project_dir)
-    if scope:
-        for f in scope:
-            print(f)
-    print(reason, file=sys.stderr)
-    if reason.startswith("ok:"):
-        return 0
-    if reason.startswith("scope-widened:"):
-        return 2
-    return 1
-
-
-def cmd_infer_critic_mode(project_dir: Path, args: str | None) -> int:
-    """Print ``<mode>|<rationale>`` for the inferred ``/critic`` mode.
-
-    Thin wrapper around ``tools.lib.critic_mode.infer_mode`` (v1.5
-    Chunk 03). The subcommand exists so the Critic SKILL can call
-    inference without expanding its ``allowed-tools`` to ``Bash(python3
-    -c *)`` — keeping the structural "no arbitrary code execution"
-    constraint enforceable.
-
-    Output format: a single stdout line ``<mode>|<rationale>`` where
-    ``<mode>`` is one of the short tokens (``chunk`` / ``final`` /
-    ``cumulative`` / ``verify-resolutions``) and ``<rationale>`` is the
-    human-readable explanation suitable for both stdout reporting and
-    the ``mode_chosen_by`` field in ``.critic-findings.json``.
-
-    Fail-safe: when ``tools/lib`` is absent (product repos that
-    haven't yet received the lib propagation), returns ``final|
-    fallback-no-tools-lib`` so the Critic falls through to thorough
-    review rather than crashing. Same fail-safe direction as the
-    SKILL's "missing/unrecognized mode → final" rule.
-    """
-    tools_dir = str(Path(__file__).resolve().parent)
-    if tools_dir not in sys.path:
-        sys.path.insert(0, tools_dir)
-    try:
-        from lib import infer_mode  # noqa: PLC0415 — lazy keeps top-level cheap
-    except ImportError:
-        print("final|fallback-no-tools-lib")
-        return 0
-    mode, rationale = infer_mode(project_dir, args)
-    print(f"{mode}|{rationale}")
-    return 0
-
-
-_USAGE = (
-    "Usage: product-hook "
-    "{clear|stop|test-status|validate-evidence|check-cumulative-critic|"
-    "verify-chunk-refs [chunk_id]|verify-coverage|"
-    "check-operator-verification|accept-operator-verification <rationale>|"
-    "check-pr-doc-only|check-pr-trivial|regen-views|infer-critic-mode [args]|"
-    "compute-verify-resolutions-scope}"
-)
-
-
 def main() -> int:
     if len(sys.argv) < 2:
-        print(_USAGE, file=sys.stderr)
+        print("Usage: product-hook {clear|stop|test-status}", file=sys.stderr)
         return 1
 
     command = sys.argv[1]
@@ -4148,33 +2174,8 @@ def main() -> int:
         return cmd_stop(project_dir)
     elif command == "test-status":
         return cmd_test_status(project_dir)
-    elif command == "validate-evidence":
-        return cmd_validate_evidence(project_dir)
-    elif command == "check-cumulative-critic":
-        return cmd_check_cumulative_critic(project_dir)
-    elif command == "verify-chunk-refs":
-        chunk_id = sys.argv[2] if len(sys.argv) > 2 else None
-        return cmd_verify_chunk_refs(project_dir, chunk_id)
-    elif command == "verify-coverage":
-        return cmd_verify_coverage(project_dir)
-    elif command == "check-operator-verification":
-        return cmd_check_operator_verification(project_dir)
-    elif command == "accept-operator-verification":
-        rationale = sys.argv[2] if len(sys.argv) > 2 else None
-        return cmd_accept_operator_verification(project_dir, rationale)
-    elif command == "check-pr-doc-only":
-        return cmd_check_pr_doc_only(project_dir)
-    elif command == "check-pr-trivial":
-        return cmd_check_pr_trivial(project_dir)
-    elif command == "regen-views":
-        return cmd_regen_views(project_dir)
-    elif command == "infer-critic-mode":
-        args = " ".join(sys.argv[2:]) if len(sys.argv) > 2 else None
-        return cmd_infer_critic_mode(project_dir, args)
-    elif command == "compute-verify-resolutions-scope":
-        return cmd_compute_verify_resolutions_scope(project_dir)
     else:
-        print(_USAGE, file=sys.stderr)
+        print("Usage: product-hook {clear|stop|test-status}", file=sys.stderr)
         return 1
 
 

--- a/tools/product-hook
+++ b/tools/product-hook
@@ -34,20 +34,62 @@ def get_prawduct_dir(project_dir: Path) -> Path:
     return project_dir / ".prawduct"
 
 
+# --- Active build-plan resolution (inline mirror of tools/lib/core.py) ---
+# product-hook is standalone in product repos and cannot import tools/lib, so
+# the resolver is duplicated here. Kept in sync with
+# core.resolve_build_plan_path / core.read_str_yaml_key by a parity test
+# (same discipline as the GITIGNORE_ENTRIES / _SESSION_GITIGNORED_PATHS mirror).
+_BUILD_PLAN_POINTER_KEY = "active_build_plan"
+_DEFAULT_BUILD_PLAN_REL = "artifacts/build-plan.md"
+
+
+def _read_str_yaml_key(state_path: Path, key: str) -> str | None:
+    """Value of a top-level (column-0) ``key: value`` scalar, or None."""
+    try:
+        content = state_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    needle = f"{key}:"
+    for raw in content.splitlines():
+        if raw[:1] in (" ", "\t"):
+            continue
+        line = raw.split("#", 1)[0].rstrip()
+        if not line.startswith(needle):
+            continue
+        value = line.split(":", 1)[1].strip().strip("\"'")
+        return value or None
+    return None
+
+
+def _resolve_build_plan_path(prawduct_dir: Path) -> Path:
+    """Resolve the active build plan via the ``active_build_plan:`` pointer
+    (relative to ``.prawduct/``); fall back to ``artifacts/build-plan.md`` when
+    unset, so repos without the pointer are unchanged. May not exist — callers
+    treat a missing plan as no active build plan."""
+    pointer = _read_str_yaml_key(prawduct_dir / "project-state.yaml", _BUILD_PLAN_POINTER_KEY)
+    if pointer:
+        return prawduct_dir / pointer
+    return prawduct_dir / _DEFAULT_BUILD_PLAN_REL
+
+
 # =============================================================================
 # Sync trigger (best-effort on session start)
 # =============================================================================
 
 
-def try_sync(project_dir: Path, *, quiet: bool = False) -> tuple[dict | None, list[dict]]:
+def try_sync(
+    project_dir: Path, *, quiet: bool = False
+) -> tuple[dict | None, list[dict], dict | None]:
     """Attempt to run framework sync. Silently does nothing on any failure.
 
     When quiet=False (default), prints sync actions for Claude's context.
     When quiet=True, runs silently.
 
-    Returns a tuple of (upgrade_info, advisories):
+    Returns a tuple of (upgrade_info, advisories, freshness):
     - upgrade_info: dict with 'previous_version' and 'new_version' if version changed, else None
     - advisories: list of template drift advisory dicts from sync
+    - freshness: dict of framework freshness facts for the briefing, or None
+      when not derivable (no manifest, etc.). See _compute_framework_freshness.
     """
     try:
         manifest_path = project_dir / ".prawduct" / "sync-manifest.json"
@@ -59,7 +101,7 @@ def try_sync(project_dir: Path, *, quiet: bool = False) -> tuple[dict | None, li
             # Prawduct repo without manifest — sync will bootstrap one
             fw_source = os.environ.get("PRAWDUCT_FRAMEWORK_DIR") or ""
         else:
-            return None, []  # Not a prawduct repo
+            return None, [], None  # Not a prawduct repo
 
         # Fall back to sibling ../prawduct if configured source not found
         if not fw_source or not Path(fw_source).is_dir():
@@ -68,14 +110,14 @@ def try_sync(project_dir: Path, *, quiet: bool = False) -> tuple[dict | None, li
                 fw_source = str(sibling)
 
         if not fw_source:
-            return None, []
+            return None, [], None
 
         sync_script = Path(fw_source) / "tools" / "prawduct-setup.py"
         if not sync_script.is_file():
             # Backward compat: fall back to old script name
             sync_script = Path(fw_source) / "tools" / "prawduct-sync.py"
         if not sync_script.is_file():
-            return None, []
+            return None, [], None
 
         result = subprocess.run(
             [sys.executable, str(sync_script), "sync", str(project_dir), "--framework-dir", fw_source, "--json"],
@@ -122,11 +164,97 @@ def try_sync(project_dir: Path, *, quiet: bool = False) -> tuple[dict | None, li
                 pass
         # Check if the framework is stale relative to this product's last sync
         _check_framework_version(project_dir, fw_source, quiet)
-        return upgrade_info, advisories
+        # Compute freshness AFTER sync so the manifest reflects any just-applied updates
+        freshness = _compute_framework_freshness(project_dir, fw_source)
+        return upgrade_info, advisories, freshness
 
     except Exception as e:  # prawduct:ok-broad-except — sync must never block session start
         print(f"NOTE: Framework sync failed: {e}", file=sys.stderr)
-        return None, []
+        return None, [], None
+
+
+def _compute_framework_freshness(project_dir: Path, fw_source: str) -> dict | None:
+    """Compute structured framework freshness facts for the session briefing.
+
+    Returns a dict with the fields below, or None if no sync-manifest exists.
+    Individual fields may be None when their source is unavailable (framework
+    dir not a git repo, manifest predates a schema addition, etc.):
+
+    - framework_head: short SHA of fw_source HEAD, or None if not git
+    - framework_head_date: YYYY-MM-DD of HEAD commit, or None
+    - framework_version: contents of fw_source/VERSION, or None
+    - last_sync_date: YYYY-MM-DD parsed from manifest.last_sync, or None
+    - last_sync_version: manifest.framework_version, or None
+    - last_sync_commit: manifest.framework_commit (recorded at sync time;
+      not present in manifests written before that field was added — those
+      will populate on next sync)
+    - commits_behind: int — commits in fw_source ahead of last_sync_commit,
+      or None when either commit is unavailable
+
+    The three drift dimensions (version, commit, template content) are
+    independent. Callers should not synthesize them into a single answer.
+    """
+    manifest_path = project_dir / ".prawduct" / "sync-manifest.json"
+    if not manifest_path.is_file():
+        return None
+    try:
+        manifest = json.loads(manifest_path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return None
+
+    out: dict[str, object] = {
+        "framework_head": None,
+        "framework_head_date": None,
+        "framework_version": None,
+        "last_sync_date": None,
+        "last_sync_version": manifest.get("framework_version") or None,
+        "last_sync_commit": manifest.get("framework_commit") or None,
+        "commits_behind": None,
+    }
+
+    last_sync = manifest.get("last_sync", "")
+    if last_sync:
+        out["last_sync_date"] = last_sync.split("T", 1)[0]
+
+    fw_dir = Path(fw_source) if fw_source else None
+    if not fw_dir or not fw_dir.is_dir():
+        return out
+
+    version_file = fw_dir / "VERSION"
+    if version_file.is_file():
+        try:
+            out["framework_version"] = version_file.read_text().strip() or None
+        except OSError:
+            pass
+
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(fw_dir), "log", "-1", "--format=%h|%ai", "HEAD"],
+            capture_output=True, text=True, timeout=10,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            parts = result.stdout.strip().split("|", 1)
+            if len(parts) == 2:
+                out["framework_head"] = parts[0]
+                out["framework_head_date"] = parts[1].split(" ", 1)[0]
+    except Exception:  # prawduct:ok-broad-except — best-effort git lookup
+        pass
+
+    if out["last_sync_commit"] and out["framework_head"]:
+        try:
+            result = subprocess.run(
+                ["git", "-C", str(fw_dir), "rev-list", "--count",
+                 f"{out['last_sync_commit']}..HEAD"],
+                capture_output=True, text=True, timeout=10,
+            )
+            if result.returncode == 0:
+                count = result.stdout.strip()
+                if count.isdigit():
+                    out["commits_behind"] = int(count)
+        except Exception:  # prawduct:ok-broad-except — best-effort
+            pass
+
+    return out
 
 
 def _check_framework_version(project_dir: Path, fw_source: str, quiet: bool) -> None:
@@ -335,10 +463,31 @@ _SESSION_GITIGNORED_PATHS = (
     ".prawduct/.session-start",
     ".prawduct/.subagent-briefing.md",
     ".prawduct/.gates-waived",
+    ".prawduct/.sync-pending",
+    ".prawduct/.advisories.json",
     ".prawduct/reflections.md",
     ".prawduct/sync-manifest.json",
     ".prawduct/artifacts/build-plan.md",
 )
+
+
+def _read_advisory_store(prawduct_dir: Path) -> dict:
+    """Read `.prawduct/.advisories.json` (the post-sync nag log).
+
+    Standalone read — product-hook ships into product repos without access to
+    tools/lib, so it cannot import advisory_store. Missing/unreadable/malformed
+    → empty store; never raises (briefing must not break on a bad file).
+    """
+    path = prawduct_dir / ".advisories.json"
+    if not path.is_file():
+        return {"schema_version": 1, "advisories": []}
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return {"schema_version": 1, "advisories": []}
+    if not isinstance(data, dict) or not isinstance(data.get("advisories"), list):
+        return {"schema_version": 1, "advisories": []}
+    return data
 
 
 def _untrack_session_files(project_dir: Path) -> list[str]:
@@ -415,8 +564,10 @@ def tests_are_current(project_dir: Path) -> tuple[bool, str]:
 
     Uses a "trust the cycle" model: evidence is current if it was written
     during this session (timestamp >= session start) and all tests passed.
-    No fingerprinting or content hashing — the build cycle (write code →
-    run tests → Critic reviews) is the trust boundary.
+    No tree-hashing or content fingerprinting (those mechanisms were
+    removed pre-v1.4 after chronic false positives from metadata churn) —
+    the build cycle (write code → run tests → Critic reviews) is the
+    trust boundary.
 
     Falls back to timestamp-only comparison when no session-start marker
     exists (e.g., running outside a governed session).
@@ -436,6 +587,15 @@ def tests_are_current(project_dir: Path) -> tuple[bool, str]:
 
     if not isinstance(evidence, dict):
         return False, "evidence is not a JSON object"
+
+    # Schema check — catches writer typos like ``ran_at`` for ``timestamp`` or
+    # ``num_passed`` for ``passed``. Without this, missing fields silently fall
+    # through ``.get()`` calls and the evidence parses as "no failures, no
+    # timestamp" which the freshness check below would reject for the wrong
+    # reason. Loud failure makes the writer bug obvious.
+    schema_ok, schema_err = _validate_evidence_schema(evidence)
+    if not schema_ok:
+        return False, schema_err
 
     # Test pass/fail check — fail counts make evidence stale regardless of timing.
     failed = evidence.get("failed")
@@ -462,6 +622,112 @@ def tests_are_current(project_dir: Path) -> tuple[bool, str]:
     # Evidence exists with passing tests and a timestamp, but we can't verify
     # it's from this session. Accept it with a note.
     return True, f"evidence has passing tests ({evidence_ts}, no session marker to verify)"
+
+
+_EVIDENCE_REQUIRED_FIELDS: dict[str, tuple[type, ...]] = {
+    "timestamp": (str,),
+    "passed": (int,),
+    "failed": (int,),
+    "skipped": (int,),
+    "duration_seconds": (int, float),
+    "command": (str,),
+}
+
+# v1.4 F4a — coverage-evidence fields. Presence of ``verifier`` is the
+# discriminator: legacy evidence without ``verifier`` validates exactly as
+# before (compat). When ``verifier`` IS present, the writer has opted into
+# the new schema and the other three fields become conditionally required —
+# so writer typos (``coverage`` vs. ``coverage_level``, ``tests_ran`` vs.
+# ``tests_executed``) fail loud instead of silently dropping coverage data.
+_EVIDENCE_COVERAGE_FIELDS: dict[str, tuple[type, ...]] = {
+    "verifier": (str,),
+    "tests_executed": (list,),
+    "changes_referenced": (list,),
+    "coverage_level": (str,),
+}
+_EVIDENCE_COVERAGE_LEVELS = frozenset({"referenced", "executed"})
+
+
+# Critic mode values persisted in .prawduct/.critic-findings.json's `mode` field.
+# Verbose strings are intentional: the JSON is read by humans during session
+# briefings and gate WARNINGs, so the value itself communicates the implication.
+# The bare short tokens ("chunk" / "final") that callers pass via $ARGUMENTS
+# are NOT accepted in the persisted form — `validate_critic_findings` rejects them
+# so writer drift surfaces immediately.
+_CRITIC_MODE_CHUNK = "chunk (lighter pass, not ready for push)"
+_CRITIC_MODE_FINAL = "final (full review, ready for push)"
+_CRITIC_MODE_CUMULATIVE = "cumulative (bundle review, ready for merge)"
+# v1.5 Chunk 02 — verify-resolutions: delta review against prior findings'
+# scope. Cheaper than chunk/final for the common case of "Critic flagged 1-2
+# BLOCKING findings, builder fixed them, re-review pays full latency to
+# confirm the fix." Scope = prior files_reviewed ∪ files changed since
+# `commit_reviewed` (Chunk 01's anchor). Demotes to /critic final when scope
+# widens past `len(delta) > 2 * len(prior) + 5` or when prior findings lack
+# the anchor.
+_CRITIC_MODE_VERIFY_RESOLUTIONS = (
+    "verify-resolutions (delta review, prior findings only)"
+)
+_CRITIC_MODE_VALUES = frozenset({
+    _CRITIC_MODE_CHUNK,
+    _CRITIC_MODE_FINAL,
+    _CRITIC_MODE_CUMULATIVE,
+    _CRITIC_MODE_VERIFY_RESOLUTIONS,
+})
+
+
+def _validate_evidence_schema(evidence: dict) -> tuple[bool, str]:
+    """Reject ``.test-evidence.json`` with missing or wrong-typed fields.
+
+    Catches writer typos that would otherwise silently parse via ``.get()``.
+    Examples this catches: ``ran_at`` instead of ``timestamp``; ``num_passed``
+    instead of ``passed``; passed/failed/skipped emitted as strings.
+
+    v1.4 F4a: when ``verifier`` is present, the writer has opted into the
+    coverage-evidence schema and ``tests_executed`` / ``changes_referenced``
+    / ``coverage_level`` are also required. Legacy evidence (pre-F4a shape:
+    no ``verifier`` field — historically called "fingerprint" though the
+    tree-hash mechanism it referred to was removed pre-v1.4) is accepted
+    unchanged; v1.5 will drop the compat path (see Chunk 10's migration
+    NOTE — `prawduct-setup migrate --enable-coverage` surfaces the
+    deprecation).
+
+    Returns ``(True, "")`` on success, ``(False, reason)`` on failure. Missing
+    fields are reported before wrong-typed fields, so a single fix-it pass
+    addresses the highest-priority violations first.
+    """
+    required = dict(_EVIDENCE_REQUIRED_FIELDS)
+    if "verifier" in evidence:
+        required.update(_EVIDENCE_COVERAGE_FIELDS)
+
+    missing: list[str] = []
+    wrong_type: list[str] = []
+    for field, allowed_types in required.items():
+        if field not in evidence:
+            missing.append(field)
+            continue
+        if not isinstance(evidence[field], allowed_types):
+            wrong_type.append(
+                f"{field} must be {' | '.join(t.__name__ for t in allowed_types)}, "
+                f"got {type(evidence[field]).__name__}"
+            )
+    if missing:
+        return False, f"evidence missing required field(s): {', '.join(sorted(missing))}"
+    if wrong_type:
+        return False, f"evidence schema violation: {'; '.join(wrong_type)}"
+
+    # Enum check for coverage_level — only when the coverage schema is in use
+    # AND the field's type is already known good (str). Bad-type errors are
+    # surfaced by the loop above; here we just refuse out-of-set values.
+    if "verifier" in evidence:
+        level = evidence.get("coverage_level")
+        if isinstance(level, str) and level not in _EVIDENCE_COVERAGE_LEVELS:
+            allowed = ", ".join(sorted(_EVIDENCE_COVERAGE_LEVELS))
+            return False, (
+                f"evidence schema violation: coverage_level must be one of "
+                f"{{{allowed}}}, got {level!r}"
+            )
+
+    return True, ""
 
 
 def _read_gates_waived(prawduct_dir: Path) -> dict[str, str]:
@@ -656,7 +922,8 @@ def staleness_scan(project_dir: Path) -> list[str]:
             pass
 
     # 4. Stale build plan detection — check Status section first, fall back to WIP
-    build_plan_path = prawduct_dir / "artifacts" / "build-plan.md"
+    build_plan_path = _resolve_build_plan_path(prawduct_dir)
+    build_plan_label = f".prawduct/{build_plan_path.relative_to(prawduct_dir).as_posix()}"
     if build_plan_path.is_file():
         try:
             status = _parse_build_plan_status(prawduct_dir)
@@ -665,7 +932,7 @@ def staleness_scan(project_dir: Path) -> list[str]:
             elif status.get("_has_status_items"):
                 # All items checked — work complete
                 findings.append(
-                    "build plan: .prawduct/artifacts/build-plan.md has all chunks complete — "
+                    f"build plan: {build_plan_label} has all chunks complete — "
                     "if work is done, delete the plan"
                 )
             else:
@@ -674,7 +941,7 @@ def staleness_scan(project_dir: Path) -> list[str]:
                 wip = _parse_wip(prawduct_dir, branch=current_branch)
                 if not wip.get("description"):
                     findings.append(
-                        "build plan: .prawduct/artifacts/build-plan.md exists but no active work — "
+                        f"build plan: {build_plan_label} exists but no active work — "
                         "if work is complete, delete the plan"
                     )
         except Exception:  # prawduct:ok-broad-except — staleness scan is best-effort
@@ -876,7 +1143,7 @@ def _parse_build_plan_status(prawduct_dir: Path) -> dict[str, str]:
     description, size, type, current_chunk, context, governance_level.
     Returns empty dict if no build plan or no Status section.
     """
-    plan_path = prawduct_dir / "artifacts" / "build-plan.md"
+    plan_path = _resolve_build_plan_path(prawduct_dir)
     if not plan_path.is_file():
         return {}
     try:
@@ -1055,6 +1322,7 @@ def assemble_session_briefing(
     *,
     upgrade_info: dict | None = None,
     advisories: list[dict] | None = None,
+    freshness: dict | None = None,
 ) -> str:
     """Assemble session briefing text. Target: <400 tokens (excluding handoff pointer)."""
     prawduct_dir = get_prawduct_dir(project_dir)
@@ -1118,12 +1386,145 @@ def assemble_session_briefing(
         for s in staleness:
             lines.append(f"Stale: {s}")
 
-    # Template drift advisories from sync
-    if advisories:
-        lines.append(f"Advisories: {len(advisories)} template(s) have new content since project setup")
+    # Framework freshness — surface only when there's actual drift to reason about.
+    # The three drift dimensions (version, commit, template content) are tracked
+    # separately so the agent doesn't have to derive deltas from raw timestamps.
+    has_commit_delta = bool(freshness and freshness.get("commits_behind"))
+    has_version_delta = bool(
+        freshness
+        and freshness.get("framework_version")
+        and freshness.get("last_sync_version")
+        and freshness["framework_version"] != freshness["last_sync_version"]
+    )
+    if freshness and (has_commit_delta or has_version_delta or advisories):
+        lines.append("Framework freshness:")
+        head = freshness.get("framework_head") or "?"
+        head_date = freshness.get("framework_head_date") or "?"
+        fw_v = freshness.get("framework_version") or "?"
+        sync_commit = freshness.get("last_sync_commit") or "(not recorded)"
+        sync_date = freshness.get("last_sync_date") or "?"
+        sync_v = freshness.get("last_sync_version") or "?"
+        behind = freshness.get("commits_behind")
+        lines.append(f"  Framework HEAD:    {head}  ({head_date})  v{fw_v}")
+        lines.append(f"  Last sync:         {sync_commit}  ({sync_date})  v{sync_v}")
+        if behind is None:
+            if not freshness.get("last_sync_commit"):
+                lines.append("  Commit delta:      unknown — manifest predates commit tracking; will populate on next sync")
+            else:
+                lines.append("  Commit delta:      unknown")
+        elif behind == 0:
+            lines.append("  Commit delta:      in sync")
+        else:
+            lines.append(f"  Commit delta:      {behind} commit(s) since sync")
+        if has_version_delta:
+            lines.append(f"  Version delta:     v{sync_v} → v{fw_v}")
+        if advisories:
+            lines.append(f"  Place-once template advisories: {len(advisories)}")
+            for adv in advisories:
+                short = adv.get("file", "?").rsplit("/", 1)[-1]
+                commit = adv.get("last_changed_commit", "")
+                date = adv.get("last_changed_date", "")
+                subject = adv.get("last_changed_subject", "")
+                if commit:
+                    subject_str = f" — \"{subject}\"" if subject else ""
+                    lines.append(f"    - {short}: changed in {commit} ({date}){subject_str}")
+                else:
+                    lines.append(f"    - {short}: changed since last sync (commit info unavailable)")
+    elif advisories:
+        # Manifest exists but freshness couldn't be computed (e.g., no fw_dir
+        # access). Fall back to the simple advisory list rather than dropping it.
+        lines.append(f"Place-once template advisories: {len(advisories)} template(s) have new content since project setup")
         for adv in advisories:
             msg = adv.get("message", "template drift detected")
             lines.append(f"  - {msg}")
+
+    # ADVISORIES (post-sync) — v1.6.0 Phase 1. The per-clone nag log written by
+    # sync's probe step (`.prawduct/.advisories.json`). Read directly here
+    # because product-hook is standalone and cannot import tools/lib. Active
+    # advisories are listed priority-ordered (urgent→warn→info, then newest
+    # first), capped at 5. Empty active set with nothing newly resolved → omit
+    # the section entirely (spec §5.2 / A5 — no "0 active" noise). Phase 1
+    # ships an empty production probe roster, so this section stays silent
+    # until a feature registers a probe.
+    adv_store = _read_advisory_store(prawduct_dir)
+    adv_all = adv_store.get("advisories", []) if isinstance(adv_store, dict) else []
+    active_adv = [a for a in adv_all if isinstance(a, dict) and a.get("state") == "active"]
+    # Stable two-pass sort: newest-first within each priority band.
+    active_adv.sort(key=lambda a: a.get("triggered_at") or "", reverse=True)
+    _adv_prio = {"urgent": 0, "warn": 1, "info": 2}
+    active_adv.sort(key=lambda a: _adv_prio.get(a.get("priority", "info"), 2))
+    # "Resolved/Dismissed since last session" — entries that transitioned at or
+    # after this session's start stamp (the just-run sync resolves; dismissals
+    # carry their own timestamp).
+    resolved_since = 0
+    dismissed_since = 0
+    session_start_path = prawduct_dir / ".session-start"
+    if session_start_path.is_file():
+        try:
+            session_start_ts = session_start_path.read_text().strip()
+        except OSError:
+            session_start_ts = ""
+        if session_start_ts:
+            resolved_since = sum(
+                1
+                for a in adv_all
+                if isinstance(a, dict)
+                and a.get("state") == "resolved"
+                and (a.get("resolved_at") or "") >= session_start_ts
+            )
+            dismissed_since = sum(
+                1
+                for a in adv_all
+                if isinstance(a, dict)
+                and a.get("state") == "dismissed"
+                and (a.get("dismissed_at") or "") >= session_start_ts
+            )
+    if active_adv or resolved_since or dismissed_since:
+        if active_adv:
+            lines.append(f"ADVISORIES (post-sync, {len(active_adv)} active):")
+            for adv in active_adv[:5]:
+                feature = adv.get("feature", "?")
+                summary = adv.get("trigger_summary", "")
+                lines.append(f"  • [{feature}] {summary}")
+                action = adv.get("recommended_action", "")
+                if action:
+                    aid = adv.get("id", "")
+                    lines.append(f"    → Run {action} (or /prawduct-advisory dismiss {aid})")
+            if len(active_adv) > 5:
+                lines.append(
+                    f"  ... and {len(active_adv) - 5} more (run /prawduct-advisory list)"
+                )
+        else:
+            lines.append("ADVISORIES (post-sync):")
+        if dismissed_since:
+            lines.append(
+                f"  Dismissed since last session: {dismissed_since} "
+                f"(run /prawduct-advisory list --state=dismissed to see)"
+            )
+        if resolved_since:
+            lines.append(f"  Resolved since last session: {resolved_since}")
+
+    # F5a sync-pending marker — surfaces when sync couldn't auto-commit
+    # framework drift because a precondition (WIP, protected branch,
+    # in-progress git op) blocked it. Surface so the user/Claude know there
+    # is uncommitted framework drift that should be resolved.
+    sync_pending_path = prawduct_dir / ".sync-pending"
+    if sync_pending_path.is_file():
+        try:
+            pending = json.loads(sync_pending_path.read_text())
+            reason = pending.get("reason", "unknown")
+            version = pending.get("version", "")
+            v_suffix = f" (v{version})" if version else ""
+            lines.append(
+                f"Framework sync pending{v_suffix}: {reason}. "
+                f"Resolve and commit `.prawduct/`/`CLAUDE.md`/etc. drift, "
+                f"or rerun sync once the blocker clears."
+            )
+        except (json.JSONDecodeError, OSError):
+            lines.append(
+                "Framework sync pending: marker file present but unreadable; "
+                "inspect `.prawduct/.sync-pending`."
+            )
 
     # CLAUDE.md size check
     claude_md_path = project_dir / "CLAUDE.md"
@@ -1152,7 +1553,7 @@ def assemble_session_briefing(
         except Exception:  # prawduct:ok-broad-except — briefing must never block session start
             pass
 
-    # Test count (computed, not tracked)
+    # Test count — informational only; .test-evidence.json is the canonical count
     try:
         test_count = _count_test_functions(project_dir)
         if test_count > 0:
@@ -1747,19 +2148,6 @@ def cmd_clear(project_dir: Path) -> int:
     # Agent-facing messages go to stdout (SessionStart hooks show stdout to the model).
     # stderr is only visible to the user in the terminal, not to the agent.
 
-    # Warn if learnings.md is oversized
-    learnings_path = prawduct_dir / "learnings.md"
-    if learnings_path.is_file():
-        try:
-            size = learnings_path.stat().st_size
-            if size > 8000:  # ~3000 tokens ≈ ~8KB
-                print(
-                    f"NOTE: .prawduct/learnings.md is {size // 1024}KB — recommend pruning to ~3,000 tokens.\n"
-                    f"  Keep concise rules in learnings.md; move detailed root cause analysis to learnings-detail.md."
-                )
-        except Exception:  # prawduct:ok-broad-except — size check must not block session start
-            pass
-
     # Warn if project-state.yaml is oversized
     state_path = prawduct_dir / "project-state.yaml"
     if state_path.is_file():
@@ -1807,7 +2195,7 @@ def cmd_clear(project_dir: Path) -> int:
             )
 
     # Trigger framework sync (best-effort)
-    upgrade_info, sync_advisories = try_sync(project_dir)
+    upgrade_info, sync_advisories, freshness = try_sync(project_dir)
 
     # Capture git status baseline AFTER sync so sync-modified files
     # (settings.json, product-hook, etc.) don't trigger spurious stop-hook gates
@@ -1821,7 +2209,11 @@ def cmd_clear(project_dir: Path) -> int:
         try:
             staleness = staleness_scan(project_dir)
             briefing = assemble_session_briefing(
-                project_dir, staleness, upgrade_info=upgrade_info, advisories=sync_advisories
+                project_dir,
+                staleness,
+                upgrade_info=upgrade_info,
+                advisories=sync_advisories,
+                freshness=freshness,
             )
             print(briefing)
         except Exception as e:  # prawduct:ok-broad-except — briefing must never block session start
@@ -1844,7 +2236,11 @@ def validate_critic_findings(findings_path: Path) -> bool:
     """Validate that critic findings JSON has required structure.
 
     Requires: non-empty files_reviewed list, findings list where each entry
-    has goal/severity/summary, and a non-empty summary string.
+    has goal/severity/summary, and a non-empty summary string. The `mode`
+    field is optional (legacy hooks pre-v1.3.13 omit it) but, when present,
+    must be one of the verbose strings in ``_CRITIC_MODE_VALUES``. The bare
+    short tokens (``"chunk"`` / ``"final"``) are rejected — those are the
+    caller-side input form, not the persistence form.
     """
     try:
         data = json.loads(findings_path.read_text())
@@ -1868,9 +2264,358 @@ def validate_critic_findings(findings_path: Path) -> bool:
         summary = data.get("summary")
         if not isinstance(summary, str) or not summary.strip():
             return False
+        # Mode field is optional (back-compat). If present, must be exactly one
+        # of the verbose strings — bare tokens, unknown strings, and non-string
+        # values are all rejected so writer drift surfaces here, not later.
+        if "mode" in data:
+            mode = data["mode"]
+            if not isinstance(mode, str) or mode not in _CRITIC_MODE_VALUES:
+                return False
+        # v1.5 Chunk 01 — commit_reviewed / base_reviewed anchor the delta
+        # computation for the verify-resolutions mode (Chunk 02). Optional
+        # for back-compat with pre-v1.5 findings files (which simply cannot
+        # serve as a verify-resolutions baseline). When present, must be a
+        # NON-EMPTY string SHA or None — wrong types and empty strings are
+        # writer drift (empty string would silently anchor at no commit,
+        # breaking Chunk 02's delta computation), surfaced here.
+        for sha_field in ("commit_reviewed", "base_reviewed"):
+            if sha_field in data:
+                val = data[sha_field]
+                if val is None:
+                    continue
+                if not isinstance(val, str) or not val.strip():
+                    return False
+        # v1.5 Chunk 03 — mode_chosen_by records which rule fired in the
+        # inference helper, or the literal "explicit-args" when the
+        # builder overrode inference. Optional for back-compat. When
+        # present, must be a non-empty string — empty strings and wrong
+        # types are writer drift (the field's whole purpose is post-hoc
+        # introspection of mode selection; empty defeats that).
+        if "mode_chosen_by" in data:
+            val = data["mode_chosen_by"]
+            if not isinstance(val, str) or not val.strip():
+                return False
         return True
     except Exception:  # prawduct:ok-broad-except — validation must not crash gate check
         return False
+
+
+def _compute_verify_resolutions_scope(
+    prawduct_dir: Path, project_dir: Path
+) -> tuple[list[str], str]:
+    """Compute the file scope a ``/critic verify-resolutions`` pass should review.
+
+    Reads the *prior* ``.prawduct/.critic-findings.json`` (the record the
+    builder is about to re-verify) and returns the union of:
+
+      1. ``files_reviewed`` from the prior record — files the Critic already
+         examined — but only when actionable findings (BLOCKING or WARNING)
+         exist. NOTE-only and clean records have nothing to verify.
+      2. Files changed since ``commit_reviewed`` — anchor recorded in Chunk
+         01 — computed as ``git diff --name-only <commit_reviewed>`` plus
+         untracked files. Mirrors ``_coverage_changed_files``'s diff +
+         ls-files-others union so the verify pass sees the same shape the
+         cumulative-Critic flow does.
+
+    Returns ``(scope, reason)``. ``scope`` is sorted; ``reason`` is human-
+    readable. Successful computations return a non-empty scope and a reason
+    prefixed ``ok:``. All other cases return an empty scope and a categorized
+    reason so the caller (Critic agent or stop-hook gate) can fall safely
+    through to ``/critic chunk`` or ``/critic final``:
+
+      - ``no-findings:`` — prior findings file missing.
+      - ``unreadable-findings:`` — JSON parse or I/O failure.
+      - ``no-commit-reviewed:`` — anchor absent / null / empty. Pre-v1.5
+        records are valid for the schema but cannot serve as a verify
+        baseline; the helper fails closed.
+      - ``no-actionable-findings:`` — only NOTEs (or empty findings). Verify-
+        resolutions has nothing to re-check.
+      - ``invalid-files-reviewed:`` — schema-permitted but unusable
+        (non-list or empty list).
+      - ``unresolved-commit:`` — ``commit_reviewed`` does not resolve in
+        the current repo (rebase, force-push, or simply never on this
+        branch). Cannot compute a delta.
+      - ``git-diff-failed:`` — the diff invocation itself failed.
+      - ``scope-widened:`` — demotion criterion ``len(delta) > 2 * len(prior)
+        + 5`` tripped. The prior surface no longer covers what changed; a
+        partial review would mislead. Fall through to ``/critic final``.
+
+    Fail-closed throughout — when the helper cannot anchor a delta it
+    refuses to compute one rather than silently shrinking the review.
+    """
+    findings_path = prawduct_dir / ".critic-findings.json"
+    if not findings_path.is_file():
+        return [], (
+            "no-findings: .prawduct/.critic-findings.json is missing — "
+            "run /critic chunk or /critic final first"
+        )
+    try:
+        data = json.loads(findings_path.read_text())
+    except (json.JSONDecodeError, OSError) as exc:
+        return [], f"unreadable-findings: {exc}"
+
+    commit_reviewed = data.get("commit_reviewed")
+    if not isinstance(commit_reviewed, str) or not commit_reviewed.strip():
+        return [], (
+            "no-commit-reviewed: prior findings lack commit_reviewed — "
+            "cannot anchor delta. Run /critic chunk or /critic final."
+        )
+
+    findings = data.get("findings")
+    if not isinstance(findings, list):
+        return [], "invalid-findings: prior findings.findings is not a list"
+    actionable = [
+        f for f in findings
+        if isinstance(f, dict) and f.get("severity") in ("blocking", "warning")
+    ]
+    if not actionable:
+        return [], (
+            "no-actionable-findings: prior review had no blocking/warning "
+            "findings — verify-resolutions has nothing to verify. "
+            "Run /critic chunk or /critic final."
+        )
+
+    prior_files = data.get("files_reviewed")
+    if not isinstance(prior_files, list) or not prior_files:
+        return [], (
+            "invalid-files-reviewed: prior findings.files_reviewed is "
+            "missing or empty"
+        )
+    prior_files_set = {f for f in prior_files if isinstance(f, str) and f.strip()}
+
+    # rev-parse with the `^{commit}` peel rejects non-commit refs and SHAs
+    # that don't resolve. fail-closed: any non-0 → no delta computable.
+    proc = subprocess.run(
+        ["git", "rev-parse", "--verify", f"{commit_reviewed}^{{commit}}"],
+        cwd=str(project_dir),
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    if proc.returncode != 0:
+        return [], (
+            f"unresolved-commit: commit_reviewed {commit_reviewed[:12]} "
+            "does not resolve in the current repo — cannot compute delta. "
+            "Run /critic chunk or /critic final."
+        )
+
+    diff_proc = subprocess.run(
+        ["git", "diff", "--name-only", commit_reviewed],
+        cwd=str(project_dir),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if diff_proc.returncode != 0:
+        return [], f"git-diff-failed: {diff_proc.stderr.strip()}"
+    delta_files = {
+        line.strip() for line in diff_proc.stdout.splitlines() if line.strip()
+    }
+
+    ls_proc = subprocess.run(
+        ["git", "ls-files", "--others", "--exclude-standard"],
+        cwd=str(project_dir),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if ls_proc.returncode == 0:
+        delta_files.update(
+            line.strip() for line in ls_proc.stdout.splitlines() if line.strip()
+        )
+
+    # Filter metadata before threshold and scope union. The session-end
+    # gate already ignores ``_is_metadata_path`` files (``.prawduct/``,
+    # ``.claude/settings.json``, etc.) when computing the chunk diff;
+    # counting them here would inflate ``delta_files`` against the
+    # widening threshold and falsely demote a legitimate fix flow whose
+    # only delta beyond the prior surface is incidental state churn
+    # (the very ``.critic-findings.json`` the prior review wrote,
+    # ``.session-reflected``, ``.session-git-baseline``, etc.). Symmetric
+    # with ``_verify_resolutions_gate_check`` — both sides of "what
+    # counts as a chunk file" agree.
+    delta_files = {f for f in delta_files if not _is_metadata_path(f)}
+
+    # Demotion: when the delta has grown well past the prior review's
+    # surface, a verify pass would mislead — most of what changed wasn't
+    # part of the prior review's scope at all. Threshold mirrors the build
+    # plan (Chunk 02): linear factor 2 plus floor 5 so small priors don't
+    # demote on a single unrelated edit.
+    if len(delta_files) > 2 * len(prior_files_set) + 5:
+        return [], (
+            f"scope-widened: {len(delta_files)} files changed since "
+            f"commit_reviewed (prior surface {len(prior_files_set)} files; "
+            f"demotion threshold len(delta) > 2 * prior + 5). Fall through "
+            "to /critic chunk or /critic final."
+        )
+
+    scope = sorted(prior_files_set | delta_files)
+    return scope, (
+        f"ok: scope = {len(scope)} files "
+        f"(prior surface {len(prior_files_set)} + delta {len(delta_files)} "
+        f"since {commit_reviewed[:12]})"
+    )
+
+
+def _verify_resolutions_gate_check(
+    prawduct_dir: Path, project_dir: Path, findings_path: Path
+) -> tuple[bool, str]:
+    """Stop-hook gate helper: when the Critic findings file is in
+    ``verify-resolutions`` mode, accept only when the current chunk diff is
+    a subset of the verify pass's declared scope.
+
+    Returns ``(True, "")`` for any other mode — the standard gate logic
+    applies. For ``verify-resolutions``:
+
+      - ``(True, "")`` — current session-changed files (excluding metadata
+        paths the regular Critic gate also ignores) are all within the
+        findings' ``files_reviewed`` set.
+      - ``(False, reason)`` — at least one chunk-diff file is outside the
+        declared scope. The verify pass is stale relative to the current
+        diff; the gate keeps the block in place and surfaces the reason so
+        the builder runs ``/critic chunk`` or ``/critic final`` instead.
+
+    Fail-closed: a JSON read failure or schema gap returns ``(False, reason)``
+    rather than silently clearing the gate (see learnings: "Escape hatches
+    in classification create silent failures").
+    """
+    try:
+        data = json.loads(findings_path.read_text())
+    except (json.JSONDecodeError, OSError) as exc:
+        return False, (
+            f"verify-resolutions findings unreadable ({exc}). Run /critic "
+            "chunk or /critic final."
+        )
+
+    if data.get("mode") != _CRITIC_MODE_VERIFY_RESOLUTIONS:
+        return True, ""
+
+    files_reviewed = data.get("files_reviewed")
+    if not isinstance(files_reviewed, list):
+        return False, (
+            "verify-resolutions findings have no files_reviewed list. "
+            "Run /critic chunk or /critic final."
+        )
+    scope = {f for f in files_reviewed if isinstance(f, str) and f.strip()}
+
+    session_changed = {
+        f for f in _get_session_changed_files(project_dir)
+        if not _is_metadata_path(f)
+    }
+
+    out_of_scope = sorted(session_changed - scope)
+    if not out_of_scope:
+        return True, ""
+
+    sample = ", ".join(out_of_scope[:3])
+    more = f" (+{len(out_of_scope) - 3} more)" if len(out_of_scope) > 3 else ""
+    return False, (
+        f"verify-resolutions findings declare {len(scope)} file(s) in scope "
+        f"but the current chunk diff includes {len(out_of_scope)} file(s) "
+        f"outside scope ({sample}{more}). Run /critic chunk or /critic final."
+    )
+
+
+def _count_build_plan_chunks(prawduct_dir: Path) -> tuple[int, int]:
+    """Count chunks in build-plan.md's Status section.
+
+    Returns ``(total, complete)``: total chunks declared, and how many are
+    marked ``[x]``. Returns ``(0, 0)`` if the plan is missing, has no Status
+    section, or has no chunk items. Mirrors the parsing rules in
+    ``_parse_build_plan_status`` (skip HTML comments; exit on next ``## ``).
+    """
+    plan_path = _resolve_build_plan_path(prawduct_dir)
+    if not plan_path.is_file():
+        return 0, 0
+    try:
+        content = plan_path.read_text()
+        in_status = False
+        in_comment = False
+        total = 0
+        complete = 0
+        for line in content.splitlines():
+            stripped = line.strip()
+            if stripped == "## Status":
+                in_status = True
+                continue
+            if not in_status:
+                continue
+            if stripped.startswith("## ") and stripped != "## Status":
+                break
+            if "<!--" in stripped:
+                in_comment = True
+            if "-->" in stripped:
+                in_comment = False
+                continue
+            if in_comment:
+                continue
+            if stripped.startswith("- [ ]"):
+                total += 1
+            elif stripped.startswith("- [x]") or stripped.startswith("- [X]"):
+                total += 1
+                complete += 1
+        return total, complete
+    except Exception:  # prawduct:ok-broad-except — gate check must not crash session end
+        return 0, 0
+
+
+_CRITIC_MODE_GOALS_1_3_ONLY = frozenset({
+    _CRITIC_MODE_CHUNK,
+    _CRITIC_MODE_VERIFY_RESOLUTIONS,
+})
+
+
+def _critic_session_satisfies_gate(prawduct_dir: Path) -> tuple[bool, str]:
+    """Check whether the latest Critic findings satisfy end-of-cycle synthesis.
+
+    Returns ``(True, "")`` when the gate is satisfied, ``(False, reason)``
+    otherwise. The gate is advisory: it fires when a multi-chunk build plan
+    has all chunks marked ``[x]`` but the most recent Critic review ran
+    Goals 1-3 only — ``chunk`` and ``verify-resolutions`` modes both skip
+    end-of-cycle goals (Coherence, Design, Learnings Cross-Check, Backlog
+    Reconciliation, Framework-Specific Checks). v1.5 Chunk 02 extended the
+    case-4 trigger to verify-resolutions so a plan that closes with a delta
+    re-review doesn't silently bypass final-mode synthesis.
+
+    Specific cases (in order):
+    1. No build plan, or no chunks declared → satisfied (non-chunked work).
+    2. Single-chunk plan → satisfied (the one Critic run is the final).
+    3. Multi-chunk plan with incomplete chunks → satisfied (mid-cycle).
+    4. Multi-chunk plan, all chunks ``[x]``, latest mode is in
+       ``_CRITIC_MODE_GOALS_1_3_ONLY`` (chunk or verify-resolutions)
+       → unsatisfied. Run ``/critic final`` for end-of-cycle synthesis.
+    5. Multi-chunk plan, all chunks ``[x]``, latest mode is ``_CRITIC_MODE_FINAL``
+       (or absent — legacy records default to final), or ``_CRITIC_MODE_CUMULATIVE``
+       → satisfied (full goal set ran).
+
+    Caller is expected to invoke this only after the existing critic-required
+    blocker has cleared (i.e. findings exist and ``validate_critic_findings``
+    returned True). Defensive checks here keep the helper standalone-safe.
+    """
+    total, complete = _count_build_plan_chunks(prawduct_dir)
+    if total == 0:
+        return True, ""
+    if total == 1:
+        return True, ""
+    if complete < total:
+        return True, ""
+
+    findings_path = prawduct_dir / ".critic-findings.json"
+    if not findings_path.is_file():
+        return True, ""
+    try:
+        data = json.loads(findings_path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return True, ""
+    mode = data.get("mode", _CRITIC_MODE_FINAL)
+    if mode in _CRITIC_MODE_GOALS_1_3_ONLY:
+        return False, (
+            f"All {total} chunks complete; last Critic review was "
+            f"'{mode}'. Run /critic final for end-of-cycle "
+            "synthesis (Coherence, Design, Learnings Cross-Check, Backlog "
+            "Reconciliation) before pushing."
+        )
+    return True, ""
 
 
 def _has_build_plan_in_state(prawduct_dir: Path) -> bool:
@@ -1994,6 +2739,12 @@ def cmd_stop(project_dir: Path) -> int:
                 "  If this session produced a durable lesson (a rule future sessions should follow),\n"
                 "  also add it to .prawduct/learnings.md. Learnings are concise standing rules;\n"
                 "  the session reflection is the story behind them.\n"
+                "\n"
+                "  Escape hatch: if this gate cannot be satisfied this session (rare for reflection —\n"
+                "  it is meant to be cheap), declare a waiver so this gate stops re-firing:\n"
+                "    echo '{\"reflection\": \"reason — be specific\"}' > .prawduct/.gates-waived\n"
+                "  Empty reasons are rejected; the file auto-clears next session. See\n"
+                "  .prawduct/build-governance.md \"Gate Waivers\" for when this is appropriate.\n"
             )
     elif (
         has_changes
@@ -2015,8 +2766,64 @@ def cmd_stop(project_dir: Path) -> int:
     # noted when the gate would have actually blocked (valid findings absent).
     # `has_changes` already reflects baseline-aware diff via git_has_session_changes,
     # so no extra "code changes" check is needed beyond `not doc_only`.
+    #
+    # v1.4 F6 — Type: designer-handoff also skips the gate (formalizes the
+    # prior user-memory carveout into a framework rule). Other declared types
+    # (code, doc-only, cleanup, cumulative-final) leave the gate behavior
+    # unchanged — only Critic's *protocol* adjusts inside the agent.
+    designer_handoff_skip = False
+    # v1.5 Chunk 04 — Type: trivial fileset + rationale enforcement. The
+    # checks fire BEFORE the Critic gate and emit BLOCKING for any
+    # violation, but the chunk is still treated as `code` for gate
+    # purposes (so the Critic gate still applies on top). Fail-closed:
+    # over-declaring `trivial` produces a named blocker pointing at the
+    # specific bound violated, never a silent carveout. The trivial
+    # check does NOT honor the doc-only skip — bounds like
+    # "no edits under agents/" matter even when the diff is empirically
+    # all-.md (the agents/ tree itself is pure prose). Doc-only only
+    # carves out the Critic protocol (which has no code to review); the
+    # trivial-declaration contract is independent.
+    trivial_block_reason = ""
+    if has_changes and has_build_plan:
+        current_chunk_id = _current_chunk_id_from_status(prawduct_dir)
+        if current_chunk_id is not None:
+            chunk_type, type_error = _parse_build_plan_chunk_type(prawduct_dir, current_chunk_id)
+            # v1.5.1 Chunk 04(a): surface typo'd Type values. Pre-fix, the
+            # parser's "unknown type: ..." message was discarded so the author
+            # never saw it. Surfacing in waiver_notes makes the typo visible
+            # at session-end and in the next stop-hook briefing without
+            # changing fail-closed semantics (chunk still runs as `code` per
+            # parser default). Restricted to "unknown type:" errors only —
+            # "chunk not found" / "missing build-plan" errors indicate a
+            # structural fixture issue, not actionable user feedback.
+            if type_error and type_error.startswith("unknown type:"):
+                waiver_notes.append(f"chunk-type-parse-error: {type_error}")
+            if chunk_type == "designer-handoff" and not doc_only:
+                designer_handoff_skip = True
+                waiver_notes.append(
+                    f"critic: skipped (Chunk {current_chunk_id} declares Type: designer-handoff — v1.4 F6 carveout)"
+                )
+            elif chunk_type == "trivial":
+                fileset_ok, fileset_reason = _is_trivial_fileset_eligible(project_dir)
+                if not fileset_ok:
+                    trivial_block_reason = fileset_reason
+                else:
+                    _, rationale_error = _parse_build_plan_chunk_trivial_rationale(
+                        prawduct_dir, current_chunk_id
+                    )
+                    if rationale_error:
+                        trivial_block_reason = rationale_error
+
     critic_would_block = False
-    if has_changes and has_build_plan and not doc_only:
+    # v1.5 Chunk 02: when the fresh, schema-valid findings file is in
+    # verify-resolutions mode, the gate must also confirm that the current
+    # chunk diff is a subset of the verify pass's declared scope. Out-of-
+    # scope means the builder added work after the verify pass — the
+    # findings are stale relative to the current diff. The reason string is
+    # surfaced verbatim in the blocker so the builder knows which files
+    # widened the scope.
+    verify_resolutions_block_reason = ""
+    if has_changes and has_build_plan and not doc_only and not designer_handoff_skip:
         critic_would_block = True
         critic_findings = prawduct_dir / ".critic-findings.json"
         session_start_file = prawduct_dir / ".session-start"
@@ -2027,20 +2834,76 @@ def cmd_stop(project_dir: Path) -> int:
                     critic_findings.stat().st_mtime, tz=timezone.utc
                 ).strftime("%Y-%m-%dT%H:%M:%SZ")
                 if findings_mtime > session_start and validate_critic_findings(critic_findings):
-                    critic_would_block = False
+                    in_scope, scope_reason = _verify_resolutions_gate_check(
+                        prawduct_dir, project_dir, critic_findings
+                    )
+                    if in_scope:
+                        critic_would_block = False
+                    else:
+                        verify_resolutions_block_reason = scope_reason
             except Exception:  # prawduct:ok-broad-except — gate check must not crash session end
                 pass
 
     if critic_would_block:
         if "critic" in waivers:
             waiver_notes.append(f"critic: waived ({waivers['critic']})")
+        elif verify_resolutions_block_reason:
+            blockers.append(
+                "CRITIC REVIEW (verify-resolutions stale): "
+                f"{verify_resolutions_block_reason}\n"
+                "  Verify-resolutions findings clear the gate only when the current chunk\n"
+                "  diff is within the verify pass's declared scope. The chunk has grown\n"
+                "  beyond that surface, so the prior review's conclusions no longer cover\n"
+                "  what changed. Re-run with a wider mode before ending the session.\n"
+                "\n"
+                "  Escape hatch: if Critic cannot run this session (e.g., wider mode is\n"
+                "  blocked by an external dependency), declare a waiver so this gate stops\n"
+                "  re-firing every turn:\n"
+                "    echo '{\"critic\": \"reason — be specific\"}' > .prawduct/.gates-waived\n"
+                "  Empty reasons are rejected; the file auto-clears next session. See\n"
+                "  .prawduct/build-governance.md \"Gate Waivers\" for when this is appropriate.\n"
+            )
         else:
             blockers.append(
                 "CRITIC REVIEW: The build plan includes Critic review in each chunk's \"Done when\" steps,\n"
                 "  but no Critic findings were recorded this session. If you have completed a chunk,\n"
                 "  run `/critic` now. The Critic reads .prawduct/critic-review.md for instructions\n"
                 "  and records findings to .prawduct/.critic-findings.json\n"
+                "\n"
+                "  Escape hatch: if Critic legitimately cannot run this session — e.g., the chunk\n"
+                "  is in a designer-handoff phase (mark `Type: designer-handoff` in the build plan\n"
+                "  to skip this gate automatically), or the GO/NO-GO is not yet verifiable because\n"
+                "  it depends on a human authoring step or external system — declare a waiver so\n"
+                "  this gate stops re-firing every turn:\n"
+                "    echo '{\"critic\": \"reason — be specific\"}' > .prawduct/.gates-waived\n"
+                "  Empty reasons are rejected; the file auto-clears next session. See\n"
+                "  .prawduct/build-governance.md \"Gate Waivers\" for when this is appropriate.\n"
             )
+
+    # v1.5 Chunk 04: Type: trivial enforcement runs alongside the Critic
+    # gate (not in place of it). The chunk is still treated as `code`
+    # for gate purposes; this block adds a separate BLOCKING if either
+    # the file-set bound or rationale presence failed.
+    if trivial_block_reason:
+        blockers.append(
+            f"TYPE: TRIVIAL — declared but {trivial_block_reason}.\n"
+            "  Either fix the violation or change Type to `code`.\n"
+        )
+
+    # Gate 2.5: Advisory mode gate — fires only when Gate 2 passed, which
+    # already enforces this-session freshness on the findings file. So if we
+    # reach this branch, the findings represent a real review the agent ran
+    # this session; the gate doesn't need to re-check freshness. When all
+    # chunks of a multi-chunk plan are complete but the latest review was
+    # chunk-mode, end-of-cycle synthesis (Coherence, Design, Learnings
+    # Cross-Check, Backlog Reconciliation) hasn't run. Advisory NOT blocking —
+    # chunk-mode reviews are valid mid-cycle, and the builder may legitimately
+    # defer the final review (e.g., next session).
+    if has_changes and not doc_only and not critic_would_block:
+        mode_satisfied, mode_reason = _critic_session_satisfies_gate(prawduct_dir)
+        if not mode_satisfied:
+            print("", file=sys.stderr)
+            print(f"NOTE: {mode_reason}", file=sys.stderr)
 
     # Gate 3: PR review evidence (when a PR exists for the current branch).
     # Skipped for doc-only changes. The waiver is only noted when the gate
@@ -2070,20 +2933,37 @@ def cmd_stop(project_dir: Path) -> int:
                         pass
 
                 if has_pr:
-                    # Check for review evidence with content validation
-                    branch_file = current_branch.replace("/", "--") + ".json"
-                    evidence_path = pr_reviews_dir / branch_file
-                    pr_review_valid = False
-                    if evidence_path.is_file():
-                        try:
-                            data = json.loads(evidence_path.read_text())
-                            if isinstance(data.get("findings"), list) and data.get("summary"):
-                                pr_review_valid = True
-                        except (json.JSONDecodeError, OSError):
-                            pass
-                    if not pr_review_valid:
-                        pr_would_block = True
-                        pr_block_branch = current_branch
+                    # Symmetry with `/pr create` Steps 1b/1c: when the PR diff
+                    # is doc-only (all .md) or trivial (every commit fileset-
+                    # eligible per Chunk 04 bounds), the cumulative-Critic and
+                    # PR-reviewer gates were legitimately skipped at create-
+                    # time and no evidence file was written. Gate 3 would
+                    # otherwise block session end with a misleading "no review
+                    # evidence" error for a PR that doesn't need one. If a
+                    # later session adds non-.md or fileset-violating commits,
+                    # both checks return False and the gate fires as intended
+                    # — matching the create-flow contract.
+                    pr_is_doc_only, _ = _pr_diff_is_doc_only(project_dir)
+                    pr_is_trivial, _ = (
+                        (False, "") if pr_is_doc_only else _pr_diff_is_trivial(project_dir)
+                    )
+                    if pr_is_doc_only or pr_is_trivial:
+                        pass  # Fast-path eligible — no evidence required
+                    else:
+                        # Check for review evidence with content validation
+                        branch_file = current_branch.replace("/", "--") + ".json"
+                        evidence_path = pr_reviews_dir / branch_file
+                        pr_review_valid = False
+                        if evidence_path.is_file():
+                            try:
+                                data = json.loads(evidence_path.read_text())
+                                if isinstance(data.get("findings"), list) and data.get("summary"):
+                                    pr_review_valid = True
+                            except (json.JSONDecodeError, OSError):
+                                pass
+                        if not pr_review_valid:
+                            pr_would_block = True
+                            pr_block_branch = current_branch
         except Exception:  # prawduct:ok-broad-except — gate check must not crash session end
             pass
 
@@ -2095,6 +2975,14 @@ def cmd_stop(project_dir: Path) -> int:
                 f"PR REVIEW: PR exists for branch '{pr_block_branch}' but no valid review evidence found.\n"
                 "  Run /pr to invoke the PR reviewer before merging.\n"
                 "  The reviewer writes evidence to .prawduct/.pr-reviews/<branch>.json\n"
+                "\n"
+                "  Escape hatch: if PR review cannot run this session (e.g., reviewer agent is\n"
+                "  unavailable and merge is not imminent), declare a waiver so this gate stops\n"
+                "  re-firing every turn:\n"
+                "    echo '{\"pr\": \"reason — be specific\"}' > .prawduct/.gates-waived\n"
+                "  Empty reasons are rejected; the file auto-clears next session. PR review is\n"
+                "  the release-readiness gate — waive only when merge will not happen this\n"
+                "  session. See .prawduct/build-governance.md \"Gate Waivers\".\n"
             )
 
     # Surface any waivers so the agent (and reviewer) can see what was skipped.
@@ -2156,13 +3044,1248 @@ def cmd_test_status(project_dir: Path) -> int:
 
 
 # =============================================================================
+# validate-evidence command
+# =============================================================================
+
+
+def cmd_validate_evidence(project_dir: Path) -> int:
+    """Schema-only check on ``.test-evidence.json``.
+
+    Useful for CI / pre-commit hooks that want a fast schema sanity check
+    without the freshness comparison ``test-status`` performs. Returns
+    exit 0 only when the file exists, parses, and matches the required
+    schema; exit 1 otherwise.
+    """
+    evidence_path = get_prawduct_dir(project_dir) / ".test-evidence.json"
+    if not evidence_path.is_file():
+        print(f"missing: {evidence_path}", file=sys.stderr)
+        return 1
+    try:
+        evidence = json.loads(evidence_path.read_text())
+    except (json.JSONDecodeError, OSError) as exc:
+        print(f"unreadable: {exc}", file=sys.stderr)
+        return 1
+    if not isinstance(evidence, dict):
+        print("evidence is not a JSON object", file=sys.stderr)
+        return 1
+    ok, err = _validate_evidence_schema(evidence)
+    if not ok:
+        print(f"invalid: {err}", file=sys.stderr)
+        return 1
+    print("valid")
+    return 0
+
+
+# =============================================================================
+# check-cumulative-critic command (v1.4 F2 — PR gate)
+# =============================================================================
+
+
+_BUILD_PLAN_PATH_RE = re.compile(r"`([^`\s]+)`")
+_BUILD_PLAN_NEW_QUALIFIER_RE = re.compile(r"\bnew\s+`([^`\s]+)`")
+# Per-chunk Type declaration (v1.4 F6 — proportional Critic via chunk type).
+# Matches `- **Type:** <token>` or `**Type:** <token>` as a list item; trailing
+# parenthetical prose is allowed and ignored.
+_BUILD_PLAN_TYPE_RE = re.compile(r"^[\s\-\*]*\*\*Type:\*\*\s*([A-Za-z][\w\-]*)")
+# v1.5 Chunk 04 — `trivial` joins the allowed set. File-set bounds (no
+# edits under agents/, methodology/, templates/; no CLAUDE.md edit; no
+# test deletion; no new files) + required `**Trivial because:**`
+# rationale are enforced structurally; semantic-fit is Critic Goal 3 in
+# Chunk 05. Size is unbounded — trivial is a semantic claim, not a LOC
+# metric.
+_BUILD_PLAN_ALLOWED_TYPES = frozenset(
+    {"code", "doc-only", "cleanup", "designer-handoff", "cumulative-final", "trivial"}
+)
+# `**Trivial because:** <rationale>` — first line; continuation lines (no
+# list-item / heading prefix) are joined onto the rationale until the next
+# field. Empty after the colon → missing-rationale.
+_BUILD_PLAN_TRIVIAL_RATIONALE_RE = re.compile(
+    r"^[\s\-\*]*\*\*Trivial because:\*\*\s*(.*)$"
+)
+
+
+def _looks_like_file_path(token: str) -> bool:
+    """A backticked token is a precise file-path reference only when it
+    contains ``/`` — i.e. the chunk author wrote a specific relative path.
+    Bare filenames in prose (e.g. ``backlog.md``, ``SKILL.md``) are usually
+    conceptual references whose actual location varies, so they're not
+    verifiable in a useful way.
+
+    Slash-commands (``/pr``, ``/learnings``, ``/critic``) also contain
+    ``/`` but are not file paths. Exclude tokens that start with ``/``,
+    have no further ``/``, and contain no ``.`` — that shape is a single
+    slash-command identifier, not a path."""
+    if "/" not in token:
+        return False
+    if token.startswith("/") and "/" not in token[1:] and "." not in token:
+        return False
+    return True
+
+
+def _parse_build_plan_chunk_refs(prawduct_dir: Path, chunk_id: str) -> dict:
+    """Extract backticked file-path references from a single chunk's section
+    in ``.prawduct/artifacts/build-plan.md``.
+
+    The section is located by name (``### Chunk <chunk_id>:`` prefix, leading
+    zeros tolerant), and parsing stops at the next ``### `` or ``## `` heading
+    — sibling chunks' refs are NOT returned. Fenced code blocks (```...```)
+    are skipped because project-structure diagrams aren't load-bearing prose.
+    Paths preceded by the word ``new`` on the same line are skipped as
+    intra-chunk forward references (files the chunk creates rather than
+    modifies).
+
+    Returns ``{"file_paths": [{"line_num": int, "ref": str}, ...],
+    "error": str | None}``. Symbol and backlog-ID extraction are deferred —
+    see Chunk 02 plan-vs-execution divergence (commit message).
+    """
+    result: dict = {"file_paths": [], "error": None}
+    plan_path = _resolve_build_plan_path(prawduct_dir)
+    if not plan_path.is_file():
+        result["error"] = f"missing build-plan: {plan_path}"
+        return result
+    try:
+        content = plan_path.read_text()
+    except OSError as exc:
+        result["error"] = f"unreadable build-plan: {exc}"
+        return result
+
+    # Normalize chunk_id: strip leading zeros for matching ("02" matches
+    # "### Chunk 2:" and vice versa) but report the original in errors.
+    target = chunk_id.lstrip("0") or "0"
+
+    in_section = False
+    in_fence = False
+    section_lines: list[tuple[int, str]] = []
+    for line_num, line in enumerate(content.splitlines(), start=1):
+        stripped = line.strip()
+        if stripped.startswith("### Chunk "):
+            # Heading format: "### Chunk NN: Name"
+            rest = stripped[len("### Chunk "):]
+            head = rest.split(":", 1)[0].strip()
+            head_norm = head.lstrip("0") or "0"
+            if in_section:
+                # Entered a sibling chunk; stop accumulating.
+                break
+            if head_norm == target:
+                in_section = True
+            continue
+        if not in_section:
+            continue
+        if stripped.startswith("## "):
+            # Left the Build Chunks section entirely.
+            break
+        if stripped.startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        section_lines.append((line_num, line))
+
+    if not in_section and not section_lines:
+        result["error"] = f"chunk {chunk_id!r} not found in build-plan"
+        return result
+
+    seen: set[tuple[str, int]] = set()
+    for line_num, line in section_lines:
+        # Collect spans preceded by "new " — these get filtered out.
+        excluded_spans: list[tuple[int, int]] = [
+            m.span(1) for m in _BUILD_PLAN_NEW_QUALIFIER_RE.finditer(line)
+        ]
+        for match in _BUILD_PLAN_PATH_RE.finditer(line):
+            token = match.group(1)
+            if not _looks_like_file_path(token):
+                continue
+            if any(start == match.start(1) for start, _ in excluded_spans):
+                continue
+            key = (token, line_num)
+            if key in seen:
+                continue
+            seen.add(key)
+            result["file_paths"].append({"line_num": line_num, "ref": token})
+    return result
+
+
+def _parse_build_plan_chunk_type(
+    prawduct_dir: Path, chunk_id: str
+) -> tuple[str | None, str | None]:
+    """Extract the `Type:` declaration from a chunk's build-plan section.
+
+    Returns ``(chunk_type, error)``. ``chunk_type`` is one of
+    ``code | doc-only | cleanup | designer-handoff | cumulative-final | trivial``.
+    Default (field absent) is ``code`` — fail-closed so a missing declaration
+    runs the full Critic protocol rather than silently triggering a carveout
+    (learnings: "escape hatches in classification create silent failures").
+    Unknown values surface as ``(None, "unknown type: <value>")`` so the
+    author fixes the typo instead of getting silent fall-through.
+
+    Section discovery mirrors ``_parse_build_plan_chunk_refs`` — name-anchored
+    on ``### Chunk <chunk_id>:`` with leading-zero tolerance; fenced code
+    blocks are skipped.
+    """
+    plan_path = _resolve_build_plan_path(prawduct_dir)
+    if not plan_path.is_file():
+        return None, f"missing build-plan: {plan_path}"
+    try:
+        content = plan_path.read_text()
+    except OSError as exc:
+        return None, f"unreadable build-plan: {exc}"
+
+    target = chunk_id.lstrip("0") or "0"
+
+    in_section = False
+    in_fence = False
+    section_found = False
+    declared: str | None = None
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("### Chunk "):
+            rest = stripped[len("### Chunk "):]
+            head = rest.split(":", 1)[0].strip()
+            head_norm = head.lstrip("0") or "0"
+            if in_section:
+                break  # hit sibling chunk
+            if head_norm == target:
+                in_section = True
+                section_found = True
+            continue
+        if not in_section:
+            continue
+        if stripped.startswith("## "):
+            break
+        if stripped.startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        m = _BUILD_PLAN_TYPE_RE.match(line)
+        if m:
+            declared = m.group(1)
+            break
+
+    if not section_found:
+        return None, f"chunk {chunk_id!r} not found in build-plan"
+
+    if declared is None:
+        return "code", None  # fail-closed default
+    if declared not in _BUILD_PLAN_ALLOWED_TYPES:
+        allowed = ", ".join(sorted(_BUILD_PLAN_ALLOWED_TYPES))
+        return None, f"unknown type: {declared!r} (allowed: {allowed})"
+    return declared, None
+
+
+def _parse_build_plan_chunk_trivial_rationale(
+    prawduct_dir: Path, chunk_id: str
+) -> tuple[str | None, str | None]:
+    """Extract the ``**Trivial because:**`` rationale from a chunk's section.
+
+    Returns ``(rationale, error)``. Empty or absent field → ``(None,
+    "missing-rationale: Type: trivial requires non-empty **Trivial
+    because:** field")``. Multi-line rationale (continuation lines without
+    a list-item / heading prefix) is joined into a single string until the
+    next field.
+
+    Section discovery mirrors ``_parse_build_plan_chunk_type`` —
+    name-anchored on ``### Chunk <chunk_id>:`` with leading-zero
+    tolerance; fenced code blocks are skipped.
+    """
+    plan_path = _resolve_build_plan_path(prawduct_dir)
+    if not plan_path.is_file():
+        return None, f"missing build-plan: {plan_path}"
+    try:
+        content = plan_path.read_text()
+    except OSError as exc:
+        return None, f"unreadable build-plan: {exc}"
+
+    target = chunk_id.lstrip("0") or "0"
+
+    in_section = False
+    in_fence = False
+    section_found = False
+    capturing = False
+    rationale_lines: list[str] = []
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("### Chunk "):
+            rest = stripped[len("### Chunk "):]
+            head = rest.split(":", 1)[0].strip()
+            head_norm = head.lstrip("0") or "0"
+            if in_section:
+                break  # hit sibling chunk
+            if head_norm == target:
+                in_section = True
+                section_found = True
+            continue
+        if not in_section:
+            continue
+        if stripped.startswith("## "):
+            break
+        if stripped.startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        m = _BUILD_PLAN_TRIVIAL_RATIONALE_RE.match(line)
+        if m:
+            capturing = True
+            first = m.group(1).strip()
+            if first:
+                rationale_lines.append(first)
+            continue
+        if capturing:
+            # Stop at the next list-item field, bolded label, or sub-heading.
+            if (
+                stripped.startswith("- **")
+                or stripped.startswith("* **")
+                or stripped.startswith("**")
+                or stripped.startswith("#")
+            ):
+                break
+            if stripped:
+                rationale_lines.append(stripped)
+
+    if not section_found:
+        return None, f"chunk {chunk_id!r} not found in build-plan"
+    if not capturing:
+        return None, (
+            "missing-rationale: Type: trivial requires non-empty "
+            "**Trivial because:** field"
+        )
+    rationale = " ".join(rationale_lines).strip()
+    if not rationale:
+        return None, (
+            "missing-rationale: Type: trivial requires non-empty "
+            "**Trivial because:** field"
+        )
+    return rationale, None
+
+
+def _classify_trivial_change(
+    *,
+    path: str,
+    src_path: str | None,
+    is_addition: bool,
+    is_deletion: bool,
+) -> str | None:
+    """Single-file path-rule check for the ``Type: trivial`` file-set
+    bounds. Returns the violation reason or ``None`` when the change
+    is eligible. Shared by ``_is_trivial_fileset_eligible`` (Chunk 04 —
+    working-tree porcelain) and ``_pr_diff_is_trivial`` (Chunk 05 —
+    per-commit name-status diff). Centralizing the rule set prevents
+    the stop-hook gate and the PR-boundary gate from drifting apart
+    silently.
+
+    Metadata paths (``.prawduct/``, ``.claude/settings.json``, etc. —
+    see ``_is_metadata_path``) are treated as out-of-scope and return
+    ``None``. The check applies to BOTH ``path`` (rename dst / single-
+    file change) AND ``src_path`` (rename src) — without that
+    symmetry, a rename FROM a metadata path that landed somewhere
+    interesting would silently be classified, and a rename TO a
+    metadata path would be classified differently depending on which
+    gate ran (the callers previously did dst-only filtering before
+    calling this helper — v1.5.1 Chunk 04(b) consolidates).
+
+    The caller translates its status format into the boolean inputs
+    (porcelain handles 2-char codes; name-status handles single-char).
+    Path bounds are catastrophic-blast-radius classes regardless of
+    size — size is intentionally not a bound.
+    """
+    if _is_metadata_path(path):
+        return None
+    if src_path is not None and _is_metadata_path(src_path):
+        return None
+    if path == "CLAUDE.md":
+        return f"claude-md-edited: {path}"
+    if path.startswith("agents/"):
+        return f"agent-file-edited: {path}"
+    if path.startswith("methodology/"):
+        return f"methodology-edited: {path}"
+    if path.startswith("templates/"):
+        return f"template-edited: {path}"
+    if is_deletion and path.startswith("tests/"):
+        return f"test-file-deleted: {path}"
+    if src_path is not None and src_path.startswith("tests/"):
+        return f"test-file-deleted: {src_path} (renamed out)"
+    if is_addition:
+        return f"new-file: {path}"
+    return None
+
+
+def _is_trivial_fileset_eligible(project_dir: Path) -> tuple[bool, str]:
+    """Check the current session's diff against the ``Type: trivial``
+    file-set bounds. Returns ``(eligible, reason)``.
+
+    Bounds (catastrophic-blast-radius classes, regardless of size):
+    no edits under ``agents/``, ``methodology/``, or ``templates/``; no
+    edits to ``CLAUDE.md``; no test-file removals (porcelain ``D`` under
+    ``tests/`` OR rename whose source path is under ``tests/`` — a
+    ``git mv`` out of the test directory is semantically a deletion);
+    no newly-tracked files (porcelain ``A`` or ``??``).
+
+    Size is intentionally NOT a bound — trivial is a semantic judgment.
+    An 80-LOC project-wide rename can qualify; a 5-line state-machine
+    change cannot. The semantic claim lives in
+    ``**Trivial because:**``; Critic Goal 3 validates rationale-vs-diff
+    fit (Chunk 05).
+
+    Reason strings name the specific bound that failed for actionable
+    stop-hook messaging — e.g. ``"agent-file-edited: agents/critic/SKILL.md"``.
+    The first violating file wins (deterministic order: porcelain
+    output ordering); the user fixes one violation at a time.
+
+    Uses session-baseline filtering so pre-session dirt doesn't count
+    against the chunk (mirrors ``git_has_session_changes``).
+
+    Path-bound rules are delegated to ``_classify_trivial_change`` so
+    the PR-boundary helper (``_pr_diff_is_trivial``) applies an
+    identical rule set — same bounds checked at session-end and at
+    PR creation.
+    """
+    output = git_status_output(project_dir)
+    if output is None:
+        # No git or git error — defer to other gates; treat as eligible
+        # so the trivial check doesn't fail the build when git itself is
+        # the problem.
+        return True, ""
+
+    prawduct_dir = get_prawduct_dir(project_dir)
+    baseline_path = prawduct_dir / ".session-git-baseline"
+    baseline_lines: set[str] = set()
+    if baseline_path.is_file():
+        try:
+            baseline_lines = set(baseline_path.read_text().splitlines())
+        except (UnicodeDecodeError, OSError):
+            pass
+
+    for line in output.splitlines():
+        if not line or line in baseline_lines:
+            continue
+        if len(line) < 4:
+            continue
+        status = line[:2]
+        raw = line[3:].strip()
+        src_path: str | None = None
+        if " -> " in raw:
+            src_raw, dst_raw = raw.split(" -> ", 1)
+            src_path = src_raw.strip()
+            if src_path.startswith('"') and src_path.endswith('"'):
+                src_path = src_path[1:-1]
+            path = dst_raw.strip()
+        else:
+            path = raw
+        if path.startswith('"') and path.endswith('"'):
+            path = path[1:-1]
+        if not path:
+            continue
+
+        # v1.5.1 Chunk 04(b): metadata-path filtering lives inside
+        # `_classify_trivial_change` (returns None for both src and dst
+        # metadata paths). Single check site = no drift between this gate
+        # and `_pr_diff_is_trivial`.
+        is_addition = status[0] == "A" or status == "??"
+        is_deletion = "D" in status
+        violation = _classify_trivial_change(
+            path=path,
+            src_path=src_path,
+            is_addition=is_addition,
+            is_deletion=is_deletion,
+        )
+        if violation is not None:
+            return False, violation
+
+    return True, ""
+
+
+def _current_chunk_id_from_status(prawduct_dir: Path) -> str | None:
+    """Extract the chunk id of the first `- [ ]` item in the build-plan Status
+    section, e.g. ``"03"`` for ``- [ ] Chunk 03: Foo``. Returns ``None`` if
+    Status is missing, has no current chunk (all complete), or the chunk text
+    isn't in the expected ``Chunk NN:`` form.
+
+    Mirrors the resolution logic in ``cmd_verify_chunk_refs`` so the stop
+    hook and the Critic helper agree on "which chunk is current."
+    """
+    status = _parse_build_plan_status(prawduct_dir)
+    current = status.get("current_chunk", "")
+    if not current.startswith("Chunk "):
+        return None
+    rest = current[len("Chunk "):]
+    chunk_id = rest.split(":", 1)[0].strip()
+    return chunk_id or None
+
+
+def _verify_chunk_refs(project_dir: Path, refs: dict) -> list[dict]:
+    """Verify each file-path ref exists relative to ``project_dir``.
+    Returns a list of ``{"kind", "ref", "line_num", "reason"}`` for missing
+    entries. Empty list = all refs resolved.
+    """
+    missing: list[dict] = []
+    for entry in refs.get("file_paths", []):
+        ref = entry["ref"]
+        target = project_dir / ref
+        if not target.exists():
+            missing.append({
+                "kind": "file_path",
+                "ref": ref,
+                "line_num": entry["line_num"],
+                "reason": "file does not exist",
+            })
+    return missing
+
+
+def cmd_verify_chunk_refs(project_dir: Path, chunk_id: str | None) -> int:
+    """Critic Goal-2 helper: verify symbols/paths referenced in the current
+    chunk's build-plan section actually exist on the filesystem.
+
+    Exit 0 = all refs resolved (or nothing to check). Exit 1 = at least one
+    ref is missing, or the gate cannot be evaluated. stderr lists each
+    missing ref so the Critic can quote it in findings.
+
+    With no ``chunk_id``, reads the current chunk from Status (first unchecked
+    ``- [ ]`` item). If Status has no current chunk (all complete or no
+    Status section), exits 0 — there is nothing to verify.
+    """
+    prawduct_dir = get_prawduct_dir(project_dir)
+    if chunk_id is None:
+        chunk_id = os.environ.get("PRAWDUCT_VERIFY_CHUNK_ID")
+    if chunk_id is None:
+        status = _parse_build_plan_status(prawduct_dir)
+        current = status.get("current_chunk", "")
+        # current is e.g. "Chunk 02: F3 — …"
+        if not current.startswith("Chunk "):
+            print("ok: no current chunk in Status; nothing to verify")
+            return 0
+        rest = current[len("Chunk "):]
+        chunk_id = rest.split(":", 1)[0].strip()
+
+    refs = _parse_build_plan_chunk_refs(prawduct_dir, chunk_id)
+    if refs["error"]:
+        print(f"error: {refs['error']}", file=sys.stderr)
+        return 1
+    missing = _verify_chunk_refs(project_dir, refs)
+    if missing:
+        for m in missing:
+            print(
+                f"missing-ref: {m['ref']} (line {m['line_num']}, {m['kind']}): {m['reason']}",
+                file=sys.stderr,
+            )
+        return 1
+    count = len(refs["file_paths"])
+    print(f"ok: chunk {chunk_id} — {count} file ref(s) verified")
+    return 0
+
+
+# v1.4 F4b — coverage-required gate inputs.
+# Helper kept parallel to ``is_views_enabled`` in tools/lib/views.py: column-0
+# key scan, fail-closed default of False. Inline rather than imported to keep
+# the product-hook surface flat (no new lib dependency just for a 10-line
+# scanner). Same idiom = same drift discipline as views_enabled.
+def _read_bool_yaml_key(state_path: Path, key: str) -> bool:
+    if not state_path.exists():
+        return False
+    try:
+        content = state_path.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    needle = f"{key}:"
+    for raw in content.splitlines():
+        if raw[:1] in (" ", "\t"):
+            continue
+        line = raw.split("#", 1)[0].rstrip()
+        if not line.startswith(needle):
+            continue
+        value = line.split(":", 1)[1].strip().lower()
+        return value == "true"
+    return False
+
+
+def _coverage_resolve_base(project_dir: Path) -> tuple[str | None, str]:
+    """Pick the git diff base for coverage verification. Mirrors
+    ``_resolve_base`` in ``tools/test-reference-verify`` so writer (verifier)
+    and reader (verify-coverage) examine the same set of changes. If the
+    bases diverge, every chunk's verify-coverage would emit spurious
+    missing-coverage findings on files outside the verifier's base.
+    """
+    for candidate in ("origin/main", "main", "HEAD~1"):
+        proc = subprocess.run(
+            ["git", "rev-parse", "--verify", candidate],
+            cwd=str(project_dir),
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if proc.returncode == 0:
+            return candidate, candidate
+    return None, "no base candidate resolved (origin/main, main, HEAD~1 all absent)"
+
+
+def _coverage_changed_files(project_dir: Path, base: str) -> list[str]:
+    """Files changed between ``base`` and the working tree, union untracked.
+    Mirrors ``_changed_files`` in ``tools/test-reference-verify`` — same
+    union over ``git diff`` + ``git ls-files --others --exclude-standard``
+    so verify-coverage sees exactly the file set the verifier scored.
+    """
+    proc = subprocess.run(
+        ["git", "diff", "--name-only", base],
+        cwd=str(project_dir),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"git diff failed: {proc.stderr.strip()}")
+    files = {line.strip() for line in proc.stdout.splitlines() if line.strip()}
+
+    proc2 = subprocess.run(
+        ["git", "ls-files", "--others", "--exclude-standard"],
+        cwd=str(project_dir),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if proc2.returncode == 0:
+        files.update(line.strip() for line in proc2.stdout.splitlines() if line.strip())
+    return sorted(files)
+
+
+def cmd_verify_coverage(project_dir: Path) -> int:
+    """Critic Goal-1 helper (v1.4 F4b): when ``coverage_required: true`` in
+    project-state.yaml, verify every changed file in the diff appears in
+    ``.test-evidence.json``'s ``changes_referenced`` list.
+
+    Exit codes:
+      0 — check passed, or skipped (``coverage_required: false`` — the v1.4
+          default; opt-in by design).
+      1 — at least one changed file is missing from ``changes_referenced``,
+          or a precondition failed (evidence missing/invalid, schema lacks
+          F4a fields, git base unresolved).
+
+    stderr lists each missing file with language scaled to the declared
+    ``coverage_level`` — ``referenced`` (floor) vs ``executed`` (real
+    coverage tool) — so the Critic can quote it directly in BLOCKING
+    findings without re-deriving the wording.
+    """
+    prawduct_dir = get_prawduct_dir(project_dir)
+    state_path = prawduct_dir / "project-state.yaml"
+
+    if not _read_bool_yaml_key(state_path, "coverage_required"):
+        print("skipped: coverage_required is false (default in v1.4)")
+        return 0
+
+    evidence_path = prawduct_dir / ".test-evidence.json"
+    if not evidence_path.is_file():
+        print(
+            f"error: coverage_required=true but {evidence_path} is missing — "
+            "run the test suite + verifier first.",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        evidence = json.loads(evidence_path.read_text())
+    except (json.JSONDecodeError, OSError) as exc:
+        print(f"error: cannot read evidence: {exc}", file=sys.stderr)
+        return 1
+
+    if "verifier" not in evidence:
+        print(
+            "error: coverage_required=true but evidence lacks F4a schema "
+            "(no `verifier` field) — emit coverage fields with "
+            "`tools/test-reference-verify` (or a stronger product-specific "
+            "verifier) before re-running.",
+            file=sys.stderr,
+        )
+        return 1
+
+    ok, reason = _validate_evidence_schema(evidence)
+    if not ok:
+        print(f"error: {reason}", file=sys.stderr)
+        return 1
+
+    coverage_level = evidence["coverage_level"]
+    referenced = set(evidence.get("changes_referenced", []))
+
+    base, base_reason = _coverage_resolve_base(project_dir)
+    if base is None:
+        print(f"error: cannot resolve diff base — {base_reason}", file=sys.stderr)
+        return 1
+
+    try:
+        changed = _coverage_changed_files(project_dir, base)
+    except RuntimeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    missing = [f for f in changed if f not in referenced]
+    if not missing:
+        print(
+            f"ok: {len(changed)} changed file(s) covered "
+            f"(level: {coverage_level})"
+        )
+        return 0
+
+    # Severity wording is per the F4a spec — the floor (``referenced``)
+    # explicitly disclaims execution, the real-coverage level
+    # (``executed``) asserts it. Critic quotes these lines verbatim.
+    if coverage_level == "executed":
+        suffix = "has no executing test."
+    else:
+        suffix = (
+            "is not referenced by any executed test "
+            "(floor check — does not prove execution)."
+        )
+
+    for m in missing:
+        print(
+            f"missing-coverage: {m} (coverage_level: {coverage_level}) — {suffix}",
+            file=sys.stderr,
+        )
+    return 1
+
+
+def cmd_check_cumulative_critic(project_dir: Path) -> int:
+    """Structural gate for `/pr create`: require a fresh cumulative-Critic record.
+
+    Exit 0 only when the Critic findings file:
+      - exists and parses,
+      - is schema-valid (``validate_critic_findings``),
+      - has ``mode == _CRITIC_MODE_CUMULATIVE`` (chunk/final do not satisfy
+        this gate — cumulative is specifically the ``merge-base...HEAD``
+        bundle review),
+      - is fresh (mtime later than the current session's ``.session-start``
+        marker; stale evidence from a prior session is rejected),
+      - contains no unresolved BLOCKING severity findings (WARNING and NOTE
+        are advisory at the PR gate, matching the PR reviewer's semantics).
+
+    Exit 1 otherwise. stderr names the specific check that failed so the
+    caller (`/pr` skill) can present an actionable message to the user.
+    """
+    prawduct_dir = get_prawduct_dir(project_dir)
+    findings_path = prawduct_dir / ".critic-findings.json"
+
+    if not findings_path.is_file():
+        print(
+            "missing: no cumulative-Critic findings at "
+            f"{findings_path}. Run /critic cumulative before opening a PR.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if not validate_critic_findings(findings_path):
+        print(
+            f"invalid: {findings_path} did not pass schema validation",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        data = json.loads(findings_path.read_text())
+    except (json.JSONDecodeError, OSError) as exc:
+        print(f"unreadable: {exc}", file=sys.stderr)
+        return 1
+
+    mode = data.get("mode")
+    if mode != _CRITIC_MODE_CUMULATIVE:
+        print(
+            f"wrong-mode: findings mode is {mode!r}, expected cumulative "
+            f"({_CRITIC_MODE_CUMULATIVE!r}). The cumulative review covers "
+            "`merge-base...HEAD` — re-run /critic cumulative.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Freshness check — fail closed if the marker is missing or the check
+    # itself crashes. Mirrors the `needs_review = True` default in
+    # `_check_previous_session_gates` around line 1872; the cumulative gate
+    # cannot vouch for freshness it can't verify. (See "Escape hatches in
+    # classification create silent failures" in learnings.md.)
+    session_start_path = prawduct_dir / ".session-start"
+    if not session_start_path.is_file():
+        print(
+            "no-session-start: missing .prawduct/.session-start — cannot "
+            "validate cumulative-Critic freshness. Run /clear to start a "
+            "session, then re-run /critic cumulative.",
+            file=sys.stderr,
+        )
+        return 1
+    try:
+        session_start = session_start_path.read_text().strip()
+        findings_mtime = datetime.fromtimestamp(
+            findings_path.stat().st_mtime, tz=timezone.utc
+        ).strftime("%Y-%m-%dT%H:%M:%SZ")
+    except Exception as exc:  # prawduct:ok-broad-except — fail closed if freshness inputs are unreadable
+        print(
+            f"freshness-check-failed: could not compare cumulative-Critic "
+            f"findings vs session-start ({exc!r}). Re-run /critic cumulative.",
+            file=sys.stderr,
+        )
+        return 1
+    # Lexicographic compare on whole-second %Y-%m-%dT%H:%M:%SZ strings is
+    # order-preserving — same convention as cmd_clear's gate check around
+    # line 1874. Adding fractional seconds to the format would break both
+    # sides; keep them in lockstep.
+    if findings_mtime <= session_start:
+        print(
+            f"stale: cumulative findings ({findings_mtime}) "
+            f"predate session-start ({session_start}). Re-run "
+            "/critic cumulative in the current session before opening a PR.",
+            file=sys.stderr,
+        )
+        return 1
+
+    findings = data.get("findings", [])
+    blocking = [f for f in findings if isinstance(f, dict) and f.get("severity") == "blocking"]
+    if blocking:
+        first = blocking[0].get("summary", "<no summary>")
+        print(
+            f"blocking: cumulative-Critic recorded {len(blocking)} BLOCKING "
+            f"finding(s). First: {first}. Resolve before opening a PR.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"satisfied: cumulative-Critic record is fresh and clean ({findings_path})")
+    return 0
+
+
+# =============================================================================
 # main
 # =============================================================================
 
 
+def cmd_regen_views(project_dir: Path) -> int:
+    """Regenerate derived views from the change-log canonical store.
+
+    Three views are produced in one pass when `views_enabled: true`:
+
+      1. Build-plan `## Status` block — checkbox flips from `status=shipped` tags
+      2. Release-notes view — `.prawduct/release-notes.md` from `release=` tags
+      3. Scope-rollup view — `scope_rollups:` block in `project-state.yaml`
+         from `scope=` tags
+
+    No-op when `views_enabled: true` is absent (enabled by default in v1.4;
+    sync auto-enables for existing repos and `false` is the explicit opt-out).
+
+    Exit codes:
+      0 - success (views disabled, no changes needed, or regen applied cleanly)
+      2 - I/O or schema error (missing change-log or build-plan)
+    """
+    # Ensure tools/ is on sys.path so `from lib import views` resolves both
+    # when invoked as a script and when imported via SourceFileLoader in tests.
+    tools_dir = str(Path(__file__).resolve().parent)
+    if tools_dir not in sys.path:
+        sys.path.insert(0, tools_dir)
+    from lib import views  # noqa: PLC0415 — lazy import keeps top-level cheap
+
+    prawduct_dir = get_prawduct_dir(project_dir)
+    try:
+        enabled, results = views.plan_regen(prawduct_dir)
+    except FileNotFoundError as e:
+        msg = str(e)
+        if "change-log" in msg:
+            print(f"ERROR: {msg}", file=sys.stderr)
+        elif "build-plan" in msg:
+            print(f"ERROR: {msg}", file=sys.stderr)
+        else:
+            print(f"ERROR: {msg}", file=sys.stderr)
+        return 2
+    except OSError as e:
+        print(f"ERROR reading view inputs: {e}", file=sys.stderr)
+        return 2
+
+    if not enabled:
+        print("Views disabled (set views_enabled: true in project-state.yaml).")
+        return 0
+
+    try:
+        views.apply_regen(prawduct_dir, results)
+    except OSError as e:
+        print(f"ERROR writing view output: {e}", file=sys.stderr)
+        return 2
+
+    for r in results:
+        print(r.summary)
+    return 0
+
+
+def cmd_check_operator_verification(project_dir: Path) -> int:
+    """Structural gate for `/pr create`: refuse open when queue has pending entries.
+
+    Mirrors :func:`cmd_check_cumulative_critic` semantics — exit 0 only
+    when the gate is satisfied, exit 1 with stderr describing the
+    blocker. The gate is only active when ``operator_verification_required:
+    true`` is set in ``project-state.yaml``; otherwise the command is a
+    no-op exit 0.
+    """
+    tools_dir = str(Path(__file__).resolve().parent)
+    if tools_dir not in sys.path:
+        sys.path.insert(0, tools_dir)
+    from lib import operator_verification as ov  # noqa: PLC0415 — lazy import
+
+    result = ov.run_check_operator_verification(project_dir)
+    if not result["required"]:
+        return 0
+    if result["pending"] == 0:
+        print(result["message"])
+        return 0
+    print(result["message"], file=sys.stderr)
+    return 1
+
+
+def cmd_accept_operator_verification(
+    project_dir: Path, rationale: str | None
+) -> int:
+    """Flip all pending entries to ``accepted`` with the supplied rationale.
+
+    Invoked by ``/pr create --accept-pending-verification "rationale"``.
+    Refuses an empty or missing rationale — the work-log capture is the
+    whole point of the override.
+    """
+    tools_dir = str(Path(__file__).resolve().parent)
+    if tools_dir not in sys.path:
+        sys.path.insert(0, tools_dir)
+    from lib import operator_verification as ov  # noqa: PLC0415 — lazy import
+
+    if rationale is None or not rationale.strip():
+        print(
+            "error: accept-operator-verification requires a non-empty "
+            "rationale argument — `/pr create --accept-pending-verification "
+            '"rationale"`. The override is recorded in operator-verification.md '
+            "as the work-log entry.",
+            file=sys.stderr,
+        )
+        return 1
+
+    result = ov.run_accept_pending(project_dir, rationale)
+    if "error" in result:
+        print(f"error: {result['error']}", file=sys.stderr)
+        return 1
+
+    for action in result["actions"]:
+        print(action)
+    for note in result["notes"]:
+        print(f"  * {note}")
+    return 0
+
+
+def _pr_diff_is_doc_only(project_dir: Path) -> tuple[bool, str]:
+    """Shared helper: is the PR diff (``merge-base...HEAD``) all ``.md``?
+
+    Returns ``(is_doc_only, status_message)``. ``is_doc_only`` is True only
+    when the diff is non-empty AND every file ends in ``.md``. The status
+    message names the specific reason for False (``no-base``, ``git-failed``,
+    ``empty-diff``, ``not-doc-only: <files>``) so both the CLI gate and the
+    stop-hook Gate 3 can surface actionable detail without re-implementing
+    the diff inspection. Base resolution mirrors ``_coverage_resolve_base``
+    so the helper sees the same diff surface as the cumulative-Critic flow.
+    """
+    base, base_note = _coverage_resolve_base(project_dir)
+    if base is None:
+        return False, f"no-base: {base_note}"
+
+    proc = subprocess.run(
+        ["git", "diff", "--name-only", f"{base}...HEAD"],
+        cwd=str(project_dir),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if proc.returncode != 0:
+        return False, f"git-failed: git diff {base}...HEAD failed: {proc.stderr.strip()}"
+
+    files = [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+    if not files:
+        return False, f"empty-diff: no files changed in {base}...HEAD"
+
+    non_md = [f for f in files if not f.endswith(".md")]
+    if non_md:
+        sample = ", ".join(non_md[:3])
+        more = f" (+{len(non_md) - 3} more)" if len(non_md) > 3 else ""
+        return False, f"not-doc-only: PR includes non-.md files: {sample}{more}"
+
+    return True, f"doc-only: {len(files)} file(s) in {base}...HEAD all .md"
+
+
+def cmd_check_pr_doc_only(project_dir: Path) -> int:
+    """Fast-path gate for `/pr create`: report whether the PR diff is doc-only.
+
+    Exit 0 when every file in ``merge-base...HEAD`` ends in ``.md`` and the
+    diff is non-empty — the `/pr` skill uses this to skip the cumulative-
+    Critic and PR-reviewer gates, mirroring the session-end stop-hook
+    behavior (`_session_changes_are_doc_only`) at the PR boundary. The
+    stop hook's PR-review evidence gate (Gate 3) consults the same helper
+    so a doc-only PR doesn't get blocked at session end for missing
+    evidence — symmetric behavior across both gates.
+
+    Exit 1 otherwise (any non-``.md`` file, empty diff, no resolvable base
+    branch, or git failure). Fails closed: when the gate cannot be evaluated,
+    fall through to the full review path rather than silently skipping it.
+    """
+    is_doc_only, status = _pr_diff_is_doc_only(project_dir)
+    if is_doc_only:
+        print(
+            f"{status} — cumulative-Critic and PR-reviewer gates may be skipped."
+        )
+        return 0
+    suffix = (
+        ". Doc-only fast-path is not applicable."
+        if status.startswith("empty-diff")
+        else ". Falling back to full review path."
+        if status.startswith(("no-base", "git-failed"))
+        else ". Full review required."
+    )
+    print(f"{status}{suffix}", file=sys.stderr)
+    return 1
+
+
+def _pr_diff_is_trivial(project_dir: Path) -> tuple[bool, str]:
+    """Shared helper: is every commit on ``merge-base...HEAD`` fileset-
+    eligible per Chunk 04's ``Type: trivial`` path bounds?
+
+    Returns ``(is_trivial, status_message)``. ``is_trivial`` is True only
+    when at least one commit exists ahead of base AND every commit's
+    file changes satisfy ``_classify_trivial_change``. The first
+    violating commit short-circuits with a reason naming the SHA and
+    the specific bound (e.g.
+    ``"not-trivial: commit a1b2c3d agent-file-edited: agents/foo.md"``).
+
+    Mirrors ``_pr_diff_is_doc_only`` at the PR boundary — same base
+    resolution via ``_coverage_resolve_base``, same fail-closed posture
+    on missing base / git failure / empty diff. Does NOT re-validate
+    rationale fit; that's the per-chunk Critic's job at chunk-mode
+    review time. This helper trusts that every chunk's rationale was
+    Critic-passed and only checks the structural file-set bounds.
+
+    Per-commit (not cumulative) walk: a PR that adds an ``agents/``
+    file in commit 1 and removes it in commit 2 has an empty cumulative
+    diff but is NOT fast-path eligible — the commit 1 violation is
+    real signal that the work crossed a catastrophic-blast-radius
+    boundary at least once during the build.
+    """
+    base, base_note = _coverage_resolve_base(project_dir)
+    if base is None:
+        return False, f"no-base: {base_note}"
+
+    # `git log --name-status --format=%H` emits one commit SHA per line
+    # followed by one tab-separated <status>\t<path> (or
+    # <status>\t<src>\t<dst> for renames) line per changed file, with
+    # a blank line between commits. Reverse order is irrelevant — we
+    # short-circuit on first violation regardless.
+    proc = subprocess.run(
+        [
+            "git",
+            "log",
+            "--name-status",
+            "-M",  # enable rename detection so test-renamed-out-of-tests/ trips
+            "--format=%H",
+            f"{base}..HEAD",
+        ],
+        cwd=str(project_dir),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if proc.returncode != 0:
+        return False, f"git-failed: git log {base}..HEAD failed: {proc.stderr.strip()}"
+
+    lines = proc.stdout.splitlines()
+    if not any(line.strip() for line in lines):
+        return False, f"empty-diff: no commits ahead of {base}"
+
+    current_sha: str | None = None
+    commits_seen = 0
+    for raw in lines:
+        line = raw.rstrip()
+        if not line:
+            continue
+        # A bare 40-hex line is a commit header.
+        if len(line) == 40 and all(c in "0123456789abcdef" for c in line):
+            current_sha = line
+            commits_seen += 1
+            continue
+        # Otherwise it's a name-status entry for the current commit.
+        if current_sha is None:
+            continue
+        parts = line.split("\t")
+        if len(parts) < 2:
+            continue
+        status = parts[0].strip()
+        if not status:
+            continue
+        # R<score> / C<score> rows are: <status>\t<src>\t<dst>
+        src_path: str | None = None
+        if status[0] in ("R", "C") and len(parts) >= 3:
+            src_path = parts[1].strip()
+            path = parts[2].strip()
+        else:
+            path = parts[-1].strip()
+        if not path:
+            continue
+        # v1.5.1 Chunk 04(b): metadata-path filtering lives inside
+        # `_classify_trivial_change` (handles both src and dst). Single
+        # check site = no drift between this PR-boundary gate and the
+        # stop-hook gate in `_is_trivial_fileset_eligible`.
+        is_addition = status == "A"
+        is_deletion = status == "D"
+        violation = _classify_trivial_change(
+            path=path,
+            src_path=src_path,
+            is_addition=is_addition,
+            is_deletion=is_deletion,
+        )
+        if violation is not None:
+            return False, f"not-trivial: commit {current_sha[:7]} {violation}"
+
+    return True, (
+        f"trivial: {commits_seen} commit(s) ahead of {base} all fileset-eligible"
+    )
+
+
+def cmd_check_pr_trivial(project_dir: Path) -> int:
+    """Fast-path gate for `/pr create`: report whether every commit in
+    ``merge-base...HEAD`` is fileset-eligible per Chunk 04's
+    ``Type: trivial`` path bounds.
+
+    Exit 0 when at least one commit exists ahead of base AND every
+    commit clears the bounds — the `/pr` skill skips the cumulative-
+    Critic and PR-reviewer gates in this case. This is the PR-boundary
+    parallel to the doc-only fast-path: same fail-closed shape, same
+    Gate-3 alignment at session end.
+
+    Exit 1 otherwise (any commit touches ``agents/``/``methodology/``/
+    ``templates/``/``CLAUDE.md``, adds a new file, removes a test
+    file, empty diff, no resolvable base, or git failure). Fails
+    closed: when the gate cannot be evaluated, fall through to the
+    full review path rather than silently skipping it.
+    """
+    is_trivial, status = _pr_diff_is_trivial(project_dir)
+    if is_trivial:
+        print(
+            f"{status} — cumulative-Critic and PR-reviewer gates may be skipped."
+        )
+        return 0
+    suffix = (
+        ". Trivial fast-path is not applicable."
+        if status.startswith("empty-diff")
+        else ". Falling back to full review path."
+        if status.startswith(("no-base", "git-failed"))
+        else ". Full review required."
+    )
+    print(f"{status}{suffix}", file=sys.stderr)
+    return 1
+
+
+def cmd_compute_verify_resolutions_scope(project_dir: Path) -> int:
+    """Print the file scope a ``/critic verify-resolutions`` pass should review.
+
+    Thin CLI wrapper around ``_compute_verify_resolutions_scope`` (v1.5
+    Chunk 02) so the Critic SKILL can call the canonical helper instead
+    of reimplementing the widening-threshold prose. Defense-in-depth: the
+    Critic's verify-resolutions invocation now computes the same scope
+    the stop-hook gate enforces; drift between the two is no longer
+    possible (v1.5.1 Chunk 03 — backlog 2026-05-21).
+
+    Output format:
+      stdout: one file path per line (the union of prior ``files_reviewed``
+              and files-changed-since-``commit_reviewed``, sorted).
+              Empty stdout when the helper returns no scope.
+      stderr: one line with the helper's reason string.
+
+    Exit codes:
+      0 - scope computed; stdout lists files; stderr reason starts ``ok:``.
+      1 - cannot compute (no prior findings, no ``commit_reviewed``,
+          unreadable findings, no actionable findings, unresolved commit,
+          git failure, invalid files_reviewed). The Critic should fall
+          back to ``/critic chunk`` or ``/critic final`` and record
+          ``mode_chosen_by: "fallback-no-prior-findings"`` (or similar).
+      2 - scope widened past the demotion threshold
+          (``len(delta) > 2 * len(prior) + 5``). The Critic should fall
+          back to ``/critic final`` and record
+          ``mode_chosen_by: "fallback-scope-widened"``.
+    """
+    prawduct_dir = get_prawduct_dir(project_dir)
+    scope, reason = _compute_verify_resolutions_scope(prawduct_dir, project_dir)
+    if scope:
+        for f in scope:
+            print(f)
+    print(reason, file=sys.stderr)
+    if reason.startswith("ok:"):
+        return 0
+    if reason.startswith("scope-widened:"):
+        return 2
+    return 1
+
+
+def cmd_infer_critic_mode(project_dir: Path, args: str | None) -> int:
+    """Print ``<mode>|<rationale>`` for the inferred ``/critic`` mode.
+
+    Thin wrapper around ``tools.lib.critic_mode.infer_mode`` (v1.5
+    Chunk 03). The subcommand exists so the Critic SKILL can call
+    inference without expanding its ``allowed-tools`` to ``Bash(python3
+    -c *)`` — keeping the structural "no arbitrary code execution"
+    constraint enforceable.
+
+    Output format: a single stdout line ``<mode>|<rationale>`` where
+    ``<mode>`` is one of the short tokens (``chunk`` / ``final`` /
+    ``cumulative`` / ``verify-resolutions``) and ``<rationale>`` is the
+    human-readable explanation suitable for both stdout reporting and
+    the ``mode_chosen_by`` field in ``.critic-findings.json``.
+
+    Fail-safe: when ``tools/lib`` is absent (product repos that
+    haven't yet received the lib propagation), returns ``final|
+    fallback-no-tools-lib`` so the Critic falls through to thorough
+    review rather than crashing. Same fail-safe direction as the
+    SKILL's "missing/unrecognized mode → final" rule.
+    """
+    tools_dir = str(Path(__file__).resolve().parent)
+    if tools_dir not in sys.path:
+        sys.path.insert(0, tools_dir)
+    try:
+        from lib import infer_mode  # noqa: PLC0415 — lazy keeps top-level cheap
+    except ImportError:
+        print("final|fallback-no-tools-lib")
+        return 0
+    mode, rationale = infer_mode(project_dir, args)
+    print(f"{mode}|{rationale}")
+    return 0
+
+
+def cmd_advisory(project_dir: Path, argv: list[str]) -> int:
+    """Dispatch the ``/prawduct-advisory`` management CLI (spec §6, Chunk 05).
+
+    Thin wrapper around ``tools.lib.advisory_cmd.run`` — the subcommand exists so
+    the skill's ``allowed-tools`` can be scoped to ``Bash(python3 tools/product-hook
+    advisory*)`` instead of arbitrary code execution, mirroring the
+    ``infer-critic-mode`` pattern. ``argv`` is ``sys.argv[2:]`` (everything after
+    ``advisory``).
+
+    Fail-safe: when ``tools/lib`` is absent (a product repo that has not yet
+    received the lib propagation), print a clear message and return 1 rather than
+    crashing — the advisory CLI is informational, never a gate.
+    """
+    tools_dir = str(Path(__file__).resolve().parent)
+    if tools_dir not in sys.path:
+        sys.path.insert(0, tools_dir)
+    try:
+        from lib import advisory_cmd  # noqa: PLC0415 — lazy keeps top-level cheap
+    except ImportError:
+        print("advisory CLI unavailable (tools/lib not present in this repo)", file=sys.stderr)
+        return 1
+    return advisory_cmd.run(project_dir, argv)
+
+
+_USAGE = (
+    "Usage: product-hook "
+    "{clear|stop|test-status|validate-evidence|check-cumulative-critic|"
+    "verify-chunk-refs [chunk_id]|verify-coverage|"
+    "check-operator-verification|accept-operator-verification <rationale>|"
+    "check-pr-doc-only|check-pr-trivial|regen-views|infer-critic-mode [args]|"
+    "compute-verify-resolutions-scope|advisory <subcmd> [args]}"
+)
+
+
 def main() -> int:
     if len(sys.argv) < 2:
-        print("Usage: product-hook {clear|stop|test-status}", file=sys.stderr)
+        print(_USAGE, file=sys.stderr)
         return 1
 
     command = sys.argv[1]
@@ -2174,8 +4297,35 @@ def main() -> int:
         return cmd_stop(project_dir)
     elif command == "test-status":
         return cmd_test_status(project_dir)
+    elif command == "validate-evidence":
+        return cmd_validate_evidence(project_dir)
+    elif command == "check-cumulative-critic":
+        return cmd_check_cumulative_critic(project_dir)
+    elif command == "verify-chunk-refs":
+        chunk_id = sys.argv[2] if len(sys.argv) > 2 else None
+        return cmd_verify_chunk_refs(project_dir, chunk_id)
+    elif command == "verify-coverage":
+        return cmd_verify_coverage(project_dir)
+    elif command == "check-operator-verification":
+        return cmd_check_operator_verification(project_dir)
+    elif command == "accept-operator-verification":
+        rationale = sys.argv[2] if len(sys.argv) > 2 else None
+        return cmd_accept_operator_verification(project_dir, rationale)
+    elif command == "check-pr-doc-only":
+        return cmd_check_pr_doc_only(project_dir)
+    elif command == "check-pr-trivial":
+        return cmd_check_pr_trivial(project_dir)
+    elif command == "regen-views":
+        return cmd_regen_views(project_dir)
+    elif command == "infer-critic-mode":
+        args = " ".join(sys.argv[2:]) if len(sys.argv) > 2 else None
+        return cmd_infer_critic_mode(project_dir, args)
+    elif command == "compute-verify-resolutions-scope":
+        return cmd_compute_verify_resolutions_scope(project_dir)
+    elif command == "advisory":
+        return cmd_advisory(project_dir, sys.argv[2:])
     else:
-        print("Usage: product-hook {clear|stop|test-status}", file=sys.stderr)
+        print(_USAGE, file=sys.stderr)
         return 1
 
 


### PR DESCRIPTION
## Summary

- Bumps Prawduct framework files in TC-v3 to upstream **v1.6.0** ([brookstalley/prawduct#45](https://github.com/brookstalley/prawduct/pull/45)).
- `tools/product-hook`: 2183 → 4333 lines, **byte-identical** to the framework source (MD5 `e1f43771…`). Restores the larger product-hook that a prior session's regression had downgraded.
- `.gitignore`: adds two new framework-introduced session files (`.prawduct/.sync-pending`, `.prawduct/.advisories.json`).
- Other framework files refreshed in the working tree (`.prawduct/*.md`, `.claude/skills/*/SKILL.md`, `.claude/settings.json`) are gitignored and therefore not in this diff.

## Why this is safe to auto-merge

- v1.6.0 is an explicit **no-op infrastructure ship** per its PR description: empty production probe roster, gitignored `.advisories.json`, build-plan-path defaults to old behavior. Zero user-visible behavior change.
- The product-hook diff is mechanical — it matches the upstream framework source exactly. No TC-specific customization was made or lost.
- The full v1.6.0 PR shipped with 1566 tests passing, 0 Critic findings, 0 blocking PR-review findings.
- Aligns with the CLAUDE.md "Chore PRs (gitignore tweaks, version updates) where the change is mechanical and doesn't shift active methodology" criterion for `--auto`.

## Test plan

- [x] Framework source verified clean fast-forward to v1.6.0 (no divergence, no conflicts).
- [x] `tools/product-hook` MD5 matches framework source byte-for-byte.
- [x] `prawduct-setup.py validate` returns healthy state post-sync.
- [x] New skills (`prawduct-advisory`, `janitor`) loaded into the active session without restart, confirming the session-start hook picks up the new framework cleanly.
- [ ] Open a fresh TC session in this project after merge and confirm session-start sync reports clean.
- [ ] Spot-check one or two other Prawduct projects (Medusa, etc.) for clean session-start sync.

## Related

- Framework PR: brookstalley/prawduct#45
- Follow-up: #262 (machine-wide Prawduct sync sweep — eager update across all TC projects)