### PR TITLE
chore(sync): bump Prawduct framework to v1.8.0

### DIFF
--- a/tools/lib/__init__.py
+++ b/tools/lib/__init__.py
@@ -1,0 +1,145 @@
+"""
+prawduct lib — extracted modules from prawduct-setup.py.
+
+Re-exports all public names for backward compatibility. Consumers that
+import via importlib (tests, shim scripts) see the same namespace as before.
+"""
+
+# Core utilities and constants
+from .core import (  # noqa: F401
+    BLOCK_BEGIN,
+    BLOCK_END,
+    BUILD_PLAN_POINTER_KEY,
+    DEFAULT_BUILD_PLAN_REL,
+    FILE_RENAMES,
+    FRAMEWORK_DIR,
+    GITIGNORE_ENTRIES,
+    MANAGED_FILES,
+    PRAWDUCT_VERSION,
+    SKILL_PLACEMENTS,
+    TEMPLATES_DIR,
+    resolve_build_plan_path,
+    read_str_yaml_key,
+    V1_GITIGNORE_ENTRIES,
+    V1_SESSION_FILES,
+    V3_GITIGNORE_ENTRIES,
+    V4_GITIGNORE_ENTRIES,
+    _resolve_framework_dir,
+    _try_pull_framework,
+    compute_block_hash,
+    compute_hash,
+    copy_hook,
+    create_manifest,
+    detect_version,
+    ensure_dir,
+    extract_block,
+    infer_product_name,
+    load_json,
+    log,
+    merge_settings,
+    render_template,
+    replace_settings,
+    untrack_gitignored_files,
+    update_gitignore,
+    write_template,
+    write_template_overwrite,
+)
+
+# Init command
+from .init_cmd import run_init  # noqa: F401
+
+# Migration operations
+from .migrate_cmd import (  # noqa: F401
+    add_block_markers,
+    archive_v1_dirs,
+    clean_gitignore,
+    clean_v1_session_files,
+    delete_v1_files,
+    enable_v1_4_coverage,
+    enable_v1_4_operator_verification,
+    enable_v1_4_settings_layout,
+    enable_v1_4_views,
+    generate_sync_manifest,
+    migrate_backlog,
+    migrate_change_log,
+    migrate_project_state_v5,
+    run_migrate,
+    run_migrate_coverage,
+    run_migrate_operator_verification,
+    run_migrate_settings_layout,
+    split_learnings_v5,
+    upgrade_manifest_strategy,
+)
+
+# Post-sync advisory infrastructure (v1.6.0 Phase 1 — store + registry + diff)
+from .advisory_store import (  # noqa: F401
+    AdvisoryCandidate,
+    Codebase,
+    ProjectState,
+    clear_registry,
+    compute_id,
+    dismiss,
+    load_project_state,
+    make_codebase,
+    read_store,
+    reconcile,
+    register_probe,
+    resolve,
+    run_all_probes,
+    run_sync_advisories,
+    undismiss,
+    write_store,
+)
+
+# Post-sync advisory management CLI (v1.6.0 Chunk 05 — /prawduct-advisory)
+from .advisory_cmd import (  # noqa: F401
+    dismiss_advisory,
+    list_advisories,
+    resolve_advisory,
+    show_advisory,
+    undismiss_advisory,
+)
+
+# Sync operations
+from .sync_cmd import (  # noqa: F401
+    _HISTORICAL_RENDER_DEPTH_CAP,
+    _bootstrap_manifest,
+    _match_historical_render,
+    apply_renames,
+    migrate_v4_to_v5,
+    run_sync,
+)
+
+# Validate command
+from .validate_cmd import run_validate  # noqa: F401
+
+# Views command (doctor `views` subcommand)
+from .views_cmd import run_views_command  # noqa: F401
+
+# Audit-learnings command (F9 — learnings lifecycle sentinel tracker)
+from .audit_learnings_cmd import (  # noqa: F401
+    LearningEntry,
+    audit_learnings,
+    parse_learning_metadata,
+    parse_learnings_file,
+    run_audit_learnings,
+    run_sentinel,
+)
+
+# Critic mode inference (v1.5 Chunk 03 — no-arg /critic picks mode from state)
+from .critic_mode import infer_mode  # noqa: F401
+
+# Operator-verification queue (F10 — pre-merge human-verification gate)
+from .operator_verification import (  # noqa: F401
+    VerificationEntry,
+    count_pending,
+    format_operator_verification,
+    is_operator_verification_required,
+    mark_accepted,
+    mark_verified,
+    parse_operator_verification,
+    pending_entries,
+    run_accept_pending,
+    run_check_operator_verification,
+    run_verify_entry,
+)

--- a/tools/lib/advisory_cmd.py
+++ b/tools/lib/advisory_cmd.py
@@ -1,0 +1,301 @@
+"""Post-sync advisory management CLI — ``/prawduct-advisory`` (spec §6).
+
+Phase 1 Chunk 05. The user-facing surface over the nag log managed by
+:mod:`advisory_store`. Five subcommands (spec §6.1):
+
+  - ``list [--state=active|dismissed|resolved|all] [--feature=<name>]``
+  - ``show <id>``      — full detail; reconstructs evidence for compact entries (Q5)
+  - ``dismiss <id> [--reason "..."]``
+  - ``undismiss <id>``
+  - ``resolve <id>``   — action-driven resolution (spec §4.3)
+
+Per the ``*_cmd.py`` convention this module holds the CLI; all *state
+transitions* delegate to :mod:`advisory_store` (``dismiss``/``undismiss``/
+``resolve``) — this module never mutates the store directly, it reads it for
+``list``/``show`` and calls the store's transition functions for the verbs.
+
+Two layers, mirroring the project's return-value convention:
+  - The per-subcommand functions (:func:`list_advisories`, :func:`show_advisory`,
+    :func:`dismiss_advisory`, :func:`undismiss_advisory`, :func:`resolve_advisory`)
+    are pure-ish library calls returning ``{status, ...}`` dicts — tested
+    directly, never raising.
+  - :func:`run` is the argv dispatcher invoked from ``product-hook advisory`` —
+    it parses flags, calls the right function, prints a human-readable summary,
+    and returns a Unix exit code (the CLI boundary, where exit codes are the
+    contract).
+"""
+
+from __future__ import annotations
+
+import sys
+
+from . import advisory_store as store_mod
+
+# Valid ``--state`` filter values. ``all`` means "no state filter".
+_LIST_STATES = ("active", "dismissed", "resolved", "all")
+
+
+# =============================================================================
+# Subcommand implementations (return-value based — never raise)
+# =============================================================================
+
+
+def _matches_feature(advisory: dict, feature: str) -> bool:
+    """True if ``advisory`` belongs to ``feature``.
+
+    Active advisories carry an explicit ``feature`` field; compacted
+    (resolved/dismissed) entries drop it (spec §3.4), but the ``feature`` token
+    is the literal id prefix (``compute_id`` builds ``<feature>-<type>-v<n>-<hash>``),
+    so an id-prefix match recovers the association for compact entries too. This
+    keeps ``--feature`` filtering correct across every state (A6).
+    """
+    if advisory.get("feature") == feature:
+        return True
+    return str(advisory.get("id") or "").startswith(f"{feature}-")
+
+
+def list_advisories(product_dir, *, state: str = "active", feature: str | None = None) -> dict:
+    """List advisories filtered by ``state`` and ``feature`` (spec §6.1, A6).
+
+    Defaults: ``state="active"``, all features. ``state="all"`` applies no state
+    filter. Returns ``{status, state, feature, count, advisories}`` — the
+    advisories are the raw store dicts (active in full form, non-active compact),
+    order preserved. Never raises.
+    """
+    store = store_mod.read_store(product_dir)
+    advisories = [a for a in store.get("advisories", []) if isinstance(a, dict)]
+    if state != "all":
+        advisories = [a for a in advisories if a.get("state") == state]
+    if feature:
+        advisories = [a for a in advisories if _matches_feature(a, feature)]
+    return {
+        "status": "ok",
+        "state": state,
+        "feature": feature,
+        "count": len(advisories),
+        "advisories": advisories,
+    }
+
+
+def show_advisory(product_dir, advisory_id: str) -> dict:
+    """Full detail on one advisory; reconstruct evidence for compact entries (Q5).
+
+    The in-store evidence array is capped at ``EVIDENCE_CAP`` and dropped
+    entirely when an entry is compacted (resolved/dismissed). To surface the
+    full forensic list on demand, ``show`` re-runs the probe roster and, if a
+    fresh candidate's id matches this advisory, attaches that candidate's
+    *uncapped* evidence (spec Q5 lean). When the probe no longer fires (e.g. the
+    advisory resolved because its answer-store fact was set), evidence can't be
+    reconstructed and the stored (possibly empty) form is returned with
+    ``evidence_reconstructed=False``.
+
+    Returns ``{status: "ok", advisory, evidence_reconstructed}`` or
+    ``{status: "not_found", id}``. Never raises.
+    """
+    store = store_mod.read_store(product_dir)
+    match = None
+    for advisory in store.get("advisories", []):
+        if isinstance(advisory, dict) and advisory.get("id") == advisory_id:
+            match = advisory
+            break
+    if match is None:
+        return {"status": "not_found", "id": advisory_id}
+
+    advisory = dict(match)
+    reconstructed = False
+    # A compacted entry has no evidence array (the field was dropped). Re-run
+    # the probes and recover the full citation list if the probe still fires.
+    if not advisory.get("evidence"):
+        state = store_mod.load_project_state(product_dir)
+        codebase = store_mod.make_codebase(product_dir)
+        for cand in store_mod.run_all_probes(state, codebase):
+            cand_id = store_mod.compute_id(cand.feature, cand.type, cand.probe_version, cand.evidence)
+            if cand_id == advisory_id:
+                advisory["evidence"] = list(cand.evidence)  # uncapped — full forensic list
+                advisory["feature"] = advisory.get("feature") or cand.feature
+                advisory["type"] = advisory.get("type") or cand.type
+                advisory["trigger_summary"] = advisory.get("trigger_summary") or cand.trigger_summary
+                advisory["recommended_action"] = advisory.get("recommended_action") or cand.recommended_action
+                reconstructed = True
+                break
+
+    return {"status": "ok", "advisory": advisory, "evidence_reconstructed": reconstructed}
+
+
+def dismiss_advisory(product_dir, advisory_id: str, reason: str | None = None) -> dict:
+    """Dismiss an advisory (sticky). Delegates to :func:`advisory_store.dismiss`."""
+    return store_mod.dismiss(product_dir, advisory_id, reason)
+
+
+def undismiss_advisory(product_dir, advisory_id: str) -> dict:
+    """Clear a dismissal. Delegates to :func:`advisory_store.undismiss`."""
+    return store_mod.undismiss(product_dir, advisory_id)
+
+
+def resolve_advisory(product_dir, advisory_id: str) -> dict:
+    """Manually resolve an advisory now. Delegates to :func:`advisory_store.resolve`
+    with ``resolved_by="action"`` (spec §4.3 immediate path)."""
+    return store_mod.resolve(product_dir, advisory_id, resolved_by="action")
+
+
+# =============================================================================
+# argv dispatcher (the CLI boundary — exit codes, human-readable output)
+# =============================================================================
+
+
+_USAGE = (
+    "Usage: product-hook advisory "
+    "{list [--state=active|dismissed|resolved|all] [--feature=<name>] | "
+    "show <id> | dismiss <id> [--reason <text>] | undismiss <id> | resolve <id>}"
+)
+
+
+def _split_flag(arg: str) -> tuple[str, str | None]:
+    """Split ``--key=value`` → ``("--key", "value")``; bare ``--key`` → value None."""
+    if "=" in arg:
+        key, _, value = arg.partition("=")
+        return key, value
+    return arg, None
+
+
+def _render_advisory_line(advisory: dict) -> str:
+    feature = advisory.get("feature")
+    prefix = f"[{feature}] " if feature else ""
+    summary = advisory.get("trigger_summary") or advisory.get("type") or ""
+    return f"  • {advisory.get('id')}  {prefix}{summary}".rstrip()
+
+
+def _print_list(result: dict) -> None:
+    advisories = result.get("advisories", [])
+    state = result.get("state")
+    feature = result.get("feature")
+    scope = f"state={state}" + (f", feature={feature}" if feature else "")
+    if not advisories:
+        print(f"No advisories ({scope}).")
+        return
+    print(f"{len(advisories)} advisory(ies) ({scope}):")
+    for advisory in advisories:
+        print(_render_advisory_line(advisory))
+        action = advisory.get("recommended_action")
+        if action and advisory.get("state") == "active":
+            print(f"      → {action}")
+
+
+def _print_show(result: dict, advisory_id: str) -> int:
+    if result.get("status") == "not_found":
+        print(f"Advisory not found: {advisory_id}", file=sys.stderr)
+        return 1
+    advisory = result["advisory"]
+    print(f"id:                {advisory.get('id')}")
+    print(f"state:             {advisory.get('state')}")
+    if advisory.get("feature"):
+        print(f"feature:           {advisory.get('feature')}")
+    if advisory.get("type"):
+        print(f"type:              {advisory.get('type')}")
+    if advisory.get("trigger_summary"):
+        print(f"trigger:           {advisory.get('trigger_summary')}")
+    if advisory.get("recommended_action"):
+        print(f"recommended:       {advisory.get('recommended_action')}")
+    evidence = advisory.get("evidence") or []
+    if evidence:
+        suffix = " (reconstructed by re-running the probe)" if result.get("evidence_reconstructed") else ""
+        print(f"evidence ({len(evidence)}){suffix}:")
+        for item in evidence:
+            print(f"  - {item}")
+    for field in ("dismissed_at", "dismissed_reason", "resolved_at", "resolved_by", "superseded_by"):
+        if advisory.get(field):
+            print(f"{field + ':':<19}{advisory.get(field)}")
+    return 0
+
+
+def _print_transition(result: dict, verb: str, advisory_id: str) -> int:
+    if result.get("status") == "not_found":
+        print(f"Advisory not found: {advisory_id}", file=sys.stderr)
+        return 1
+    print(f"Advisory {verb}: {advisory_id}")
+    return 0
+
+
+def run(product_dir, argv: list[str]) -> int:
+    """Dispatch ``advisory <subcommand> ...``; print a summary, return an exit code.
+
+    Argv is the tokens *after* ``advisory`` (i.e. ``sys.argv[2:]`` from the
+    hook). Unknown subcommands / missing ids / bad flags print usage to stderr
+    and return 1 (the CLI fail-closed boundary). The underlying lib calls never
+    raise, so this never crashes on a malformed store.
+    """
+    if not argv:
+        print(_USAGE, file=sys.stderr)
+        return 1
+    sub = argv[0]
+    rest = argv[1:]
+
+    if sub == "list":
+        state = "active"
+        feature = None
+        for arg in rest:
+            key, value = _split_flag(arg)
+            if key == "--state":
+                if value not in _LIST_STATES:
+                    print(f"Invalid --state {value!r}; expected one of {', '.join(_LIST_STATES)}", file=sys.stderr)
+                    return 1
+                state = value
+            elif key == "--feature":
+                if not value:
+                    print("--feature requires a value (use --feature=<name>)", file=sys.stderr)
+                    return 1
+                feature = value
+            else:
+                print(f"Unknown flag for list: {arg}", file=sys.stderr)
+                return 1
+        _print_list(list_advisories(product_dir, state=state, feature=feature))
+        return 0
+
+    if sub == "show":
+        if not rest:
+            print("show requires an advisory id", file=sys.stderr)
+            return 1
+        advisory_id = rest[0]
+        return _print_show(show_advisory(product_dir, advisory_id), advisory_id)
+
+    if sub == "dismiss":
+        if not rest:
+            print("dismiss requires an advisory id", file=sys.stderr)
+            return 1
+        advisory_id = rest[0]
+        reason = None
+        flags = rest[1:]
+        i = 0
+        while i < len(flags):
+            key, value = _split_flag(flags[i])
+            if key == "--reason":
+                if value is not None:
+                    reason = value
+                elif i + 1 < len(flags):
+                    reason = flags[i + 1]
+                    i += 1
+                else:
+                    print("--reason requires a value", file=sys.stderr)
+                    return 1
+            else:
+                print(f"Unknown flag for dismiss: {flags[i]}", file=sys.stderr)
+                return 1
+            i += 1
+        return _print_transition(dismiss_advisory(product_dir, advisory_id, reason), "dismissed", advisory_id)
+
+    if sub == "undismiss":
+        if not rest:
+            print("undismiss requires an advisory id", file=sys.stderr)
+            return 1
+        advisory_id = rest[0]
+        return _print_transition(undismiss_advisory(product_dir, advisory_id), "undismissed", advisory_id)
+
+    if sub == "resolve":
+        if not rest:
+            print("resolve requires an advisory id", file=sys.stderr)
+            return 1
+        advisory_id = rest[0]
+        return _print_transition(resolve_advisory(product_dir, advisory_id), "resolved", advisory_id)
+
+    print(_USAGE, file=sys.stderr)
+    return 1

--- a/tools/lib/advisory_store.py
+++ b/tools/lib/advisory_store.py
@@ -1,0 +1,736 @@
+"""Post-sync advisory infrastructure — store, registry, and sync-diff.
+
+Implements Phase 1 of ``documentation/post-sync-advisory-spec.md`` (v0.2): the
+shared mechanism by which sync probes surface "this project should probably do
+X, but we won't force it" nudges to the user at session start.
+
+Two stores, sharply distinct (spec §3.5):
+  - ``.prawduct/.advisories.json`` (gitignored, per-clone) — the *nag log*.
+    Holds active triggers and per-developer dismissal/resolution state. Owned
+    by this module.
+  - ``.prawduct/project-state.yaml`` (committed, shared) — the *answer store*.
+    Holds settled facts probes consult (read-only here, via ``ProjectState``).
+
+Deviations from the spec's illustrative ``tools/lib/probes/__init__.py`` layout
+(reasoned in the build plan): the registry lives in this plain module — no
+import-time registration in an ``__init__`` (avoids the re-export shadowing
+documented in learnings) — and the CLI lands in ``advisory_cmd.py`` per the
+``*_cmd.py`` convention. The spec's *semantics* (registry, ``(feature, type)``
+keying, deterministic candidates, evidence-hash id) are preserved.
+
+**Phase 1 scope.** The store, registry, id-hash, ProjectState/Codebase
+wrappers, the sync diff covering ``active``/``resolved`` states (Ch 01),
+sticky dismissal (Ch 02), probe-version supersession (Ch 03), and
+retention/compaction/schema-migration (Ch 04). The CLI surface
+(``advisory_cmd.py``) lands in Ch 05. The production probe roster is **empty**
+— nothing is registered at import time — so a real sync produces an empty store
+and no briefing section (no-op infrastructure ship).
+
+Conventions (project-preferences): functions are return-value based — they
+return dicts/values and never raise within tool internals; disk reads/writes
+catch ``OSError``/``json.JSONDecodeError`` and degrade to a safe default so a
+sync can never crash on a malformed store.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass, replace
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Callable, Iterable
+
+# Schema version of the on-disk store. Incremented only on breaking changes;
+# read-tolerance / forward-migration is implemented by ``_migrate_store`` (A7).
+SCHEMA_VERSION = 1
+
+# Relative location of the per-clone nag log (gitignored).
+ADVISORY_STORE_REL = ".prawduct/.advisories.json"
+
+# In-store evidence cap (spec §3.3, Q5 lean): keep the array short so the
+# briefing stays scannable; the full list is reconstructible on demand via
+# ``/prawduct-advisory show <id>`` (Chunk 05).
+EVIDENCE_CAP = 5
+
+# Retention policy (spec §3.4, Q4) — applied at sync-persist time by
+# :func:`apply_retention`. Resolved entries are kept for reporting then GC'd;
+# dismissed entries are kept forever (the dismissal is the load-bearing fact).
+# The caps are *soft*: bound the store so it can't grow without limit in a
+# long-running project. The active cap is a defensive guard — a real project
+# never approaches 100 simultaneous live advisories (Phase 1 ships zero probes).
+RESOLVED_TTL_DAYS = 30
+ACTIVE_CAP = 100
+RESOLVED_CAP = 50
+DISMISSED_CAP = 200
+
+# Priority vocabulary and briefing ordering (spec §3.3, §5.1).
+VALID_PRIORITIES = ("info", "warn", "urgent")
+PRIORITY_ORDER = {"urgent": 0, "warn": 1, "info": 2}
+
+# Directories skipped by the Codebase scanner — cheap read-only scans only
+# (spec §7.1: probes run on every sync).
+_SCAN_SKIP_DIRS = {".git", ".hg", "node_modules", "__pycache__", ".venv", "venv", ".prawduct"}
+
+
+# =============================================================================
+# Value objects (lock the probe signature for Phase 2/3)
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class AdvisoryCandidate:
+    """One advisory a probe wants to raise.
+
+    A probe sets ``type``, ``evidence``, ``trigger_summary``,
+    ``recommended_action`` (and optionally ``priority`` / ``alternative_actions``).
+    ``feature`` and ``probe_version`` are stamped from the registration by
+    :func:`run_all_probes`, so a probe body need not repeat them. The ``id`` and
+    ``triggered_at`` are computed by the store at write time, not by the probe.
+    """
+
+    type: str
+    evidence: tuple[str, ...] = ()
+    trigger_summary: str = ""
+    recommended_action: str = ""
+    alternative_actions: tuple[str, ...] = ()
+    priority: str = "info"
+    feature: str = ""
+    probe_version: int = 0
+
+
+class ProjectState:
+    """Read-only view of top-level scalar facts from ``project-state.yaml``.
+
+    The *answer store* (spec §3.5). Probes read resolution-condition facts here
+    (e.g. ``uses_llm_inference``) — never from local code state — so a
+    teammate's committed answer resolves the advisory for everyone on next sync.
+    """
+
+    def __init__(self, data: dict | None = None) -> None:
+        self._data = dict(data or {})
+
+    def get(self, key: str, default=None):
+        return self._data.get(key, default)
+
+    def as_dict(self) -> dict:
+        return dict(self._data)
+
+
+@dataclass(frozen=True)
+class Codebase:
+    """Minimal read-only codebase wrapper exposing the two scan primitives the
+    spec's example probes name (``has_imports``, ``has_files_matching``).
+
+    Phase 1 implements only what the synthetic test probe exercises — a richer
+    content scanner is built by the first feature that needs it (Phase 2/3, see
+    Out of Scope). The point here is to *lock the probe signature* so later
+    chunks don't churn it.
+    """
+
+    root: Path
+
+    def has_imports(self, modules: Iterable[str]) -> bool:
+        """True if any ``*.py`` file under ``root`` imports one of ``modules``."""
+        mods = [m for m in modules if m]
+        if not mods:
+            return False
+        pattern = re.compile(
+            r"^\s*(?:import|from)\s+(?:"
+            + "|".join(re.escape(m) for m in mods)
+            + r")(?:\.|\s|$)",
+            re.MULTILINE,
+        )
+        for py in self._iter_source_files("*.py"):
+            try:
+                text = py.read_text()
+            except (OSError, UnicodeDecodeError):
+                continue
+            if pattern.search(text):
+                return True
+        return False
+
+    def has_files_matching(self, *globs: str) -> bool:
+        """True if any glob (relative to ``root``) matches at least one path."""
+        for g in globs:
+            if not g:
+                continue
+            if any(True for _ in self.root.glob(g)):
+                return True
+        return False
+
+    def _iter_source_files(self, pattern: str):
+        for path in self.root.rglob(pattern):
+            if any(part in _SCAN_SKIP_DIRS for part in path.relative_to(self.root).parts):
+                continue
+            if path.is_file():
+                yield path
+
+
+ProbeFn = Callable[[ProjectState, Codebase], Iterable[AdvisoryCandidate]]
+
+
+# =============================================================================
+# Probe registry — EMPTY in Phase 1 (no production probes registered)
+# =============================================================================
+
+# Keyed by ``f"{feature}:{probe_type}"`` → registration record. Module-level
+# mutable state; tests register a synthetic probe and call clear_registry() in
+# teardown. No production probe is registered at import time (no-op ship).
+_REGISTRY: dict[str, dict] = {}
+
+
+def register_probe(feature: str, probe_type: str, probe_version: int, fn: ProbeFn) -> None:
+    """Register a probe under ``(feature, probe_type)``.
+
+    Re-registering the same key overwrites — a feature owns its probe types.
+    """
+    _REGISTRY[f"{feature}:{probe_type}"] = {
+        "feature": feature,
+        "probe_type": probe_type,
+        "probe_version": probe_version,
+        "fn": fn,
+    }
+
+
+def clear_registry() -> None:
+    """Empty the registry. Primarily for test isolation."""
+    _REGISTRY.clear()
+
+
+def run_all_probes(state: ProjectState, codebase: Codebase) -> list[AdvisoryCandidate]:
+    """Run every registered probe and return enriched candidates.
+
+    Each candidate is stamped with the ``feature`` and ``probe_version`` from
+    its registration (and ``type`` defaults to the registered ``probe_type``
+    when the probe left it blank). A probe that raises is skipped — one bad
+    probe must not block the others or the sync.
+    """
+    candidates: list[AdvisoryCandidate] = []
+    for record in _REGISTRY.values():
+        fn = record["fn"]
+        try:
+            produced = list(fn(state, codebase))
+        except Exception:  # prawduct:ok-broad-except — a faulty probe must not block sync; skip it
+            continue
+        for cand in produced:
+            candidates.append(
+                replace(
+                    cand,
+                    feature=record["feature"],
+                    probe_version=record["probe_version"],
+                    type=cand.type or record["probe_type"],
+                )
+            )
+    return candidates
+
+
+# =============================================================================
+# Identity
+# =============================================================================
+
+
+def compute_id(feature: str, probe_type: str, probe_version: int, evidence: Iterable[str]) -> str:
+    """Stable advisory id: ``<feature>-<probe_type>-v<probe_version>-<hash6>``.
+
+    The hash is a 6-char SHA-256 digest of the *full* evidence list (joined by
+    newlines), so the id reflects the true trigger even though the store keeps
+    only the first ``EVIDENCE_CAP`` citations (spec Q5). Same evidence + same
+    probe version → same id (idempotent, spec §2.2). Bumping ``probe_version``
+    yields a new id, enabling clean supersession (spec §2.8, Chunk 03).
+
+    Phase 1 uses the literal ``feature`` token as the id prefix; the spec's
+    "feature-prefix" abbreviation (``prompts`` for ``prompt-management``) is
+    illustrative and a probe simply chooses a short ``feature`` token.
+    """
+    joined = "\n".join(evidence)
+    digest = hashlib.sha256(joined.encode("utf-8")).hexdigest()[:6]
+    return f"{feature}-{probe_type}-v{probe_version}-{digest}"
+
+
+# =============================================================================
+# Store I/O
+# =============================================================================
+
+
+def _store_path(product_dir) -> Path:
+    return Path(product_dir) / ADVISORY_STORE_REL
+
+
+def _empty_store() -> dict:
+    return {"schema_version": SCHEMA_VERSION, "advisories": []}
+
+
+def _migrate_store(data: dict) -> dict:
+    """Forward-migrate an on-disk store to the current schema (spec A7).
+
+    A lower or absent ``schema_version`` is normalized up to ``SCHEMA_VERSION``
+    in place — at v1 there are no field renames, so migration is a relabel;
+    future breaking versions add per-version transforms here keyed on the
+    starting ``version``. A *higher* version (a store written by a newer
+    prawduct) is read as-is rather than crashing — unknown fields round-trip
+    untouched. Either way the read never raises (return-value convention).
+    """
+    version = data.get("schema_version")
+    if not isinstance(version, int):
+        version = 0  # absent / garbage → treat as pre-v1
+    if version < SCHEMA_VERSION:
+        data["schema_version"] = SCHEMA_VERSION
+    return data
+
+
+def read_store(product_dir) -> dict:
+    """Read the nag log. Missing/unreadable/malformed → empty default (no raise).
+
+    A lower/absent ``schema_version`` is migrated forward on read (spec A7);
+    the migrated version persists on the next :func:`write_store`.
+    """
+    path = _store_path(product_dir)
+    if not path.is_file():
+        return _empty_store()
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return _empty_store()
+    if not isinstance(data, dict) or not isinstance(data.get("advisories"), list):
+        return _empty_store()
+    return _migrate_store(data)
+
+
+def write_store(product_dir, store: dict) -> dict:
+    """Write the nag log as pretty JSON. Returns ``{status, ...}`` (no raise)."""
+    path = _store_path(product_dir)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(store, indent=2) + "\n")
+    except OSError as exc:
+        return {"status": "error", "reason": str(exc)}
+    return {"status": "ok", "path": str(path)}
+
+
+# =============================================================================
+# ProjectState / Codebase loaders
+# =============================================================================
+
+
+def _coerce_scalar(value: str):
+    low = value.lower()
+    if low in ("true", "yes", "on"):
+        return True
+    if low in ("false", "no", "off"):
+        return False
+    if low in ("null", "~", "none"):
+        return None
+    if re.fullmatch(r"-?\d+", value):
+        return int(value)
+    return value
+
+
+def load_project_state(product_dir) -> ProjectState:
+    """Parse top-level scalar fields from ``project-state.yaml`` (column-0 scan).
+
+    No PyYAML dependency — mirrors the column-0 pattern used elsewhere
+    (``_read_sync_config``, ``views_enabled``). Only top-level ``key: value``
+    scalars are captured; nested-block headers (``key:`` with no value) are
+    skipped. Resolution-condition facts probes consult (e.g.
+    ``uses_llm_inference``) live at the top level.
+    """
+    path = Path(product_dir) / ".prawduct" / "project-state.yaml"
+    data: dict = {}
+    if not path.is_file():
+        return ProjectState(data)
+    try:
+        text = path.read_text()
+    except OSError:
+        return ProjectState(data)
+    for line in text.splitlines():
+        if not line or line[0] in (" ", "\t", "#"):
+            continue
+        if ":" not in line:
+            continue
+        key, _, rest = line.partition(":")
+        key = key.strip()
+        val = rest.split("#", 1)[0].strip().strip("\"'")
+        if val == "":
+            continue  # nested-block header, not a scalar
+        data[key] = _coerce_scalar(val)
+    return ProjectState(data)
+
+
+def make_codebase(product_dir) -> Codebase:
+    """Build the read-only Codebase wrapper rooted at ``product_dir``."""
+    return Codebase(root=Path(product_dir))
+
+
+# =============================================================================
+# Reconcile (the sync diff) + orchestration
+# =============================================================================
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _new_advisory(candidate: AdvisoryCandidate, *, advisory_id: str, now: str, sync_version: str) -> dict:
+    priority = candidate.priority if candidate.priority in VALID_PRIORITIES else "info"
+    return {
+        "id": advisory_id,
+        "feature": candidate.feature,
+        "type": candidate.type,
+        "probe_version": candidate.probe_version,
+        "triggered_at": now,
+        "triggered_by_sync_version": sync_version,
+        "trigger_summary": candidate.trigger_summary,
+        "evidence": list(candidate.evidence[:EVIDENCE_CAP]),
+        "recommended_action": candidate.recommended_action,
+        "alternative_actions": list(candidate.alternative_actions),
+        "priority": priority,
+        "state": "active",
+        "superseded_by": None,
+        "dismissed_at": None,
+        "dismissed_reason": None,
+        "resolved_at": None,
+        "resolved_by": None,
+    }
+
+
+def _supersession_targets(
+    cand_by_id: dict[str, AdvisoryCandidate], existing_ids: set[str]
+) -> dict[tuple[str, str], tuple[int, str]]:
+    """Map ``(feature, type)`` → ``(version, id)`` of the highest-version *new*
+    candidate for that tuple (spec §2.8, Q1).
+
+    Only candidates whose id is absent from the store count as supersession
+    *sources* — an id already present is an idempotent re-fire, not a probe
+    refinement. When a probe-version bump fires, the bumped candidate carries a
+    new id (version is in the hash), so the prior active advisory for the same
+    ``(feature, type)`` drops out of the candidate set and is superseded *by*
+    this entry rather than plainly resolved.
+    """
+    targets: dict[tuple[str, str], tuple[int, str]] = {}
+    for advisory_id, cand in cand_by_id.items():
+        if advisory_id in existing_ids:
+            continue
+        key = (cand.feature, cand.type)
+        prev = targets.get(key)
+        if prev is None or cand.probe_version > prev[0]:
+            targets[key] = (cand.probe_version, advisory_id)
+    return targets
+
+
+def reconcile(store: dict, candidates: Iterable[AdvisoryCandidate], *, now: str | None = None, sync_version: str = "") -> dict:
+    """Diff fresh probe candidates against the existing store (spec §4.2, §2.8).
+
+    Decides advisory *states* — ``active``, ``resolved``, ``dismissed``, and
+    probe-version supersession. The complementary question of *what form to
+    keep non-active entries in* (compaction, TTL GC, soft caps) belongs to the
+    sync-persist pass :func:`apply_retention`, kept separate so this function
+    stays a clean state-diff. The six cases:
+
+      - id in candidates, not in store        → new ``active`` advisory
+      - id in candidates, ``active`` in store  → no-op (idempotent; ``triggered_at`` unchanged)
+      - id in candidates, ``resolved`` in store → re-activate (the answer was un-set)
+      - id in candidates, ``dismissed`` in store → kept dismissed (sticky, A4)
+      - id ``active`` in store, superseded by a higher-version new candidate for
+        the same ``(feature, type)`` → ``resolved`` / ``resolved_by: probe-update`` /
+        ``superseded_by: <new-id>`` (spec §2.8, A8)
+      - id ``active`` in store, not in candidates and not superseded → ``resolved`` / ``resolved_by: sync``
+      - non-active in store, not in candidates → kept as-is (compaction/GC is
+        a separate sync-persist pass, :func:`apply_retention`)
+
+    A ``dismissed`` advisory whose probe bumps version is *not* superseded: its
+    dismissal is the load-bearing per-clone fact (kept), and the new id is a
+    distinct condition that surfaces as a fresh ``active`` advisory — the user
+    dismissed the old probe's finding, so a materially-refined probe gets a new
+    chance to nag (recorded in the change-log / A8 test).
+
+    Pure function — does not touch disk. Existing-entry order is preserved and
+    new advisories append, for a deterministic store.
+    """
+    now = now or _utcnow_iso()
+    cand_by_id: dict[str, AdvisoryCandidate] = {}
+    for cand in candidates:
+        advisory_id = compute_id(cand.feature, cand.type, cand.probe_version, cand.evidence)
+        cand_by_id[advisory_id] = cand
+
+    existing_ids = {a.get("id") for a in store.get("advisories", [])}
+    supersedes = _supersession_targets(cand_by_id, existing_ids)
+
+    result: list[dict] = []
+    seen: set[str] = set()
+    for advisory in store.get("advisories", []):
+        advisory_id = advisory.get("id")
+        seen.add(advisory_id)
+        state = advisory.get("state")
+        if advisory_id in cand_by_id:
+            if state == "dismissed":
+                # Sticky dismissal (spec §2.4, A4): a dismissed id never
+                # re-triggers, even though its probe still fires. Kept as-is;
+                # only undismiss() returns it to active.
+                result.append(advisory)
+            elif state == "resolved":
+                # The probe fires again — the resolution fact was removed. Return
+                # to active, preserving the original first-seen metadata.
+                result.append(
+                    _new_advisory(
+                        cand_by_id[advisory_id],
+                        advisory_id=advisory_id,
+                        now=advisory.get("triggered_at") or now,
+                        sync_version=advisory.get("triggered_by_sync_version") or sync_version,
+                    )
+                )
+            elif not advisory.get("triggered_at"):
+                # A compacted entry that was undismissed (Chunk 05): undismiss
+                # flips state→active on the compact stub, but compaction had
+                # already dropped feature/evidence/trigger_summary/action. The
+                # probe still fires, so rehydrate the full advisory from the
+                # fresh candidate (fresh triggered_at — it resurfaces as a new
+                # occurrence). Without this it would render in the briefing with
+                # a blank summary and no action indefinitely. A normal active
+                # entry always carries triggered_at, so this never disturbs the
+                # idempotent path below.
+                result.append(
+                    _new_advisory(cand_by_id[advisory_id], advisory_id=advisory_id, now=now, sync_version=sync_version)
+                )
+            else:
+                result.append(advisory)  # active → idempotent no-op
+        elif state == "active":
+            target = supersedes.get((advisory.get("feature"), advisory.get("type")))
+            resolved = dict(advisory)
+            resolved["state"] = "resolved"
+            resolved["resolved_at"] = now
+            if target is not None and target[0] > (advisory.get("probe_version") or 0):
+                # Probe-version bump: link old → new instead of a plain resolve.
+                resolved["resolved_by"] = "probe-update"
+                resolved["superseded_by"] = target[1]
+            else:
+                # Plain resolution — the probe stopped firing (resolution fact
+                # landed). The strict ``>`` also routes a version *downgrade*
+                # here (versions are monotonic per spec §3.3, so this is a
+                # defensive default, not an expected path).
+                resolved["resolved_by"] = "sync"
+            result.append(resolved)
+        else:
+            result.append(advisory)  # already non-active — compaction/GC happens in apply_retention
+
+    for advisory_id, cand in cand_by_id.items():
+        if advisory_id not in seen:
+            result.append(_new_advisory(cand, advisory_id=advisory_id, now=now, sync_version=sync_version))
+
+    return {"schema_version": SCHEMA_VERSION, "advisories": result}
+
+
+# =============================================================================
+# Retention: compaction, TTL garbage-collection, soft caps (spec §3.4, Q4) — Chunk 04
+# =============================================================================
+
+
+def _parse_iso(ts) -> datetime | None:
+    """Parse a ``%Y-%m-%dT%H:%M:%SZ`` stamp to an aware UTC datetime, or None."""
+    if not isinstance(ts, str) or not ts:
+        return None
+    try:
+        return datetime.strptime(ts, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+
+
+def _compact_advisory(advisory: dict) -> dict:
+    """Shrink a non-active advisory to the load-bearing fields (spec §3.4).
+
+    Active entries are returned untouched (full payload kept while live).
+    Resolved → ``id``/``state``/``resolved_at``/``resolved_by`` (+ ``superseded_by``
+    when set). Dismissed → ``id``/``state``/``dismissed_at``/``dismissed_reason``.
+    Idempotent: compacting an already-compact entry yields the same dict.
+    """
+    state = advisory.get("state")
+    if state == "resolved":
+        compact = {
+            "id": advisory.get("id"),
+            "state": "resolved",
+            "resolved_at": advisory.get("resolved_at"),
+            "resolved_by": advisory.get("resolved_by"),
+        }
+        if advisory.get("superseded_by"):
+            compact["superseded_by"] = advisory["superseded_by"]
+        return compact
+    if state == "dismissed":
+        return {
+            "id": advisory.get("id"),
+            "state": "dismissed",
+            "dismissed_at": advisory.get("dismissed_at"),
+            "dismissed_reason": advisory.get("dismissed_reason"),
+        }
+    return advisory  # active (or unrecognized) — leave full payload intact
+
+
+def _resolved_expired(advisory: dict, now_dt: datetime | None) -> bool:
+    """True if a resolved advisory is older than the 30-day TTL (spec §3.4).
+
+    Unparseable/absent ``resolved_at`` or ``now`` → not expired (keep it; a
+    missing timestamp must never silently delete an entry)."""
+    if advisory.get("state") != "resolved":
+        return False
+    resolved_dt = _parse_iso(advisory.get("resolved_at"))
+    if resolved_dt is None or now_dt is None:
+        return False
+    return (now_dt - resolved_dt) > timedelta(days=RESOLVED_TTL_DAYS)
+
+
+def _over_cap_ids(advisories: list[dict], state: str, ts_field: str, cap: int) -> set[str]:
+    """Ids of the oldest entries in ``state`` beyond ``cap`` (by ``ts_field``).
+
+    Entries with a missing/empty timestamp sort oldest and are dropped first."""
+    entries = [a for a in advisories if a.get("state") == state]
+    if len(entries) <= cap:
+        return set()
+    newest_first = sorted(entries, key=lambda a: a.get(ts_field) or "", reverse=True)
+    return {a.get("id") for a in newest_first[cap:]}
+
+
+def apply_retention(store: dict, *, now: str | None = None) -> dict:
+    """Compact non-active entries, GC expired resolved, and apply soft caps.
+
+    The sync-persist hygiene pass (spec §3.4, Q4), kept separate from
+    :func:`reconcile` (which is a pure state-diff): reconcile decides *states*,
+    retention decides *what to keep and in what form*. Pure — does not touch
+    disk. Order within each state band is preserved; only over-cap and expired
+    entries are removed. Idempotent.
+    """
+    now = now or _utcnow_iso()
+    now_dt = _parse_iso(now)
+    compacted = [_compact_advisory(a) for a in store.get("advisories", []) if isinstance(a, dict)]
+    kept = [a for a in compacted if not _resolved_expired(a, now_dt)]
+    drop: set[str] = set()
+    drop |= _over_cap_ids(kept, "active", "triggered_at", ACTIVE_CAP)
+    drop |= _over_cap_ids(kept, "resolved", "resolved_at", RESOLVED_CAP)
+    drop |= _over_cap_ids(kept, "dismissed", "dismissed_at", DISMISSED_CAP)
+    final = [a for a in kept if a.get("id") not in drop]
+    return {"schema_version": SCHEMA_VERSION, "advisories": final}
+
+
+def run_sync_advisories(product_dir, *, now: str | None = None, sync_version: str = "") -> dict:
+    """Sync entry point: run probes, diff against the store, retain, persist.
+
+    Loads the answer store + codebase, runs the (empty in Phase 1) probe
+    roster, reconciles, applies retention (compaction / TTL GC / soft caps),
+    and writes the nag log. Returns a summary dict. Never raises — the
+    underlying reads/writes/probes all degrade safely.
+    """
+    product = Path(product_dir)
+    now = now or _utcnow_iso()
+    state = load_project_state(product)
+    codebase = make_codebase(product)
+    # Load feature probes before running the roster. Lazy import (avoids a
+    # circular import — backlog_probes imports from this module) and idempotent
+    # registration (survives clear_registry between syncs). Defensive: a faulty
+    # probe module must not break the advisory step.
+    try:
+        from . import backlog_probes  # noqa: PLC0415 — feature-probe registration point
+
+        backlog_probes.register_backlog_probes()
+    except Exception:  # prawduct:ok-broad-except — probe registration must never block sync
+        pass
+    candidates = run_all_probes(state, codebase)
+    store = read_store(product)
+    reconciled = reconcile(store, candidates, now=now, sync_version=sync_version)
+    new_store = apply_retention(reconciled, now=now)
+    write_result = write_store(product, new_store)
+    advisories = new_store["advisories"]
+    active = [a for a in advisories if a.get("state") == "active"]
+    newly_resolved = [
+        a["id"]
+        for a in advisories
+        if a.get("state") == "resolved" and a.get("resolved_by") == "sync" and a.get("resolved_at") == now
+    ]
+    return {
+        "status": write_result.get("status", "ok"),
+        "active": len(active),
+        "newly_resolved": newly_resolved,
+    }
+
+
+# =============================================================================
+# Dismissal lifecycle (spec §2.4, §6.1) — Chunk 02; resolve added Chunk 05
+# =============================================================================
+
+
+def _mutate_advisory(product_dir, advisory_id: str, apply: Callable[[dict], None]) -> dict:
+    """Read the store, run ``apply(advisory)`` on the entry matching
+    ``advisory_id``, and write back. Returns ``{status: "ok"|"not_found", id}``.
+
+    The shared read-scan-mutate-write skeleton behind :func:`dismiss`,
+    :func:`undismiss`, and :func:`resolve` — each verb supplies only its field
+    mutation. The store is written only when the id is found; a miss is a no-op
+    write. Never raises (the underlying read/write degrade safely).
+    """
+    store = read_store(product_dir)
+    for advisory in store.get("advisories", []):
+        if advisory.get("id") == advisory_id:
+            apply(advisory)
+            write_store(product_dir, store)
+            return {"status": "ok", "id": advisory_id}
+    return {"status": "not_found", "id": advisory_id}
+
+
+def dismiss(product_dir, advisory_id: str, reason: str | None = None, *, now: str | None = None) -> dict:
+    """Mark an advisory ``dismissed`` (sticky — it won't re-trigger; spec §2.4).
+
+    The dismissal lives only in the per-clone nag log, never in the shared
+    ``project-state.yaml`` (spec §3.5). ``dismiss`` writes the full payload
+    (cheap, between syncs); the next sync's :func:`apply_retention` shrinks it
+    to the load-bearing dismissal fact (spec §3.4). Returns
+    ``{status: "ok"|"not_found"}``.
+    """
+    now = now or _utcnow_iso()
+
+    def _apply(advisory: dict) -> None:
+        advisory["state"] = "dismissed"
+        advisory["dismissed_at"] = now
+        advisory["dismissed_reason"] = reason
+        advisory["resolved_at"] = None
+        advisory["resolved_by"] = None
+
+    return _mutate_advisory(product_dir, advisory_id, _apply)
+
+
+def undismiss(product_dir, advisory_id: str) -> dict:
+    """Clear a dismissal — the advisory returns to ``active`` (spec §6.1).
+
+    The next sync reconciles it: if the probe still fires it stays active (and
+    :func:`reconcile` rehydrates the entry should compaction have shrunk it; see
+    the ``triggered_at`` branch there); if not, it auto-resolves. Returns
+    ``{status: "ok"|"not_found"}``.
+    """
+
+    def _apply(advisory: dict) -> None:
+        advisory["state"] = "active"
+        advisory["dismissed_at"] = None
+        advisory["dismissed_reason"] = None
+
+    return _mutate_advisory(product_dir, advisory_id, _apply)
+
+
+def resolve(product_dir, advisory_id: str, *, resolved_by: str = "action", now: str | None = None) -> dict:
+    """Mark an advisory ``resolved`` immediately (action-driven, spec §4.3, Q3).
+
+    The action-resolution path: when the user runs a ``recommended_action`` the
+    action's success can clear the advisory now, without waiting for the next
+    sync's probe re-run. ``resolved_by`` defaults to ``"action"`` to distinguish
+    it from sync-driven (``"sync"``) and supersession (``"probe-update"``)
+    resolutions. Note the authoritative resolution path remains the
+    ``project-state.yaml`` fact + probe re-run (spec Q3); this is the immediate-
+    feedback shortcut. The next sync's :func:`apply_retention` shrinks the entry
+    to compact form. Returns ``{status: "ok"|"not_found"}``.
+    """
+    now = now or _utcnow_iso()
+
+    def _apply(advisory: dict) -> None:
+        advisory["state"] = "resolved"
+        advisory["resolved_at"] = now
+        advisory["resolved_by"] = resolved_by
+        advisory["dismissed_at"] = None
+        advisory["dismissed_reason"] = None
+
+    return _mutate_advisory(product_dir, advisory_id, _apply)

--- a/tools/lib/audit_learnings_cmd.py
+++ b/tools/lib/audit_learnings_cmd.py
@@ -1,0 +1,461 @@
+"""F9 — Learnings lifecycle sentinel tracker.
+
+Parses `.prawduct/learnings.md` for optional per-entry metadata, identifies
+promotion / retirement / stale candidates, and (with ``apply=True``) moves
+sentinel-protected entries to ``learnings-detail.md``'s historical section.
+
+Schema (all fields optional; absence → "active, no lifecycle metadata"):
+
+    ## Entry title
+    <!-- prawduct-learning: confirmations=N; created=YYYY-MM-DD; sentinel=path/to/test.py::test_name -->
+
+The HTML comment must be on the line immediately after the ``## Title`` line.
+A comment placed deeper in the entry body is ignored — the strict placement
+avoids parsing surprises when entries quote example metadata in their prose.
+
+Public surface mirrors the ``run_migrate_*`` runners so JSON-mode callers
+see the same dict shape (``product_dir``, ``applied``, plus per-category
+lists). The runner does not raise on partial-result conditions — missing
+``learnings.md`` is a clean empty result; only structural problems
+(``.prawduct/`` absent) surface as ``{"error": "..."}``.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from pathlib import Path
+
+# Threshold for "stale" entries: confirmations <= 1 AND created >= this many
+# days ago. 90d matches the v1.4 plan's F9 section.
+_STALE_THRESHOLD_DAYS = 90
+
+# Metadata fields recognized in the per-entry comment. Unknown keys are
+# preserved in the entry's metadata dict (so future fields don't break the
+# parser) but the audit logic only consults this set.
+_KNOWN_METADATA_KEYS = frozenset({"confirmations", "created", "sentinel"})
+
+_METADATA_RE = re.compile(
+    r"<!--\s*prawduct-learning:\s*(?P<body>.*?)\s*-->\s*$"
+)
+
+_HISTORICAL_SECTION_HEADER = "## Historical (structurally enforced)"
+_HISTORICAL_SECTION_BLURB = (
+    "Learnings retired by `audit-learnings --apply` after their declared "
+    "sentinel test passed — the failure mode the rule warned about is now "
+    "structurally enforced by a test. Kept here as historical context.\n"
+)
+
+
+@dataclass
+class LearningEntry:
+    """A single ``## Title`` block from ``learnings.md``.
+
+    ``body_lines`` is the verbatim slice between the title and the next entry
+    (or end of file), excluding the title itself but INCLUDING the metadata
+    comment line if present. This lets the serializer round-trip without
+    reconstructing comments.
+    """
+
+    title: str
+    body_lines: list[str]
+    metadata: dict[str, str] = field(default_factory=dict)
+
+
+def parse_learning_metadata(line: str) -> dict[str, str] | None:
+    """Parse a single ``<!-- prawduct-learning: ... -->`` comment line.
+
+    Returns the metadata dict on match, ``None`` otherwise. Unknown keys are
+    kept (audit logic ignores them); malformed key/value pairs (no ``=``) are
+    dropped silently so a stray semicolon in prose can't break parsing.
+
+    Whitespace and trailing semicolons are tolerated. Multiple instances of
+    the same key keep the first occurrence (typical of accidental
+    duplication during manual editing).
+    """
+    match = _METADATA_RE.match(line.strip())
+    if not match:
+        return None
+
+    body = match.group("body")
+    result: dict[str, str] = {}
+    for raw_pair in body.split(";"):
+        pair = raw_pair.strip()
+        if not pair or "=" not in pair:
+            continue
+        key, _, value = pair.partition("=")
+        key = key.strip()
+        value = value.strip()
+        if not key:
+            continue
+        if key not in result:
+            result[key] = value
+    return result
+
+
+def parse_learnings_file(content: str) -> list[LearningEntry]:
+    """Segment ``learnings.md`` content into entries by ``## `` headers.
+
+    The metadata comment is only honored when it appears on the line
+    immediately following the title — a comment in the body is ignored. This
+    matters because some entries quote example metadata in their prose
+    (this module's own docstring, for instance).
+
+    Lines before the first ``## `` heading (file preamble) are discarded —
+    they belong to the file structure, not to any entry. The caller
+    reconstructs them in :func:`serialize_learnings`.
+    """
+    entries: list[LearningEntry] = []
+    lines = content.split("\n")
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if line.startswith("## "):
+            title = line[3:].strip()
+            body_start = i + 1
+            # Find next entry boundary (next ## heading or EOF).
+            j = body_start
+            while j < len(lines) and not lines[j].startswith("## "):
+                j += 1
+            body_lines = lines[body_start:j]
+
+            metadata: dict[str, str] = {}
+            # Metadata must be on the first non-blank line of the body to
+            # count. Blank lines between title and comment are tolerated.
+            for body_line in body_lines:
+                if not body_line.strip():
+                    continue
+                parsed = parse_learning_metadata(body_line)
+                if parsed is not None:
+                    metadata = parsed
+                break
+
+            entries.append(
+                LearningEntry(
+                    title=title, body_lines=body_lines, metadata=metadata
+                )
+            )
+            i = j
+        else:
+            i += 1
+    return entries
+
+
+def _entry_block(entry: LearningEntry) -> str:
+    """Serialize a single entry back to its original markdown form."""
+    body = "\n".join(entry.body_lines)
+    return f"## {entry.title}\n{body}"
+
+
+def run_sentinel(
+    product_dir: Path, sentinel: str, *, timeout: int = 120
+) -> tuple[bool, str]:
+    """Run ``python3 -m pytest <sentinel> -q`` from ``product_dir``.
+
+    Returns ``(passed, excerpt)``. The excerpt is the trailing portion of
+    pytest's combined stdout/stderr (last ~20 lines) so callers can surface
+    actionable failure context without dumping the full transcript.
+
+    Subprocess failures (timeout, missing pytest, OS errors) return
+    ``(False, "<diagnostic>")`` rather than raising — the audit must keep
+    walking through remaining entries even when one sentinel is misconfigured.
+    """
+    try:
+        result = subprocess.run(
+            ["python3", "-m", "pytest", sentinel, "-q"],
+            cwd=str(product_dir),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return False, f"sentinel timed out after {timeout}s"
+    except (OSError, FileNotFoundError) as exc:
+        return False, f"could not invoke pytest: {exc}"
+
+    combined = (result.stdout or "") + (result.stderr or "")
+    tail = "\n".join(combined.splitlines()[-20:])
+    return result.returncode == 0, tail
+
+
+def _parse_iso_date(value: str) -> date | None:
+    """Parse ``YYYY-MM-DD``. Returns ``None`` on malformed input."""
+    try:
+        return datetime.strptime(value.strip(), "%Y-%m-%d").date()
+    except (ValueError, TypeError):
+        return None
+
+
+def _coerce_int(value: str) -> int | None:
+    try:
+        return int(value.strip())
+    except (ValueError, TypeError):
+        return None
+
+
+def audit_learnings(
+    product_dir: Path,
+    *,
+    apply: bool = False,
+    today: date | None = None,
+    run_sentinels: bool = True,
+) -> dict:
+    """Classify entries in ``learnings.md`` by lifecycle stage.
+
+    Returns a dict with five lists plus the run mode:
+
+      * ``promotions`` — entries with ``confirmations >= 2``. Advisory only;
+        no file mutation regardless of ``apply``. Promotion in this design
+        means "surface the confirmation count" — `learnings.md` doesn't have
+        a sectioned active/promoted split.
+      * ``retirements`` — entries with a passing sentinel. Each carries the
+        sentinel string, the pass/fail bit, and the output excerpt. With
+        ``apply=True`` *and* a passing sentinel, the entry is moved to
+        ``learnings-detail.md`` under the historical section.
+      * ``stale_flags`` — entries with ``created`` more than 90 days ago and
+        ``confirmations <= 1``. The ``created`` field is required for
+        staleness detection — entries that lack it never appear here.
+      * ``errors`` — entries whose declared sentinel exists but failed, plus
+        entries with unparseable date fields. The audit keeps going; the
+        per-entry error string tells the user what to fix.
+      * ``applied`` — bool mirror of the ``apply`` argument; surfaces in the
+        result so JSON-mode callers know whether mutations happened.
+
+    ``today`` and ``run_sentinels`` are test seams. ``today=None`` uses the
+    real wall clock; ``run_sentinels=False`` short-circuits the subprocess
+    call (entries with sentinels just appear in ``retirements`` with
+    ``passed=None`` and don't trigger errors). Both default to production
+    behavior.
+    """
+    if today is None:
+        today = date.today()
+
+    promotions: list[dict] = []
+    retirements: list[dict] = []
+    stale_flags: list[dict] = []
+    errors: list[dict] = []
+
+    learnings_path = product_dir / ".prawduct" / "learnings.md"
+    if not learnings_path.is_file():
+        return {
+            "product_dir": str(product_dir),
+            "applied": apply,
+            "promotions": promotions,
+            "retirements": retirements,
+            "stale_flags": stale_flags,
+            "errors": errors,
+        }
+
+    content = learnings_path.read_text()
+    entries = parse_learnings_file(content)
+
+    retained_entries: list[LearningEntry] = []
+    retired_entries: list[LearningEntry] = []
+
+    for entry in entries:
+        meta = entry.metadata
+        if not meta:
+            retained_entries.append(entry)
+            continue
+
+        # Promotions: confirmations >= 2. Advisory only — surface but never
+        # rewrite the file.
+        confirmations_raw = meta.get("confirmations")
+        confirmations: int | None = None
+        if confirmations_raw is not None:
+            confirmations = _coerce_int(confirmations_raw)
+            if confirmations is None:
+                errors.append({
+                    "title": entry.title,
+                    "error": (
+                        f"could not parse confirmations='{confirmations_raw}' "
+                        "as integer"
+                    ),
+                })
+            elif confirmations >= 2:
+                promotions.append({
+                    "title": entry.title,
+                    "confirmations": confirmations,
+                })
+
+        # Sentinel handling: an entry with a declared sentinel is a
+        # retirement candidate. Whether the sentinel currently passes
+        # determines whether `apply=True` actually moves the entry.
+        sentinel = meta.get("sentinel")
+        sentinel_passed: bool | None = None
+        sentinel_excerpt = ""
+        if sentinel:
+            if run_sentinels:
+                sentinel_passed, sentinel_excerpt = run_sentinel(
+                    product_dir, sentinel
+                )
+            retirement_record = {
+                "title": entry.title,
+                "sentinel": sentinel,
+                "passed": sentinel_passed,
+                "output_excerpt": sentinel_excerpt,
+                "applied": False,
+            }
+            if sentinel_passed is False:
+                # Failing sentinel: surfaced as both a retirement attempt
+                # (record on disk) AND an error (so users see "fix me"
+                # without needing to inspect every retirement entry).
+                errors.append({
+                    "title": entry.title,
+                    "error": (
+                        f"sentinel '{sentinel}' is failing — fix the test "
+                        "or update the learning before retiring"
+                    ),
+                })
+                retirements.append(retirement_record)
+                retained_entries.append(entry)
+            elif sentinel_passed is True:
+                if apply:
+                    retirement_record["applied"] = True
+                    retired_entries.append(entry)
+                else:
+                    retained_entries.append(entry)
+                retirements.append(retirement_record)
+            else:
+                # run_sentinels=False — record as candidate without
+                # actually trying to retire.
+                retirements.append(retirement_record)
+                retained_entries.append(entry)
+        else:
+            retained_entries.append(entry)
+
+        # Staleness: created > 90d ago AND confirmations <= 1. The ``created``
+        # field is required — entries without it never show up here. (Stale
+        # check is independent of sentinel; a sentineled stale entry surfaces
+        # in both lists, which is the right read for the user.)
+        created_raw = meta.get("created")
+        if created_raw:
+            created = _parse_iso_date(created_raw)
+            if created is None:
+                errors.append({
+                    "title": entry.title,
+                    "error": (
+                        f"could not parse created='{created_raw}' "
+                        "as YYYY-MM-DD"
+                    ),
+                })
+            else:
+                age_days = (today - created).days
+                effective_confirmations = (
+                    confirmations if confirmations is not None else 0
+                )
+                if (
+                    age_days >= _STALE_THRESHOLD_DAYS
+                    and effective_confirmations <= 1
+                ):
+                    stale_flags.append({
+                        "title": entry.title,
+                        "created": created_raw,
+                        "age_days": age_days,
+                        "confirmations": effective_confirmations,
+                    })
+
+    if apply and retired_entries:
+        _apply_retirements(learnings_path, retained_entries, retired_entries, content)
+
+    return {
+        "product_dir": str(product_dir),
+        "applied": apply,
+        "promotions": promotions,
+        "retirements": retirements,
+        "stale_flags": stale_flags,
+        "errors": errors,
+    }
+
+
+def _apply_retirements(
+    learnings_path: Path,
+    retained_entries: list[LearningEntry],
+    retired_entries: list[LearningEntry],
+    original_content: str,
+) -> None:
+    """Rewrite ``learnings.md`` with retired entries removed, and append
+    those entries to ``learnings-detail.md`` under the historical section.
+
+    The preamble of ``learnings.md`` (everything before the first ``## ``
+    heading) is preserved verbatim. The detail file is created with a
+    minimal header if absent; the historical section is created if absent.
+    """
+    # Rebuild learnings.md preserving the preamble.
+    lines = original_content.split("\n")
+    preamble_end = len(lines)
+    for idx, line in enumerate(lines):
+        if line.startswith("## "):
+            preamble_end = idx
+            break
+
+    preamble = "\n".join(lines[:preamble_end]).rstrip("\n")
+    rebuilt_parts: list[str] = []
+    if preamble:
+        rebuilt_parts.append(preamble + "\n")
+    for entry in retained_entries:
+        rebuilt_parts.append(_entry_block(entry).rstrip("\n") + "\n")
+    new_content = "\n".join(rebuilt_parts).rstrip("\n") + "\n"
+    learnings_path.write_text(new_content)
+
+    # Append to learnings-detail.md.
+    detail_path = learnings_path.parent / "learnings-detail.md"
+    if detail_path.is_file():
+        detail_content = detail_path.read_text()
+    else:
+        detail_content = (
+            "# Learnings — Full Detail\n\n"
+            "Historical record of learnings with their full context. "
+            "See `learnings.md` for the active rule list.\n"
+        )
+
+    if _HISTORICAL_SECTION_HEADER not in detail_content:
+        if not detail_content.endswith("\n"):
+            detail_content += "\n"
+        detail_content += (
+            "\n" + _HISTORICAL_SECTION_HEADER + "\n\n"
+            + _HISTORICAL_SECTION_BLURB
+        )
+
+    appended_blocks = "\n".join(
+        _entry_block(entry).rstrip("\n") + "\n" for entry in retired_entries
+    )
+    if not detail_content.endswith("\n"):
+        detail_content += "\n"
+    detail_content += "\n" + appended_blocks
+    detail_path.write_text(detail_content)
+
+
+def run_audit_learnings(product_dir: str, *, apply: bool = False) -> dict:
+    """User-facing runner for ``prawduct-setup audit-learnings``.
+
+    Matches the ``run_migrate_*`` shape so the CLI dispatch and JSON-mode
+    callers see a consistent contract:
+
+        {
+          "product_dir": "/abs/path",
+          "applied": bool,
+          "promotions": [...],
+          "retirements": [...],
+          "stale_flags": [...],
+          "errors": [...],
+        }
+
+    Returns ``{"error": "..."}`` only for structural problems (no
+    ``.prawduct/`` directory) — a missing ``learnings.md`` is a clean empty
+    result, not an error. Sentinel subprocess failures are absorbed into
+    per-entry ``errors`` entries; the runner itself does not raise.
+    """
+    product_path = Path(product_dir).resolve()
+    prawduct_dir = product_path / ".prawduct"
+    if not prawduct_dir.is_dir():
+        return {
+            "error": (
+                f"Not a prawduct product: {product_path} has no .prawduct/ "
+                "directory"
+            )
+        }
+
+    return audit_learnings(product_path, apply=apply)

--- a/tools/lib/backlog_probes.py
+++ b/tools/lib/backlog_probes.py
@@ -1,0 +1,142 @@
+"""Backlog feature probes — registered against the post-sync advisory infra.
+
+Phase 2 (v1.7.0) ships exactly one production probe: ``legacy-backlog-format``,
+which nudges a product whose ``.prawduct/backlog.md`` is still in the legacy
+unstructured form (no ``[PFX-XXXX]`` ids) to run ``/backlog migrate``. The other
+three probes from backlog-system-requirements.md §8.2 (external-detected,
+legacy-section-schema, overdue-grooming) are deferred — see the v1.7.0 build
+plan's "Out of scope (deferred)".
+
+**Registration model.** Unlike the spec's import-time-side-effect sketch, this
+module exposes an *idempotent* ``register_backlog_probes()`` that
+``advisory_store.run_sync_advisories`` calls on every sync. Import-time
+registration would be wiped by the ``clear_registry()`` that advisory tests run
+in teardown and never restored (a cached module's top-level code does not
+re-run), so a later sync would silently lose the probe. An explicit idempotent
+call sidesteps that entirely (``register_probe`` overwrites the same key).
+
+Conventions (project-preferences): return-value based, no raising in probe
+internals — disk reads degrade to a safe default so a sync never crashes on a
+malformed or absent backlog file. The probe's evidence is deliberately *stable*
+across incidental item-count changes (``compute_id`` hashes the evidence): the
+live count lives in ``trigger_summary`` (not hashed), so adding a legacy item
+between syncs doesn't churn the advisory id (idempotency, spec A2).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from .advisory_store import AdvisoryCandidate, Codebase, ProjectState, register_probe
+
+# A structured id token as it appears in an item title: ``**[STH-K7p2]**``.
+# PFX = 2–3 uppercase letters; the 4-char suffix is base36 (mixed case allowed).
+_ID_RE = re.compile(r"\[[A-Z]{2,3}-[A-Za-z0-9]{4}\]")
+_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+# Top-level markdown list item (column-0 bullet) — the start of a backlog item.
+_TOP_ITEM_RE = re.compile(r"^- ", re.MULTILINE)
+_LEGACY_HEADINGS = ("## Active — next up", "## Queue")
+
+# Migration is "done" once the skill writes this fact to project-state.yaml.
+_RESOLVED_FORMAT_VERSION = 2
+# Trigger floor (requirements §8.2): >5 items, none structured.
+_LEGACY_ITEM_FLOOR = 5
+
+
+def _strip_comments(text: str) -> str:
+    """Drop HTML comment blocks so example/instruction bullets inside the
+    template's conventions header are not counted as real items."""
+    return _COMMENT_RE.sub("", text)
+
+
+def count_backlog_items(text: str) -> tuple[int, int]:
+    """Return ``(total_top_level_items, structured_items)`` for backlog markdown.
+
+    A top-level item is a column-0 ``- `` bullet (after stripping HTML
+    comments). ``structured`` counts those whose line carries a ``[PFX-XXXX]``
+    id. Public (return-value helper) so it can be unit-tested directly.
+    """
+    body = _strip_comments(text)
+    total = 0
+    structured = 0
+    for line in body.splitlines():
+        if not _TOP_ITEM_RE.match(line):
+            continue
+        total += 1
+        if _ID_RE.search(line):
+            structured += 1
+    return total, structured
+
+
+def _has_legacy_headings(text: str) -> bool:
+    body = _strip_comments(text)
+    return any(h in body for h in _LEGACY_HEADINGS)
+
+
+def _format_migrated(state: ProjectState) -> bool:
+    """True once ``backlog_format_version`` indicates migration is complete."""
+    value = state.get("backlog_format_version")
+    if value is None:
+        return False
+    try:
+        return int(value) >= _RESOLVED_FORMAT_VERSION
+    except (TypeError, ValueError):
+        return False
+
+
+def legacy_backlog_format_probe(
+    state: ProjectState, codebase: Codebase
+) -> list[AdvisoryCandidate]:
+    """Fire when ``.prawduct/backlog.md`` has >5 items, none structured, and the
+    project has not recorded ``backlog_format_version: 2``.
+
+    Resolution condition (shared answer store, spec §7.1): reads
+    ``backlog_format_version`` from project-state.yaml — set by ``/backlog
+    migrate`` on completion — so a teammate's migration auto-resolves the
+    advisory for everyone on next sync, decoupled from local code state.
+    """
+    if _format_migrated(state):
+        return []
+
+    backlog_path = Path(codebase.root) / ".prawduct" / "backlog.md"
+    try:
+        text = backlog_path.read_text(encoding="utf-8")
+    except OSError:
+        return []  # no backlog file → nothing to nag about
+
+    total, structured = count_backlog_items(text)
+    # Trigger only when nothing has been migrated yet (requirements §8.2:
+    # ">5 items, none carrying [PFX-XXXX] ids"). A partially-migrated file is
+    # mid-flight; the format_version fact is the authoritative "done" signal.
+    if total <= _LEGACY_ITEM_FLOOR or structured > 0:
+        return []
+
+    # Stable evidence (hashed into the id) — qualitative, count-independent so
+    # the id stays put as items come and go. Live count goes in the summary.
+    evidence = [".prawduct/backlog.md contains items without [PFX-XXXX] structured ids"]
+    if _has_legacy_headings(text):
+        evidence.append(
+            "legacy section headings present (## Active — next up / ## Queue)"
+        )
+
+    summary = (
+        f"{total} backlog items lack [PFX-XXXX] structured ids — run "
+        "/backlog migrate to add metadata and enable pick/find/list filtering."
+    )
+    return [
+        AdvisoryCandidate(
+            type="legacy-backlog-format",
+            evidence=tuple(evidence),
+            trigger_summary=summary,
+            recommended_action="/backlog migrate",
+            priority="info",
+        )
+    ]
+
+
+def register_backlog_probes() -> None:
+    """Register the backlog feature's production probes. Idempotent — safe to
+    call on every sync (``register_probe`` overwrites the same ``(feature,
+    type)`` key). Called by ``advisory_store.run_sync_advisories``."""
+    register_probe("backlog", "legacy-backlog-format", 1, legacy_backlog_format_probe)

--- a/tools/lib/core.py
+++ b/tools/lib/core.py
@@ -1,0 +1,881 @@
+"""
+Core utilities, constants, and shared helpers for prawduct-setup.
+
+All constants and functions that are used across multiple commands live here.
+Command-specific logic lives in init_cmd.py, migrate_cmd.py, sync_cmd.py,
+and validate_cmd.py.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shutil
+import stat
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+FRAMEWORK_DIR = Path(__file__).resolve().parent.parent.parent
+TEMPLATES_DIR = FRAMEWORK_DIR / "templates"
+
+
+# =============================================================================
+# Constants
+# =============================================================================
+
+try:
+    PRAWDUCT_VERSION = (FRAMEWORK_DIR / "VERSION").read_text().strip()
+except FileNotFoundError:
+    PRAWDUCT_VERSION = "dev"
+
+BLOCK_BEGIN = "<!-- PRAWDUCT:BEGIN -->"
+BLOCK_END = "<!-- PRAWDUCT:END -->"
+
+# Canonical list of framework-managed files. Used by create_manifest (at init)
+# and run_sync (to backfill files added after a product was initialized).
+# "description" is shown to the user when a file is backfilled (new capability onboarding).
+MANAGED_FILES = {
+    "CLAUDE.md": {
+        "template": "templates/product-claude.md",
+        "strategy": "block_template",
+        "description": "Core principles and methodology instructions",
+    },
+    ".prawduct/critic-review.md": {
+        "template": "templates/critic-review.md",
+        "strategy": "template",
+        "description": "Independent Critic review instructions (7 quality goals + coordinator pattern)",
+    },
+    ".prawduct/pr-review.md": {
+        "template": "templates/pr-review.md",
+        "strategy": "template",
+        "description": "PR reviewer instructions for release-readiness assessment",
+    },
+    ".prawduct/build-governance.md": {
+        "template": "templates/build-governance.md",
+        "strategy": "template",
+        "description": "Build governance reference — how to build against a plan (read before coding)",
+    },
+    ".claude/skills/pr/SKILL.md": {
+        "template": ".claude/skills/pr/SKILL.md",
+        "strategy": "template",
+        "description": "/pr skill — PR lifecycle management (create, update, merge, status). Configure PR behavior in project-preferences.md",
+    },
+    ".claude/skills/janitor/SKILL.md": {
+        "template": ".claude/skills/janitor/SKILL.md",
+        "strategy": "template",
+        "description": "/janitor skill — Periodic codebase maintenance (encapsulation, deduplication, cleanup)",
+    },
+    ".claude/skills/prawduct-doctor/SKILL.md": {
+        "template": ".claude/skills/prawduct-doctor/SKILL.md",
+        "strategy": "template",
+        "description": "/prawduct-doctor skill — Product repo setup, health check, and repair",
+    },
+    ".claude/skills/learnings/SKILL.md": {
+        "template": ".claude/skills/learnings/SKILL.md",
+        "strategy": "template",
+        "description": "/learnings skill — Look up project learnings and preferences relevant to your current task",
+    },
+    ".claude/skills/prawduct-advisory/SKILL.md": {
+        "template": ".claude/skills/prawduct-advisory/SKILL.md",
+        "strategy": "template",
+        "description": "/prawduct-advisory skill — Manage post-sync advisories (list, show, dismiss, undismiss, resolve)",
+    },
+    ".claude/skills/backlog/SKILL.md": {
+        "template": ".claude/skills/backlog/SKILL.md",
+        "strategy": "template",
+        "description": "/backlog skill — Structured backlog management (pick, add, find, list, update, migrate)",
+    },
+    ".claude/skills/critic/SKILL.md": {
+        "template": "templates/skill-critic.md",
+        "strategy": "template",
+        "description": "/critic skill — Independent Critic review with structural tool restrictions (cannot run tests)",
+    },
+    "tools/product-hook": {
+        "source": "tools/product-hook",
+        "strategy": "always_update",
+        "description": "Session governance hooks (reflection gate, Critic gate, session briefing)",
+    },
+    ".claude/settings.json": {
+        "template": "templates/product-settings.json",
+        "strategy": "merge_settings",
+        "description": "Claude Code settings with hook configuration",
+    },
+}
+
+# Managed directories: every matching file is synced like an always_update
+# managed file, enumerated dynamically from the framework so new modules ship
+# automatically without editing MANAGED_FILES. product-hook imports tools/lib
+# at runtime (regen-views, operator-verification, advisories), so product repos
+# MUST carry it — listing the package statically would re-introduce the
+# ModuleNotFoundError class of bug every time a module is added.
+MANAGED_DIRS: dict[str, dict] = {
+    "tools/lib": {
+        "glob": "*.py",
+        "strategy": "always_update",
+        "description": "product-hook runtime library (regen-views, operator-verification, advisories)",
+    },
+}
+
+
+def effective_managed_files(framework_dir: Path) -> dict[str, dict]:
+    """MANAGED_FILES plus every file under MANAGED_DIRS, enumerated from the
+    framework directory.
+
+    Managed-directory files are framework-owned (``always_update``), so they
+    propagate to product repos on every sync and pick up newly-added modules
+    without a code change here. Enumeration keys off ``framework_dir`` — when a
+    caller passes an empty/fake framework dir (unit tests), no managed-dir files
+    are added, preserving the static MANAGED_FILES set.
+    """
+    result: dict[str, dict] = dict(MANAGED_FILES)
+    for dir_rel, dir_config in MANAGED_DIRS.items():
+        src_dir = framework_dir / dir_rel
+        if not src_dir.is_dir():
+            continue
+        for path in sorted(src_dir.glob(dir_config.get("glob", "*"))):
+            if path.is_file():
+                rel = f"{dir_rel}/{path.name}"
+                result[rel] = {
+                    "source": rel,
+                    "strategy": dir_config.get("strategy", "always_update"),
+                    "description": dir_config.get("description", ""),
+                }
+    return result
+
+
+# Place-once files: created if missing, never overwritten. Template hashes
+# are tracked in manifest["place_once_templates"] for drift detection.
+# Shared between init_cmd.py and sync_cmd.py.
+PLACE_ONCE_TEMPLATES: dict[str, str] = {
+    ".prawduct/artifacts/project-preferences.md": "templates/project-preferences.md",
+    ".prawduct/artifacts/boundary-patterns.md": "templates/boundary-patterns.md",
+    ".prawduct/change-log.md": "templates/change-log.md",
+    ".prawduct/backlog.md": "templates/backlog.md",
+}
+
+# Place-once binary files: copied without template rendering.
+PLACE_ONCE_COPY: dict[str, str] = {
+    "tests/conftest.py": "templates/conftest.py",
+}
+
+# Maps old file paths to new file paths. Applied during sync before the
+# MANAGED_FILES loop, so product repos get file moves automatically.
+FILE_RENAMES: dict[str, str] = {
+    ".claude/commands/pr.md": ".claude/skills/pr/SKILL.md",
+    ".claude/commands/janitor.md": ".claude/skills/janitor/SKILL.md",
+    ".claude/skills/prawduct-setup/SKILL.md": ".claude/skills/prawduct-doctor/SKILL.md",
+}
+
+# Skill files placed during init. Each tuple: (skill_name, source_path).
+# Source is either the framework's own .claude/skills/ copy or templates/.
+SKILL_PLACEMENTS: list[tuple[str, Path]] = [
+    ("pr", FRAMEWORK_DIR / ".claude" / "skills" / "pr" / "SKILL.md"),
+    ("janitor", FRAMEWORK_DIR / ".claude" / "skills" / "janitor" / "SKILL.md"),
+    ("prawduct-doctor", FRAMEWORK_DIR / ".claude" / "skills" / "prawduct-doctor" / "SKILL.md"),
+    ("learnings", FRAMEWORK_DIR / ".claude" / "skills" / "learnings" / "SKILL.md"),
+    ("prawduct-advisory", FRAMEWORK_DIR / ".claude" / "skills" / "prawduct-advisory" / "SKILL.md"),
+    ("backlog", FRAMEWORK_DIR / ".claude" / "skills" / "backlog" / "SKILL.md"),
+    ("critic", TEMPLATES_DIR / "skill-critic.md"),
+]
+
+# Session files that should be gitignored in product repos
+GITIGNORE_ENTRIES = [
+    ".claude/settings.local.json",
+    ".prawduct/.critic-findings.json",
+    ".prawduct/.test-evidence.json",
+    ".prawduct/.pr-reviews/",
+    ".prawduct/.session-git-baseline",
+    ".prawduct/.session-handoff.md",
+    ".prawduct/.session-reflected",
+    ".prawduct/.session-start",
+    ".prawduct/.subagent-briefing.md",
+    ".prawduct/.gates-waived",
+    ".prawduct/.sync-pending",
+    ".prawduct/.advisories.json",
+    ".prawduct/reflections.md",
+    ".prawduct/sync-manifest.json",
+    ".prawduct/artifacts/build-plan.md",
+    "__pycache__/",
+]
+
+# Migration-era gitignore constants
+V4_GITIGNORE_ENTRIES = [
+    ".claude/settings.local.json",
+    ".prawduct/.critic-findings.json",
+    ".prawduct/.test-evidence.json",
+    ".prawduct/.pr-reviews/",
+    ".prawduct/.session-git-baseline",
+    ".prawduct/.session-handoff.md",
+    ".prawduct/.session-reflected",
+    ".prawduct/.session-start",
+    ".prawduct/.subagent-briefing.md",
+    ".prawduct/reflections.md",
+    ".prawduct/sync-manifest.json",
+    ".prawduct/artifacts/build-plan.md",
+    "__pycache__/",
+]
+
+V3_GITIGNORE_ENTRIES = [
+    ".claude/settings.local.json",
+    ".prawduct/.critic-findings.json",
+    ".prawduct/.session-reflected",
+    ".prawduct/.session-start",
+    "__pycache__/",
+]
+
+V1_GITIGNORE_ENTRIES = [
+    ".prawduct/traces/",
+    ".prawduct/framework-observations/",
+    ".prawduct/.cross-repo-edits",
+    ".prawduct/.session-governance.json",
+    ".prawduct/.orchestrator-activated",
+]
+
+V1_SESSION_FILES = [
+    ".prawduct/.session-governance.json",
+    ".prawduct/.orchestrator-activated",
+    ".prawduct/.skill-context.json",
+    ".prawduct/.active-skill",
+]
+
+
+# =============================================================================
+# Core utilities
+# =============================================================================
+
+
+def log(msg: str) -> None:
+    """Print status to stderr."""
+    print(msg, file=sys.stderr)
+
+
+def ensure_dir(path: Path) -> bool:
+    """Create directory if missing. Returns True if created."""
+    if path.is_dir():
+        return False
+    path.mkdir(parents=True, exist_ok=True)
+    return True
+
+
+# Optional project-state pointer naming the active build plan (relative to the
+# `.prawduct/` dir). When unset, tooling uses the conventional default below, so
+# repos that don't set it keep their existing behavior.
+BUILD_PLAN_POINTER_KEY = "active_build_plan"
+DEFAULT_BUILD_PLAN_REL = "artifacts/build-plan.md"
+
+
+def read_str_yaml_key(state_path: Path, key: str) -> str | None:
+    """Value of a top-level (column-0) ``key: value`` scalar, or None.
+
+    Mirrors the column-0 idiom used by ``is_views_enabled`` and product-hook's
+    ``_read_bool_yaml_key`` — no PyYAML dependency, fail-soft to None on a
+    missing/unreadable file or absent key. Surrounding quotes and inline ``#``
+    comments are stripped; an empty value reads as None.
+    """
+    try:
+        content = state_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    needle = f"{key}:"
+    for raw in content.splitlines():
+        if raw[:1] in (" ", "\t"):
+            continue
+        line = raw.split("#", 1)[0].rstrip()
+        if not line.startswith(needle):
+            continue
+        value = line.split(":", 1)[1].strip().strip("\"'")
+        return value or None
+    return None
+
+
+def resolve_build_plan_path(prawduct_dir: Path) -> Path:
+    """Resolve the active build-plan path (supports standard + scope-named plans).
+
+    Reads an optional ``active_build_plan:`` pointer (a path relative to the
+    ``.prawduct/`` dir) from ``project-state.yaml``; when set, that file is the
+    active plan, letting a project name its plan by scope
+    (``artifacts/v1.6.0-foo-plan.md``). When the pointer is absent, falls back to
+    the conventional ``artifacts/build-plan.md`` — so repos that don't set it
+    behave exactly as before. The returned path may not exist; callers treat a
+    missing plan as "no active build plan."
+
+    Kept in sync with the inline mirror in ``tools/product-hook``
+    (``_resolve_build_plan_path``), which cannot import this module in product
+    repos — a parity test pins the two together.
+    """
+    pointer = read_str_yaml_key(prawduct_dir / "project-state.yaml", BUILD_PLAN_POINTER_KEY)
+    if pointer:
+        return prawduct_dir / pointer
+    return prawduct_dir / DEFAULT_BUILD_PLAN_REL
+
+
+def compute_hash(path: Path) -> str | None:
+    """Compute SHA-256 hex digest of a file's contents. Returns None if file missing."""
+    if not path.is_file():
+        return None
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def extract_block(content: str) -> tuple[str | None, str, str]:
+    """Extract content between PRAWDUCT markers.
+
+    Returns (block, before, after) where before + block + after == content.
+    Returns (None, content, "") if markers are missing or malformed
+    (e.g. BEGIN without END, or END before BEGIN).
+    """
+    begin_idx = content.find(BLOCK_BEGIN)
+    end_idx = content.find(BLOCK_END)
+
+    if begin_idx == -1 or end_idx == -1 or end_idx <= begin_idx:
+        return (None, content, "")
+
+    before = content[:begin_idx]
+    block = content[begin_idx : end_idx + len(BLOCK_END)]
+    after = content[end_idx + len(BLOCK_END) :]
+
+    return (block, before, after)
+
+
+def compute_block_hash(content: str) -> str | None:
+    """SHA-256 of just the block content between markers. None if no markers."""
+    block, _, _ = extract_block(content)
+    if block is None:
+        return None
+    return hashlib.sha256(block.encode()).hexdigest()
+
+
+def load_json(path: Path) -> dict:
+    """Read and parse a JSON file. Raises on missing file or invalid JSON."""
+    return json.loads(path.read_text())
+
+
+def render_template(template_path: Path, subs: dict[str, str]) -> str:
+    """Read a template file and apply variable substitutions."""
+    content = template_path.read_text()
+    for key, value in subs.items():
+        content = content.replace(key, value)
+    return content
+
+
+def merge_settings(
+    dst: Path,
+    template_path: Path,
+    subs: dict[str, str] | None = None,
+    *,
+    legacy_cleanup: bool = False,
+) -> bool:
+    """Create or merge .claude/settings.json.
+
+    Merges hooks and companyAnnouncements from template into existing settings.
+    Preserves user hooks and other settings keys. Applies subs to template before
+    parsing (for banner {{PRODUCT_NAME}} substitution).
+
+    With legacy_cleanup=True (migration path): also removes v1/v3 hooks and
+    v1 statusLine references.
+
+    Returns True if file was written.
+    """
+    template_text = template_path.read_text()
+    if subs:
+        for key, value in subs.items():
+            template_text = template_text.replace(key, value)
+    template = json.loads(template_text)
+
+    if not dst.is_file():
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        dst.write_text(json.dumps(template, indent=2) + "\n")
+        return True
+
+    try:
+        existing = load_json(dst)
+    except json.JSONDecodeError:
+        log(f"  ! Could not parse {dst.name} — skipping merge")
+        return False
+
+    template_hooks = template.get("hooks", {})
+
+    if legacy_cleanup:
+        # Migration path: strip v1/v3 hooks AND current v4 hooks, keep user hooks.
+        v1_markers = ["framework-path", "governance-hook", "prawduct-statusline"]
+
+        def _is_v1_hook_entry(entry: dict) -> bool:
+            for hook in entry.get("hooks", []):
+                cmd = hook.get("command", "")
+                if any(marker in cmd for marker in v1_markers):
+                    return True
+            return False
+
+        v4_commands: set[str] = set()
+        for entries in template_hooks.values():
+            for entry in entries:
+                for hook in entry.get("hooks", []):
+                    if hook.get("type") == "command":
+                        v4_commands.add(hook["command"])
+
+        def _is_old_prawduct_hook(entry: dict) -> bool:
+            if _is_v1_hook_entry(entry):
+                return True
+            for hook in entry.get("hooks", []):
+                cmd = hook.get("command", "")
+                if "product-hook" in cmd and not cmd.startswith("python3 "):
+                    return True
+            return False
+
+        merged_hooks: dict = dict(template_hooks)
+        for event, entries in existing.get("hooks", {}).items():
+            if event not in merged_hooks:
+                user_entries = [e for e in entries if not _is_old_prawduct_hook(e)]
+                if user_entries:
+                    merged_hooks[event] = user_entries
+                continue
+
+            user_entries = []
+            for entry in entries:
+                if _is_old_prawduct_hook(entry):
+                    continue
+                is_v4 = any(
+                    hook.get("command") in v4_commands
+                    for hook in entry.get("hooks", [])
+                    if hook.get("type") == "command"
+                )
+                if not is_v4:
+                    user_entries.append(entry)
+
+            if user_entries:
+                merged_hooks[event] = merged_hooks[event] + user_entries
+    else:
+        # Normal sync: strip current prawduct hooks, keep user hooks.
+        def _is_prawduct_hook(entry: dict) -> bool:
+            for hook in entry.get("hooks", []):
+                if hook.get("type") != "command":
+                    continue
+                cmd = hook.get("command", "")
+                if '/product-hook"' in cmd or "/product-hook " in cmd or cmd.endswith("/product-hook"):
+                    return True
+            return False
+
+        merged_hooks = dict(template_hooks)
+        for event, entries in existing.get("hooks", {}).items():
+            user_entries = [e for e in entries if not _is_prawduct_hook(e)]
+
+            if event not in merged_hooks:
+                if user_entries:
+                    merged_hooks[event] = user_entries
+            else:
+                if user_entries:
+                    merged_hooks[event] = merged_hooks[event] + user_entries
+
+    # Preserve other settings keys, but always update banner from template
+    merged = dict(existing)
+    merged["hooks"] = merged_hooks
+
+    # Legacy cleanup: remove v1 statusLine if it references prawduct
+    if legacy_cleanup and "statusLine" in merged:
+        status_line = merged["statusLine"]
+        if isinstance(status_line, str) and "prawduct" in status_line.lower():
+            del merged["statusLine"]
+        elif isinstance(status_line, dict):
+            cmd = status_line.get("command", "")
+            if "prawduct" in cmd.lower():
+                del merged["statusLine"]
+
+    # Always update companyAnnouncements from template (framework-managed)
+    if "companyAnnouncements" in template:
+        merged["companyAnnouncements"] = template["companyAnnouncements"]
+
+    if json.dumps(merged, sort_keys=True) == json.dumps(existing, sort_keys=True):
+        return False
+
+    dst.write_text(json.dumps(merged, indent=2) + "\n")
+    return True
+
+
+def create_manifest(
+    product_dir: Path,
+    framework_dir: Path,
+    product_name: str,
+    file_hashes: dict[str, str | None],
+) -> dict:
+    """Build a sync manifest from the given file hashes.
+
+    file_hashes maps relative file paths to their SHA-256 hex digests (or None).
+    """
+    files: dict[str, dict] = {}
+
+    for rel_path, config in effective_managed_files(framework_dir).items():
+        entry = dict(config)
+        entry["generated_hash"] = file_hashes.get(rel_path)
+        files[rel_path] = entry
+
+    return {
+        "format_version": 2,
+        "framework_source": str(framework_dir),
+        "framework_version": PRAWDUCT_VERSION,
+        "product_name": product_name,
+        "auto_pull": True,
+        "last_sync": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "files": files,
+    }
+
+
+# =============================================================================
+# Framework resolution
+# =============================================================================
+
+
+def _resolve_framework_dir(
+    manifest: dict, cli_framework_dir: str | None, product_dir: Path | None = None
+) -> Path | None:
+    """Resolve the framework directory from CLI arg, env var, manifest, or sibling.
+
+    Resolution order:
+      1. --framework-dir CLI argument (explicit override; fail if invalid)
+      2. PRAWDUCT_FRAMEWORK_DIR env var (explicit override; fail if invalid)
+      3. framework_source from manifest (recorded at init; fall through if stale)
+      4. Sibling ../prawduct relative to product dir (convention-based discovery)
+    """
+    # 1. CLI argument
+    if cli_framework_dir:
+        p = Path(cli_framework_dir).resolve()
+        if p.is_dir():
+            return p
+        return None
+
+    # 2. Environment variable
+    env_dir = os.environ.get("PRAWDUCT_FRAMEWORK_DIR")
+    if env_dir:
+        p = Path(env_dir).resolve()
+        if p.is_dir():
+            return p
+        return None
+
+    # 3. Manifest value
+    source = manifest.get("framework_source", "")
+    if source:
+        p = Path(source).resolve()
+        if p.is_dir():
+            return p
+
+    # 4. Sibling ../prawduct relative to product dir
+    if product_dir:
+        sibling = (product_dir.parent / "prawduct").resolve()
+        if sibling.is_dir():
+            return sibling
+
+    return None
+
+
+def _try_pull_framework(fw_dir: Path, auto_pull: bool) -> list[str]:
+    """Best-effort git pull/fetch of the framework repo before syncing.
+
+    When auto_pull is True: runs ``git pull --ff-only`` (safe fast-forward).
+    When auto_pull is False: runs ``git fetch`` and reports if behind upstream.
+
+    Returns a list of human-readable notes (may be empty). Never raises.
+    """
+    notes: list[str] = []
+    try:
+        # Verify fw_dir is inside a git repo
+        result = subprocess.run(
+            ["git", "rev-parse", "--git-dir"],
+            capture_output=True,
+            text=True,
+            cwd=str(fw_dir),
+            timeout=30,
+        )
+        if result.returncode != 0:
+            return notes  # Not a git repo — silently skip
+
+        if auto_pull:
+            # Check for dirty working tree
+            status = subprocess.run(
+                ["git", "status", "--porcelain"],
+                capture_output=True,
+                text=True,
+                cwd=str(fw_dir),
+                timeout=30,
+            )
+            if status.returncode == 0 and status.stdout.strip():
+                notes.append("Framework has uncommitted changes — skipping pull")
+                return notes
+
+            # Fast-forward pull
+            pull = subprocess.run(
+                ["git", "pull", "--ff-only"],
+                capture_output=True,
+                text=True,
+                cwd=str(fw_dir),
+                timeout=30,
+            )
+            if pull.returncode == 0:
+                if "Already up to date" not in pull.stdout:
+                    notes.append("Framework updated via git pull")
+            else:
+                stderr = pull.stderr.strip()
+                if "Not possible to fast-forward" in stderr or "fatal" in stderr:
+                    notes.append("Framework pull failed (not fast-forwardable) — run git pull manually")
+                else:
+                    notes.append("Framework pull failed — run git pull manually")
+        else:
+            # Advisory mode: fetch + check if behind
+            fetch = subprocess.run(
+                ["git", "fetch", "--quiet"],
+                capture_output=True,
+                text=True,
+                cwd=str(fw_dir),
+                timeout=30,
+            )
+            if fetch.returncode != 0:
+                return notes  # Fetch failed — silently skip
+
+            behind = subprocess.run(
+                ["git", "rev-list", "--count", "HEAD..@{upstream}"],
+                capture_output=True,
+                text=True,
+                cwd=str(fw_dir),
+                timeout=30,
+            )
+            if behind.returncode == 0:
+                count = behind.stdout.strip()
+                if count and int(count) > 0:
+                    notes.append(f"Framework is {count} commit(s) behind upstream — consider running git pull")
+
+    except FileNotFoundError:
+        pass  # git not on PATH
+    except subprocess.TimeoutExpired:
+        notes.append("Framework git operation timed out")
+    except Exception:  # prawduct:ok-broad-except — sync helper must never block session start
+        pass
+
+    return notes
+
+
+# =============================================================================
+# Template / file operations
+# =============================================================================
+
+
+def write_template(src: Path, dst: Path, subs: dict[str, str], *, overwrite: bool = False) -> bool:
+    """Copy a template with variable substitution.
+
+    Without overwrite: skips if dst exists.
+    With overwrite: idempotent via content comparison.
+    Returns True if file was written.
+    """
+    content = render_template(src, subs)
+
+    if dst.is_file():
+        if not overwrite:
+            return False
+        if dst.read_text() == content:
+            return False  # Already up to date
+
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    dst.write_text(content)
+    return True
+
+
+def copy_hook(src: Path, dst: Path) -> bool:
+    """Copy a hook script and make it executable. Updates if content changed.
+    Returns True if file was written."""
+    src_bytes = src.read_bytes()
+
+    if dst.is_file():
+        if dst.read_bytes() == src_bytes:
+            return False  # Already up to date
+        # Hook content changed — update it (hooks should stay current)
+        dst.write_bytes(src_bytes)
+        dst.chmod(dst.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        return True
+
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src, dst)
+    dst.chmod(dst.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return True
+
+
+def update_gitignore(target: Path) -> dict:
+    """Add prawduct entries to .gitignore and remove incorrect ones.
+
+    Managed files (MANAGED_FILES) should be committed, not gitignored.
+    Session files (GITIGNORE_ENTRIES) should be gitignored.
+    Returns dict with 'modified' bool and 'unignored' list of paths
+    that were removed from .gitignore (caller should advise user to
+    git-add these).
+    """
+    gitignore = target / ".gitignore"
+
+    if gitignore.is_file():
+        content = gitignore.read_text()
+        existing_lines = set(content.splitlines())
+    else:
+        content = ""
+        existing_lines = set()
+
+    modified = False
+    unignored: list[str] = []
+
+    # Remove lines that gitignore managed files (they should be committed)
+    incorrectly_ignored = set()
+    for rel_path in MANAGED_FILES:
+        if rel_path in existing_lines:
+            incorrectly_ignored.add(rel_path)
+
+    if incorrectly_ignored:
+        lines = content.splitlines(keepends=True)
+        filtered = [line for line in lines if line.rstrip("\n") not in incorrectly_ignored]
+        content = "".join(filtered)
+        existing_lines -= incorrectly_ignored
+        unignored = sorted(incorrectly_ignored)
+        modified = True
+
+    # Add missing session file entries
+    missing = [e for e in GITIGNORE_ENTRIES if e not in existing_lines]
+    if missing:
+        parts = []
+        if content and not content.endswith("\n"):
+            parts.append("\n")
+        if content.strip():
+            parts.append("\n")
+        parts.append("# Prawduct session files\n")
+        for entry in missing:
+            parts.append(entry + "\n")
+        content += "".join(parts)
+        modified = True
+
+    if modified:
+        gitignore.write_text(content)
+
+    return {"modified": modified, "unignored": unignored}
+
+
+def untrack_gitignored_files(target: Path) -> list[str]:
+    """Remove gitignored session files from git tracking without deleting them.
+
+    Runs 'git rm --cached' for any GITIGNORE_ENTRIES path that is currently
+    tracked by git. Safe to call even if the repo has no such tracked files.
+    Returns a list of paths that were untracked (may be empty).
+    """
+    # Verify this is a git repo
+    check = subprocess.run(
+        ["git", "rev-parse", "--git-dir"],
+        capture_output=True,
+        text=True,
+        cwd=str(target),
+        timeout=10,
+    )
+    if check.returncode != 0:
+        return []
+
+    untracked: list[str] = []
+    for entry in GITIGNORE_ENTRIES:
+        # Strip trailing slash on directory patterns (e.g. "__pycache__/").
+        # ls-files needs the bare path; rm needs `-r` to recurse into the dir.
+        rel = entry.rstrip("/")
+        result = subprocess.run(
+            ["git", "ls-files", "--error-unmatch", rel],
+            capture_output=True,
+            text=True,
+            cwd=str(target),
+            timeout=10,
+        )
+        if result.returncode != 0:
+            continue  # Not tracked
+        # File is tracked — remove it from the index. -r is required for
+        # directory entries (e.g. .prawduct/.pr-reviews/) and harmless for files.
+        rm = subprocess.run(
+            ["git", "rm", "--cached", "--quiet", "-r", rel],
+            capture_output=True,
+            text=True,
+            cwd=str(target),
+            timeout=10,
+        )
+        if rm.returncode == 0:
+            untracked.append(rel)
+
+    return untracked
+
+
+# =============================================================================
+# Version detection
+# =============================================================================
+
+
+def detect_version(target: Path) -> str:
+    """Detect repo version. Returns 'v1', 'v3', 'v4', 'v5', 'partial', or 'unknown'."""
+    has_framework_path = (target / ".prawduct" / "framework-path").is_file()
+    has_product_hook = (target / "tools" / "product-hook").is_file()
+    has_sync_manifest = (target / ".prawduct" / "sync-manifest.json").is_file()
+
+    if has_framework_path and not has_product_hook:
+        return "v1"
+    if has_framework_path and has_product_hook:
+        return "partial"
+    if has_product_hook and has_sync_manifest:
+        # Distinguish v4 from v5 by manifest format_version
+        try:
+            manifest = load_json(
+                target / ".prawduct" / "sync-manifest.json"
+            )
+            if manifest.get("format_version", 1) >= 2:
+                return "v5"
+        except (json.JSONDecodeError, OSError):
+            pass
+        return "v4"
+    if has_product_hook and not has_framework_path:
+        return "v3"
+    return "unknown"
+
+
+def infer_product_name(target: Path) -> str | None:
+    """Read product_identity.name from project-state.yaml via regex.
+
+    No PyYAML dependency — scans line by line for the name field under
+    product_identity. Returns None if the file is missing, the field is
+    absent, or the value is a template placeholder.
+    """
+    state_file = target / ".prawduct" / "project-state.yaml"
+    if not state_file.is_file():
+        return None
+
+    in_product_identity = False
+    for line in state_file.read_text().splitlines():
+        stripped = line.strip()
+
+        # Track when we're inside product_identity block
+        if stripped == "product_identity:" or stripped.startswith("product_identity:"):
+            in_product_identity = True
+            continue
+
+        # Exit block on unindented line (new top-level key)
+        if in_product_identity and line and not line[0].isspace():
+            in_product_identity = False
+            continue
+
+        if in_product_identity:
+            match = re.match(r'\s*name:\s*["\']?([^"\'#\n]+?)["\']?\s*$', line)
+            if match:
+                name = match.group(1).strip()
+                if name and "{{" not in name and name != "null":
+                    return name
+
+    return None
+
+
+# =============================================================================
+# Migration-shared operations
+# =============================================================================
+
+
+def write_template_overwrite(src: Path, dst: Path, subs: dict[str, str]) -> bool:
+    """Compat alias for write_template(overwrite=True)."""
+    return write_template(src, dst, subs, overwrite=True)
+
+
+def replace_settings(dst: Path, template_path: Path, subs: dict[str, str] | None = None) -> bool:
+    """Compat alias for merge_settings(legacy_cleanup=True)."""
+    return merge_settings(dst, template_path, subs, legacy_cleanup=True)

--- a/tools/lib/critic_mode.py
+++ b/tools/lib/critic_mode.py
@@ -1,0 +1,419 @@
+"""Critic mode inference — picks the right ``/critic`` mode from git +
+build-plan state so the builder doesn't have to declare it at every chunk.
+
+Explicit ``$ARGUMENTS`` always wins (override path). When ``$ARGUMENTS`` is
+empty / None / unrecognized, :func:`infer_mode` walks four rules in
+precedence order and returns the first that fires:
+
+  1. ``verify-resolutions`` — prior ``.critic-findings.json`` has
+     BLOCKING/WARNING findings + ``commit_reviewed`` anchor resolves +
+     uncommitted diff is non-empty AND is a subset of prior
+     ``files_reviewed``. Signal: builder is in the middle of fixing
+     findings from the last review.
+  2. ``cumulative`` — working tree is clean (no uncommitted code) AND
+     branch is ≥2 commits ahead of the detected base branch AND no
+     ``cumulative``-mode findings file exists for current HEAD. Signal:
+     builder has shipped chunks and is at the ``/pr create`` precondition
+     point.
+  3. ``final`` — active build plan with exactly one unchecked chunk left
+     AND uncommitted work is present (the builder is on the last chunk),
+     OR no build plan + uncommitted diff has ≥5 files (medium+
+     non-chunked work).
+  4. ``chunk`` when an active build plan grounds the choice (default
+     for mid-plan reviews); ``final`` otherwise (no plan + no other
+     rule fired — fail-safe to thoroughness, matching the SKILL's
+     historical "missing/unrecognized → final" norm).
+
+Deviation from build-plan rule 2: the spec reads "branch ahead of base by
+≥2 commits AND no cumulative-mode record exists for the current HEAD"
+with no working-tree-clean guard. Implemented WITH the clean-tree guard
+so the rule doesn't over-fire mid-chunk-3-of-5 (which would silently
+demote ``chunk``-mode reviews to 4-10 min ``cumulative`` runs at every
+commit). The user-feedback motivation for the whole proportionality
+thread was reducing review latency for small fixes — over-firing
+cumulative would undo that. The guard preserves the spec's intent (run
+cumulative when about to PR) without the cost.
+
+Pure-ish: takes ``project_dir``, reads files under it, runs ``git``
+subprocesses against it. Deterministic given fixed git state. Imports
+only from the stdlib — no ``tools.product-hook`` dependency (per the
+v1.5 Chunk 03 plan: "Imports only `tools.lib.core`"; product-hook
+helpers are intentionally re-implemented here to keep the module
+lightweight and importable from the slash-command shim).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+from .core import resolve_build_plan_path
+
+# Verbose-string mode constants — used to recognize prior findings'
+# ``mode`` field. Must stay in lockstep with ``tools/product-hook``'s
+# ``_CRITIC_MODE_*`` constants. (Persisted form is verbose; caller-side
+# short tokens are what we return / accept as ``args``.)
+_MODE_VERIFY_RESOLUTIONS_VERBOSE = (
+    "verify-resolutions (delta review, prior findings only)"
+)
+_MODE_CUMULATIVE_VERBOSE = "cumulative (bundle review, ready for merge)"
+
+# Short-token caller-side mode names — what ``$ARGUMENTS`` carries and
+# what :func:`infer_mode` returns as the first element of its tuple.
+_VALID_ARG_MODES = frozenset({
+    "chunk",
+    "final",
+    "cumulative",
+    "verify-resolutions",
+})
+
+# Candidate base branches probed in order — first one that resolves wins.
+# Mirrors the convention used by ``/pr`` and the cumulative-Critic gate
+# (typically ``main``; ``develop`` for gitflow projects).
+_DEFAULT_BASE_BRANCHES = ("main", "master", "develop")
+
+# Mirrors ``_METADATA_PREFIXES`` in ``tools/product-hook``. Kept in sync
+# manually — duplication is acceptable for this small set; extracting to
+# ``tools.lib.core`` would expand core's surface for one consumer.
+_METADATA_PREFIXES = (
+    ".prawduct/",
+    ".claude/settings.json",
+    ".claude/skills/",
+    "tools/product-hook",
+)
+
+
+def infer_mode(
+    project_dir: Path | str,
+    args: str | None = None,
+) -> tuple[str, str]:
+    """Infer the right ``/critic`` mode for the current project state.
+
+    Parameters
+    ----------
+    project_dir : Path | str
+        Project root (contains ``.prawduct/``). Coerced to ``Path``.
+    args : str | None
+        The ``$ARGUMENTS`` string passed to ``/critic``. When non-empty
+        and parseable as one of the recognized mode tokens, that token
+        wins outright (rationale ``"explicit-args"``). Empty / None /
+        unrecognized → trigger inference.
+
+    Returns
+    -------
+    (mode, rationale) : tuple[str, str]
+        ``mode`` is the short-token form (``chunk`` / ``final`` /
+        ``cumulative`` / ``verify-resolutions``). ``rationale`` is a
+        human-readable string suitable both for stdout reporting and the
+        ``mode_chosen_by`` field in ``.critic-findings.json``.
+    """
+    project_dir = Path(project_dir)
+
+    if args is not None:
+        stripped = args.strip()
+        if stripped:
+            token = stripped.split()[0]
+            if token in _VALID_ARG_MODES:
+                return token, "explicit-args"
+
+    prawduct_dir = project_dir / ".prawduct"
+
+    if _rule_verify_resolutions_fires(prawduct_dir, project_dir):
+        return "verify-resolutions", (
+            "rule-1 verify-resolutions: prior findings have actionable "
+            "(BLOCKING/WARNING) entries with a resolvable commit_reviewed "
+            "anchor, and the current uncommitted diff is a non-empty "
+            "subset of prior files_reviewed (builder is mid-fix)"
+        )
+
+    cumulative_reason = _rule_cumulative_fires(prawduct_dir, project_dir)
+    if cumulative_reason:
+        return "cumulative", f"rule-2 cumulative: {cumulative_reason}"
+
+    final_reason = _rule_final_fires(prawduct_dir, project_dir)
+    if final_reason:
+        return "final", f"rule-3 final: {final_reason}"
+
+    # Rule 4: chunk only when an active build plan grounds the choice;
+    # otherwise fall through to ``final`` (the historical fail-safe norm
+    # documented in the SKILL files). Without a plan there's no "chunk"
+    # for chunk-mode to scope to — defaulting to ``final`` matches the
+    # rule "missing/unrecognized → final" the SKILL has always promised.
+    total, _complete = _count_build_plan_chunks(prawduct_dir)
+    if total > 0:
+        return "chunk", (
+            "rule-4 chunk: active build plan, prior chunks committed, "
+            "no fix-in-progress signal, no cumulative precondition"
+        )
+    return "final", (
+        "rule-4 final: no active build plan and no other rule fired — "
+        "fail-safe to thoroughness"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Rule predicates
+# ---------------------------------------------------------------------------
+
+
+def _rule_verify_resolutions_fires(
+    prawduct_dir: Path, project_dir: Path
+) -> bool:
+    """Rule 1: prior findings + anchor resolves + diff ⊆ prior scope."""
+    findings_path = prawduct_dir / ".critic-findings.json"
+    if not findings_path.is_file():
+        return False
+    try:
+        data = json.loads(findings_path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return False
+
+    commit_reviewed = data.get("commit_reviewed")
+    if not isinstance(commit_reviewed, str) or not commit_reviewed.strip():
+        return False
+
+    findings = data.get("findings")
+    if not isinstance(findings, list):
+        return False
+    actionable = [
+        f for f in findings
+        if isinstance(f, dict) and f.get("severity") in ("blocking", "warning")
+    ]
+    if not actionable:
+        return False
+
+    prior_files = data.get("files_reviewed")
+    if not isinstance(prior_files, list) or not prior_files:
+        return False
+    prior_set = {f for f in prior_files if isinstance(f, str) and f.strip()}
+    if not prior_set:
+        return False
+
+    if not _commit_resolves(project_dir, commit_reviewed):
+        return False
+
+    diff_files = _get_uncommitted_code_files(project_dir)
+    if not diff_files:
+        return False
+
+    # Subset check: every uncommitted file must be in the prior review's
+    # surface. Even one file outside scope means the builder added new
+    # work alongside the fix — that's a chunk/final case, not a verify
+    # pass. (Symmetric with ``_verify_resolutions_gate_check`` in
+    # product-hook; same "diff ⊆ scope" contract.)
+    return diff_files.issubset(prior_set)
+
+
+def _rule_cumulative_fires(
+    prawduct_dir: Path, project_dir: Path
+) -> str:
+    """Rule 2: clean tree + ≥2 commits ahead + no fresh cumulative record.
+
+    Returns rationale string when the rule fires, empty string otherwise.
+    """
+    # Clean working tree — see module docstring's deviation note for why
+    # this guard is added on top of the spec.
+    if _get_uncommitted_code_files(project_dir):
+        return ""
+
+    base_branch = _detect_base_branch(project_dir)
+    if not base_branch:
+        return ""
+
+    commits_ahead = _commits_ahead_of_base(project_dir, base_branch)
+    if commits_ahead < 2:
+        return ""
+
+    # Skip if a cumulative-mode record already covers current HEAD.
+    head_sha = _git_head_sha(project_dir)
+    findings_path = prawduct_dir / ".critic-findings.json"
+    if head_sha and findings_path.is_file():
+        try:
+            data = json.loads(findings_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            data = {}
+        if (
+            data.get("mode") == _MODE_CUMULATIVE_VERBOSE
+            and data.get("commit_reviewed") == head_sha
+        ):
+            return ""
+
+    return (
+        f"branch is {commits_ahead} commits ahead of {base_branch}, "
+        "working tree clean, no fresh cumulative-mode record for "
+        "current HEAD"
+    )
+
+
+def _rule_final_fires(prawduct_dir: Path, project_dir: Path) -> str:
+    """Rule 3: last unchecked chunk in progress, or no-plan medium+ work.
+
+    Returns rationale string when the rule fires, empty string otherwise.
+    """
+    total, complete = _count_build_plan_chunks(prawduct_dir)
+    if total > 0:
+        # Active build plan.
+        unchecked = total - complete
+        if unchecked == 1 and _get_uncommitted_code_files(project_dir):
+            return (
+                f"last unchecked chunk of {total}-chunk plan is in "
+                f"progress ({complete} marked [x], current chunk has "
+                "uncommitted work)"
+            )
+        return ""
+
+    # No active plan — fall back to size-based final for medium+ work.
+    diff_files = _get_uncommitted_code_files(project_dir)
+    if len(diff_files) >= 5:
+        return (
+            f"no build plan, session diff has {len(diff_files)} changed "
+            "files (medium+ work — full review warranted)"
+        )
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers — git + build-plan parsing
+# ---------------------------------------------------------------------------
+
+
+def _is_metadata_path(filepath: str) -> bool:
+    """Mirrors ``tools/product-hook``'s ``_is_metadata_path``."""
+    return any(filepath.startswith(p) for p in _METADATA_PREFIXES)
+
+
+def _get_uncommitted_code_files(project_dir: Path) -> set[str]:
+    """Return uncommitted-change file paths (vs HEAD), minus metadata.
+
+    Includes modifications, staged changes, untracked files. Rename
+    targets are returned (porcelain ``XY <old> -> <new>``). Uses
+    ``--untracked-files=all`` so a new directory expands to per-file
+    entries rather than collapsing to ``?? subdir/`` (the default
+    ``--untracked-files=normal`` undercounts new directories — caught
+    by ``test_wins_for_no_plan_medium_plus_work``).
+    """
+    proc = subprocess.run(
+        ["git", "status", "--porcelain", "--untracked-files=all"],
+        cwd=str(project_dir),
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    if proc.returncode != 0:
+        return set()
+    files: set[str] = set()
+    for line in proc.stdout.splitlines():
+        if len(line) < 4:
+            continue
+        path = line[3:].strip()
+        if " -> " in path:
+            path = path.split(" -> ", 1)[1].strip()
+        # Strip optional surrounding quotes (porcelain quotes paths
+        # containing special chars).
+        if path.startswith('"') and path.endswith('"'):
+            path = path[1:-1]
+        if path and not _is_metadata_path(path):
+            files.add(path)
+    return files
+
+
+def _commit_resolves(project_dir: Path, sha: str) -> bool:
+    """True iff ``sha`` resolves to a commit in this repo."""
+    proc = subprocess.run(
+        ["git", "rev-parse", "--verify", f"{sha}^{{commit}}"],
+        cwd=str(project_dir),
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    return proc.returncode == 0
+
+
+def _detect_base_branch(project_dir: Path) -> str:
+    """First ``_DEFAULT_BASE_BRANCHES`` candidate that resolves, or ``""``."""
+    for candidate in _DEFAULT_BASE_BRANCHES:
+        proc = subprocess.run(
+            ["git", "rev-parse", "--verify", "--quiet", candidate],
+            cwd=str(project_dir),
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if proc.returncode == 0:
+            return candidate
+    return ""
+
+
+def _commits_ahead_of_base(project_dir: Path, base: str) -> int:
+    """Number of commits on HEAD since merge-base with ``base``. ``-1`` on failure."""
+    proc = subprocess.run(
+        ["git", "rev-list", "--count", f"{base}..HEAD"],
+        cwd=str(project_dir),
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    if proc.returncode != 0:
+        return -1
+    try:
+        return int(proc.stdout.strip())
+    except ValueError:
+        return -1
+
+
+def _git_head_sha(project_dir: Path) -> str:
+    """``git rev-parse HEAD`` or ``""`` on failure."""
+    proc = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=str(project_dir),
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    if proc.returncode != 0:
+        return ""
+    return proc.stdout.strip()
+
+
+def _count_build_plan_chunks(prawduct_dir: Path) -> tuple[int, int]:
+    """Count chunks in the active build plan's Status section.
+
+    Mirrors ``tools/product-hook``'s ``_count_build_plan_chunks``. Resolves the
+    plan via the ``active_build_plan:`` pointer (falls back to
+    ``artifacts/build-plan.md``), so scope-named plans are counted too.
+    Returns ``(total, complete)``; ``(0, 0)`` if plan/Status absent.
+    """
+    plan_path = resolve_build_plan_path(prawduct_dir)
+    if not plan_path.is_file():
+        return 0, 0
+    try:
+        content = plan_path.read_text()
+    except OSError:
+        return 0, 0
+    in_status = False
+    in_comment = False
+    total = 0
+    complete = 0
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped == "## Status":
+            in_status = True
+            continue
+        if not in_status:
+            continue
+        if stripped.startswith("## ") and stripped != "## Status":
+            break
+        if "<!--" in stripped:
+            in_comment = True
+        if "-->" in stripped:
+            in_comment = False
+            continue
+        if in_comment:
+            continue
+        if stripped.startswith("- [ ]"):
+            total += 1
+        elif stripped.startswith("- [x]") or stripped.startswith("- [X]"):
+            total += 1
+            complete += 1
+    return total, complete

--- a/tools/lib/init_cmd.py
+++ b/tools/lib/init_cmd.py
@@ -1,0 +1,250 @@
+"""
+Init command for prawduct product repos.
+
+Initializes a new product repo with all prawduct files, hooks, and settings.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+
+from .core import (
+    BLOCK_BEGIN,
+    FRAMEWORK_DIR,
+    PLACE_ONCE_COPY,
+    PLACE_ONCE_TEMPLATES,
+    PRAWDUCT_VERSION,
+    SKILL_PLACEMENTS,
+    TEMPLATES_DIR,
+    compute_block_hash,
+    compute_hash,
+    copy_hook,
+    create_manifest,
+    ensure_dir,
+    merge_settings,
+    render_template,
+    update_gitignore,
+    write_template,
+)
+
+
+def run_init(target_dir: str, product_name: str) -> dict:
+    """Initialize a product repo. Returns a summary of actions taken."""
+    target = Path(target_dir).resolve()
+    actions: list[str] = []
+
+    subs = {
+        "{{PRODUCT_NAME}}": product_name,
+        "{{PRAWDUCT_VERSION}}": PRAWDUCT_VERSION,
+    }
+
+    # 1. .prawduct/ structure
+    for subdir in [".prawduct", ".prawduct/artifacts"]:
+        path = target / subdir
+        if ensure_dir(path):
+            actions.append(f"Created {subdir}/")
+
+    # 2. CLAUDE.md — three-way handling for existing repos
+    claude_dst = target / "CLAUDE.md"
+    if not claude_dst.is_file():
+        # New file — write full template
+        if write_template(TEMPLATES_DIR / "product-claude.md", claude_dst, subs):
+            actions.append("Created CLAUDE.md")
+    elif BLOCK_BEGIN not in claude_dst.read_text():
+        # Existing file without markers — merge: template + user content below
+        existing_content = claude_dst.read_text()
+        template_content = render_template(TEMPLATES_DIR / "product-claude.md", subs)
+        merged = template_content.rstrip("\n") + "\n\n" + existing_content
+        claude_dst.write_text(merged)
+        actions.append("Merged framework content into existing CLAUDE.md")
+    # else: already has markers — skip (sync handles updates)
+
+    # 3. Critic review instructions
+    if write_template(
+        TEMPLATES_DIR / "critic-review.md",
+        target / ".prawduct" / "critic-review.md",
+        subs,
+    ):
+        actions.append("Created .prawduct/critic-review.md")
+
+    # 4. Project state
+    if write_template(
+        TEMPLATES_DIR / "project-state.yaml",
+        target / ".prawduct" / "project-state.yaml",
+        subs,
+    ):
+        actions.append("Created .prawduct/project-state.yaml")
+
+    # 5. Project preferences template
+    if write_template(
+        TEMPLATES_DIR / "project-preferences.md",
+        target / ".prawduct" / "artifacts" / "project-preferences.md",
+        subs,
+    ):
+        actions.append("Created .prawduct/artifacts/project-preferences.md")
+
+    # 6. Boundary patterns template
+    if write_template(
+        TEMPLATES_DIR / "boundary-patterns.md",
+        target / ".prawduct" / "artifacts" / "boundary-patterns.md",
+        subs,
+    ):
+        actions.append("Created .prawduct/artifacts/boundary-patterns.md")
+
+    # 6.5. PR review evidence directory
+    pr_reviews_dir = target / ".prawduct" / ".pr-reviews"
+    if ensure_dir(pr_reviews_dir):
+        actions.append("Created .prawduct/.pr-reviews/")
+
+    # 6.7. PR review instructions
+    if write_template(
+        TEMPLATES_DIR / "pr-review.md",
+        target / ".prawduct" / "pr-review.md",
+        subs,
+    ):
+        actions.append("Created .prawduct/pr-review.md")
+
+    # 6.72. Build governance
+    if write_template(
+        TEMPLATES_DIR / "build-governance.md",
+        target / ".prawduct" / "build-governance.md",
+        subs,
+    ):
+        actions.append("Created .prawduct/build-governance.md")
+
+    # 6.75. Backlog
+    if write_template(
+        TEMPLATES_DIR / "backlog.md",
+        target / ".prawduct" / "backlog.md",
+        subs,
+    ):
+        actions.append("Created .prawduct/backlog.md")
+
+    # 6.8–6.12. Skills
+    for skill_name, skill_src in SKILL_PLACEMENTS:
+        skill_dir = target / ".claude" / "skills" / skill_name
+        if ensure_dir(skill_dir):
+            actions.append(f"Created .claude/skills/{skill_name}/")
+        skill_dst = skill_dir / "SKILL.md"
+        if skill_src.is_file() and write_template(skill_src, skill_dst, subs):
+            actions.append(f"Created .claude/skills/{skill_name}/SKILL.md")
+
+    # 7. Test infrastructure (conftest.py — only for Python projects)
+    is_python = any(
+        (target / f).is_file()
+        for f in ("pyproject.toml", "setup.py", "setup.cfg", "Pipfile", "requirements.txt")
+    )
+    tests_dir = target / "tests"
+    if ensure_dir(tests_dir):
+        actions.append("Created tests/")
+    if is_python:
+        conftest_dst = tests_dir / "conftest.py"
+        if not conftest_dst.is_file():
+            shutil.copy2(TEMPLATES_DIR / "conftest.py", conftest_dst)
+            actions.append("Created tests/conftest.py (parallel test support)")
+
+    # 8. Learnings starter
+    learnings = target / ".prawduct" / "learnings.md"
+    if not learnings.is_file():
+        learnings.write_text(
+            "# Learnings\n\nAccumulated wisdom from building this product.\n"
+        )
+        actions.append("Created .prawduct/learnings.md")
+
+    # 9. Product hook
+    if copy_hook(
+        FRAMEWORK_DIR / "tools" / "product-hook",
+        target / "tools" / "product-hook",
+    ):
+        actions.append("Created tools/product-hook")
+
+    # 9b. Product-hook runtime library (tools/lib). product-hook imports this at
+    # runtime (regen-views, operator-verification, advisories); without it a
+    # synced repo crashes with ModuleNotFoundError. Mirrors MANAGED_DIRS.
+    # Idempotent: only copy modules that are missing or changed so a re-init is
+    # a genuine no-op (writes nothing, reports no action).
+    lib_src = FRAMEWORK_DIR / "tools" / "lib"
+    if lib_src.is_dir():
+        lib_dst = target / "tools" / "lib"
+        lib_dst.mkdir(parents=True, exist_ok=True)
+        wrote_lib = False
+        for module in sorted(lib_src.glob("*.py")):
+            dst_module = lib_dst / module.name
+            if compute_hash(dst_module) != compute_hash(module):
+                shutil.copy2(module, dst_module)
+                wrote_lib = True
+        if wrote_lib:
+            actions.append("Created tools/lib/")
+
+    # 10. Settings.json (with subs for banner)
+    if merge_settings(
+        target / ".claude" / "settings.json",
+        TEMPLATES_DIR / "product-settings.json",
+        subs,
+    ):
+        actions.append("Created/updated .claude/settings.json")
+
+    # 11. .gitignore
+    if update_gitignore(target)["modified"]:
+        actions.append("Updated .gitignore")
+
+    # 12. Sync manifest
+    manifest_path = target / ".prawduct" / "sync-manifest.json"
+    if not manifest_path.is_file():
+        claude_content = (target / "CLAUDE.md").read_text()
+        file_hashes = {
+            "CLAUDE.md": compute_block_hash(claude_content),
+            ".prawduct/critic-review.md": compute_hash(
+                target / ".prawduct" / "critic-review.md"
+            ),
+            ".prawduct/pr-review.md": compute_hash(
+                target / ".prawduct" / "pr-review.md"
+            ),
+            "tools/product-hook": compute_hash(target / "tools" / "product-hook"),
+            ".claude/settings.json": None,  # merge_settings doesn't use hash
+        }
+        for skill_name, _ in SKILL_PLACEMENTS:
+            rel = f".claude/skills/{skill_name}/SKILL.md"
+            file_hashes[rel] = compute_hash(target / rel)
+        for module in sorted((FRAMEWORK_DIR / "tools" / "lib").glob("*.py")):
+            rel = f"tools/lib/{module.name}"
+            file_hashes[rel] = compute_hash(target / rel)
+        manifest = create_manifest(target, FRAMEWORK_DIR, product_name, file_hashes)
+
+        # Record place-once template hashes so sync can detect template drift
+        pot: dict[str, dict] = {}
+        now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        for rel_path, template_rel in PLACE_ONCE_TEMPLATES.items():
+            template_path = TEMPLATES_DIR / template_rel.removeprefix("templates/")
+            if template_path.is_file():
+                rendered = render_template(template_path, subs)
+                pot[rel_path] = {
+                    "template": template_rel,
+                    "template_hash": hashlib.sha256(rendered.encode()).hexdigest(),
+                    "created_at": now,
+                }
+        for rel_path, template_rel in PLACE_ONCE_COPY.items():
+            template_path = TEMPLATES_DIR / template_rel.removeprefix("templates/")
+            if template_path.is_file():
+                content = template_path.read_bytes()
+                pot[rel_path] = {
+                    "template": template_rel,
+                    "template_hash": hashlib.sha256(content).hexdigest(),
+                    "created_at": now,
+                }
+        if pot:
+            manifest["place_once_templates"] = pot
+
+        manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+        actions.append("Created .prawduct/sync-manifest.json")
+
+    return {
+        "target": str(target),
+        "product_name": product_name,
+        "actions": actions,
+        "files_written": len(actions),
+    }

--- a/tools/lib/migrate_cmd.py
+++ b/tools/lib/migrate_cmd.py
@@ -1,0 +1,1709 @@
+"""
+Migration operations for prawduct product repos.
+
+Handles v1→v3→v4→v5 migrations, changelog/backlog extraction,
+and sync manifest generation.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+from .core import (
+    BLOCK_BEGIN,
+    BLOCK_END,
+    FRAMEWORK_DIR,
+    PRAWDUCT_VERSION,
+    TEMPLATES_DIR,
+    V1_GITIGNORE_ENTRIES,
+    V1_SESSION_FILES,
+    V4_GITIGNORE_ENTRIES,
+    _resolve_framework_dir,
+    compute_block_hash,
+    compute_hash,
+    copy_hook,
+    create_manifest,
+    detect_version,
+    infer_product_name,
+    load_json,
+    merge_settings,
+    render_template,
+    write_template,
+)
+
+
+def delete_v1_files(target: Path) -> list[str]:
+    """Remove v1-only marker files. Returns list of deleted file names."""
+    v1_files = [
+        ".prawduct/framework-path",
+        ".prawduct/framework-version",
+        ".prawduct/.cross-repo-edits",
+    ]
+    deleted = []
+    for rel in v1_files:
+        path = target / rel
+        if path.is_file():
+            path.unlink()
+            deleted.append(rel)
+    return deleted
+
+
+def archive_v1_dirs(target: Path) -> list[str]:
+    """Move v1 directories to .prawduct/archive/. Returns list of archived dir names."""
+    v1_dirs = [
+        ".prawduct/framework-observations",
+        ".prawduct/traces",
+    ]
+    archived = []
+    for rel in v1_dirs:
+        src = target / rel
+        if not src.is_dir():
+            continue
+        archive_dir = target / ".prawduct" / "archive"
+        dst = archive_dir / Path(rel).name
+        if dst.exists():
+            continue  # Already archived
+        archive_dir.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(src), str(dst))
+        archived.append(rel)
+    return archived
+
+
+def clean_v1_session_files(target: Path) -> list[str]:
+    """Remove transient v1 session files. Returns list of deleted file names."""
+    deleted = []
+    for rel in V1_SESSION_FILES:
+        path = target / rel
+        if path.is_file():
+            path.unlink()
+            deleted.append(rel)
+    return deleted
+
+
+def clean_gitignore(target: Path) -> bool:
+    """Remove v1-specific entries, add v4 entries. Returns True if modified."""
+    gitignore = target / ".gitignore"
+    changed = False
+
+    if gitignore.is_file():
+        content = gitignore.read_text()
+        lines = content.splitlines()
+    else:
+        content = ""
+        lines = []
+
+    # Remove v1 entries
+    filtered = []
+    for line in lines:
+        stripped = line.strip()
+        if stripped in V1_GITIGNORE_ENTRIES:
+            changed = True
+            continue
+        filtered.append(line)
+
+    # Add missing v4 entries
+    existing_set = set(l.strip() for l in filtered)
+    missing = [e for e in V4_GITIGNORE_ENTRIES if e not in existing_set]
+
+    if missing:
+        changed = True
+        if filtered and filtered[-1].strip():
+            filtered.append("")
+        filtered.append("# Prawduct session files")
+        for entry in missing:
+            filtered.append(entry)
+
+    if not changed:
+        return False
+
+    gitignore.write_text("\n".join(filtered) + "\n")
+    return True
+
+
+def add_block_markers(target: Path, subs: dict[str, str]) -> bool:
+    """Add PRAWDUCT block markers to CLAUDE.md if missing.
+
+    - If already has markers → no-op.
+    - Otherwise → wrap the body (everything from the first ## heading onward)
+      in markers.
+
+    Returns True if the file was modified.
+    """
+    claude_path = target / "CLAUDE.md"
+    if not claude_path.is_file():
+        return False
+
+    content = claude_path.read_text()
+
+    # Already has markers — no-op
+    if BLOCK_BEGIN in content and BLOCK_END in content:
+        return False
+
+    # Wrap everything from the first ## heading onward in markers
+    lines = content.split("\n")
+    body_start = 0
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped.startswith("## "):
+            body_start = i
+            break
+    else:
+        # No section headers found — wrap everything after first non-empty lines
+        body_start = min(2, len(lines))
+
+    before_lines = lines[:body_start]
+    body_lines = lines[body_start:]
+
+    # Build new content
+    before = "\n".join(before_lines)
+    if before and not before.endswith("\n"):
+        before += "\n"
+    before += "\n"
+
+    body = "\n".join(body_lines)
+    if body and not body.endswith("\n"):
+        body += "\n"
+
+    new_content = before + BLOCK_BEGIN + "\n\n" + body + "\n" + BLOCK_END + "\n"
+    claude_path.write_text(new_content)
+    return True
+
+
+def upgrade_manifest_strategy(target: Path) -> bool:
+    """Upgrade manifest CLAUDE.md strategy from 'template' to 'block_template'.
+
+    Recomputes the hash as a block hash. Returns True if modified.
+    """
+    manifest_path = target / ".prawduct" / "sync-manifest.json"
+    if not manifest_path.is_file():
+        return False
+
+    try:
+        manifest = load_json(manifest_path)
+    except json.JSONDecodeError:
+        return False
+
+    files = manifest.get("files", {})
+    claude_config = files.get("CLAUDE.md")
+    if claude_config is None:
+        return False
+
+    if claude_config.get("strategy") == "block_template":
+        return False  # Already upgraded
+
+    # Change strategy
+    claude_config["strategy"] = "block_template"
+
+    # Recompute hash as block hash
+    claude_path = target / "CLAUDE.md"
+    if claude_path.is_file():
+        content = claude_path.read_text()
+        claude_config["generated_hash"] = compute_block_hash(content)
+
+    manifest["files"]["CLAUDE.md"] = claude_config
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+    return True
+
+
+def split_learnings_v5(product_dir: Path) -> list[str]:
+    """Create learnings-detail.md as reference backup of learnings.md.
+
+    Part of v4→v5 migration. If learnings.md exists with meaningful content
+    and learnings-detail.md doesn't exist yet, copies the content.
+    Idempotent: skips if detail file already exists.
+
+    Returns list of actions taken.
+    """
+    actions: list[str] = []
+    learnings = product_dir / ".prawduct" / "learnings.md"
+    detail = product_dir / ".prawduct" / "learnings-detail.md"
+
+    if not learnings.is_file():
+        return actions
+    if detail.is_file():
+        return actions  # Already split
+
+    content = learnings.read_text()
+    # Only split if there's meaningful content beyond the header
+    lines = [l for l in content.strip().splitlines()
+             if l.strip() and not l.startswith("#")]
+    if not lines:
+        return actions
+
+    detail.write_text(content)
+    actions.append("Created .prawduct/learnings-detail.md (reference backup)")
+    return actions
+
+
+def strip_test_tracking(product_dir: Path) -> list[str]:
+    """Remove build_state.test_tracking from project-state.yaml.
+
+    Test count is derived data — computed dynamically by the hook, never tracked
+    as a static artifact. Idempotent: no-op if test_tracking is absent.
+
+    Returns list of actions taken.
+    """
+    actions: list[str] = []
+    state_path = product_dir / ".prawduct" / "project-state.yaml"
+    if not state_path.is_file():
+        return actions
+
+    content = state_path.read_text()
+    if "test_tracking:" not in content:
+        return actions
+
+    lines = content.split("\n")
+    tt_start = None
+    tt_end = None
+
+    for i, line in enumerate(lines):
+        if tt_start is None:
+            stripped = line.strip()
+            if stripped.startswith("test_tracking:") and line.startswith("  "):
+                tt_start = i
+        elif tt_start is not None:
+            # End when we hit a non-blank/non-comment line at indent <= 2
+            if line.strip() and not line.strip().startswith("#"):
+                indent = len(line) - len(line.lstrip())
+                if indent <= 2:
+                    tt_end = i
+                    break
+
+    if tt_start is None:
+        return actions
+    if tt_end is None:
+        tt_end = len(lines)
+
+    new_lines = lines[:tt_start] + lines[tt_end:]
+    cleaned = "\n".join(new_lines)
+    while "\n\n\n" in cleaned:
+        cleaned = cleaned.replace("\n\n\n", "\n\n")
+    state_path.write_text(cleaned)
+    actions.append("Removed build_state.test_tracking from project-state.yaml")
+    return actions
+
+
+def enable_v1_4_views(product_dir: Path, manifest: dict) -> list[str]:
+    """One-shot v1.4 migration: auto-enable derived views for existing repos.
+
+    Per the v1.4 rollout decision ("all users should get views for free, no
+    mandatory opt-in"), sync silently upgrades v1.3.x product repos so the
+    next ``regen-views`` run produces the three derived views (Status,
+    release-notes, scope_rollups).
+
+    Operates on ``.prawduct/project-state.yaml``:
+      * Adds ``scope_rollups: {}`` block with header comment if absent.
+      * Adds ``views_enabled: true`` with header if absent.
+      * Flips ``views_enabled: false`` → ``views_enabled: true`` (the post-Chunk-06
+        template default that v1.3.x bootstrapped products will be holding).
+
+    One-shot tracking via ``manifest['v1_4_views_enabled']``. After the first
+    successful run, the flag is set and subsequent syncs are no-ops — users who
+    edit ``views_enabled`` back to ``false`` afterwards aren't fought.
+
+    Mutates ``manifest`` in place (caller persists via existing write-back).
+    Returns list of action strings.
+    """
+    actions: list[str] = []
+
+    if manifest.get("v1_4_views_enabled"):
+        return actions  # Already migrated this repo
+
+    state_path = product_dir / ".prawduct" / "project-state.yaml"
+    if not state_path.is_file():
+        return actions
+
+    content = state_path.read_text()
+    original = content
+
+    has_views_key = "\nviews_enabled:" in content or content.startswith("views_enabled:")
+    has_scope_key = "\nscope_rollups:" in content or content.startswith("scope_rollups:")
+
+    # Flip false → true when key already present (post-Chunk-06 template default).
+    # We only rewrite the standalone ``views_enabled: false`` line, leaving any
+    # commented-out occurrences or unrelated substrings alone.
+    if has_views_key:
+        new_lines: list[str] = []
+        flipped = False
+        for line in content.split("\n"):
+            if line.strip() == "views_enabled: false" and not flipped:
+                new_lines.append("views_enabled: true")
+                flipped = True
+            else:
+                new_lines.append(line)
+        if flipped:
+            content = "\n".join(new_lines)
+            actions.append(
+                "Flipped views_enabled: false → true in project-state.yaml "
+                "(v1.4 derived views auto-enabled)"
+            )
+
+    # Append scope_rollups: {} placeholder if absent.
+    if not has_scope_key:
+        if content and not content.endswith("\n"):
+            content += "\n"
+        content += (
+            "\n"
+            "# =============================================================================\n"
+            "# SCOPE ROLLUPS (derived view, v1.4+)\n"
+            "# =============================================================================\n"
+            "# Auto-generated by `python3 tools/product-hook regen-views` from\n"
+            "# .prawduct/change-log.md `scope=` tags. Do not hand-edit — edits will be\n"
+            "# overwritten on next regen.\n"
+            "\n"
+            "scope_rollups: {}\n"
+        )
+        actions.append("Added scope_rollups: {} placeholder to project-state.yaml")
+
+    # Append views_enabled: true if absent (pre-Chunk-06 v1.3.x bootstrap).
+    if not has_views_key:
+        if content and not content.endswith("\n"):
+            content += "\n"
+        content += (
+            "\n"
+            "# =============================================================================\n"
+            "# DERIVED VIEWS (enabled by default, v1.4+)\n"
+            "# =============================================================================\n"
+            "# When true (default), three derived views are regenerated from\n"
+            "# change-log.md tagged entries (see that file for the tag format):\n"
+            "#   * build-plan `## Status` block (checkboxes from `status=shipped` tags)\n"
+            "#   * `.prawduct/release-notes.md` (from `release=` tags)\n"
+            "#   * `scope_rollups:` block above (from `scope=` tags)\n"
+            "# Run `python3 tools/product-hook regen-views` to apply. Set to `false`\n"
+            "# to opt out.\n"
+            "\n"
+            "views_enabled: true\n"
+        )
+        actions.append(
+            "Added views_enabled: true to project-state.yaml "
+            "(v1.4 derived views auto-enabled)"
+        )
+
+    if content != original:
+        state_path.write_text(content)
+
+    # Record one-shot completion regardless of whether the file needed changes —
+    # an already-on repo still counts as migrated, and we want subsequent syncs
+    # to skip the file read entirely.
+    manifest["v1_4_views_enabled"] = True
+
+    return actions
+
+
+def enable_v1_4_coverage(
+    product_dir: Path,
+    manifest: dict,
+    *,
+    force: bool = False,
+) -> tuple[list[str], list[str]]:
+    """User-invoked v1.4 migration: enable F4 coverage enforcement.
+
+    Unlike ``enable_v1_4_views`` (silent auto-enable on every sync — the
+    decision was "all users should get views for free"), coverage
+    enforcement is opt-in: turning it on commits the project to BLOCKING
+    Critic findings whenever a changed file is missing from
+    ``.test-evidence.json``'s ``changes_referenced``. The migration is
+    intentionally explicit — invoked via the new ``prawduct-setup migrate
+    --enable-coverage`` subcommand, never silently from sync.
+
+    Mutates ``.prawduct/project-state.yaml`` in place:
+      * Flips standalone ``coverage_required: false`` → ``true``.
+      * Appends a ``coverage_required: true`` block with header comment
+        when the key is absent entirely.
+      * No rewrite when the key is already ``true``.
+
+    Mutates ``manifest`` to set ``v1_4_coverage_enabled: True`` so a later
+    accidental re-invocation short-circuits. ``force=True`` ignores the
+    one-shot flag and re-surfaces NOTEs (useful when a user re-runs to
+    re-check evidence shape after wiring up a verifier).
+
+    Returns ``(actions, notes)``. Actions are file mutations; notes
+    surface deprecation + next-step guidance:
+      * Legacy-shape ``.test-evidence.json`` (no ``verifier`` field) →
+        a v1.5-removal-warning NOTE pointing at ``tools/test-reference-verify``
+        as the floor (or a stronger product-supplied verifier).
+      * Missing evidence file → a NOTE telling the user to run the test
+        suite + verifier before relying on the new gate.
+      * Successful flip → a NOTE summarizing the next-PR consequence
+        (Critic Goal 1 now BLOCKS on missing coverage).
+    """
+    actions: list[str] = []
+    notes: list[str] = []
+
+    if manifest.get("v1_4_coverage_enabled") and not force:
+        return actions, notes
+
+    state_path = product_dir / ".prawduct" / "project-state.yaml"
+    if not state_path.is_file():
+        return actions, notes
+
+    content = state_path.read_text()
+    original = content
+
+    # ``has_*_key`` checks scan column-0 occurrences (preceded by a newline
+    # or at start-of-file) so a comment-quoted ``coverage_required:`` or
+    # an indented nested mention doesn't trick the detector.
+    has_coverage_key = (
+        "\ncoverage_required:" in content
+        or content.startswith("coverage_required:")
+    )
+
+    already_on = False
+    if has_coverage_key:
+        for raw in content.splitlines():
+            if raw[:1] in (" ", "\t"):
+                continue
+            stripped = raw.split("#", 1)[0].rstrip()
+            if stripped.startswith("coverage_required:"):
+                value = stripped.split(":", 1)[1].strip().lower()
+                already_on = value == "true"
+                break
+
+    if has_coverage_key and not already_on:
+        # Flip the first column-0 ``coverage_required: false`` line, regardless
+        # of trailing inline comment (``false  # opt-in``). Detector and
+        # mutator must agree on shape — Critic Chunk 10 NOTE flagged the
+        # earlier asymmetry where the detector stripped comments but the
+        # mutator only matched the bare line, leaving inline-commented forms
+        # in a silent no-op state.
+        new_lines: list[str] = []
+        flipped = False
+        for line in content.split("\n"):
+            if flipped or line[:1] in (" ", "\t"):
+                new_lines.append(line)
+                continue
+            stripped = line.split("#", 1)[0].rstrip()
+            if (
+                stripped.startswith("coverage_required:")
+                and stripped.split(":", 1)[1].strip().lower() == "false"
+            ):
+                # Preserve any inline comment by re-attaching the post-#
+                # tail; only the value changes.
+                tail = line.split("#", 1)[1] if "#" in line else ""
+                rewritten = "coverage_required: true"
+                if tail:
+                    rewritten += "  #" + tail
+                new_lines.append(rewritten)
+                flipped = True
+            else:
+                new_lines.append(line)
+        if flipped:
+            content = "\n".join(new_lines)
+            actions.append(
+                "Flipped coverage_required: false → true in project-state.yaml "
+                "(v1.4 F4 symbol-coverage enforcement enabled)"
+            )
+
+    if not has_coverage_key:
+        if content and not content.endswith("\n"):
+            content += "\n"
+        content += (
+            "\n"
+            "# =============================================================================\n"
+            "# COVERAGE EVIDENCE (opt-in, v1.4+)\n"
+            "# =============================================================================\n"
+            "# When true, the Critic's Goal 1 requires every changed file to appear\n"
+            "# in `.test-evidence.json`'s `changes_referenced` list and scales severity\n"
+            "# language to the declared `coverage_level` (`referenced` floor vs.\n"
+            "# `executed` real). See `methodology/building.md` + the reference\n"
+            "# verifier at `tools/test-reference-verify`. Enabled by\n"
+            "# `prawduct-setup migrate --enable-coverage`.\n"
+            "\n"
+            "coverage_required: true\n"
+        )
+        actions.append(
+            "Added coverage_required: true to project-state.yaml "
+            "(v1.4 F4 symbol-coverage enforcement enabled)"
+        )
+
+    if content != original:
+        state_path.write_text(content)
+
+    if already_on and not actions:
+        notes.append(
+            "coverage_required is already true — nothing to flip. "
+            "Re-running with --force re-surfaces evidence-shape NOTEs."
+        )
+
+    # Inspect the latest test evidence to surface deprecation / next-step
+    # guidance. The evidence file is gitignored in normal product layouts,
+    # so missing-file is a likely state for a project that has never run
+    # the verifier — surface explicitly rather than failing silently.
+    evidence_path = product_dir / ".prawduct" / ".test-evidence.json"
+    if not evidence_path.is_file():
+        notes.append(
+            "No .prawduct/.test-evidence.json on disk — run the test suite and "
+            "`python3 tools/test-reference-verify --merge-into .prawduct/.test-evidence.json` "
+            "before relying on the new Critic gate."
+        )
+    else:
+        try:
+            evidence = json.loads(evidence_path.read_text())
+        except (json.JSONDecodeError, OSError) as exc:
+            notes.append(
+                f"Could not parse .prawduct/.test-evidence.json ({exc}); "
+                "re-emit with `python3 tools/test-reference-verify` "
+                "before relying on the new gate."
+            )
+        else:
+            if "verifier" not in evidence:
+                notes.append(
+                    "Legacy evidence shape detected (no `verifier` field). "
+                    "v1.5 will drop the legacy-shape compat path — emit the "
+                    "F4a fields with `python3 tools/test-reference-verify "
+                    "--merge-into .prawduct/.test-evidence.json` (Python "
+                    "floor) or plug in a language-native coverage tool "
+                    "and set `coverage_level: executed`."
+                )
+
+    # One-shot manifest tracking. Set even when nothing changed in the
+    # YAML (an already-on repo still counts as migrated) so accidental
+    # re-runs short-circuit. ``--force`` callers bypass this check at the
+    # top of the function.
+    manifest["v1_4_coverage_enabled"] = True
+
+    if actions and not already_on:
+        notes.append(
+            "Next-PR consequence: Critic Goal 1 will BLOCK on changed files "
+            "missing from changes_referenced. Wire a verifier into your test "
+            "command — `tools/test-reference-verify` is the shipped Python "
+            "floor; see `methodology/building.md` for stronger alternatives."
+        )
+
+    return actions, notes
+
+
+def run_migrate_coverage(product_dir: str, *, force: bool = False) -> dict:
+    """User-facing runner for ``prawduct-setup migrate --enable-coverage``.
+
+    Loads ``sync-manifest.json``, invokes :func:`enable_v1_4_coverage`,
+    persists the manifest, and returns a dict shaped for both human and
+    JSON output:
+
+        {
+          "product_dir": "/abs/path",
+          "enabled": bool,           # True iff coverage_required ended up true
+          "force": bool,
+          "actions": [str, ...],     # file mutations
+          "notes": [str, ...],       # deprecation + next-step guidance
+        }
+
+    On error returns ``{"error": "..."}`` and skips manifest write-back.
+
+    The runner is intentionally thin: the policy lives in
+    :func:`enable_v1_4_coverage`. This wrapper exists so the CLI surface
+    matches the other ``run_*`` commands (init / sync / validate / views)
+    — a single dict result that the ``prawduct-setup.py`` layer can
+    render or json-dump uniformly.
+    """
+    product_path = Path(product_dir).resolve()
+    prawduct_dir = product_path / ".prawduct"
+    if not prawduct_dir.is_dir():
+        return {
+            "error": f"Not a prawduct product: {product_path} has no .prawduct/ directory"
+        }
+
+    manifest_path = prawduct_dir / "sync-manifest.json"
+    if not manifest_path.is_file():
+        return {
+            "error": (
+                f"No sync-manifest.json at {manifest_path} — run "
+                "`prawduct-setup setup` to initialize the product repo before "
+                "migrating."
+            )
+        }
+
+    try:
+        manifest = load_json(manifest_path)
+    except (json.JSONDecodeError, OSError) as exc:
+        return {"error": f"Could not read sync-manifest.json: {exc}"}
+
+    try:
+        actions, notes = enable_v1_4_coverage(product_path, manifest, force=force)
+    except OSError as exc:
+        return {"error": f"Migration failed: {exc}"}
+
+    # Persist manifest regardless of whether anything changed in the YAML —
+    # the one-shot flag may have been set even on a no-op so subsequent
+    # accidental invocations short-circuit.
+    try:
+        manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+    except OSError as exc:
+        return {"error": f"Could not write sync-manifest.json: {exc}"}
+
+    # Re-read coverage_required from the on-disk state to report ground
+    # truth (the manifest flag tracks "we ran the migration", not "the
+    # YAML currently says true" — a user could re-edit between runs).
+    state_path = prawduct_dir / "project-state.yaml"
+    enabled = False
+    if state_path.is_file():
+        for raw in state_path.read_text().splitlines():
+            if raw[:1] in (" ", "\t"):
+                continue
+            stripped = raw.split("#", 1)[0].rstrip()
+            if stripped.startswith("coverage_required:"):
+                enabled = stripped.split(":", 1)[1].strip().lower() == "true"
+                break
+
+    return {
+        "product_dir": str(product_path),
+        "enabled": enabled,
+        "force": force,
+        "actions": actions,
+        "notes": notes,
+    }
+
+
+# =============================================================================
+# F5b — settings.json layout migration (manifest flag + legacy_cleanup pass).
+# =============================================================================
+#
+# Unlike ``enable_v1_4_views`` (silent auto-enable every sync) and unlike
+# ``enable_v1_4_coverage`` (commits the project to BLOCKING Critic findings),
+# the settings-layout migration is mostly a *signal* operation: it stamps
+# ``v1_4_settings_migrated: true`` in the manifest as the explicit user opt-in.
+# For products already on the canonical minimal layout (the framework's own
+# template since v1.3.x), the file mutation is a no-op; for older repos with
+# v1/v3 hook markers that normal sync skipped, the ``legacy_cleanup=True``
+# pass strips them. The flag exists so v1.4.1's Critic NOTE on unmigrated
+# repos has a single state bit to read — not so this migration does anything
+# load-bearing in v1.4.0.
+
+def enable_v1_4_settings_layout(
+    product_dir: Path,
+    template_path: Path,
+    subs: dict[str, str],
+    manifest: dict,
+    *,
+    force: bool = False,
+) -> tuple[list[str], list[str]]:
+    """User-invoked v1.4 migration: stamp settings.json as on the canonical
+    minimal layout.
+
+    Invokes :func:`merge_settings` with ``legacy_cleanup=True`` against the
+    product's ``.claude/settings.json``, then records the migration in the
+    manifest. The cleanup pass is the same one used by v1→v5 migration
+    (``migrate_cmd.py:run_migrate``); running it again on a v5 product is a
+    no-op when nothing predates the current layout, which is the expected
+    state for products that have been syncing regularly.
+
+    Sets ``manifest["v1_4_settings_migrated"] = True`` on success so an
+    accidental re-invocation short-circuits. The flag means "the user
+    explicitly opted into the canonical layout," not "the file changed" —
+    products already minimal get the flag and a single explanatory NOTE.
+
+    Returns ``(actions, notes)``:
+      * Actions are file mutations (one line if settings.json was rewritten).
+      * Notes surface the already-minimal-no-op case, parse failures, and
+        the v1.4.1-NOTE consequence.
+
+    Tolerates missing settings.json (returns empty, no flag) and unparseable
+    settings.json (returns empty, surfaces diagnostic note, no flag). In both
+    cases the migration didn't actually run to completion, so flipping the
+    flag would falsely advertise success.
+    """
+    actions: list[str] = []
+    notes: list[str] = []
+
+    if manifest.get("v1_4_settings_migrated") and not force:
+        return actions, notes
+
+    settings_path = product_dir / ".claude" / "settings.json"
+    if not settings_path.is_file():
+        return actions, notes
+
+    # Validate JSON shape up front. ``merge_settings`` already handles bad
+    # JSON by logging and returning False, but we need to surface the parse
+    # failure as a NOTE *and* refuse to set the manifest flag — otherwise a
+    # silently-broken settings.json gets "migrated" with no diagnostic trail.
+    try:
+        json.loads(settings_path.read_text())
+    except json.JSONDecodeError as exc:
+        notes.append(
+            f"Could not parse .claude/settings.json ({exc}); fix the JSON "
+            "syntax and re-run migrate --enable-settings-layout."
+        )
+        return actions, notes
+
+    changed = merge_settings(
+        settings_path, template_path, subs, legacy_cleanup=True
+    )
+
+    if changed:
+        actions.append(
+            "Normalized .claude/settings.json (stripped legacy hooks, "
+            "regenerated banner; user hooks preserved)"
+        )
+    else:
+        # Distinguish "already minimal" from "we wrote something" so the user
+        # knows whether their file changed. Without this NOTE, a no-op migration
+        # is indistinguishable from a silently-failed one.
+        notes.append(
+            "Settings.json was already on the canonical minimal layout; "
+            "no file changes were necessary. Manifest flag updated."
+        )
+
+    notes.append(
+        "Next-release consequence: v1.4.1's Critic surfaces a NOTE on "
+        "products that haven't run this migration. Running migrate "
+        "--enable-settings-layout silences that NOTE going forward."
+    )
+
+    # One-shot manifest tracking. Set after the cleanup pass succeeds so a
+    # parse-failure path above can't silently advertise migration.
+    manifest["v1_4_settings_migrated"] = True
+
+    return actions, notes
+
+
+def run_migrate_settings_layout(
+    product_dir: str, *, force: bool = False
+) -> dict:
+    """User-facing runner for ``prawduct-setup migrate --enable-settings-layout``.
+
+    Loads ``sync-manifest.json``, resolves the framework path the same way
+    ``run_sync`` does (manifest ``framework_source`` → ``PRAWDUCT_FRAMEWORK_DIR``
+    env → sibling ``../prawduct`` fallback), constructs the canonical
+    ``{{PRODUCT_NAME}}`` / ``{{PRAWDUCT_VERSION}}`` subs, invokes
+    :func:`enable_v1_4_settings_layout`, and persists the manifest.
+
+    Returns a dict shaped for both human and JSON output:
+
+        {
+          "product_dir": "/abs/path",
+          "migrated": bool,           # True iff manifest flag ended up true
+          "force": bool,
+          "actions": [str, ...],     # file mutations
+          "notes": [str, ...],       # already-minimal / next-release guidance
+        }
+
+    On error returns ``{"error": "..."}`` and skips manifest write-back.
+    Errors are actionable: each names the next command to run rather than
+    just "not found" (mirrors ``run_migrate_coverage`` shape).
+
+    The runner is intentionally thin: policy lives in
+    :func:`enable_v1_4_settings_layout`. The framework-resolution layer
+    matches ``run_sync`` so the recovery advice users see is consistent
+    across commands.
+    """
+    product_path = Path(product_dir).resolve()
+    prawduct_dir = product_path / ".prawduct"
+    if not prawduct_dir.is_dir():
+        return {
+            "error": f"Not a prawduct product: {product_path} has no .prawduct/ directory"
+        }
+
+    manifest_path = prawduct_dir / "sync-manifest.json"
+    if not manifest_path.is_file():
+        return {
+            "error": (
+                f"No sync-manifest.json at {manifest_path} — run "
+                "`prawduct-setup setup` to initialize the product repo before "
+                "migrating."
+            )
+        }
+
+    try:
+        manifest = load_json(manifest_path)
+    except (json.JSONDecodeError, OSError) as exc:
+        return {"error": f"Could not read sync-manifest.json: {exc}"}
+
+    framework = _resolve_framework_dir(manifest, None, product_path)
+    if framework is None:
+        return {
+            "error": (
+                "Could not resolve framework directory (checked manifest "
+                "framework_source, PRAWDUCT_FRAMEWORK_DIR env, and sibling "
+                "../prawduct). Set PRAWDUCT_FRAMEWORK_DIR or clone the "
+                "framework as a sibling directory, then re-run."
+            )
+        }
+
+    template_path = framework / "templates" / "product-settings.json"
+    if not template_path.is_file():
+        return {
+            "error": (
+                f"Framework at {framework} is missing "
+                "templates/product-settings.json — the resolved framework "
+                "checkout looks incomplete."
+            )
+        }
+
+    product_name = (
+        infer_product_name(product_path)
+        or manifest.get("product_name")
+        or product_path.name
+    )
+    subs = {
+        "{{PRODUCT_NAME}}": product_name,
+        "{{PRAWDUCT_VERSION}}": PRAWDUCT_VERSION,
+    }
+
+    try:
+        actions, notes = enable_v1_4_settings_layout(
+            product_path, template_path, subs, manifest, force=force
+        )
+    except OSError as exc:
+        return {"error": f"Migration failed: {exc}"}
+
+    # Persist manifest regardless of whether anything changed in the file —
+    # the one-shot flag may have been set even on a no-op so subsequent
+    # accidental invocations short-circuit.
+    try:
+        manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+    except OSError as exc:
+        return {"error": f"Could not write sync-manifest.json: {exc}"}
+
+    return {
+        "product_dir": str(product_path),
+        "migrated": bool(manifest.get("v1_4_settings_migrated")),
+        "force": force,
+        "actions": actions,
+        "notes": notes,
+    }
+
+
+def migrate_project_state_v5(product_dir: Path) -> list[str]:
+    """Add v5 sections to project-state.yaml, remove v4-only fields.
+
+    Adds work_in_progress (backward compat for existing repos) and
+    health_check sections if missing. Removes current_phase if present.
+    Idempotent.
+
+    Note: New repos (v6+) no longer include work_in_progress or build_plan
+    in the template — build plan Status is the source of truth. This
+    migration keeps adding work_in_progress so existing repos that read
+    from it continue to work during the transition.
+
+    Returns list of actions taken.
+    """
+    actions: list[str] = []
+    state_path = product_dir / ".prawduct" / "project-state.yaml"
+
+    if not state_path.is_file():
+        return actions
+
+    content = state_path.read_text()
+    original = content
+
+    # Remove current_phase field (v4 artifact) — top-level key, single line
+    if "\ncurrent_phase:" in content or content.startswith("current_phase:"):
+        lines = content.split("\n")
+        new_lines = [l for l in lines if not l.startswith("current_phase:")]
+        content = "\n".join(new_lines)
+
+    # Add work_in_progress section if missing
+    if "work_in_progress:" not in content:
+        content = content.rstrip("\n") + "\n\n" + (
+            "# =============================================================================\n"
+            "# WORK IN PROGRESS (branch-scoped)\n"
+            "# =============================================================================\n"
+            "# Each branch gets its own entry. See project-state.yaml template for format.\n"
+            "\n"
+            "work_in_progress: {}\n"
+        )
+
+    # Add health_check section if missing
+    if "health_check:" not in content:
+        content = content.rstrip("\n") + "\n\n" + (
+            "# =============================================================================\n"
+            "# HEALTH CHECK\n"
+            "# =============================================================================\n"
+            "# Tracks periodic health check state.\n"
+            "\n"
+            "health_check:\n"
+            "  last_full_check: null\n"
+            "  last_check_findings: null\n"
+        )
+
+    if content != original:
+        state_path.write_text(content)
+        actions.append("Updated .prawduct/project-state.yaml for v5")
+
+    return actions
+
+
+def migrate_change_log(product_dir: Path) -> list[str]:
+    """Move change_log from project-state.yaml to .prawduct/change-log.md.
+
+    Parses YAML change_log entries, converts to markdown sections, writes
+    to change-log.md (appending if it exists), and removes the change_log
+    section from project-state.yaml. Idempotent: skips if no change_log
+    section exists in project-state.yaml.
+
+    Returns list of actions taken.
+    """
+    actions: list[str] = []
+    state_path = product_dir / ".prawduct" / "project-state.yaml"
+    if not state_path.is_file():
+        return actions
+
+    content = state_path.read_text()
+
+    # Check if change_log: exists with actual entries (not just [] or {})
+    if "\nchange_log:" not in content and not content.startswith("change_log:"):
+        return actions
+
+    # Find the change_log section boundaries
+    lines = content.split("\n")
+    cl_start = None
+    cl_end = None
+    for i, line in enumerate(lines):
+        if line.startswith("change_log:") or line.strip() == "change_log:":
+            cl_start = i
+        elif cl_start is not None and not line.startswith(" ") and not line.startswith("#") and line.strip() and not line.startswith("change_log"):
+            # Hit next top-level key
+            cl_end = i
+            break
+    if cl_start is None:
+        return actions
+
+    if cl_end is None:
+        cl_end = len(lines)
+
+    # Also capture any comment lines immediately before change_log:
+    comment_start = cl_start
+    while comment_start > 0 and (lines[comment_start - 1].startswith("#") or lines[comment_start - 1].strip() == ""):
+        if lines[comment_start - 1].startswith("# ===") or "CHANGE LOG" in lines[comment_start - 1]:
+            comment_start -= 1
+        elif lines[comment_start - 1].strip() == "":
+            comment_start -= 1
+        elif lines[comment_start - 1].startswith("#"):
+            comment_start -= 1
+        else:
+            break
+
+    cl_section = lines[cl_start:cl_end]
+
+    # Parse entries from the YAML section (lightweight, no PyYAML)
+    entries: list[dict[str, str]] = []
+    current_entry: dict[str, str] = {}
+    current_key: str | None = None
+
+    for line in cl_section:
+        stripped = line.strip()
+        if stripped.startswith("- what:") or stripped.startswith("- what :"):
+            if current_entry:
+                entries.append(current_entry)
+            current_entry = {}
+            current_key = "what"
+            val = stripped.split(":", 1)[1].strip().strip("\"'")
+            if val:
+                current_entry["what"] = val
+        elif stripped.startswith("why:") and current_entry is not None:
+            current_key = "why"
+            val = stripped.split(":", 1)[1].strip().strip("\"'")
+            if val:
+                current_entry["why"] = val
+        elif stripped.startswith("blast_radius:") and current_entry is not None:
+            current_key = "blast_radius"
+            val = stripped.split(":", 1)[1].strip().strip("\"'")
+            if val:
+                current_entry["blast_radius"] = val
+        elif stripped.startswith("classification:") and current_entry is not None:
+            current_key = "classification"
+            val = stripped.split(":", 1)[1].strip().strip("\"'")
+            if val:
+                current_entry["classification"] = val
+        elif stripped.startswith("date:") and current_entry is not None:
+            current_key = "date"
+            val = stripped.split(":", 1)[1].strip().strip("\"'")
+            if val:
+                current_entry["date"] = val
+        elif current_key and current_entry is not None and stripped and not stripped.startswith("#") and not stripped.startswith("- "):
+            # Continuation line for multiline YAML value
+            prev = current_entry.get(current_key, "")
+            continuation = stripped.strip("\"'")
+            if prev:
+                current_entry[current_key] = prev + " " + continuation
+            else:
+                current_entry[current_key] = continuation
+
+    if current_entry:
+        entries.append(current_entry)
+
+    if not entries:
+        # change_log: exists but is empty ([] or no entries) — just remove the section
+        new_lines = lines[:comment_start] + lines[cl_end:]
+        # Clean up double blank lines
+        cleaned = "\n".join(new_lines)
+        while "\n\n\n" in cleaned:
+            cleaned = cleaned.replace("\n\n\n", "\n\n")
+        state_path.write_text(cleaned)
+        actions.append("Removed empty change_log section from project-state.yaml")
+        return actions
+
+    # Convert entries to markdown
+    md_entries: list[str] = []
+    for entry in entries:
+        date = entry.get("date", "unknown")
+        what = entry.get("what", "Untitled change")
+        md = f"## {date}: {what}"
+        if entry.get("why"):
+            md += f"\n\n**Why:** {entry['why']}"
+        if entry.get("blast_radius"):
+            md += f"\n\n**Blast radius:** {entry['blast_radius']}"
+        if entry.get("classification"):
+            md += f"\n\n**Classification:** {entry['classification']}"
+        md_entries.append(md)
+
+    # Write to change-log.md
+    cl_path = product_dir / ".prawduct" / "change-log.md"
+    product_name = product_dir.name
+    if cl_path.is_file():
+        existing = cl_path.read_text()
+        # Append migrated entries at the end with a separator
+        separator = "\n\n<!-- Migrated from project-state.yaml -->\n\n"
+        cl_path.write_text(existing.rstrip("\n") + separator + "\n\n".join(md_entries) + "\n")
+    else:
+        header = f"# Change Log — {product_name}\n\n<!-- Append new entries at the top. -->\n\n"
+        cl_path.write_text(header + "\n\n".join(md_entries) + "\n")
+
+    actions.append(f"Migrated {len(entries)} change_log entries to .prawduct/change-log.md")
+
+    # Remove change_log section from project-state.yaml
+    # Replace with a pointer comment
+    pointer = (
+        "# =============================================================================\n"
+        "# CHANGE LOG\n"
+        "# =============================================================================\n"
+        "# Change log moved to .prawduct/change-log.md (separate file for merge-friendliness).\n"
+    )
+    new_lines = lines[:comment_start] + pointer.split("\n") + lines[cl_end:]
+    cleaned = "\n".join(new_lines)
+    while "\n\n\n" in cleaned:
+        cleaned = cleaned.replace("\n\n\n", "\n\n")
+    state_path.write_text(cleaned)
+    actions.append("Removed change_log section from project-state.yaml (replaced with pointer)")
+
+    return actions
+
+
+def migrate_backlog(product_dir: Path) -> list[str]:
+    """Move remaining_work/future_work/deferred_work from project-state.yaml to backlog.md.
+
+    For remaining_work (under build_plan): parses item/description/phase fields,
+    skips completed items, converts pending items to markdown bullets.
+    For other sections (future_work, deferred_work, backlog): extracts raw YAML
+    and wraps in a code block with cleanup marker.
+
+    Idempotent: skips if no matching sections exist in project-state.yaml.
+    Returns list of actions taken.
+    """
+    actions: list[str] = []
+    state_path = product_dir / ".prawduct" / "project-state.yaml"
+    if not state_path.is_file():
+        return actions
+
+    content = state_path.read_text()
+    lines = content.split("\n")
+    backlog_items: list[str] = []
+    raw_sections: list[str] = []
+    sections_removed: list[tuple[int, int, str]] = []  # (start, end, pointer)
+
+    # --- remaining_work under build_plan ---
+    rw_start = None
+    rw_end = None
+    rw_comment_start = None
+    for i, line in enumerate(lines):
+        if rw_start is None:
+            # Match indented remaining_work: under build_plan
+            stripped = line.strip()
+            if stripped.startswith("remaining_work:") and line.startswith("  "):
+                rw_start = i
+                # Capture preceding comment lines at same or deeper indent
+                rw_comment_start = i
+                while rw_comment_start > 0:
+                    prev = lines[rw_comment_start - 1]
+                    if prev.strip().startswith("#") and prev.startswith("  "):
+                        rw_comment_start -= 1
+                    else:
+                        break
+        elif rw_start is not None and rw_end is None:
+            # Find end: next line at same or lesser indentation (not blank/comment)
+            if line.strip() and not line.strip().startswith("#"):
+                indent = len(line) - len(line.lstrip())
+                if indent <= 2:
+                    rw_end = i
+                    break
+
+    if rw_start is not None:
+        if rw_end is None:
+            rw_end = len(lines)
+
+        rw_section = lines[rw_start:rw_end]
+
+        # Parse remaining_work entries
+        entries: list[dict[str, str]] = []
+        current_entry: dict[str, str] = {}
+        current_key: str | None = None
+
+        for line in rw_section:
+            stripped = line.strip()
+            if stripped.startswith("- item:"):
+                if current_entry:
+                    entries.append(current_entry)
+                current_entry = {}
+                current_key = "item"
+                val = stripped.split(":", 1)[1].strip().strip("\"'")
+                if val:
+                    current_entry["item"] = val
+            elif stripped.startswith("description:") and current_entry:
+                current_key = "description"
+                val = stripped.split(":", 1)[1].strip().strip("\"'")
+                if val:
+                    current_entry["description"] = val
+            elif stripped.startswith("phase:") and current_entry:
+                current_key = "phase"
+                val = stripped.split(":", 1)[1].strip().strip("\"'")
+                if val:
+                    current_entry["phase"] = val
+            elif current_key and current_entry and stripped and not stripped.startswith("#") and not stripped.startswith("- "):
+                # Continuation line
+                prev = current_entry.get(current_key, "")
+                continuation = stripped.strip("\"'")
+                if prev:
+                    current_entry[current_key] = prev + " " + continuation
+                else:
+                    current_entry[current_key] = continuation
+
+        if current_entry:
+            entries.append(current_entry)
+
+        # Convert non-completed entries to markdown
+        for entry in entries:
+            phase = entry.get("phase", "").lower()
+            if phase == "completed":
+                continue
+            item = entry.get("item", "Untitled")
+            desc = entry.get("description", "")
+            bullet = f"- **{item}**"
+            if desc:
+                bullet += f" — {desc}"
+            bullet += " (migrated)"
+            backlog_items.append(bullet)
+
+        # Mark for removal (use comment_start to capture preceding comments)
+        pointer = "    # remaining_work: migrated to .prawduct/backlog.md\n"
+        sections_removed.append((rw_comment_start, rw_end, pointer))
+
+    # --- Top-level sections: future_work, deferred_work, backlog ---
+    top_level_keys = ["future_work", "deferred_work", "backlog"]
+    for key in top_level_keys:
+        marker = f"{key}:"
+        if f"\n{marker}" not in content and not content.startswith(marker):
+            continue
+
+        sec_start = None
+        sec_end = None
+        for i, line in enumerate(lines):
+            if sec_start is None:
+                if line.startswith(marker) or line.strip() == marker:
+                    sec_start = i
+            elif sec_start is not None:
+                if line.strip() and not line.startswith(" ") and not line.startswith("#"):
+                    sec_end = i
+                    break
+
+        if sec_start is None:
+            continue
+        if sec_end is None:
+            sec_end = len(lines)
+
+        # Capture preceding comments
+        comment_start = sec_start
+        while comment_start > 0:
+            prev = lines[comment_start - 1]
+            if prev.strip().startswith("#") or prev.strip() == "":
+                comment_start -= 1
+            else:
+                break
+
+        raw_yaml = "\n".join(lines[sec_start:sec_end]).rstrip()
+        raw_sections.append(
+            f"<!-- CLEANUP: Migrated from project-state.yaml ({key}).\n"
+            f"     Review and convert to standard backlog items, then delete this block. -->\n"
+            f"```yaml\n{raw_yaml}\n```"
+        )
+
+        pointer = f"# {key}: migrated to .prawduct/backlog.md\n"
+        sections_removed.append((comment_start, sec_end, pointer))
+
+    if not backlog_items and not raw_sections:
+        return actions
+
+    # Build backlog content
+    md_parts: list[str] = []
+    if backlog_items:
+        md_parts.extend(backlog_items)
+    if raw_sections:
+        md_parts.extend(raw_sections)
+    migrated_content = "\n".join(md_parts)
+
+    # Write to backlog.md
+    backlog_path = product_dir / ".prawduct" / "backlog.md"
+    product_name = product_dir.name
+    if backlog_path.is_file():
+        existing = backlog_path.read_text()
+        separator = "\n\n<!-- Migrated from project-state.yaml -->\n\n"
+        backlog_path.write_text(existing.rstrip("\n") + separator + migrated_content + "\n")
+    else:
+        header = (
+            f"# Backlog — {product_name}\n\n"
+            "<!-- Work discovered during sessions but out of current scope.\n"
+            "     Add items at the top. Each is a bullet with source marker:\n"
+            "     (builder), (critic), (reflection), or (migrated).\n"
+            "     Review with /janitor or when planning new work. -->\n\n"
+        )
+        backlog_path.write_text(header + migrated_content + "\n")
+
+    item_count = len(backlog_items) + len(raw_sections)
+    actions.append(f"Migrated {item_count} backlog item(s) to .prawduct/backlog.md")
+
+    # Remove sections from project-state.yaml (process in reverse order to preserve indices)
+    sections_removed.sort(key=lambda x: x[0], reverse=True)
+    for start, end, pointer in sections_removed:
+        lines[start:end] = pointer.split("\n")
+
+    cleaned = "\n".join(lines)
+    while "\n\n\n" in cleaned:
+        cleaned = cleaned.replace("\n\n\n", "\n\n")
+    state_path.write_text(cleaned)
+    actions.append("Removed migrated sections from project-state.yaml")
+
+    return actions
+
+
+def generate_sync_manifest(target: Path, product_name: str) -> bool:
+    """Generate sync manifest for the product repo. Returns True if created."""
+    manifest_path = target / ".prawduct" / "sync-manifest.json"
+    if manifest_path.is_file():
+        return False
+
+    claude_path = target / "CLAUDE.md"
+    if claude_path.is_file():
+        claude_hash = compute_block_hash(claude_path.read_text())
+        if claude_hash is None:
+            claude_hash = compute_hash(claude_path)
+    else:
+        claude_hash = None
+
+    file_hashes = {
+        "CLAUDE.md": claude_hash,
+        ".prawduct/critic-review.md": compute_hash(
+            target / ".prawduct" / "critic-review.md"
+        ),
+        "tools/product-hook": compute_hash(target / "tools" / "product-hook"),
+        ".claude/settings.json": None,
+    }
+    manifest = create_manifest(target, FRAMEWORK_DIR, product_name, file_hashes)
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+    return True
+
+
+def run_migrate(target_dir: str, product_name: str | None = None) -> dict:
+    """Migrate a product repo to v5. Returns a summary of actions taken."""
+    target = Path(target_dir).resolve()
+    actions: list[str] = []
+
+    version = detect_version(target)
+
+    # Safety: refuse to migrate directories that aren't Prawduct repos
+    if version == "unknown":
+        return {
+            "target": str(target),
+            "product_name": product_name or target.name,
+            "version_before": version,
+            "version_after": version,
+            "actions": [],
+            "files_changed": 0,
+            "error": "Not a Prawduct repo (no .prawduct/framework-path or tools/product-hook found)",
+        }
+
+    # Infer product name if not provided
+    if product_name is None:
+        product_name = infer_product_name(target)
+    if product_name is None:
+        product_name = target.name
+
+    subs = {"{{PRODUCT_NAME}}": product_name, "{{PRAWDUCT_VERSION}}": PRAWDUCT_VERSION}
+
+    # Deprecation notice for old versions
+    if version == "v1":
+        actions.append(
+            "DEPRECATION: v1 repos are no longer supported. "
+            "Migrating to v5 — review CLAUDE.md and .prawduct/ after migration."
+        )
+    elif version == "v3":
+        actions.append(
+            "DEPRECATION: v3 repos are no longer supported. "
+            "Migrating to v5 — review CLAUDE.md and .prawduct/ after migration."
+        )
+    elif version == "partial":
+        actions.append(
+            "DEPRECATION: partial (v1→v3) repos are no longer supported. "
+            "Migrating to v5 — review CLAUDE.md and .prawduct/ after migration."
+        )
+
+    # === V1-specific steps (v1 and partial) ===
+    if version in ("v1", "partial"):
+        # 1. Overwrite CLAUDE.md with current template
+        if write_template(
+            TEMPLATES_DIR / "product-claude.md", target / "CLAUDE.md", subs, overwrite=True
+        ):
+            actions.append("Overwrote CLAUDE.md with current template")
+
+        # 2. Delete v1 marker files
+        deleted = delete_v1_files(target)
+        for f in deleted:
+            actions.append(f"Deleted {f}")
+
+        # 3. Archive v1 directories
+        archived = archive_v1_dirs(target)
+        for d in archived:
+            actions.append(f"Archived {d} → .prawduct/archive/")
+
+        # 4. Clean v1 session files
+        cleaned = clean_v1_session_files(target)
+        for f in cleaned:
+            actions.append(f"Deleted session file {f}")
+
+    # === Steps for all non-v4 repos (v1, v3, partial) ===
+
+    # Replace hooks in settings.json (handles v1, v3 bash, and adds banner)
+    if merge_settings(
+        target / ".claude" / "settings.json",
+        TEMPLATES_DIR / "product-settings.json",
+        subs,
+        legacy_cleanup=True,
+    ):
+        actions.append("Updated .claude/settings.json (hooks + banner)")
+
+    # Copy product-hook (Python version)
+    if copy_hook(
+        FRAMEWORK_DIR / "tools" / "product-hook",
+        target / "tools" / "product-hook",
+    ):
+        actions.append("Installed tools/product-hook (Python)")
+
+    # Ship tools/lib alongside the hook — product-hook imports it at runtime
+    # (regen-views, operator-verification). Eager + idempotent so a migrated
+    # repo is never in the degraded "hook present, lib absent" state that
+    # crashes those commands; mirrors init step 9b and MANAGED_DIRS.
+    lib_src = FRAMEWORK_DIR / "tools" / "lib"
+    if lib_src.is_dir():
+        lib_dst = target / "tools" / "lib"
+        lib_dst.mkdir(parents=True, exist_ok=True)
+        wrote_lib = False
+        for module in sorted(lib_src.glob("*.py")):
+            dst_module = lib_dst / module.name
+            if compute_hash(dst_module) != compute_hash(module):
+                shutil.copy2(module, dst_module)
+                wrote_lib = True
+        if wrote_lib:
+            actions.append("Installed tools/lib/")
+
+    # Create critic-review.md if missing
+    if write_template(
+        TEMPLATES_DIR / "critic-review.md",
+        target / ".prawduct" / "critic-review.md",
+        subs,
+    ):
+        actions.append("Created .prawduct/critic-review.md")
+
+    # Create learnings.md if missing
+    learnings = target / ".prawduct" / "learnings.md"
+    if not learnings.is_file():
+        learnings.parent.mkdir(parents=True, exist_ok=True)
+        learnings.write_text(
+            "# Learnings\n\nAccumulated wisdom from building this product.\n"
+        )
+        actions.append("Created .prawduct/learnings.md")
+
+    # Generate sync manifest
+    if generate_sync_manifest(target, product_name):
+        actions.append("Created .prawduct/sync-manifest.json")
+
+    # Clean gitignore
+    if clean_gitignore(target):
+        actions.append("Updated .gitignore")
+
+    # Add block markers to CLAUDE.md if missing
+    if add_block_markers(target, subs):
+        actions.append("Added block markers to CLAUDE.md")
+
+    # Upgrade manifest strategy from template to block_template
+    if upgrade_manifest_strategy(target):
+        actions.append("Upgraded CLAUDE.md sync strategy to block_template")
+
+    # === V5 migration steps (idempotent, applies to all repos) ===
+
+    # Remove stale test_tracking from project-state.yaml (test count is derived)
+    actions.extend(strip_test_tracking(target))
+
+    # Split learnings into active rules + reference detail
+    actions.extend(split_learnings_v5(target))
+
+    # Update project-state.yaml (add v5 sections, remove v4 fields)
+    actions.extend(migrate_project_state_v5(target))
+
+    # Place boundary-patterns.md if missing
+    bp_src = TEMPLATES_DIR / "boundary-patterns.md"
+    bp_dst = target / ".prawduct" / "artifacts" / "boundary-patterns.md"
+    if bp_src.is_file() and not bp_dst.is_file():
+        rendered = render_template(bp_src, subs)
+        bp_dst.parent.mkdir(parents=True, exist_ok=True)
+        bp_dst.write_text(rendered)
+        actions.append("Created .prawduct/artifacts/boundary-patterns.md")
+
+    # Bump manifest version to 2 if needed
+    manifest_path = target / ".prawduct" / "sync-manifest.json"
+    if manifest_path.is_file():
+        try:
+            mf = load_json(manifest_path)
+            if mf.get("format_version", 1) < 2:
+                mf["format_version"] = 2
+                manifest_path.write_text(json.dumps(mf, indent=2) + "\n")
+                actions.append("Bumped manifest to format_version 2 (v5)")
+        except json.JSONDecodeError:
+            pass
+
+    return {
+        "target": str(target),
+        "product_name": product_name,
+        "version_before": version,
+        "version_after": detect_version(target),
+        "actions": actions,
+        "files_changed": len(actions),
+    }
+
+
+# =============================================================================
+# F10 — operator-verification queue (manifest flag + project-state flip +
+# template placement). Mirrors ``enable_v1_4_coverage`` rather than
+# ``enable_v1_4_settings_layout``: the migration is enforcement-touching, so
+# turning it on commits the project to BLOCKING /pr gates whenever the queue
+# has pending entries. Per the "Auto-enable belongs with visibility, not
+# enforcement" learning, this never auto-fires from sync — only from explicit
+# ``prawduct-setup migrate --enable-operator-verification``.
+# =============================================================================
+
+
+def enable_v1_4_operator_verification(
+    product_dir: Path,
+    manifest: dict,
+    *,
+    force: bool = False,
+) -> tuple[list[str], list[str]]:
+    """User-invoked v1.4 migration: enable F10 operator-verification gate.
+
+    Three side effects, each idempotent:
+
+      1. Flips ``operator_verification_required: false`` → ``true`` in
+         ``project-state.yaml`` (appends a documented block when the key
+         is absent — same column-0 detector/mutator pattern as
+         ``enable_v1_4_coverage`` so inline-comment forms are tolerated).
+      2. Places ``.prawduct/operator-verification.md`` from the framework
+         template if absent (the queue file must exist before the
+         ``/pr`` gate can read it).
+      3. Sets ``manifest['v1_4_operator_verification_enabled'] = True`` so
+         accidental re-invocations short-circuit. ``force=True`` bypasses
+         the one-shot check.
+
+    Returns ``(actions, notes)``. Actions are file mutations; notes
+    surface the next-PR consequence (Critic Goal 2 NOTE for visual-change
+    chunks; ``/pr create`` BLOCKING on pending entries).
+    """
+    actions: list[str] = []
+    notes: list[str] = []
+
+    if manifest.get("v1_4_operator_verification_enabled") and not force:
+        return actions, notes
+
+    prawduct_dir = product_dir / ".prawduct"
+    state_path = prawduct_dir / "project-state.yaml"
+    queue_path = prawduct_dir / "operator-verification.md"
+
+    if not state_path.is_file():
+        return actions, notes
+
+    content = state_path.read_text()
+    original = content
+
+    has_key = (
+        "\noperator_verification_required:" in content
+        or content.startswith("operator_verification_required:")
+    )
+
+    already_on = False
+    if has_key:
+        for raw in content.splitlines():
+            if raw[:1] in (" ", "\t"):
+                continue
+            stripped = raw.split("#", 1)[0].rstrip()
+            if stripped.startswith("operator_verification_required:"):
+                value = stripped.split(":", 1)[1].strip().lower()
+                already_on = value == "true"
+                break
+
+    if has_key and not already_on:
+        new_lines: list[str] = []
+        flipped = False
+        for line in content.split("\n"):
+            if flipped or line[:1] in (" ", "\t"):
+                new_lines.append(line)
+                continue
+            stripped = line.split("#", 1)[0].rstrip()
+            if (
+                stripped.startswith("operator_verification_required:")
+                and stripped.split(":", 1)[1].strip().lower() == "false"
+            ):
+                tail = line.split("#", 1)[1] if "#" in line else ""
+                rewritten = "operator_verification_required: true"
+                if tail:
+                    rewritten += "  #" + tail
+                new_lines.append(rewritten)
+                flipped = True
+            else:
+                new_lines.append(line)
+        if flipped:
+            content = "\n".join(new_lines)
+            actions.append(
+                "Flipped operator_verification_required: false → true in "
+                "project-state.yaml (v1.4 F10 operator-verification gate enabled)"
+            )
+
+    if not has_key:
+        if content and not content.endswith("\n"):
+            content += "\n"
+        content += (
+            "\n"
+            "# =============================================================================\n"
+            "# OPERATOR VERIFICATION (opt-in, v1.4+)\n"
+            "# =============================================================================\n"
+            "# When true, `/pr create` BLOCKS if `.prawduct/operator-verification.md`\n"
+            "# has any entry with `**Status:** pending`. Drain via\n"
+            "# `python3 tools/prawduct-setup.py verify <product_dir> <VRF-ID>` or\n"
+            "# override per-PR with `--accept-pending-verification \"rationale\"`.\n"
+            "# Enabled by `prawduct-setup migrate --enable-operator-verification`.\n"
+            "\n"
+            "operator_verification_required: true\n"
+        )
+        actions.append(
+            "Added operator_verification_required: true to project-state.yaml "
+            "(v1.4 F10 operator-verification gate enabled)"
+        )
+
+    if content != original:
+        state_path.write_text(content)
+
+    if already_on and not actions:
+        notes.append(
+            "operator_verification_required is already true — nothing to "
+            "flip. Re-running with --force re-places the queue template if missing."
+        )
+
+    # Place the queue template if absent. Mutates only on first run (and on
+    # --force re-placement when the file is missing); existing queues are
+    # never overwritten — they are append-only user state.
+    if not queue_path.is_file():
+        template_path = TEMPLATES_DIR / "operator-verification.md"
+        if template_path.is_file():
+            prawduct_dir.mkdir(parents=True, exist_ok=True)
+            queue_path.write_text(template_path.read_text())
+            actions.append(
+                f"Placed {queue_path.relative_to(product_dir)} from template "
+                "(empty queue; ready for chunk-close enqueues)"
+            )
+        else:
+            notes.append(
+                f"Could not place {queue_path.relative_to(product_dir)}: "
+                f"framework template missing at {template_path}. "
+                "Verify the framework checkout is complete."
+            )
+
+    notes.append(
+        "Next-PR consequence: `/pr create` will BLOCK whenever "
+        "`.prawduct/operator-verification.md` has pending entries. "
+        "Append entries during chunk-close for visual / live-integration "
+        "changes (see methodology/building.md). Override with "
+        "`/pr create --accept-pending-verification \"rationale\"`."
+    )
+
+    manifest["v1_4_operator_verification_enabled"] = True
+
+    return actions, notes
+
+
+def run_migrate_operator_verification(
+    product_dir: str, *, force: bool = False
+) -> dict:
+    """User-facing runner for ``prawduct-setup migrate --enable-operator-verification``.
+
+    Loads ``sync-manifest.json``, invokes :func:`enable_v1_4_operator_verification`,
+    persists the manifest, and returns a dict shaped like the other migrate
+    runners (``product_dir``, ``enabled``, ``force``, ``actions``, ``notes``)
+    or ``{"error": "..."}``.
+
+    Re-reads ``operator_verification_required`` from on-disk state after
+    the migration so ``enabled`` reflects ground truth (the manifest flag
+    records "we ran the migration"; the YAML may have been hand-edited
+    between runs).
+    """
+    product_path = Path(product_dir).resolve()
+    prawduct_dir = product_path / ".prawduct"
+    if not prawduct_dir.is_dir():
+        return {
+            "error": (
+                f"Not a prawduct product: {product_path} has no .prawduct/ directory"
+            )
+        }
+
+    manifest_path = prawduct_dir / "sync-manifest.json"
+    if not manifest_path.is_file():
+        return {
+            "error": (
+                f"No sync-manifest.json at {manifest_path} — run "
+                "`prawduct-setup setup` to initialize the product repo before "
+                "migrating."
+            )
+        }
+
+    try:
+        manifest = load_json(manifest_path)
+    except (json.JSONDecodeError, OSError) as exc:
+        return {"error": f"Could not read sync-manifest.json: {exc}"}
+
+    try:
+        actions, notes = enable_v1_4_operator_verification(
+            product_path, manifest, force=force
+        )
+    except OSError as exc:
+        return {"error": f"Migration failed: {exc}"}
+
+    try:
+        manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+    except OSError as exc:
+        return {"error": f"Could not write sync-manifest.json: {exc}"}
+
+    state_path = prawduct_dir / "project-state.yaml"
+    enabled = False
+    if state_path.is_file():
+        for raw in state_path.read_text().splitlines():
+            if raw[:1] in (" ", "\t"):
+                continue
+            stripped = raw.split("#", 1)[0].rstrip()
+            if stripped.startswith("operator_verification_required:"):
+                enabled = stripped.split(":", 1)[1].strip().lower() == "true"
+                break
+
+    return {
+        "product_dir": str(product_path),
+        "enabled": enabled,
+        "force": force,
+        "actions": actions,
+        "notes": notes,
+    }

--- a/tools/lib/operator_verification.py
+++ b/tools/lib/operator_verification.py
@@ -1,0 +1,460 @@
+"""F10 — Operator-verification queue.
+
+Append-only queue of pre-merge human-verification items for visual or
+live-integration changes. Each entry is a ``## VRF-NNN — <Chunk N> — title``
+section whose first non-blank body line carries ``**Status:**
+pending | verified | accepted``.
+
+The queue is gated by ``operator_verification_required: true`` in
+``project-state.yaml``. When the flag is on, ``/pr create`` blocks if any
+entry's status is ``pending``; the user drains entries via
+``prawduct-setup verify <dir> <ID>``, or overrides for the current PR via
+``/pr create --accept-pending-verification "rationale"``.
+
+The schema is read-first / append-only by design: this module exposes a
+parser, in-memory mutators, and a round-tripping serializer. Mutators
+preserve every body line outside the status line so user-authored
+``**Where to verify:**`` / ``**Verify:**`` prose stays intact across
+``verify``/``accept`` operations.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from datetime import date
+from pathlib import Path
+
+# Recognized status tokens. ``pending`` is the only status that blocks
+# ``/pr create``; ``verified`` and ``accepted`` are both drained states
+# kept in the file as append-only history.
+_STATUS_PENDING = "pending"
+_STATUS_VERIFIED = "verified"
+_STATUS_ACCEPTED = "accepted"
+_VALID_STATUSES = frozenset({_STATUS_PENDING, _STATUS_VERIFIED, _STATUS_ACCEPTED})
+
+_VRF_HEADING_RE = re.compile(r"^##\s+(?P<vrf_id>VRF-\S+?)(?:\s+|$)")
+_STATUS_LINE_RE = re.compile(
+    r"^\*\*Status:\*\*\s+(?P<status>\S+)\s*$"
+)
+
+
+@dataclass
+class VerificationEntry:
+    """A single ``## VRF-NNN`` block.
+
+    ``body_lines`` is the verbatim slice between the heading and the next
+    heading (or end-of-file), excluding the heading itself but including
+    blank lines, the ``**Status:**`` line, and any trailing
+    ``**Verified:**`` / ``**Accepted:**`` lines. This lets the serializer
+    round-trip user-authored content without reconstruction.
+    """
+
+    vrf_id: str
+    heading: str  # full ``## VRF-NNN — ...`` line, verbatim
+    body_lines: list[str] = field(default_factory=list)
+
+    @property
+    def status(self) -> str:
+        """Returns the entry's status token, or ``pending`` if unparseable.
+
+        Missing or invalid ``**Status:**`` lines fall back to ``pending`` —
+        "unknown" classification defaults to blocked (the cautious branch),
+        matching the "Escape hatches in classification create silent
+        failures" learning.
+        """
+        for raw in self.body_lines:
+            stripped = raw.strip()
+            if not stripped:
+                continue
+            match = _STATUS_LINE_RE.match(stripped)
+            if not match:
+                # First non-blank body line that isn't a Status line means
+                # the entry is malformed — treat as pending so the gate
+                # surfaces it rather than silently passing.
+                return _STATUS_PENDING
+            status = match.group("status").lower()
+            return status if status in _VALID_STATUSES else _STATUS_PENDING
+        return _STATUS_PENDING
+
+
+def parse_operator_verification(content: str) -> tuple[str, list[VerificationEntry]]:
+    """Split ``operator-verification.md`` content into (preamble, entries).
+
+    ``preamble`` is the file header up to (but not including) the first
+    ``## VRF-`` heading — kept verbatim so round-tripping preserves
+    user-authored intro prose and HTML comments.
+
+    Entries are returned in file order. A heading without a recognizable
+    ``VRF-<id>`` shape is ignored (treated as preamble continuation) — the
+    parser is lenient on headings unrelated to the queue (e.g. ``## Notes``
+    sections users may append).
+    """
+    lines = content.splitlines(keepends=False)
+
+    preamble_lines: list[str] = []
+    entries: list[VerificationEntry] = []
+    current: VerificationEntry | None = None
+
+    for line in lines:
+        match = _VRF_HEADING_RE.match(line)
+        if match:
+            if current is not None:
+                entries.append(current)
+            current = VerificationEntry(
+                vrf_id=match.group("vrf_id"),
+                heading=line,
+                body_lines=[],
+            )
+        elif current is not None:
+            current.body_lines.append(line)
+        else:
+            preamble_lines.append(line)
+
+    if current is not None:
+        entries.append(current)
+
+    preamble = "\n".join(preamble_lines)
+    if preamble and not preamble.endswith("\n"):
+        preamble += "\n"
+    return preamble, entries
+
+
+def format_operator_verification(
+    preamble: str, entries: list[VerificationEntry]
+) -> str:
+    """Round-trip serializer for ``operator-verification.md``.
+
+    The preamble is emitted verbatim, then each entry's heading + body. A
+    trailing newline is enforced so re-reads parse cleanly. Body lines are
+    written without trailing-whitespace normalization to preserve any
+    user-applied formatting (markdown table alignment, etc.).
+    """
+    parts: list[str] = []
+    if preamble:
+        parts.append(preamble)
+        if not preamble.endswith("\n"):
+            parts.append("\n")
+    for entry in entries:
+        parts.append(entry.heading + "\n")
+        for line in entry.body_lines:
+            parts.append(line + "\n")
+    out = "".join(parts)
+    if not out.endswith("\n"):
+        out += "\n"
+    return out
+
+
+def _set_status_line(entry: VerificationEntry, new_status: str) -> bool:
+    """Rewrite the first ``**Status:**`` line in place.
+
+    Returns True if the status line was found and changed, False otherwise.
+    Used by ``mark_verified`` and ``mark_accepted`` — the caller appends
+    timestamp/rationale lines after this returns.
+    """
+    for idx, raw in enumerate(entry.body_lines):
+        match = _STATUS_LINE_RE.match(raw.strip())
+        if match:
+            entry.body_lines[idx] = f"**Status:** {new_status}"
+            return True
+    return False
+
+
+def mark_verified(entry: VerificationEntry, *, today: date | None = None) -> None:
+    """Flip pending → verified and append a ``**Verified:**`` line.
+
+    Idempotent on already-verified entries (no-op). Refuses to verify an
+    ``accepted`` entry — accept is a deliberate override and shouldn't be
+    silently upgraded to verified.
+    """
+    if entry.status == _STATUS_VERIFIED:
+        return
+    if entry.status == _STATUS_ACCEPTED:
+        raise ValueError(
+            f"Entry {entry.vrf_id} was accepted via --accept-pending-verification; "
+            "verifying an accepted entry would erase the override rationale. "
+            "If verification is now genuine, edit the file by hand."
+        )
+    today = today or date.today()
+    _set_status_line(entry, _STATUS_VERIFIED)
+    entry.body_lines.append("")
+    entry.body_lines.append(f"**Verified:** {today.isoformat()}")
+
+
+def mark_accepted(
+    entry: VerificationEntry,
+    *,
+    rationale: str,
+    today: date | None = None,
+) -> None:
+    """Flip pending → accepted and append a ``**Accepted:** ... rationale: ...`` line.
+
+    Idempotent on already-accepted entries (no-op). No-op on already-verified
+    entries (a verified entry is drained — no rationale needed).
+    """
+    if entry.status in {_STATUS_ACCEPTED, _STATUS_VERIFIED}:
+        return
+    if not rationale or not rationale.strip():
+        raise ValueError(
+            "Acceptance requires a non-empty rationale — the override "
+            "is recorded in the queue file as the work-log entry."
+        )
+    today = today or date.today()
+    _set_status_line(entry, _STATUS_ACCEPTED)
+    entry.body_lines.append("")
+    entry.body_lines.append(
+        f"**Accepted:** {today.isoformat()} — rationale: {rationale.strip()}"
+    )
+
+
+def count_pending(entries: list[VerificationEntry]) -> int:
+    return sum(1 for e in entries if e.status == _STATUS_PENDING)
+
+
+def pending_entries(entries: list[VerificationEntry]) -> list[VerificationEntry]:
+    return [e for e in entries if e.status == _STATUS_PENDING]
+
+
+def is_operator_verification_required(state_path: Path) -> bool:
+    """Read ``operator_verification_required`` from ``project-state.yaml``.
+
+    Column-0 scanner mirroring the convention shared with
+    ``coverage_required`` and ``views_enabled`` (see ``migrate_cmd.py``):
+    only top-level keys count; commented-out and indented occurrences are
+    ignored. Defaults to ``False`` when the file or key is absent — the
+    explicit-opt-in posture for v1.4 enforcement features.
+    """
+    if not state_path.is_file():
+        return False
+    try:
+        content = state_path.read_text()
+    except OSError:
+        return False
+    for raw in content.splitlines():
+        if raw[:1] in (" ", "\t"):
+            continue
+        stripped = raw.split("#", 1)[0].rstrip()
+        if stripped.startswith("operator_verification_required:"):
+            return stripped.split(":", 1)[1].strip().lower() == "true"
+    return False
+
+
+def _load_queue(queue_path: Path) -> tuple[str, list[VerificationEntry]]:
+    if not queue_path.is_file():
+        return "", []
+    return parse_operator_verification(queue_path.read_text())
+
+
+def _write_queue(
+    queue_path: Path, preamble: str, entries: list[VerificationEntry]
+) -> None:
+    queue_path.write_text(format_operator_verification(preamble, entries))
+
+
+# =============================================================================
+# Runners — shape matches ``run_migrate_*`` so JSON-mode callers see the same
+# dict layout across prawduct-setup subcommands.
+# =============================================================================
+
+
+def run_check_operator_verification(product_dir: str | Path) -> dict:
+    """Read-only gate check. Mirrors ``check-cumulative-critic`` semantics.
+
+    Returns ``{"required": bool, "pending": int, "queue_path": str,
+    "first_pending": str | None, "message": str}``. The caller decides what
+    exit code to map this to — the product-hook wrapper uses 0 when the
+    gate is satisfied (not required OR no pending) and 1 otherwise.
+    """
+    product_path = Path(product_dir).resolve()
+    prawduct_dir = product_path / ".prawduct"
+    state_path = prawduct_dir / "project-state.yaml"
+    queue_path = prawduct_dir / "operator-verification.md"
+
+    required = is_operator_verification_required(state_path)
+    if not required:
+        return {
+            "required": False,
+            "pending": 0,
+            "queue_path": str(queue_path),
+            "first_pending": None,
+            "message": (
+                "operator-verification gate not required "
+                "(operator_verification_required is false or unset)"
+            ),
+        }
+
+    _, entries = _load_queue(queue_path)
+    pending = pending_entries(entries)
+    if not pending:
+        return {
+            "required": True,
+            "pending": 0,
+            "queue_path": str(queue_path),
+            "first_pending": None,
+            "message": (
+                f"operator-verification queue is empty ({queue_path})"
+                if queue_path.is_file()
+                else f"operator-verification queue is empty (no queue file at {queue_path})"
+            ),
+        }
+    first = pending[0]
+    return {
+        "required": True,
+        "pending": len(pending),
+        "queue_path": str(queue_path),
+        "first_pending": first.vrf_id,
+        "message": (
+            f"blocking: {len(pending)} pending operator-verification "
+            f"entr{'y' if len(pending) == 1 else 'ies'} "
+            f"({first.vrf_id}{', ...' if len(pending) > 1 else ''}). "
+            f"Drain via `python3 tools/prawduct-setup.py verify {product_path} <ID>` "
+            "or override with `/pr create --accept-pending-verification \"rationale\"`."
+        ),
+    }
+
+
+def run_verify_entry(
+    product_dir: str | Path,
+    vrf_id: str,
+    *,
+    today: date | None = None,
+) -> dict:
+    """Drain a single pending entry to ``verified``.
+
+    Returns ``{"product_dir", "vrf_id", "previous_status", "status",
+    "queue_path", "actions": [str], "notes": [str]}`` or
+    ``{"error": "..."}`` on lookup failures (no ``.prawduct/``, no queue
+    file, unknown ID).
+    """
+    product_path = Path(product_dir).resolve()
+    prawduct_dir = product_path / ".prawduct"
+    if not prawduct_dir.is_dir():
+        return {
+            "error": (
+                f"Not a prawduct product: {product_path} has no .prawduct/ directory"
+            )
+        }
+
+    queue_path = prawduct_dir / "operator-verification.md"
+    if not queue_path.is_file():
+        return {
+            "error": (
+                f"No operator-verification queue at {queue_path}. "
+                "Run `prawduct-setup migrate --enable-operator-verification` "
+                "to enable the gate (creates the queue from template)."
+            )
+        }
+
+    preamble, entries = _load_queue(queue_path)
+    target = next((e for e in entries if e.vrf_id == vrf_id), None)
+    if target is None:
+        known = [e.vrf_id for e in entries]
+        return {
+            "error": (
+                f"Unknown verification ID {vrf_id!r}. "
+                f"Known IDs in {queue_path}: {known if known else '(empty queue)'}"
+            )
+        }
+
+    previous_status = target.status
+    actions: list[str] = []
+    notes: list[str] = []
+
+    if previous_status == _STATUS_VERIFIED:
+        notes.append(
+            f"{vrf_id} is already verified — no change. Edit the queue file "
+            "directly if the entry needs to be re-opened."
+        )
+    elif previous_status == _STATUS_ACCEPTED:
+        return {
+            "error": (
+                f"{vrf_id} was accepted via --accept-pending-verification; "
+                "verifying an accepted entry would erase the override rationale. "
+                "Edit the file by hand if the verification is now genuine."
+            )
+        }
+    else:
+        mark_verified(target, today=today)
+        _write_queue(queue_path, preamble, entries)
+        actions.append(
+            f"Marked {vrf_id} verified in {queue_path.relative_to(product_path)}"
+        )
+
+    return {
+        "product_dir": str(product_path),
+        "vrf_id": vrf_id,
+        "previous_status": previous_status,
+        "status": target.status,
+        "queue_path": str(queue_path),
+        "actions": actions,
+        "notes": notes,
+    }
+
+
+def run_accept_pending(
+    product_dir: str | Path,
+    rationale: str,
+    *,
+    today: date | None = None,
+) -> dict:
+    """Flip all pending entries to ``accepted`` with the supplied rationale.
+
+    Used by ``/pr create --accept-pending-verification "rationale"`` — the
+    override is recorded in the queue file itself so the work-log shows
+    why the gate was bypassed for this PR.
+
+    Returns ``{"product_dir", "accepted_ids": [str], "queue_path",
+    "actions", "notes"}`` or ``{"error": "..."}``.
+    """
+    product_path = Path(product_dir).resolve()
+    prawduct_dir = product_path / ".prawduct"
+    if not prawduct_dir.is_dir():
+        return {
+            "error": (
+                f"Not a prawduct product: {product_path} has no .prawduct/ directory"
+            )
+        }
+    if not rationale or not rationale.strip():
+        return {
+            "error": (
+                "Rationale required: `/pr create --accept-pending-verification` "
+                "must record why the operator-verification gate was bypassed."
+            )
+        }
+
+    queue_path = prawduct_dir / "operator-verification.md"
+    preamble, entries = _load_queue(queue_path)
+    pending = pending_entries(entries)
+
+    if not pending:
+        return {
+            "product_dir": str(product_path),
+            "accepted_ids": [],
+            "queue_path": str(queue_path),
+            "actions": [],
+            "notes": [
+                "No pending entries to accept — operator-verification gate "
+                "already satisfied."
+            ],
+        }
+
+    accepted_ids: list[str] = []
+    for entry in pending:
+        mark_accepted(entry, rationale=rationale, today=today)
+        accepted_ids.append(entry.vrf_id)
+
+    _write_queue(queue_path, preamble, entries)
+
+    return {
+        "product_dir": str(product_path),
+        "accepted_ids": accepted_ids,
+        "queue_path": str(queue_path),
+        "actions": [
+            f"Marked {vid} accepted in {queue_path.relative_to(product_path)}"
+            for vid in accepted_ids
+        ],
+        "notes": [
+            f"Rationale recorded in {queue_path.name} for {len(accepted_ids)} "
+            "entr" + ("y" if len(accepted_ids) == 1 else "ies") + "."
+        ],
+    }

--- a/tools/lib/sync_cmd.py
+++ b/tools/lib/sync_cmd.py
@@ -1,0 +1,1189 @@
+"""
+Sync command for prawduct product repos.
+
+Syncs product repo files with framework template updates, handling
+manifests, renames, version migrations, and place-once files.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import hashlib
+import json
+import shutil
+import stat
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+from .core import (
+    BLOCK_BEGIN,
+    BLOCK_END,
+    FILE_RENAMES,
+    MANAGED_FILES,
+    PLACE_ONCE_COPY,
+    PLACE_ONCE_TEMPLATES,
+    PRAWDUCT_VERSION,
+    _resolve_framework_dir,
+    _try_pull_framework,
+    compute_block_hash,
+    compute_hash,
+    effective_managed_files,
+    extract_block,
+    infer_product_name,
+    load_json,
+    merge_settings,
+    render_template,
+    untrack_gitignored_files,
+    update_gitignore,
+)
+from .advisory_store import run_sync_advisories
+from .migrate_cmd import (
+    enable_v1_4_views,
+    migrate_backlog,
+    migrate_change_log,
+    migrate_project_state_v5,
+    split_learnings_v5,
+)
+
+
+def _get_framework_head_commit(fw_dir: Path) -> str | None:
+    """Return short SHA of framework HEAD, or None if fw_dir is not a git repo
+    or git is unavailable. Used to record what commit a sync was anchored to.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(fw_dir), "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except Exception:  # prawduct:ok-broad-except — best-effort lookup at sync time
+        pass
+    return None
+
+
+def _get_template_last_change(fw_dir: Path, template_rel: str) -> dict[str, str] | None:
+    """Return the most recent commit that modified the given template, as
+    {commit, date, subject}, or None when not derivable (not a git repo,
+    template never committed, etc.). Used to enrich template-drift advisories
+    so the briefing can show why a template drifted.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(fw_dir), "log", "-1", "--format=%h|%ai|%s", "--", template_rel],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            parts = result.stdout.strip().split("|", 2)
+            if len(parts) == 3:
+                return {
+                    "commit": parts[0],
+                    "date": parts[1].split(" ", 1)[0],
+                    "subject": parts[2],
+                }
+    except Exception:  # prawduct:ok-broad-except — best-effort lookup
+        pass
+    return None
+
+
+_HISTORICAL_RENDER_DEPTH_CAP = 100
+
+
+def _match_historical_render(
+    fw_dir: Path,
+    template_rel: str,
+    target_hash: str,
+    subs: dict[str, str],
+    cache: dict[tuple[str, str], str] | None = None,
+) -> str | None:
+    """Find a historical commit whose rendered template matches target_hash.
+
+    Walks the framework's git history of `template_rel` (with --follow for
+    renames), capped at `_HISTORICAL_RENDER_DEPTH_CAP` commits. For each
+    historical commit, checks out the template content via `git show`,
+    applies current `subs`, hashes, and compares to `target_hash`.
+
+    A match means the product file's current content was produced by the
+    framework at some past template version — i.e. the file is "stale-clean"
+    rather than user-edited. Sync uses this to safely auto-resolve files that
+    look edited only because the manifest's stored hash drifted.
+
+    Returns short SHA (first 12 chars) on match, or None when:
+      - fw_dir is not a git repo
+      - the template was never tracked
+      - no historical render matches within the depth cap
+      - git is unavailable
+
+    The optional `cache` (mutated in-place) maps (commit_sha, template_rel) →
+    rendered_hash to avoid redundant git-show + render + hash work when
+    multiple stale files share template history within one sync run.
+    """
+    if cache is None:
+        cache = {}
+
+    try:
+        # --name-only emits each commit's SHA followed by the path the file
+        # had at that commit, with blank-line separators. Parsing the path
+        # per-commit lets us follow renames: `git show <sha>:<historical-path>`
+        # works for old commits where the file lived at a different path,
+        # whereas `git show <sha>:<current-path>` would fail.
+        log_result = subprocess.run(
+            ["git", "-C", str(fw_dir), "log", "--follow", "--format=%H",
+             "--name-only", f"-n{_HISTORICAL_RENDER_DEPTH_CAP}",
+             "--", template_rel],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except Exception:  # prawduct:ok-broad-except — best-effort lookup at sync time
+        return None
+
+    if log_result.returncode != 0 or not log_result.stdout.strip():
+        return None
+
+    # Parse alternating SHA / blank / path / blank entries into (sha, path) pairs.
+    entries: list[tuple[str, str]] = []
+    lines = log_result.stdout.splitlines()
+    i = 0
+    while i < len(lines):
+        sha = lines[i].strip()
+        i += 1
+        if not sha:
+            continue
+        # Skip blank lines between sha and path
+        while i < len(lines) and not lines[i].strip():
+            i += 1
+        if i < len(lines):
+            path = lines[i].strip()
+            entries.append((sha, path))
+            i += 1
+        # Skip trailing blank line(s) before next entry
+        while i < len(lines) and not lines[i].strip():
+            i += 1
+
+    for sha, historical_path in entries:
+        # Cache key uses the historical path so renamed templates cache correctly.
+        cache_key = (sha, historical_path)
+        if cache_key in cache:
+            rendered_hash = cache[cache_key]
+        else:
+            try:
+                show_result = subprocess.run(
+                    ["git", "-C", str(fw_dir), "show", f"{sha}:{historical_path}"],
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+            except Exception:  # prawduct:ok-broad-except — best-effort lookup
+                continue
+            if show_result.returncode != 0:
+                continue
+            content = show_result.stdout
+            for key, value in subs.items():
+                content = content.replace(key, value)
+            rendered_hash = hashlib.sha256(content.encode()).hexdigest()
+            cache[cache_key] = rendered_hash
+        if rendered_hash == target_hash:
+            return sha[:12]
+
+    return None
+
+
+def _bootstrap_manifest(product: Path, fw_dir: Path) -> dict:
+    """Create initial sync manifest for a prawduct repo that doesn't have one.
+
+    Computes hashes of existing managed files so sync can track future changes.
+    Files that don't exist get None (triggers creation on first sync).
+    For files at old rename paths, uses the old path's content for hash computation
+    so the rename + sync flow works correctly.
+    """
+    from .core import create_manifest
+
+    # Read product_identity.name from project-state.yaml (committed, stable across
+    # clones). Falls back to the directory name only when the identity block is
+    # missing or unset — which would otherwise make the banner substitution drift
+    # whenever the repo is cloned into a differently-named directory.
+    product_name = infer_product_name(product) or product.name
+
+    file_hashes: dict[str, str | None] = {}
+    for rel_path, config in effective_managed_files(fw_dir).items():
+        strategy = config.get("strategy", "template")
+        file_path = product / rel_path
+
+        # If file doesn't exist at new path, check old rename paths
+        if not file_path.is_file():
+            for old_rel, new_rel in FILE_RENAMES.items():
+                if new_rel == rel_path and (product / old_rel).is_file():
+                    file_path = product / old_rel
+                    break
+
+        if strategy == "block_template":
+            if file_path.is_file():
+                file_hashes[rel_path] = compute_block_hash(file_path.read_text())
+            else:
+                file_hashes[rel_path] = None
+        elif strategy == "merge_settings":
+            file_hashes[rel_path] = None  # merge_settings doesn't use hash
+        else:
+            file_hashes[rel_path] = compute_hash(file_path)
+
+    return create_manifest(product, fw_dir, product_name, file_hashes)
+
+
+def apply_renames(
+    product: Path,
+    manifest: dict,
+    actions: list[str],
+) -> None:
+    """Apply file renames from FILE_RENAMES. Mutates manifest['files'] in place."""
+    files = manifest.get("files", {})
+
+    for old_rel, new_rel in FILE_RENAMES.items():
+        old_path = product / old_rel
+        new_path = product / new_rel
+
+        old_in_manifest = old_rel in files
+
+        if old_path.is_file() and new_path.is_file():
+            # Both exist — delete old (it's a leftover)
+            old_path.unlink()
+            if old_in_manifest:
+                del files[old_rel]
+            # Ensure new path uses canonical config if available
+            if new_rel in MANAGED_FILES and new_rel in files:
+                saved_hash = files[new_rel].get("generated_hash")
+                files[new_rel] = dict(MANAGED_FILES[new_rel])
+                files[new_rel]["generated_hash"] = saved_hash
+            actions.append(f"Removed leftover: {old_rel}")
+        elif old_path.is_file():
+            # Normal rename: move file, transfer manifest entry
+            new_path.parent.mkdir(parents=True, exist_ok=True)
+            old_path.rename(new_path)
+            if old_in_manifest:
+                old_entry = files.pop(old_rel)
+                # Use canonical config if available (fixes stale template paths),
+                # otherwise transfer the old entry as-is
+                if new_rel in MANAGED_FILES:
+                    files[new_rel] = dict(MANAGED_FILES[new_rel])
+                    files[new_rel]["generated_hash"] = compute_hash(new_path)
+                else:
+                    files[new_rel] = old_entry
+            actions.append(f"Moved: {old_rel} → {new_rel}")
+        elif old_in_manifest and not old_path.is_file():
+            # Stale manifest entry (file already deleted/moved)
+            del files[old_rel]
+            actions.append(f"Cleaned stale manifest entry: {old_rel}")
+        # else: neither exists — nothing to do
+
+    # Clean up empty parent directories of old paths
+    seen_parents: set[Path] = set()
+    for old_rel in FILE_RENAMES:
+        parent = product / Path(old_rel).parent
+        if parent not in seen_parents and parent.is_dir() and parent != product:
+            seen_parents.add(parent)
+            try:
+                parent.rmdir()  # Only succeeds if empty
+                actions.append(f"Removed empty directory: {Path(old_rel).parent}")
+            except OSError:
+                pass  # Not empty — that's fine
+
+
+def migrate_v4_to_v5(product_dir: Path) -> list[str]:
+    """Migrate a v4 product to v5 structure. Called from run_sync().
+
+    Checks manifest format_version; skips if already v5.
+    Runs learnings split, project-state update, and version bump.
+    Idempotent.
+
+    Returns list of actions taken.
+    """
+    actions: list[str] = []
+    manifest_path = product_dir / ".prawduct" / "sync-manifest.json"
+
+    if not manifest_path.is_file():
+        return actions
+
+    try:
+        manifest = load_json(manifest_path)
+    except json.JSONDecodeError:
+        return actions
+
+    if manifest.get("format_version", 1) >= 2:
+        return actions  # Already v5
+
+    # 1. Split learnings
+    actions.extend(split_learnings_v5(product_dir))
+
+    # 2. Update project-state.yaml
+    actions.extend(migrate_project_state_v5(product_dir))
+
+    # 3. Bump manifest version
+    manifest["format_version"] = 2
+    manifest["last_sync"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+    actions.append("Bumped manifest to format_version 2 (v5)")
+
+    return actions
+
+
+# F5a auto-commit defaults. Kept as constants so tests can introspect them
+# without re-parsing project-state.yaml. `release/*` is a fnmatch glob, not a
+# regex — see `_branch_is_protected`.
+_DEFAULT_PROTECTED_BRANCHES: tuple[str, ...] = ("main", "master", "release/*")
+_SYNC_PENDING_MARKER = ".prawduct/.sync-pending"
+
+
+def _read_sync_config(product: Path) -> dict:
+    """Read F5a sync config from `.prawduct/project-state.yaml`.
+
+    Returns a dict with keys:
+      - auto_commit: bool — default True (F5 ships on by default; protected
+        branches and WIP checks are the safety net)
+      - protected_branches: list[str] — fnmatch globs; default
+        ('main', 'master', 'release/*')
+
+    Parsed via column-0 YAML scan (no PyYAML dependency) matching the pattern
+    used elsewhere in product-hook for `views_enabled` / `coverage_required`.
+    The block looked for is::
+
+        sync:
+          auto_commit: true
+          protected_branches:
+            - main
+            - master
+            - "release/*"
+
+    Anything malformed falls back to defaults — sync must never block on
+    config parse errors.
+    """
+    config = {
+        "auto_commit": True,
+        "protected_branches": list(_DEFAULT_PROTECTED_BRANCHES),
+    }
+    state_path = product / ".prawduct" / "project-state.yaml"
+    if not state_path.is_file():
+        return config
+    try:
+        text = state_path.read_text()
+    except OSError:
+        return config
+
+    lines = text.splitlines()
+    in_sync = False
+    in_protected = False
+    for line in lines:
+        stripped = line.rstrip()
+        if not stripped or stripped.lstrip().startswith("#"):
+            continue
+        # Column-0 keys exit sub-block scope.
+        if not line.startswith((" ", "\t")):
+            in_sync = stripped.startswith("sync:")
+            in_protected = False
+            continue
+        if not in_sync:
+            continue
+        # Two-space indented child keys of `sync:`.
+        if line.startswith("  ") and not line.startswith("   "):
+            key_part = line[2:].split("#", 1)[0].rstrip()
+            if key_part.startswith("auto_commit:"):
+                value = key_part.split(":", 1)[1].strip().strip("\"'").lower()
+                config["auto_commit"] = value in ("true", "yes", "on", "1")
+                in_protected = False
+            elif key_part.startswith("protected_branches:"):
+                # Multi-line list follows; reset to capture entries.
+                config["protected_branches"] = []
+                in_protected = True
+            else:
+                in_protected = False
+        elif in_protected and line.lstrip().startswith("- "):
+            entry = line.lstrip()[2:].split("#", 1)[0].strip().strip("\"'")
+            if entry:
+                config["protected_branches"].append(entry)
+    if not config["protected_branches"]:
+        # User wrote `protected_branches:` with no entries — interpret as
+        # "no protected branches" only if they spelled it `protected_branches: []`.
+        # The empty-list-from-no-entries case is more likely a YAML mistake;
+        # fall back to defaults to stay safe.
+        config["protected_branches"] = list(_DEFAULT_PROTECTED_BRANCHES)
+    return config
+
+
+def _branch_is_protected(branch: str, patterns: list[str]) -> bool:
+    """fnmatch each pattern against branch name. Empty branch (detached HEAD)
+    is treated as protected — we don't auto-commit in detached HEAD because
+    the commit would be unreachable after checkout."""
+    if not branch:
+        return True
+    return any(fnmatch.fnmatchcase(branch, p) for p in patterns)
+
+
+def _current_branch(product: Path) -> str:
+    """Return current branch name or empty string when detached / not a repo."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(product), "symbolic-ref", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except (subprocess.SubprocessError, OSError, FileNotFoundError):
+        pass
+    return ""
+
+
+def _git_op_in_progress(product: Path) -> str:
+    """Return the in-progress git op name, or empty string when none.
+
+    Checks the well-known marker files in `.git/`. If `.git` is a file (git
+    worktree), resolve the actual gitdir.
+    """
+    git_path = product / ".git"
+    if not git_path.exists():
+        return ""
+    if git_path.is_file():
+        # Worktree: .git is a file like `gitdir: /path/to/main/.git/worktrees/x`
+        try:
+            content = git_path.read_text().strip()
+            if content.startswith("gitdir:"):
+                git_path = Path(content.split(":", 1)[1].strip())
+        except OSError:
+            return ""
+    markers = [
+        ("MERGE_HEAD", "merge"),
+        ("REBASE_HEAD", "rebase"),
+        ("CHERRY_PICK_HEAD", "cherry-pick"),
+        ("REVERT_HEAD", "revert"),
+    ]
+    for filename, op in markers:
+        if (git_path / filename).exists():
+            return op
+    # Interactive rebase uses a directory, not a file.
+    if (git_path / "rebase-merge").is_dir() or (git_path / "rebase-apply").is_dir():
+        return "rebase"
+    return ""
+
+
+def _git_porcelain(product: Path) -> list[tuple[str, str]]:
+    """Return list of (status_code, path) from `git status --porcelain -z`.
+
+    Empty list when not a git repo or git fails. Status codes are the raw
+    two-char porcelain v1 codes (e.g., ' M', 'M ', '??', 'A ', 'AM').
+    """
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(product), "status", "--porcelain", "-z"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (subprocess.SubprocessError, OSError, FileNotFoundError):
+        return []
+    if result.returncode != 0:
+        return []
+    entries: list[tuple[str, str]] = []
+    # -z separates entries with NUL; each entry is "XY path" where rename/copy
+    # would add a second NUL-separated source path. We don't auto-commit
+    # renames anyway, so flatten the source-path entries into themselves.
+    raw = result.stdout
+    i = 0
+    parts = raw.split("\0")
+    while i < len(parts):
+        entry = parts[i]
+        if not entry:
+            i += 1
+            continue
+        if len(entry) < 3:
+            i += 1
+            continue
+        code = entry[:2]
+        path = entry[3:]
+        entries.append((code, path))
+        # Rename/copy: next NUL field is the source path; skip it.
+        if code[0] in ("R", "C"):
+            i += 2
+        else:
+            i += 1
+    return entries
+
+
+def _framework_known_paths(manifest: dict) -> set[str]:
+    """Paths sync owns or mutates — auto-commit may claim any of these.
+
+    Anything NOT in this set is, by definition, outside the framework's
+    write surface; user WIP. Sources:
+      - manifest["files"] — the canonical per-product managed file list
+        (every entry has a `template`/`source` that sync re-renders on
+        each run, so drift here is always framework-authored)
+      - `.prawduct/sync-manifest.json` — written every sync
+      - `.prawduct/project-state.yaml` — mutated by enable_v1_4_views and
+        the v5 migration path
+      - `.gitignore` — kept current by update_gitignore
+
+    `PLACE_ONCE_TEMPLATES` / `PLACE_ONCE_COPY` are *deliberately excluded*:
+    sync only creates them when absent and never re-writes thereafter, so
+    porcelain drift on `.prawduct/change-log.md`, `.prawduct/backlog.md`,
+    or `tests/conftest.py` is virtually always user-authored content —
+    sweeping that into `chore(sync):` would re-create the exact
+    co-mingling F5a aims to prevent. The trade-off: first-time creation of
+    a place-once file leaves an untracked file in the working tree for the
+    user to commit deliberately, which is appropriate (initial content of
+    change-log.md / backlog.md is a moment that deserves explicit
+    acknowledgement).
+    """
+    known = set(manifest.get("files", {}).keys())
+    known.add(".prawduct/sync-manifest.json")
+    known.add(".prawduct/project-state.yaml")
+    known.add(".gitignore")
+    return known
+
+
+def _classify_changes(
+    porcelain: list[tuple[str, str]], known: set[str]
+) -> tuple[list[str], list[str]]:
+    """Partition porcelain entries into (framework_changed, wip_changed).
+
+    A path counts as framework when it appears in `known` (see
+    `_framework_known_paths`). Everything else is user WIP and blocks
+    auto-commit.
+    """
+    framework_changed: list[str] = []
+    wip: list[str] = []
+    for _code, path in porcelain:
+        if path in known:
+            framework_changed.append(path)
+        else:
+            wip.append(path)
+    return framework_changed, wip
+
+
+def _write_sync_pending(product: Path, reason: str, blocked_by: list[str]) -> None:
+    """Write the F5a sync-pending marker. Best-effort — never raises."""
+    marker = product / _SYNC_PENDING_MARKER
+    payload = {
+        "reason": reason,
+        "blocked_by": blocked_by,
+        "version": PRAWDUCT_VERSION,
+        "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+    try:
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    except OSError:
+        pass
+
+
+def _clear_sync_pending(product: Path) -> None:
+    """Remove the F5a sync-pending marker if present. Best-effort."""
+    marker = product / _SYNC_PENDING_MARKER
+    try:
+        if marker.is_file():
+            marker.unlink()
+    except OSError:
+        pass
+
+
+def _try_auto_commit(
+    product: Path,
+    *,
+    actions: list[str],
+    notes: list[str],
+    manifest: dict,
+) -> None:
+    """F5a: auto-commit framework drift as a single marker commit per upgrade.
+
+    Inspects `git status` after sync has finished writing files. Partitions
+    changes into framework-known and user WIP using
+    `_framework_known_paths(manifest)`. The auto-commit only stages and
+    commits known framework paths; anything else is user WIP and blocks the
+    commit (a `.sync-pending` marker explains why).
+
+    Mutates `actions` and `notes` in place. Side effects:
+      - on success: creates one commit, appends to `actions`, clears any
+        prior `.sync-pending` marker
+      - on precondition failure: writes `.sync-pending` marker, appends a
+        descriptive note (visible to user via product-hook briefing)
+      - silent no-op when not a git repo, when auto_commit is disabled, or
+        when there is no framework drift to commit
+
+    The contract is best-effort: any subprocess failure or unexpected git
+    state degrades to "skip auto-commit, leave drift in working tree" — sync
+    itself must never fail because of this step.
+    """
+    git_dir = product / ".git"
+    if not git_dir.exists():
+        return  # Not a git repo — nothing to commit against.
+
+    config = _read_sync_config(product)
+    if not config["auto_commit"]:
+        return
+
+    porcelain = _git_porcelain(product)
+    known = _framework_known_paths(manifest)
+    managed_changed, wip = _classify_changes(porcelain, known)
+    if not managed_changed:
+        # No framework-managed drift to commit. If a stale marker exists,
+        # clear it — drift is resolved.
+        _clear_sync_pending(product)
+        return
+
+    blocked_by: list[str] = []
+    if wip:
+        sample = ", ".join(wip[:3])
+        extra = f" (+{len(wip) - 3} more)" if len(wip) > 3 else ""
+        blocked_by.append(f"non-framework changes present: {sample}{extra}")
+
+    op = _git_op_in_progress(product)
+    if op:
+        blocked_by.append(f"git {op} in progress")
+
+    branch = _current_branch(product)
+    if not branch:
+        blocked_by.append("detached HEAD")
+    elif _branch_is_protected(branch, config["protected_branches"]):
+        blocked_by.append(f"branch '{branch}' is protected")
+
+    if blocked_by:
+        reason = "; ".join(blocked_by)
+        _write_sync_pending(product, reason, blocked_by)
+        notes.append(
+            f"Auto-commit skipped: {reason}. "
+            f"Framework-managed drift left in working tree; "
+            f"resolve and commit when ready."
+        )
+        return
+
+    # Preconditions pass — stage and commit the framework-managed paths only.
+    try:
+        add_result = subprocess.run(
+            ["git", "-C", str(product), "add", "--", *managed_changed],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        if add_result.returncode != 0:
+            notes.append(
+                f"Auto-commit skipped: git add failed ({add_result.stderr.strip()})"
+            )
+            _write_sync_pending(product, "git add failed", [add_result.stderr.strip()])
+            return
+
+        message = f"chore(sync): prawduct v{PRAWDUCT_VERSION}"
+        # Use -- only to disambiguate; we already staged via add.
+        commit_result = subprocess.run(
+            ["git", "-C", str(product), "commit", "-m", message],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if commit_result.returncode != 0:
+            # Most common cause: pre-commit hook rejected the change. Surface
+            # the error and leave the staged changes for the user to inspect.
+            err = commit_result.stderr.strip() or commit_result.stdout.strip()
+            notes.append(
+                f"Auto-commit failed at git commit ({err[:200]}); "
+                f"changes remain staged for manual commit."
+            )
+            _write_sync_pending(product, "git commit failed", [err[:200]])
+            return
+
+        sha_result = subprocess.run(
+            ["git", "-C", str(product), "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        sha = sha_result.stdout.strip() if sha_result.returncode == 0 else ""
+        suffix = f" (commit {sha})" if sha else ""
+        actions.append(f"Auto-committed framework sync as '{message}'{suffix}")
+        _clear_sync_pending(product)
+    except (subprocess.SubprocessError, OSError, FileNotFoundError) as exc:
+        notes.append(f"Auto-commit skipped: {exc}")
+        _write_sync_pending(product, "auto-commit subprocess error", [str(exc)])
+
+
+def run_sync(product_dir: str, framework_dir: str | None = None, *, no_pull: bool = False, force: bool = False) -> dict:
+    """Run the sync algorithm on a product directory.
+
+    Returns a summary dict with actions taken, notes, and any warnings.
+    """
+    product = Path(product_dir).resolve()
+    manifest_path = product / ".prawduct" / "sync-manifest.json"
+
+    bootstrapped = False
+
+    if not manifest_path.is_file():
+        if not (product / ".prawduct").is_dir():
+            return {
+                "product_dir": str(product),
+                "synced": False,
+                "reason": "not a prawduct repo",
+                "actions": [],
+                "notes": [],
+            }
+        # Bootstrap: create manifest for prawduct repo that doesn't have one
+        fw_dir = _resolve_framework_dir({}, framework_dir, product)
+        if fw_dir is None:
+            return {
+                "product_dir": str(product),
+                "synced": False,
+                "reason": "framework not found",
+                "actions": [],
+                "notes": [],
+            }
+        manifest = _bootstrap_manifest(product, fw_dir)
+        manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+        bootstrapped = True
+    else:
+        try:
+            manifest = load_json(manifest_path)
+        except json.JSONDecodeError:
+            return {
+                "product_dir": str(product),
+                "synced": False,
+                "reason": "invalid manifest JSON",
+                "actions": [],
+                "notes": [],
+            }
+
+    fw_dir = _resolve_framework_dir(manifest, framework_dir, product)
+    if fw_dir is None:
+        return {
+            "product_dir": str(product),
+            "synced": False,
+            "reason": "framework not found",
+            "actions": [],
+            "notes": [],
+        }
+
+    # Best-effort framework pull before syncing templates
+    if not no_pull:
+        auto_pull = manifest.get("auto_pull", True)
+        pull_notes = _try_pull_framework(fw_dir, auto_pull)
+    else:
+        pull_notes = []
+
+    previous_version = manifest.get("framework_version", "")
+    actions: list[str] = []
+    notes: list[str] = list(pull_notes)
+
+    # Source of truth for the product name is product_identity.name in the
+    # committed project-state.yaml. The manifest-cached product_name is a legacy
+    # fallback for manifests written before identity existed (pre-v1.3.9
+    # bootstraps, or v4 manifests). When identity is present, use it for
+    # rendering and self-heal the manifest cache to match — without this, old
+    # clones whose manifest was bootstrapped against a now-fixed bug would never
+    # recover. Absence of identity keeps the cached value untouched so products
+    # that predate the identity block aren't disturbed.
+    identity_name = infer_product_name(product)
+    cached_name = manifest.get("product_name")
+    product_name = identity_name or cached_name or product.name
+
+    if identity_name and cached_name != identity_name:
+        manifest["product_name"] = identity_name
+        if cached_name:
+            actions.append(
+                f"Corrected product_name in manifest: '{cached_name}' → '{identity_name}' "
+                f"(source of truth is .prawduct/project-state.yaml)"
+            )
+        else:
+            actions.append(
+                f"Populated product_name in manifest from project-state.yaml: '{identity_name}'"
+            )
+
+    subs = {"{{PRODUCT_NAME}}": product_name, "{{PRAWDUCT_VERSION}}": PRAWDUCT_VERSION}
+
+    if bootstrapped:
+        actions.append("Bootstrapped sync manifest (first framework sync for this repo)")
+
+    # V4→V5 migration (if needed)
+    v5_actions = migrate_v4_to_v5(product)
+    actions.extend(v5_actions)
+    if v5_actions:
+        # Re-read manifest since migration updated it
+        manifest = load_json(manifest_path)
+
+    # Migrate change_log from project-state.yaml to change-log.md
+    actions.extend(migrate_change_log(product))
+
+    # Migrate remaining_work/future_work/backlog from project-state.yaml to backlog.md
+    actions.extend(migrate_backlog(product))
+
+    # v1.4: auto-enable derived views for existing repos (one-shot; mutates
+    # manifest in place; existing write-back below persists the flag).
+    actions.extend(enable_v1_4_views(product, manifest))
+
+    files = manifest.get("files", {})
+
+    # Renames: move files from old paths to new paths (e.g., commands → skills)
+    if FILE_RENAMES:
+        apply_renames(product, manifest, actions)
+
+    # Backfill: add any managed files missing from the manifest (added after init)
+    # Also repair stale config (e.g., old template paths from renamed entries).
+    # effective_managed_files() expands MANAGED_DIRS (tools/lib) from the
+    # framework, so existing synced repos self-heal: the lib package lands as
+    # `New:` entries on the next sync without any per-product migration.
+    for rel_path, config in effective_managed_files(fw_dir).items():
+        if rel_path not in files:
+            files[rel_path] = dict(config)
+            files[rel_path]["generated_hash"] = None  # Forces creation on first sync
+            desc = config.get("description", "")
+            if desc:
+                actions.append(f"New: {rel_path} — {desc}")
+            else:
+                actions.append(f"New: {rel_path}")
+        else:
+            # Repair stale config: if template/source/strategy differs from
+            # canonical MANAGED_FILES, update it (preserving generated_hash)
+            existing = files[rel_path]
+            canonical = config
+            stale = False
+            for key in ("template", "source", "strategy"):
+                if key in canonical and existing.get(key) != canonical.get(key):
+                    stale = True
+                    break
+            if stale:
+                saved_hash = existing.get("generated_hash")
+                files[rel_path] = dict(canonical)
+                files[rel_path]["generated_hash"] = saved_hash
+                actions.append(f"Repaired manifest config for {rel_path}")
+
+    updated_files = dict(files)
+
+    # Cache for stale-clean detection (Chunk 02 of stale-clean-detection feature).
+    # Shared across all files in this sync run so multiple stale files using the
+    # same template don't redundantly re-render shared history. Keyed by
+    # (commit_sha, historical_path) — see _match_historical_render.
+    historical_render_cache: dict[tuple[str, str], str] = {}
+
+    for rel_path, config in files.items():
+        strategy = config.get("strategy", "template")
+        dst = product / rel_path
+
+        if strategy == "template":
+            template_rel = config.get("template", "")
+            template_path = fw_dir / template_rel
+            if not template_path.is_file():
+                notes.append(f"Template missing: {template_rel}")
+                continue
+
+            # Render current template
+            rendered = render_template(template_path, subs)
+            rendered_hash = hashlib.sha256(rendered.encode()).hexdigest()
+
+            # Check if template has changed since last sync
+            stored_hash = config.get("generated_hash")
+            if stored_hash == rendered_hash:
+                continue  # Template hasn't changed
+
+            # Template changed — check if user edited the file
+            current_hash = compute_hash(dst)
+
+            # Auto-fix: local already matches current template. Catches stale
+            # stored_hash, null stored_hash with matching content, and hand-pasted
+            # template state. Refresh the manifest — there is nothing to merge,
+            # so no warning, but record the hash repair as an action so the
+            # manifest gets persisted and `git status` shows the resolved state.
+            if current_hash == rendered_hash:
+                updated_files[rel_path] = dict(config)
+                updated_files[rel_path]["generated_hash"] = rendered_hash
+                actions.append(f"Refreshed manifest for {rel_path} (file already at target)")
+                continue
+
+            if current_hash is not None and current_hash != stored_hash:
+                # Stale-clean detection: when the file's content matches a
+                # historical render of this template, the file is framework-
+                # produced from an older version, not user-edited. Safe to
+                # auto-resolve to the current template without --force. This
+                # rescues the common case where sync-manifest.json is gitignored
+                # and bootstraps fresh per-clone with hashes that drift from
+                # what subsequent syncs would produce.
+                matched_sha = _match_historical_render(
+                    fw_dir, template_rel, current_hash, subs, historical_render_cache
+                )
+                if matched_sha is not None:
+                    dst.write_text(rendered)
+                    new_hash = compute_hash(dst)
+                    updated_files[rel_path] = dict(config)
+                    updated_files[rel_path]["generated_hash"] = new_hash
+                    actions.append(
+                        f"Auto-resolved {rel_path} (stale-clean from {matched_sha})"
+                    )
+                    continue
+
+                if force:
+                    dst.write_text(rendered)
+                    new_hash = compute_hash(dst)
+                    updated_files[rel_path] = dict(config)
+                    updated_files[rel_path]["generated_hash"] = new_hash
+                    actions.append(f"Force-updated {rel_path} (local edits overwritten)")
+                    if rel_path in ("CLAUDE.md",):
+                        notes.append(f"Updated {rel_path} — re-read to pick up changes")
+                else:
+                    notes.append(
+                        f"Skipped {rel_path} — new template available but file has local edits (re-run with --force to overwrite)"
+                    )
+                continue
+
+            # Safe to update
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            dst.write_text(rendered)
+            new_hash = compute_hash(dst)
+            updated_files[rel_path] = dict(config)
+            updated_files[rel_path]["generated_hash"] = new_hash
+            actions.append(f"Updated {rel_path}")
+            # CLAUDE.md and settings.json are pre-loaded — flag for restart
+            if rel_path in ("CLAUDE.md",):
+                notes.append(f"Updated {rel_path} — re-read to pick up changes")
+
+        elif strategy == "block_template":
+            # Marker contract: content between PRAWDUCT:BEGIN/END is framework-owned
+            # and always overwritten. User customization belongs outside the markers
+            # (before/after), which sync preserves verbatim. The stored hash is
+            # informational only — we don't gate on local edits inside the block.
+            template_rel = config.get("template", "")
+            template_path = fw_dir / template_rel
+            if not template_path.is_file():
+                notes.append(f"Template missing: {template_rel}")
+                continue
+
+            rendered = render_template(template_path, subs)
+            rendered_block, _, _ = extract_block(rendered)
+            if rendered_block is None:
+                notes.append(f"Template {template_rel} has no markers — skipping block sync")
+                continue
+
+            rendered_block_hash = hashlib.sha256(rendered_block.encode()).hexdigest()
+            stored_hash = config.get("generated_hash")
+
+            if not dst.is_file():
+                dst.parent.mkdir(parents=True, exist_ok=True)
+                dst.write_text(rendered)
+                updated_files[rel_path] = dict(config)
+                updated_files[rel_path]["generated_hash"] = rendered_block_hash
+                actions.append(f"Created {rel_path}")
+                notes.append(f"Created {rel_path} — re-read to pick up changes")
+                continue
+
+            product_content = dst.read_text()
+            product_block, before, after = extract_block(product_content)
+
+            if product_block is None:
+                notes.append(
+                    f"Skipped {rel_path} — no markers (add markers to enable sync)"
+                )
+                continue
+
+            product_block_hash = hashlib.sha256(product_block.encode()).hexdigest()
+
+            if product_block_hash == rendered_block_hash:
+                # Already at target. Refresh manifest if hash drifted, silently otherwise.
+                if stored_hash != rendered_block_hash:
+                    updated_files[rel_path] = dict(config)
+                    updated_files[rel_path]["generated_hash"] = rendered_block_hash
+                    actions.append(f"Refreshed manifest for {rel_path} (block already at target)")
+                continue
+
+            new_content = before + rendered_block + after
+            dst.write_text(new_content)
+            updated_files[rel_path] = dict(config)
+            updated_files[rel_path]["generated_hash"] = rendered_block_hash
+            actions.append(f"Updated {rel_path} block")
+            notes.append(f"Updated {rel_path} — re-read to pick up changes")
+
+        elif strategy == "always_update":
+            source_rel = config.get("source", "")
+            source_path = fw_dir / source_rel
+            if not source_path.is_file():
+                notes.append(f"Source missing: {source_rel}")
+                continue
+
+            source_bytes = source_path.read_bytes()
+            if dst.is_file() and dst.read_bytes() == source_bytes:
+                continue  # Already up to date
+
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            dst.write_bytes(source_bytes)
+            # Make executable
+            dst.chmod(dst.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+            new_hash = compute_hash(dst)
+            updated_files[rel_path] = dict(config)
+            updated_files[rel_path]["generated_hash"] = new_hash
+            actions.append(f"Updated {rel_path}")
+
+        elif strategy == "merge_settings":
+            template_rel = config.get("template", "")
+            template_path = fw_dir / template_rel
+            if not template_path.is_file():
+                notes.append(f"Template missing: {template_rel}")
+                continue
+
+            if merge_settings(dst, template_path, subs):
+                actions.append(f"Merged {rel_path}")
+                notes.append(f"Updated {rel_path} — re-read to pick up changes")
+
+    # Place-once files: create if missing, never tracked for ongoing sync.
+    # Template hashes are recorded in manifest["place_once_templates"] so
+    # future syncs can detect when the framework template has evolved.
+    manifest_snapshot_pot = dict(manifest.get("place_once_templates", {}))
+    pot = manifest.get("place_once_templates", {})
+    for rel_path, template_rel in PLACE_ONCE_TEMPLATES.items():
+        template_path = fw_dir / template_rel
+        dst = product / rel_path
+        if not dst.is_file():
+            if not template_path.is_file():
+                continue
+            rendered = render_template(template_path, subs)
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            dst.write_text(rendered)
+            actions.append(f"Created {rel_path}")
+        # Record template hash (on creation or bootstrap for pre-existing products).
+        # For pre-existing products without tracking, we bootstrap using the
+        # *current* template hash — we can't know what version was originally
+        # deployed, but we can detect drift from this sync forward.
+        if template_path.is_file() and rel_path not in pot:
+            rendered_for_hash = render_template(template_path, subs)
+            pot[rel_path] = {
+                "template": template_rel,
+                "template_hash": hashlib.sha256(rendered_for_hash.encode()).hexdigest(),
+                "created_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            }
+
+    # Place-once binary files: copy if missing (no template rendering)
+    for rel_path, template_rel in PLACE_ONCE_COPY.items():
+        template_path = fw_dir / template_rel
+        dst = product / rel_path
+        if not dst.is_file():
+            if not template_path.is_file():
+                continue
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(template_path, dst)
+            actions.append(f"Created {rel_path}")
+        # Record template hash for binary place-once files
+        if template_path.is_file() and rel_path not in pot:
+            content = template_path.read_bytes()
+            pot[rel_path] = {
+                "template": template_rel,
+                "template_hash": hashlib.sha256(content).hexdigest(),
+                "created_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            }
+
+    if pot:
+        manifest["place_once_templates"] = pot
+
+    # Detect template drift: compare stored hashes against current templates.
+    # Only check entries that existed before this sync (not freshly bootstrapped
+    # ones, which by definition match the current template).
+    advisories: list[dict[str, str]] = []
+    for rel_path, entry in manifest_snapshot_pot.items():
+        template_rel = entry.get("template", "")
+        template_path = fw_dir / template_rel
+        if not template_path.is_file():
+            continue
+        stored_hash = entry.get("template_hash", "")
+        if not stored_hash:
+            continue
+        # Compute current template hash (same method used at storage time)
+        if template_rel.endswith(".py"):
+            current_hash = hashlib.sha256(template_path.read_bytes()).hexdigest()
+        else:
+            current_content = render_template(template_path, subs)
+            current_hash = hashlib.sha256(current_content.encode()).hexdigest()
+        if current_hash != stored_hash:
+            # Template has evolved since this product was created/last reviewed
+            short_name = rel_path.rsplit("/", 1)[-1]
+            last_change = _get_template_last_change(fw_dir, template_rel) or {}
+            advisories.append({
+                "type": "template_drift",
+                "file": rel_path,
+                "template": template_rel,
+                "message": f"{short_name} template has new content since project setup — run /janitor scope=templates to review",
+                "last_changed_commit": last_change.get("commit", ""),
+                "last_changed_date": last_change.get("date", ""),
+                "last_changed_subject": last_change.get("subject", ""),
+            })
+            # Fire ONCE per template change, not every session forever. Refresh
+            # the stored hash to current so the next sync sees no drift. Place-
+            # once files are user-owned ("surface the change once, then it's
+            # yours"); re-nagging indefinitely with no dismiss path was pure tax.
+            live_entry = pot.get(rel_path)
+            if live_entry is not None:
+                live_entry["template_hash"] = current_hash
+                live_entry["last_surfaced_at"] = datetime.now(timezone.utc).strftime(
+                    "%Y-%m-%dT%H:%M:%SZ"
+                )
+
+    # Post-sync migration advisories (v1.6.0 Phase 1). Distinct from the
+    # template-drift `advisories` collected above — these come from the probe
+    # registry (empty in Phase 1, so this is a no-op) and land in the per-clone
+    # nag log `.prawduct/.advisories.json`. run_sync_advisories is return-value
+    # based and degrades safely; the broad guard is belt-and-suspenders so a
+    # future feature's faulty probe can never block a sync.
+    try:
+        run_sync_advisories(
+            product,
+            now=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            sync_version=PRAWDUCT_VERSION,
+        )
+    except Exception as exc:  # prawduct:ok-broad-except — advisory probes must never block sync
+        notes.append(f"Advisory probe step skipped: {exc}")
+
+    # Ensure gitignore stays current
+    gi_result = update_gitignore(product)
+    if gi_result["modified"]:
+        actions.append("Updated .gitignore")
+    for path in gi_result["unignored"]:
+        notes.append(
+            f"Removed {path} from .gitignore — it should be committed. "
+            f"Run: git add {path}"
+        )
+
+    # Untrack any session files that were previously committed
+    untracked = untrack_gitignored_files(product)
+    for path in untracked:
+        actions.append(f"Untracked {path} (removed from git index, file kept locally)")
+
+    # Always refresh freshness markers on a successful sync — even when no
+    # files changed. Otherwise a repo that is byte-identical to the framework
+    # keeps reporting a phantom "N commit(s) behind" in every session briefing,
+    # because last_sync / framework_commit were frozen at the last sync that
+    # happened to change a file. Refreshing them every sync makes a healthy,
+    # up-to-date repo report "in sync" and emit zero freshness noise — the
+    # whole point of the happy-path-silence work. (The manifest is gitignored,
+    # so rewriting it every session creates no git churn.)
+    manifest["files"] = updated_files
+    manifest["framework_version"] = PRAWDUCT_VERSION
+    fw_commit = _get_framework_head_commit(fw_dir)
+    if fw_commit:
+        manifest["framework_commit"] = fw_commit
+    manifest["last_sync"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+
+    # F5a: after all framework-managed mutations land on disk and the
+    # manifest is updated, attempt the single marker commit. Quarantines
+    # framework drift to one dated `chore(sync): prawduct vX.Y.Z` per upgrade,
+    # never co-mingling with chunk diffs. Best-effort — never blocks sync.
+    _try_auto_commit(product, actions=actions, notes=notes, manifest=manifest)
+
+    # Include version change info so callers can surface upgrade notices
+    version_info: dict[str, str] = {"new_version": PRAWDUCT_VERSION}
+    if previous_version and previous_version != PRAWDUCT_VERSION:
+        version_info["previous_version"] = previous_version
+
+    return {
+        "product_dir": str(product),
+        "synced": bool(actions),
+        "reason": "ok" if actions else "no updates needed",
+        "actions": actions,
+        "notes": notes,
+        "advisories": advisories,
+        "version": version_info,
+    }

--- a/tools/lib/validate_cmd.py
+++ b/tools/lib/validate_cmd.py
@@ -1,0 +1,388 @@
+"""
+Validate command for prawduct product repos.
+
+Health check — verifies repo structure, configuration, and framework currency.
+No mutations.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from pathlib import Path
+
+from .core import (
+    BLOCK_BEGIN,
+    BLOCK_END,
+    MANAGED_FILES,
+    PRAWDUCT_VERSION,
+    _resolve_framework_dir,
+    compute_hash,
+    detect_version,
+    extract_block,
+    load_json,
+    render_template,
+)
+from .sync_cmd import _match_historical_render
+
+
+def run_validate(target_dir: str, *, framework_dir: str | None = None) -> dict:
+    """Health check for a prawduct product repo. No mutations.
+
+    Returns structured results with per-check pass/warn/fail status,
+    overall health, restart recommendation, and actionable recommendations.
+    """
+    target = Path(target_dir).resolve()
+    checks: list[dict] = []
+    recommendations: list[str] = []
+    needs_restart = False
+
+    # --- Basic structure ---
+    prawduct_dir = target / ".prawduct"
+    if not prawduct_dir.is_dir():
+        return {
+            "target": str(target),
+            "overall": "broken",
+            "version": "unknown",
+            "checks": [{"name": "prawduct_dir", "status": "fail", "detail": ".prawduct/ directory does not exist"}],
+            "needs_restart": False,
+            "recommendations": ["Run prawduct-setup.py setup to initialize this repo"],
+        }
+
+    version = detect_version(target)
+
+    # --- Managed files ---
+    missing_managed = []
+    for rel_path in MANAGED_FILES:
+        if not (target / rel_path).is_file():
+            missing_managed.append(rel_path)
+    if missing_managed:
+        checks.append({
+            "name": "managed_files",
+            "status": "fail",
+            "detail": f"Missing: {', '.join(missing_managed)}",
+        })
+        recommendations.append("Run prawduct-setup.py setup to create missing files")
+    else:
+        checks.append({"name": "managed_files", "status": "pass", "detail": f"All {len(MANAGED_FILES)} managed files present"})
+
+    # --- settings.json hooks ---
+    settings_path = target / ".claude" / "settings.json"
+    if settings_path.is_file():
+        try:
+            settings = load_json(settings_path)
+            hooks = settings.get("hooks", {})
+            expected_events = ["SessionStart", "Stop"]
+            missing_events = [e for e in expected_events if e not in hooks]
+
+            if missing_events:
+                checks.append({
+                    "name": "settings_hooks",
+                    "status": "fail",
+                    "detail": f"Missing hook events: {', '.join(missing_events)}",
+                })
+                recommendations.append("Run prawduct-setup.py setup to fix settings.json hooks")
+            else:
+                # Verify hooks reference product-hook
+                all_point_to_hook = True
+                for event in expected_events:
+                    entries = hooks.get(event, [])
+                    has_product_hook = any(
+                        "product-hook" in h.get("command", "")
+                        for entry in entries
+                        for h in entry.get("hooks", [])
+                    )
+                    if not has_product_hook:
+                        all_point_to_hook = False
+                        break
+
+                if all_point_to_hook:
+                    checks.append({"name": "settings_hooks", "status": "pass", "detail": "All hook events configured correctly"})
+                else:
+                    checks.append({
+                        "name": "settings_hooks",
+                        "status": "warn",
+                        "detail": "Some hooks don't reference product-hook",
+                    })
+        except json.JSONDecodeError:
+            checks.append({"name": "settings_hooks", "status": "fail", "detail": "settings.json is not valid JSON"})
+            recommendations.append("Fix or regenerate .claude/settings.json")
+    else:
+        checks.append({"name": "settings_hooks", "status": "fail", "detail": ".claude/settings.json does not exist"})
+
+    # --- product-hook executable ---
+    hook_path = target / "tools" / "product-hook"
+    if hook_path.is_file():
+        is_executable = os.access(str(hook_path), os.X_OK)
+        first_line = hook_path.read_text().split("\n", 1)[0] if hook_path.stat().st_size > 0 else ""
+        if is_executable and first_line.startswith("#!/usr/bin/env python3"):
+            checks.append({"name": "hook_executable", "status": "pass", "detail": "product-hook exists, executable, correct shebang"})
+        elif not is_executable:
+            checks.append({"name": "hook_executable", "status": "fail", "detail": "product-hook exists but is not executable"})
+            recommendations.append("chmod +x tools/product-hook")
+        else:
+            checks.append({"name": "hook_executable", "status": "warn", "detail": f"Unexpected shebang: {first_line[:50]}"})
+    else:
+        checks.append({"name": "hook_executable", "status": "fail", "detail": "tools/product-hook does not exist"})
+
+    # --- product-hook runtime library (tools/lib) ---
+    # product-hook imports tools/lib at runtime (regen-views, operator-
+    # verification, advisories). A repo missing it crashes on those commands.
+    lib_dir = target / "tools" / "lib"
+    lib_modules = sorted(lib_dir.glob("*.py")) if lib_dir.is_dir() else []
+    if lib_modules and (lib_dir / "__init__.py").is_file():
+        checks.append({"name": "hook_library", "status": "pass", "detail": f"tools/lib present ({len(lib_modules)} modules)"})
+    elif hook_path.is_file():
+        # Only a problem when product-hook is present (it's the importer).
+        checks.append({"name": "hook_library", "status": "fail", "detail": "tools/lib missing or incomplete — regen-views / operator-verification will crash"})
+        recommendations.append("Run prawduct-setup.py sync to install tools/lib")
+
+    # --- CLAUDE.md block markers ---
+    claude_path = target / "CLAUDE.md"
+    if claude_path.is_file():
+        content = claude_path.read_text()
+        has_begin = BLOCK_BEGIN in content
+        has_end = BLOCK_END in content
+        if has_begin and has_end:
+            begin_idx = content.find(BLOCK_BEGIN)
+            end_idx = content.find(BLOCK_END)
+            if begin_idx < end_idx:
+                checks.append({"name": "claude_md_markers", "status": "pass", "detail": "Block markers present and well-formed"})
+            else:
+                checks.append({"name": "claude_md_markers", "status": "fail", "detail": "Block markers in wrong order (END before BEGIN)"})
+        elif has_begin or has_end:
+            checks.append({"name": "claude_md_markers", "status": "fail", "detail": "Only one block marker found (need both BEGIN and END)"})
+        else:
+            checks.append({"name": "claude_md_markers", "status": "warn", "detail": "No block markers — framework updates won't sync to CLAUDE.md"})
+    else:
+        checks.append({"name": "claude_md_markers", "status": "fail", "detail": "CLAUDE.md does not exist"})
+
+    # --- Sync manifest ---
+    manifest_path = prawduct_dir / "sync-manifest.json"
+    if manifest_path.is_file():
+        try:
+            manifest = load_json(manifest_path)
+            fmt_ver = manifest.get("format_version", 0)
+            if fmt_ver >= 2:
+                checks.append({"name": "sync_manifest", "status": "pass", "detail": f"Valid manifest, format_version {fmt_ver}"})
+            else:
+                checks.append({"name": "sync_manifest", "status": "warn", "detail": f"Manifest format_version {fmt_ver} (expected >= 2, will auto-migrate)"})
+
+            # Check framework reachable
+            fw_source = manifest.get("framework_source", "")
+            fw_dir = _resolve_framework_dir(manifest, framework_dir, target)
+            if fw_dir and fw_dir.is_dir():
+                checks.append({"name": "framework_reachable", "status": "pass", "detail": f"Framework at {fw_dir}"})
+            else:
+                checks.append({
+                    "name": "framework_reachable",
+                    "status": "warn",
+                    "detail": f"Framework not reachable (configured: {fw_source})",
+                })
+                recommendations.append("Set PRAWDUCT_FRAMEWORK_DIR or clone framework as sibling ../prawduct")
+
+            # Check last sync time
+            last_sync = manifest.get("last_sync", "")
+            if last_sync:
+                checks.append({"name": "last_sync", "status": "pass", "detail": f"Last sync: {last_sync}"})
+
+        except json.JSONDecodeError:
+            checks.append({"name": "sync_manifest", "status": "fail", "detail": "sync-manifest.json is not valid JSON"})
+    else:
+        checks.append({"name": "sync_manifest", "status": "warn", "detail": "No sync manifest — will be bootstrapped on next sync"})
+
+    # --- Template variable residue ---
+    template_var_files = []
+    for rel_path in MANAGED_FILES:
+        file_path = target / rel_path
+        if file_path.is_file():
+            try:
+                content = file_path.read_text()
+                if re.search(r"\{\{[A-Z_]+\}\}", content):
+                    template_var_files.append(rel_path)
+            except Exception:  # prawduct:ok-broad-except — validation must not crash
+                pass
+    if template_var_files:
+        checks.append({
+            "name": "template_variables",
+            "status": "warn",
+            "detail": f"Unresolved template variables in: {', '.join(template_var_files)}",
+        })
+    else:
+        checks.append({"name": "template_variables", "status": "pass", "detail": "No unresolved template variables"})
+
+    # --- Gitignore ---
+    gitignore = target / ".gitignore"
+    if gitignore.is_file():
+        gi_content = gitignore.read_text()
+        gi_lines = set(gi_content.splitlines())
+        essential = [".prawduct/.critic-findings.json", ".prawduct/.session-start", ".prawduct/sync-manifest.json"]
+        missing_gi = [e for e in essential if e not in gi_lines]
+        if missing_gi:
+            checks.append({"name": "gitignore", "status": "warn", "detail": f"Missing entries: {', '.join(missing_gi)}"})
+        else:
+            checks.append({"name": "gitignore", "status": "pass", "detail": "Essential prawduct entries present"})
+
+        # Check for managed files incorrectly gitignored (they should be committed)
+        incorrectly_ignored = [rel for rel in MANAGED_FILES if rel in gi_lines]
+        if incorrectly_ignored:
+            checks.append({
+                "name": "gitignore_hygiene",
+                "status": "warn",
+                "detail": f"Managed files incorrectly gitignored (should be committed): {', '.join(incorrectly_ignored)}",
+            })
+            recommendations.append("Run sync to fix .gitignore (removes incorrect entries, adds missing ones)")
+        else:
+            checks.append({"name": "gitignore_hygiene", "status": "pass", "detail": "No managed files incorrectly gitignored"})
+    else:
+        checks.append({"name": "gitignore", "status": "warn", "detail": ".gitignore does not exist"})
+
+    # --- Session state (are hooks actually firing?) ---
+    session_start = prawduct_dir / ".session-start"
+    if session_start.is_file():
+        try:
+            stamp = session_start.read_text().strip()
+            checks.append({"name": "session_state", "status": "pass", "detail": f"Last session start: {stamp}"})
+        except Exception:  # prawduct:ok-broad-except — validation must not crash
+            checks.append({"name": "session_state", "status": "pass", "detail": "Session start file exists"})
+    else:
+        checks.append({
+            "name": "session_state",
+            "status": "warn",
+            "detail": "No .session-start file — hooks may not have fired yet (normal for first run)",
+        })
+
+    # --- Framework currency (are files up to date?) ---
+    try:
+        manifest_for_fw = load_json(manifest_path) if manifest_path.is_file() else {}
+    except json.JSONDecodeError:
+        manifest_for_fw = {}
+    fw_dir_resolved = _resolve_framework_dir(
+        manifest_for_fw,
+        framework_dir,
+        target,
+    )
+    if fw_dir_resolved and fw_dir_resolved.is_dir():
+        # Classify each managed file:
+        # - "stale-clean": current content matches a historical framework render
+        #   (sync auto-resolves on next run, no --force needed)
+        # - "local-edit": current content matches no known render (sync would skip
+        #   without --force; user should review the diff before forcing)
+        # - "missing": file expected but not present (sync creates on next run)
+        # block_template and always_update strategies are always overwritten on
+        # sync, so any drift is auto-resolvable (classified as stale-clean).
+        per_file_class: dict[str, str] = {}
+        product_name_for_check = "Unknown"
+        if manifest_path.is_file():
+            try:
+                mf = load_json(manifest_path)
+                product_name_for_check = mf.get("product_name", "Unknown")
+            except json.JSONDecodeError:
+                pass
+        check_subs = {"{{PRODUCT_NAME}}": product_name_for_check, "{{PRAWDUCT_VERSION}}": PRAWDUCT_VERSION}
+        history_cache: dict[tuple[str, str], str] = {}
+
+        for rel_path, config in MANAGED_FILES.items():
+            strategy = config.get("strategy", "template")
+            dst = target / rel_path
+            if not dst.is_file():
+                per_file_class[rel_path] = "missing"
+                continue
+
+            if strategy == "template":
+                template_rel = config.get("template", "")
+                template_path = fw_dir_resolved / template_rel
+                if not template_path.is_file():
+                    continue
+                rendered = render_template(template_path, check_subs)
+                rendered_hash = hashlib.sha256(rendered.encode()).hexdigest()
+                current_hash = compute_hash(dst)
+                if current_hash == rendered_hash:
+                    continue
+                matched = _match_historical_render(
+                    fw_dir_resolved, template_rel, current_hash, check_subs, history_cache
+                )
+                per_file_class[rel_path] = "stale-clean" if matched else "local-edit"
+            elif strategy == "block_template":
+                template_rel = config.get("template", "")
+                template_path = fw_dir_resolved / template_rel
+                if not template_path.is_file():
+                    continue
+                rendered = render_template(template_path, check_subs)
+                rendered_block, _, _ = extract_block(rendered)
+                if not rendered_block:
+                    continue
+                product_content = dst.read_text()
+                product_block, _, _ = extract_block(product_content)
+                if not product_block:
+                    continue
+                if hashlib.sha256(product_block.encode()).hexdigest() != hashlib.sha256(rendered_block.encode()).hexdigest():
+                    # block_template always overwrites in-marker content on sync
+                    # (marker contract from v1.3.13). Drift is always auto-resolvable.
+                    per_file_class[rel_path] = "stale-clean"
+            elif strategy == "always_update":
+                source_rel = config.get("source", "")
+                source_path = fw_dir_resolved / source_rel
+                if source_path.is_file():
+                    if source_path.read_bytes() != dst.read_bytes():
+                        per_file_class[rel_path] = "stale-clean"
+            # merge_settings: skip — hard to compare without side effects
+
+        if not per_file_class:
+            checks.append({"name": "framework_currency", "status": "pass", "detail": "All managed files match framework templates"})
+        else:
+            stale_clean = [r for r, c in per_file_class.items() if c == "stale-clean"]
+            local_edit = [r for r, c in per_file_class.items() if c == "local-edit"]
+            missing = [r for r, c in per_file_class.items() if c == "missing"]
+            parts: list[str] = []
+            if stale_clean:
+                parts.append(f"{len(stale_clean)} auto-resolve on next sync ({', '.join(stale_clean)})")
+            if local_edit:
+                parts.append(
+                    f"{len(local_edit)} have local edits ({', '.join(local_edit)} — review diff or sync --force)"
+                )
+            if missing:
+                parts.append(f"{len(missing)} missing ({', '.join(missing)} — sync will create)")
+            detail = f"{len(per_file_class)} files differ — " + "; ".join(parts)
+            checks.append({
+                "name": "framework_currency",
+                "status": "warn",
+                "detail": detail,
+            })
+
+            # Action-oriented recommendation
+            if local_edit:
+                recommendations.append(
+                    "Review files with local edits before running sync; for stale-clean files, sync auto-resolves them on next run"
+                )
+            elif stale_clean or missing:
+                recommendations.append("Run prawduct-sync to bring files up to date (no --force needed)")
+
+            # Restart needed only for files that will actually change
+            restart_files = [
+                f for f, c in per_file_class.items()
+                if f in ("CLAUDE.md", ".claude/settings.json") and c in ("stale-clean", "missing")
+            ]
+            if restart_files:
+                needs_restart = True
+                recommendations.append(f"Restart Claude Code after sync ({', '.join(restart_files)} will update)")
+
+    # --- Compute overall ---
+    overall = "healthy"
+    for c in checks:
+        if c["status"] == "fail":
+            overall = "broken"
+            break
+        if c["status"] == "warn" and overall == "healthy":
+            overall = "degraded"
+
+    return {
+        "target": str(target),
+        "overall": overall,
+        "version": version,
+        "checks": checks,
+        "needs_restart": needs_restart,
+        "recommendations": recommendations,
+    }

--- a/tools/lib/views.py
+++ b/tools/lib/views.py
@@ -1,0 +1,671 @@
+"""Derived-view builders for the prawduct work-log canonical store.
+
+When `.prawduct/project-state.yaml` has `views_enabled: true`, the build-plan
+`## Status` block becomes a derived view of `.prawduct/change-log.md` tagged
+entries — `product-hook regen-views` rewrites the checkboxes from
+`status=shipped` tags. Chunk titles, the `## Status` heading, the introductory
+HTML comment, and the freeform `Context:` line are author-curated; regen never
+touches them.
+
+Tagged-entry format (in change-log.md, on a line after each ``## YYYY-MM-DD:``
+header — blank lines between are tolerated):
+
+    <!-- prawduct: chunks=00,01,02 | release=v1.3.18 | status=shipped | scope=v1.4 -->
+
+Recognized keys:
+
+* ``chunks``  comma-separated chunk IDs (zero-padded, matching build-plan headers)
+* ``release`` version string (used by release-notes view, Chunk 06)
+* ``status``  ``shipped`` | ``in-progress`` | ``deferred``
+* ``scope``   rollup identifier, e.g., ``v1.4``
+
+Entries without a tag line are ignored — untagged historical entries coexist
+with tagged ones. Only chunks with a ``status=shipped`` tag flip to ``[x]``;
+all other Chunk lines flip to ``[ ]`` so the view is fully derived.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .core import resolve_build_plan_path
+
+
+TAG_LINE_RE = re.compile(r"<!--\s*prawduct:\s*(.+?)\s*-->")
+H2_RE = re.compile(r"^##\s+(.+?)\s*$")
+CHUNK_LINE_RE = re.compile(
+    r"^(?P<prefix>\s*-\s+)\[(?P<state>[ xX])\](?P<rest>\s+Chunk\s+(?P<id>[A-Za-z0-9_-]+):.*)$"
+)
+
+
+@dataclass
+class ChangeLogEntry:
+    """A change-log entry with optional tagged metadata."""
+
+    title: str
+    tags: dict[str, object] = field(default_factory=dict)
+    line_number: int = 0  # 1-indexed line of the H2 header
+
+    @property
+    def shipped_chunks(self) -> list[str]:
+        """Chunk IDs marked shipped by this entry, or []."""
+        if self.tags.get("status") != "shipped":
+            return []
+        chunks = self.tags.get("chunks")
+        if isinstance(chunks, list):
+            return [c for c in chunks if isinstance(c, str)]
+        return []
+
+
+def parse_tag_line(tag_body: str) -> dict[str, object]:
+    """Parse the body of a tag-line (between ``prawduct:`` and ``-->``).
+
+    Pipe-delimited ``key=value`` pairs. ``chunks`` is split on commas into a list;
+    other keys are kept as plain strings. Unknown keys are preserved as-is so
+    future views can read them without a schema bump.
+    """
+    tags: dict[str, object] = {}
+    for part in tag_body.split("|"):
+        part = part.strip()
+        if "=" not in part:
+            continue
+        k, v = part.split("=", 1)
+        k = k.strip()
+        v = v.strip()
+        if not k:
+            continue
+        if k == "chunks":
+            tags[k] = [c.strip() for c in v.split(",") if c.strip()]
+        else:
+            tags[k] = v
+    return tags
+
+
+def parse_change_log(content: str) -> list[ChangeLogEntry]:
+    """Parse change-log markdown into a list of entries.
+
+    An entry is ``## YYYY-MM-DD: title`` followed (after up to a few blank
+    lines) by ``<!-- prawduct: key=value | ... -->``. The tag line, if present,
+    must appear before the next non-blank content line under the H2.
+    """
+    entries: list[ChangeLogEntry] = []
+    lines = content.splitlines()
+    i = 0
+    while i < len(lines):
+        m = H2_RE.match(lines[i])
+        if not m:
+            i += 1
+            continue
+        entry = ChangeLogEntry(title=m.group(1), line_number=i + 1)
+        j = i + 1
+        while j < len(lines):
+            stripped = lines[j].strip()
+            if not stripped:
+                j += 1
+                continue
+            tag_match = TAG_LINE_RE.search(lines[j])
+            if tag_match:
+                entry.tags = parse_tag_line(tag_match.group(1))
+            # First non-blank line settles the question — tag line or not.
+            break
+        entries.append(entry)
+        i += 1
+    return entries
+
+
+def collect_shipped_chunks(
+    entries: list[ChangeLogEntry], scope: str | None = None
+) -> set[str]:
+    """Aggregate shipped chunk IDs across all entries.
+
+    When ``scope`` is set, only entries whose ``scope=`` tag equals ``scope``
+    contribute — this prevents cross-version chunk-ID collisions (e.g., v1.4's
+    ``chunks=05 | scope=v1.4`` flipping v1.5's chunk 05). When ``scope`` is
+    ``None``, all shipped entries contribute (legacy unfiltered behavior).
+    """
+    shipped: set[str] = set()
+    for entry in entries:
+        if scope is not None and entry.tags.get("scope") != scope:
+            continue
+        shipped.update(entry.shipped_chunks)
+    return shipped
+
+
+def _parse_build_plan_frontmatter_scope(content: str) -> str | None:
+    """Parse ``scope:`` from a build-plan's YAML frontmatter block.
+
+    The frontmatter is the block bounded by ``---`` on its own line. A leading
+    HTML comment block (``<!-- ... -->``) and blank lines before the opening
+    ``---`` are tolerated — every real build-plan in the codebase begins with a
+    comment header before the frontmatter, so requiring ``---`` on line 1 would
+    make the field inert in practice.
+
+    Returns the bare string value (quotes stripped) or ``None`` if the field is
+    absent, empty, set to the YAML null literal (``null`` / ``~``), nested
+    inside another key, outside the frontmatter, or the file lacks a
+    frontmatter entirely.
+    """
+    lines = content.splitlines()
+    i = 0
+    # Skip leading blank lines, then any leading HTML comment block (possibly
+    # multi-line). Build-plans conventionally start with a comment header.
+    while i < len(lines) and not lines[i].strip():
+        i += 1
+    if i < len(lines) and lines[i].lstrip().startswith("<!--"):
+        # Walk to the closing `-->` (inclusive).
+        while i < len(lines) and "-->" not in lines[i]:
+            i += 1
+        if i < len(lines):
+            i += 1  # consume the line containing `-->`
+    while i < len(lines) and not lines[i].strip():
+        i += 1
+    if i >= len(lines) or lines[i].strip() != "---":
+        return None
+    for j in range(i + 1, len(lines)):
+        line = lines[j]
+        if line.strip() == "---":
+            return None
+        if line[:1] in (" ", "\t"):
+            continue
+        stripped = line.split("#", 1)[0].rstrip()
+        if not stripped.startswith("scope:"):
+            continue
+        value = stripped.split(":", 1)[1].strip().strip('"').strip("'")
+        if not value or value.lower() in ("null", "~"):
+            return None
+        return value
+    return None
+
+
+def _detect_active_scope(
+    build_plan_content: str, change_log_content: str | None = None
+) -> str | None:
+    """Detect the active scope for filtering change-log entries.
+
+    Resolution order (highest precedence first):
+
+    1. ``scope:`` field in build-plan YAML frontmatter — explicit, preferred.
+    2. Most recent change-log entry's ``scope=`` tag — inferred.
+    3. ``None`` — no scope detected; fail-safe to legacy unfiltered union.
+    """
+    fm_scope = _parse_build_plan_frontmatter_scope(build_plan_content)
+    if fm_scope:
+        return fm_scope
+    if change_log_content:
+        entries = parse_change_log(change_log_content)
+        for entry in entries:
+            scope = entry.tags.get("scope")
+            if isinstance(scope, str) and scope:
+                return scope
+    return None
+
+
+def extract_status_section(content: str) -> tuple[int, int, list[str]]:
+    """Find the ``## Status`` section.
+
+    Returns ``(start_idx, end_idx_exclusive, section_lines)``. Section runs from
+    the ``## Status`` line to (but not including) the next ``## `` H2 — matching
+    the conventional build-plan layout. Returns ``(-1, -1, [])`` if absent.
+    """
+    lines = content.splitlines()
+    start = -1
+    for i, line in enumerate(lines):
+        if line.startswith("## Status"):
+            start = i
+            break
+    if start < 0:
+        return (-1, -1, [])
+    end = len(lines)
+    for j in range(start + 1, len(lines)):
+        if lines[j].startswith("## "):
+            end = j
+            break
+    return (start, end, lines[start:end])
+
+
+def regenerate_status_section(
+    section_lines: list[str], shipped_chunks: set[str]
+) -> tuple[list[str], list[tuple[str, str, str]]]:
+    """Rewrite Chunk checkbox lines from the shipped-chunks set.
+
+    Returns ``(new_lines, changes)`` where each change is
+    ``(chunk_id, old_state, new_state)`` with ``state`` in ``{" ", "x"}``.
+    Non-chunk lines (the ``## Status`` heading, HTML comments, blanks, the
+    ``Context:`` line) pass through unchanged. Order is preserved.
+    """
+    out: list[str] = []
+    changes: list[tuple[str, str, str]] = []
+    for line in section_lines:
+        m = CHUNK_LINE_RE.match(line)
+        if not m:
+            out.append(line)
+            continue
+        chunk_id = m.group("id")
+        current = m.group("state")
+        new_state = "x" if chunk_id in shipped_chunks else " "
+        if current.lower() != new_state:
+            changes.append((chunk_id, current, new_state))
+        out.append(f"{m.group('prefix')}[{new_state}]{m.group('rest')}")
+    return out, changes
+
+
+def build_status_view(
+    change_log_content: str, build_plan_content: str
+) -> tuple[str | None, list[tuple[str, str, str]]]:
+    """Produce updated build-plan content with regenerated Status section.
+
+    Returns ``(new_content, changes)``. ``new_content`` is ``None`` when no
+    checkbox flips were needed (idempotent no-op). ``changes`` is empty in
+    that case.
+    """
+    entries = parse_change_log(change_log_content)
+    active_scope = _detect_active_scope(build_plan_content, change_log_content)
+    shipped = collect_shipped_chunks(entries, scope=active_scope)
+    start, end, section = extract_status_section(build_plan_content)
+    if start < 0:
+        return None, []
+    new_section, changes = regenerate_status_section(section, shipped)
+    if not changes:
+        return None, []
+    lines = build_plan_content.splitlines()
+    new_lines = lines[:start] + new_section + lines[end:]
+    trailing = "\n" if build_plan_content.endswith("\n") else ""
+    return "\n".join(new_lines) + trailing, changes
+
+
+YAML_TOP_LEVEL_KEY_RE = re.compile(r"^(?P<key>[A-Za-z_][A-Za-z0-9_]*):\s*")
+
+
+def extract_yaml_top_level_block(
+    content: str, key: str
+) -> tuple[int, int, list[str]]:
+    """Find a column-0 YAML key and its body block.
+
+    Returns ``(start_idx, end_idx_exclusive, block_lines)``. The block starts at
+    the ``key:`` line and continues across all subsequent indented or blank
+    lines, ending at the first column-0 non-blank line (next key or comment
+    header). Trailing blank lines are excluded so they belong to the next
+    block's leading whitespace. Returns ``(-1, -1, [])`` if the key is absent.
+    """
+    lines = content.splitlines()
+    start = -1
+    key_re = re.compile(rf"^{re.escape(key)}:\s*")
+    for i, line in enumerate(lines):
+        if key_re.match(line):
+            start = i
+            break
+    if start < 0:
+        return (-1, -1, [])
+    end = len(lines)
+    for j in range(start + 1, len(lines)):
+        line = lines[j]
+        if not line.strip():
+            continue
+        if line[:1] in (" ", "\t"):
+            continue
+        end = j
+        break
+    # Drop trailing blank lines so they stay with the following block.
+    while end > start + 1 and not lines[end - 1].strip():
+        end -= 1
+    return (start, end, lines[start:end])
+
+
+def _collect_scope_rollups(
+    entries: list[ChangeLogEntry],
+) -> dict[str, dict[str, list[str]]]:
+    """Aggregate shipped entries by ``scope`` tag.
+
+    Returns ``{scope_id: {"chunks": [...], "releases": [...]}}`` with chunks
+    sorted, releases sorted, scope IDs sorted alphabetically. Only entries with
+    ``status=shipped`` AND a non-empty ``scope=`` tag contribute.
+    """
+    raw: dict[str, dict[str, set[str]]] = {}
+    for entry in entries:
+        if entry.tags.get("status") != "shipped":
+            continue
+        scope = entry.tags.get("scope")
+        if not isinstance(scope, str) or not scope:
+            continue
+        rec = raw.setdefault(scope, {"chunks": set(), "releases": set()})
+        chunks = entry.tags.get("chunks")
+        if isinstance(chunks, list):
+            rec["chunks"].update(c for c in chunks if isinstance(c, str))
+        release = entry.tags.get("release")
+        if isinstance(release, str) and release:
+            rec["releases"].add(release)
+    return {
+        scope: {
+            "chunks": sorted(raw[scope]["chunks"]),
+            "releases": sorted(raw[scope]["releases"]),
+        }
+        for scope in sorted(raw)
+    }
+
+
+def _format_scope_rollups_block(scopes: dict[str, dict[str, list[str]]]) -> str:
+    """Format the ``scope_rollups:`` YAML block from the aggregated dict.
+
+    Chunk IDs are quoted to preserve leading zeros (unquoted ``00`` is the
+    integer 0 in YAML's octal/leading-zero handling).
+    """
+    if not scopes:
+        return "scope_rollups: {}"
+    lines = ["scope_rollups:"]
+    for scope_id in scopes:
+        rec = scopes[scope_id]
+        lines.append(f"  {scope_id}:")
+        chunks_yaml = ", ".join(f'"{c}"' for c in rec["chunks"])
+        lines.append(f"    chunks: [{chunks_yaml}]")
+        releases_yaml = ", ".join(f'"{r}"' for r in rec["releases"])
+        lines.append(f"    releases: [{releases_yaml}]")
+    return "\n".join(lines)
+
+
+SCOPE_ROLLUPS_HEADER = (
+    "# =============================================================================\n"
+    "# SCOPE ROLLUPS (derived view, v1.4+)\n"
+    "# =============================================================================\n"
+    "# Auto-generated by `python3 tools/product-hook regen-views` from\n"
+    "# .prawduct/change-log.md `scope=` tags. Do not hand-edit — edits will be\n"
+    "# overwritten on next regen.\n"
+)
+
+
+def build_scope_view(
+    change_log_content: str, project_state_content: str
+) -> tuple[str | None, dict[str, dict[str, list[str]]]]:
+    """Regenerate the ``scope_rollups:`` block in project-state.yaml.
+
+    Returns ``(new_content, scopes)``. ``new_content`` is ``None`` when the
+    existing block already matches (idempotent no-op). ``scopes`` is the
+    computed mapping so callers can render human-readable diffs.
+
+    If no ``scope_rollups:`` block exists, one is appended at end-of-file with
+    a comment header. If the block exists, only the key + body is replaced;
+    surrounding comments and other keys are preserved verbatim.
+    """
+    entries = parse_change_log(change_log_content)
+    scopes = _collect_scope_rollups(entries)
+    new_block = _format_scope_rollups_block(scopes)
+    new_block_lines = new_block.splitlines()
+
+    start, end, existing_block = extract_yaml_top_level_block(
+        project_state_content, "scope_rollups"
+    )
+
+    if start < 0:
+        # No existing block — append at end of file with header comment.
+        sep = "" if project_state_content.endswith("\n") else "\n"
+        appended = (
+            project_state_content
+            + sep
+            + "\n"
+            + SCOPE_ROLLUPS_HEADER
+            + "\n"
+            + new_block
+            + "\n"
+        )
+        return appended, scopes
+
+    if existing_block == new_block_lines:
+        return None, scopes
+
+    lines = project_state_content.splitlines()
+    new_lines = lines[:start] + new_block_lines + lines[end:]
+    trailing = "\n" if project_state_content.endswith("\n") else ""
+    return "\n".join(new_lines) + trailing, scopes
+
+
+def _collect_releases(
+    entries: list[ChangeLogEntry],
+) -> list[dict[str, object]]:
+    """Aggregate shipped entries by ``release`` tag, preserving change-log order.
+
+    Returns a list of ``{release, title, chunks, scope}`` dicts in the order
+    releases first appear in the change-log (which by convention is
+    newest-first). Multiple entries sharing a release are merged; chunks union
+    and dedupe; ``title`` and ``scope`` come from the first entry seen.
+    """
+    seen: dict[str, dict[str, object]] = {}
+    order: list[str] = []
+    for entry in entries:
+        if entry.tags.get("status") != "shipped":
+            continue
+        release = entry.tags.get("release")
+        if not isinstance(release, str) or not release:
+            continue
+        if release not in seen:
+            seen[release] = {
+                "release": release,
+                "title": entry.title,
+                "chunks": set(),
+                "scope": entry.tags.get("scope")
+                if isinstance(entry.tags.get("scope"), str)
+                else None,
+            }
+            order.append(release)
+        chunks = entry.tags.get("chunks")
+        if isinstance(chunks, list):
+            seen[release]["chunks"].update(
+                c for c in chunks if isinstance(c, str)
+            )
+    out: list[dict[str, object]] = []
+    for release in order:
+        rec = dict(seen[release])
+        rec["chunks"] = sorted(rec["chunks"])
+        out.append(rec)
+    return out
+
+
+RELEASE_NOTES_HEADER = (
+    "# Release Notes\n"
+    "\n"
+    "<!-- Auto-generated by `python3 tools/product-hook regen-views` from\n"
+    "     .prawduct/change-log.md `release=` tags. Do not hand-edit — edits will\n"
+    "     be overwritten on next regen. See change-log.md for full per-release\n"
+    "     bodies; this file is a digest. -->\n"
+)
+
+
+def build_release_notes_view(change_log_content: str) -> str | None:
+    """Generate release-notes.md content from release-tagged shipped entries.
+
+    Returns the full desired file content, or ``None`` if no shipped+released
+    entries exist (caller decides whether to create an empty placeholder or
+    leave any existing file alone).
+    """
+    entries = parse_change_log(change_log_content)
+    releases = _collect_releases(entries)
+    if not releases:
+        return None
+    out: list[str] = [RELEASE_NOTES_HEADER]
+    for rec in releases:
+        out.append(f"## {rec['release']}\n")
+        out.append(f"**Entry:** {rec['title']}\n")
+        chunks = rec["chunks"]
+        if chunks:
+            out.append(f"**Chunks shipped:** {', '.join(chunks)}\n")
+        if rec["scope"]:
+            out.append(f"**Scope:** {rec['scope']}\n")
+        out.append("See `.prawduct/change-log.md` for full details.\n")
+    return "\n".join(out).rstrip() + "\n"
+
+
+@dataclass
+class ViewRegenResult:
+    """Outcome of one view's regen pass."""
+
+    name: str  # "status" | "release-notes" | "scope-rollups"
+    action: str  # "noop" | "write" | "create"
+    summary: str  # human-readable detail
+    new_content: str | None = None  # new file content (None for noop)
+    path_relative: str = ""  # path relative to prawduct_dir, for caller to write
+
+
+def plan_regen(prawduct_dir: Path) -> tuple[bool, list[ViewRegenResult]]:
+    """Compute what regen-views would do; do NOT write.
+
+    Returns ``(enabled, results)``. ``enabled`` is False when views_enabled is
+    not set — in that case results is empty. Otherwise results contains one
+    entry per view (status, release-notes, scope-rollups) describing the
+    intended action and the new content to write.
+
+    Callers (product-hook regen-views, prawduct-setup.py views) decide whether
+    to apply the changes.
+    """
+    state_path = prawduct_dir / "project-state.yaml"
+    if not is_views_enabled(state_path):
+        return False, []
+
+    change_log_path = prawduct_dir / "change-log.md"
+    # Resolve the active plan via the optional `active_build_plan:` pointer
+    # (supports scope-named plans); falls back to artifacts/build-plan.md.
+    build_plan_path = resolve_build_plan_path(prawduct_dir)
+    build_plan_rel = build_plan_path.relative_to(prawduct_dir).as_posix()
+    release_notes_path = prawduct_dir / "release-notes.md"
+    if not change_log_path.exists():
+        raise FileNotFoundError(f"change-log not found at {change_log_path}")
+    if not build_plan_path.exists():
+        raise FileNotFoundError(f"build-plan not found at {build_plan_path}")
+
+    change_log = change_log_path.read_text(encoding="utf-8")
+    build_plan = build_plan_path.read_text(encoding="utf-8")
+    project_state = state_path.read_text(encoding="utf-8")
+
+    results: list[ViewRegenResult] = []
+
+    # --- Status view ---
+    status_new, status_changes = build_status_view(change_log, build_plan)
+    if status_new is None:
+        results.append(
+            ViewRegenResult(
+                name="status",
+                action="noop",
+                summary="Status: up to date",
+                path_relative=build_plan_rel,
+            )
+        )
+    else:
+        shipped = sorted(cid for cid, _, new in status_changes if new == "x")
+        unshipped = sorted(cid for cid, _, new in status_changes if new == " ")
+        parts = []
+        if shipped:
+            parts.append(f"shipped [{', '.join(shipped)}]")
+        if unshipped:
+            parts.append(f"unshipped [{', '.join(unshipped)}]")
+        results.append(
+            ViewRegenResult(
+                name="status",
+                action="write",
+                summary=(
+                    f"Status: {len(status_changes)} chunk(s) flipped — "
+                    + "; ".join(parts)
+                ),
+                new_content=status_new,
+                path_relative=build_plan_rel,
+            )
+        )
+
+    # --- Release-notes view ---
+    rn_new = build_release_notes_view(change_log)
+    if rn_new is None:
+        results.append(
+            ViewRegenResult(
+                name="release-notes",
+                action="noop",
+                summary="Release notes: no release-tagged shipped entries",
+                path_relative="release-notes.md",
+            )
+        )
+    else:
+        existing_rn = (
+            release_notes_path.read_text(encoding="utf-8")
+            if release_notes_path.exists()
+            else None
+        )
+        if existing_rn == rn_new:
+            results.append(
+                ViewRegenResult(
+                    name="release-notes",
+                    action="noop",
+                    summary="Release notes: up to date",
+                    path_relative="release-notes.md",
+                )
+            )
+        else:
+            action = "write" if existing_rn is not None else "create"
+            results.append(
+                ViewRegenResult(
+                    name="release-notes",
+                    action=action,
+                    summary=f"Release notes: {action} release-notes.md",
+                    new_content=rn_new,
+                    path_relative="release-notes.md",
+                )
+            )
+
+    # --- Scope-rollups view ---
+    scope_new, scopes = build_scope_view(change_log, project_state)
+    if scope_new is None:
+        results.append(
+            ViewRegenResult(
+                name="scope-rollups",
+                action="noop",
+                summary="Scope rollups: up to date",
+                path_relative="project-state.yaml",
+            )
+        )
+    else:
+        if scopes:
+            scope_summary = ", ".join(
+                f"{s}={len(scopes[s]['chunks'])} chunk(s)" for s in scopes
+            )
+            summary = f"Scope rollups: {scope_summary}"
+        else:
+            summary = "Scope rollups: empty (no scope tags)"
+        results.append(
+            ViewRegenResult(
+                name="scope-rollups",
+                action="write",
+                summary=summary,
+                new_content=scope_new,
+                path_relative="project-state.yaml",
+            )
+        )
+
+    return True, results
+
+
+def apply_regen(prawduct_dir: Path, results: list[ViewRegenResult]) -> None:
+    """Write the new content for each result whose action is not 'noop'."""
+    for r in results:
+        if r.action == "noop" or r.new_content is None:
+            continue
+        target = prawduct_dir / r.path_relative
+        target.write_text(r.new_content, encoding="utf-8")
+
+
+def is_views_enabled(project_state_path: Path) -> bool:
+    """True if project-state.yaml has top-level ``views_enabled: true``.
+
+    Scans for a column-0 ``views_enabled:`` key, ignoring comments. Returns
+    False on any error or missing key — opt-in by design.
+    """
+    if not project_state_path.exists():
+        return False
+    try:
+        content = project_state_path.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    for raw in content.splitlines():
+        if raw[:1] in (" ", "\t"):
+            continue
+        line = raw.split("#", 1)[0].rstrip()
+        if not line.startswith("views_enabled:"):
+            continue
+        value = line.split(":", 1)[1].strip().lower()
+        return value == "true"
+    return False

--- a/tools/lib/views_cmd.py
+++ b/tools/lib/views_cmd.py
@@ -1,0 +1,65 @@
+"""Doctor `views` subcommand — inspect or refresh derived views.
+
+Wraps `tools/lib/views.py`'s shared `plan_regen` + `apply_regen` helpers so
+the `prawduct-setup.py views <dir>` (and its `--refresh` form) and the
+`tools/product-hook regen-views` subcommand reach the same regen logic.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from . import views as _views
+
+
+def run_views_command(product_dir: str, *, refresh: bool) -> dict:
+    """Inspect (or, with refresh=True, apply) derived-view regeneration.
+
+    Returns a dict shape suitable for both human and JSON output:
+
+        {
+          "product_dir": "/abs/path",
+          "enabled": bool,
+          "refresh": bool,
+          "views": [
+            {"name": "status", "action": "noop|write|create", "summary": "..."},
+            ...
+          ],
+        }
+
+    On error returns ``{"error": "..."}`` with no other keys.
+    """
+    product_path = Path(os.path.abspath(product_dir))
+    prawduct_dir = product_path / ".prawduct"
+    if not prawduct_dir.is_dir():
+        return {
+            "error": f"Not a prawduct product: {product_path} has no .prawduct/ directory"
+        }
+
+    try:
+        enabled, results = _views.plan_regen(prawduct_dir)
+    except FileNotFoundError as e:
+        return {"error": str(e)}
+    except OSError as e:
+        return {"error": f"I/O error reading view inputs: {e}"}
+
+    payload: dict = {
+        "product_dir": str(product_path),
+        "enabled": enabled,
+        "refresh": refresh,
+        "views": [
+            {"name": r.name, "action": r.action, "summary": r.summary}
+            for r in results
+        ],
+    }
+
+    if not enabled or not refresh:
+        return payload
+
+    try:
+        _views.apply_regen(prawduct_dir, results)
+    except OSError as e:
+        payload["error"] = f"I/O error writing view output: {e}"
+
+    return payload

--- a/tools/product-hook
+++ b/tools/product-hook
@@ -146,18 +146,24 @@ def try_sync(
                         print("  (banner will show new version next session)")
 
                 if actions and not quiet:
-                    is_bootstrap = any("Bootstrapped" in a for a in actions)
+                    non_bootstrap = [a for a in actions if "Bootstrapped" not in a]
+                    is_bootstrap = len(non_bootstrap) != len(actions)
 
-                    # Header (skip if we already printed upgrade banner)
+                    # Collapse the per-file action dump to a single count line —
+                    # a routine sync (or the tools/lib self-heal, which touches
+                    # ~14 files) should not wallpaper the briefing with "+ New: …"
+                    # lines. The manifest records exactly what changed; re-read
+                    # prompts and gitignore fixes still surface as notes below.
                     if is_bootstrap:
-                        print("PRAWDUCT SYNC: First framework sync for this repo")
-                    elif not upgrade_info:
-                        print("PRAWDUCT SYNC: Framework updated")
-
-                    # List changes
-                    for action in actions:
-                        if "Bootstrapped" not in action:  # Already shown in header
-                            print(f"  + {action}")
+                        print("PRAWDUCT SYNC: first framework sync for this repo")
+                    if non_bootstrap:
+                        n = len(non_bootstrap)
+                        if upgrade_info or is_bootstrap:
+                            print(f"  ({n} framework file(s) updated)")
+                        else:
+                            print(f"PRAWDUCT SYNC: {n} framework file(s) updated")
+                    # Notes carry the genuinely actionable bits (re-read X,
+                    # un-ignored a path to git add) — keep them.
                     for note in notes:
                         print(f"  * {note}")
             except json.JSONDecodeError:
@@ -301,17 +307,19 @@ def _check_framework_version(project_dir: Path, fw_source: str, quiet: bool) -> 
         synced_parsed = _parse_version(synced_version)
 
         if fw_parsed < synced_parsed and not quiet:
+            # Framework checkout is behind its own history — git pull is the fix,
+            # not sync. One line; the version pair says the rest.
             print(
-                f"NOTE: Framework at {fw_source} is version {fw_version} but this product "
-                f"was last synced with {synced_version}. Templates may be stale. "
-                f"Run 'git pull' in the framework directory to update."
+                f"NOTE: framework checkout at {fw_source} is v{fw_version}, behind this "
+                f"product's last sync (v{synced_version}) — git pull the framework repo."
             )
         elif fw_parsed > synced_parsed and not quiet:
+            # Framework is ahead but the session-start auto-sync didn't land
+            # (failed/timed out/unreachable) — otherwise versions would match.
+            # One line, not a wall; this fires only on genuine sync failure now.
             print(
-                f"NOTE: This product is synced at v{synced_version} but the framework at "
-                f"{fw_source} is v{fw_version} — the auto-sync at session start did not "
-                f"apply. tools/product-hook and templates here are stale. Run: "
-                f"python3 {fw_source}/tools/prawduct-setup.py sync {project_dir}"
+                f"NOTE: framework is v{fw_version} but this product synced at "
+                f"v{synced_version} — session-start sync didn't apply; run prawduct-setup.py sync."
             )
     except Exception:  # prawduct:ok-broad-except — version check must never block session start
         pass
@@ -445,6 +453,22 @@ def git_has_code_changes(project_dir: Path) -> bool:
     framework metadata (.prawduct/, .claude/settings.json, etc.).
     """
     return bool(git_has_session_changes(project_dir))
+
+
+def _is_framework_tooling(f: Path, project_dir: Path) -> bool:
+    """True if ``f`` is Prawduct framework infrastructure shipped into a product
+    repo (``tools/product-hook`` or ``tools/lib/*``), not the product's own code.
+
+    Used by the "has product code?" heuristic so that sync-delivered tooling
+    doesn't make a freshly-initialized empty repo look like it contains source.
+    Deliberately NOT used by the compliance canary's source detection: in the
+    framework repo itself these paths ARE the source under test.
+    """
+    try:
+        rel = f.relative_to(project_dir).as_posix()
+    except ValueError:
+        return False
+    return rel == "tools/product-hook" or rel.startswith("tools/lib/")
 
 
 # Canonical list of session files that should be gitignored, never tracked.
@@ -766,68 +790,6 @@ def _read_gates_waived(prawduct_dir: Path) -> dict[str, str]:
 # =============================================================================
 # Staleness Scan (v5: content-based artifact freshness)
 # =============================================================================
-
-
-def _count_tests_via_runner(project_dir: Path) -> int:
-    """Try to get exact test count from test runner (pytest or jest). Returns 0 on failure."""
-    # Only run pytest --co if the project has a pytest config file.
-    # Without one, pytest discovers upward and may collect the wrong project's tests.
-    has_pytest_config = (
-        (project_dir / "pyproject.toml").is_file()
-        or (project_dir / "pytest.ini").is_file()
-        or (project_dir / "setup.cfg").is_file()
-    )
-    if has_pytest_config:
-        try:
-            result = subprocess.run(
-                [sys.executable, "-m", "pytest", "--co", "-q", "--no-header", "--rootdir", str(project_dir)],
-                capture_output=True,
-                text=True,
-                cwd=str(project_dir),
-                timeout=15,
-            )
-            if result.returncode == 0:
-                # Last non-empty line is like "601 tests collected" or "601 test collected"
-                for line in reversed(result.stdout.strip().splitlines()):
-                    match = re.match(r"(\d+)\s+tests?\s+collected", line.strip())
-                    if match:
-                        return int(match.group(1))
-        except Exception:  # prawduct:ok-broad-except — test counting is best-effort
-            pass
-    return 0
-
-
-def _count_test_functions(project_dir: Path) -> int:
-    """Count tests across the project. Tries test runner first for exact count,
-    falls back to regex heuristic. Returns 0 if none found."""
-    # Try exact count from test runner (handles parametrized tests correctly)
-    exact = _count_tests_via_runner(project_dir)
-    if exact > 0:
-        return exact
-
-    # Fall back to regex heuristic (undercounts parametrized tests)
-    count = 0
-    skip_dirs = {".prawduct", "node_modules", ".git", "__pycache__", "venv", ".venv", ".tox"}
-
-    for root, dirs, files in os.walk(project_dir):
-        dirs[:] = [d for d in dirs if d not in skip_dirs]
-        for fname in files:
-            fpath = Path(root) / fname
-            # Python test files
-            if (fname.startswith("test_") or fname.endswith("_test.py")) and fname.endswith(".py"):
-                try:
-                    content = fpath.read_text()
-                    count += len(re.findall(r"^\s*def test_", content, re.MULTILINE))
-                except Exception:  # prawduct:ok-broad-except — test counting is best-effort
-                    pass
-            # JS/TS test files
-            elif fname.endswith((".test.js", ".test.ts", ".test.jsx", ".test.tsx", ".spec.js", ".spec.ts")):
-                try:
-                    content = fpath.read_text()
-                    count += len(re.findall(r"\b(?:it|test)\s*\(", content))
-                except Exception:  # prawduct:ok-broad-except — test counting is best-effort
-                    pass
-    return count
 
 
 def _extract_dependency_names(dep_file: Path) -> list[str]:
@@ -1386,57 +1348,21 @@ def assemble_session_briefing(
         for s in staleness:
             lines.append(f"Stale: {s}")
 
-    # Framework freshness — surface only when there's actual drift to reason about.
-    # The three drift dimensions (version, commit, template content) are tracked
-    # separately so the agent doesn't have to derive deltas from raw timestamps.
+    # Framework freshness — one line, only on REAL drift, and only for the
+    # commit delta. Version drift is owned by _check_framework_version (printed
+    # during sync with the correct git-pull-vs-sync remedy) so the two never say
+    # the same thing twice. Raw SHAs/dates are no longer dumped here — they live
+    # in the sync manifest. After Chunk B an up-to-date repo keeps last_sync /
+    # framework_commit current, so commits_behind is 0 and this stays silent.
     has_commit_delta = bool(freshness and freshness.get("commits_behind"))
-    has_version_delta = bool(
-        freshness
-        and freshness.get("framework_version")
-        and freshness.get("last_sync_version")
-        and freshness["framework_version"] != freshness["last_sync_version"]
-    )
-    if freshness and (has_commit_delta or has_version_delta or advisories):
-        lines.append("Framework freshness:")
-        head = freshness.get("framework_head") or "?"
-        head_date = freshness.get("framework_head_date") or "?"
-        fw_v = freshness.get("framework_version") or "?"
-        sync_commit = freshness.get("last_sync_commit") or "(not recorded)"
-        sync_date = freshness.get("last_sync_date") or "?"
-        sync_v = freshness.get("last_sync_version") or "?"
+    if has_commit_delta:
         behind = freshness.get("commits_behind")
-        lines.append(f"  Framework HEAD:    {head}  ({head_date})  v{fw_v}")
-        lines.append(f"  Last sync:         {sync_commit}  ({sync_date})  v{sync_v}")
-        if behind is None:
-            if not freshness.get("last_sync_commit"):
-                lines.append("  Commit delta:      unknown — manifest predates commit tracking; will populate on next sync")
-            else:
-                lines.append("  Commit delta:      unknown")
-        elif behind == 0:
-            lines.append("  Commit delta:      in sync")
-        else:
-            lines.append(f"  Commit delta:      {behind} commit(s) since sync")
-        if has_version_delta:
-            lines.append(f"  Version delta:     v{sync_v} → v{fw_v}")
-        if advisories:
-            lines.append(f"  Place-once template advisories: {len(advisories)}")
-            for adv in advisories:
-                short = adv.get("file", "?").rsplit("/", 1)[-1]
-                commit = adv.get("last_changed_commit", "")
-                date = adv.get("last_changed_date", "")
-                subject = adv.get("last_changed_subject", "")
-                if commit:
-                    subject_str = f" — \"{subject}\"" if subject else ""
-                    lines.append(f"    - {short}: changed in {commit} ({date}){subject_str}")
-                else:
-                    lines.append(f"    - {short}: changed since last sync (commit info unavailable)")
-    elif advisories:
-        # Manifest exists but freshness couldn't be computed (e.g., no fw_dir
-        # access). Fall back to the simple advisory list rather than dropping it.
-        lines.append(f"Place-once template advisories: {len(advisories)} template(s) have new content since project setup")
-        for adv in advisories:
-            msg = adv.get("message", "template drift detected")
-            lines.append(f"  - {msg}")
+        lines.append(f"Framework drift: {behind} commit(s) since last sync — run a framework sync")
+    if advisories:
+        # Template-drift advisories are fire-once (Chunk B), so this surfaces at
+        # most once per template change. One line naming the files, not a table.
+        names = ", ".join(adv.get("file", "?").rsplit("/", 1)[-1] for adv in advisories)
+        lines.append(f"Template update(s) since setup: {names} — /janitor scope=templates to review")
 
     # ADVISORIES (post-sync) — v1.6.0 Phase 1. The per-clone nag log written by
     # sync's probe step (`.prawduct/.advisories.json`). Read directly here
@@ -1545,64 +1471,37 @@ def assemble_session_briefing(
                 elif in_prawduct:
                     prawduct_lines += 1
             project_lines = total_lines - prawduct_lines
-            if project_lines > 150:
+            # Only surface genuine bloat. The soft ~150-line guideline is already
+            # enforced by the Critic at review time (the actionable moment); a
+            # 250+ line CLAUDE.md is a real problem worth a standing reminder.
+            # Re-nagging every session at the soft threshold was pure tax.
+            if project_lines > 250:
                 lines.append(
-                    f"CLAUDE.md is large ({project_lines} project lines, {total_lines} total) "
-                    f"— move architecture docs, config tables, and component inventories to docs/ or .prawduct/artifacts/"
+                    f"CLAUDE.md is large ({project_lines} project lines) — move architecture "
+                    f"docs, config tables, and component inventories to docs/ or .prawduct/artifacts/"
                 )
         except Exception:  # prawduct:ok-broad-except — briefing must never block session start
             pass
 
-    # Test count — informational only; .test-evidence.json is the canonical count
-    try:
-        test_count = _count_test_functions(project_dir)
-        if test_count > 0:
-            lines.append(f"Tests: ~{test_count}")
-    except Exception:  # prawduct:ok-broad-except — briefing must never block session start
-        pass
+    # (Cut: per-session "Tests: ~N" count and the "Last Critic review took …"
+    # timing quip. Neither is actionable at session start — the canonical test
+    # count lives in .test-evidence.json, and a past review's duration is noise.)
 
-    # Last Critic review duration (set expectations for wait time)
-    critic_path = prawduct_dir / ".critic-findings.json"
-    if critic_path.is_file():
-        try:
-            critic_data = json.loads(critic_path.read_text())
-            duration = critic_data.get("duration_seconds")
-            if duration and isinstance(duration, (int, float)) and duration > 0:
-                minutes = int(duration) // 60
-                seconds = int(duration) % 60
-                if minutes > 0:
-                    dur_str = f"{minutes}m{seconds:02d}s"
-                else:
-                    dur_str = f"{seconds}s"
-                lines.append(f"Last Critic review took {dur_str} — pestering the Critic will only make it grumpier")
-        except Exception:  # prawduct:ok-broad-except — briefing must never block session start
-            pass
-
-    # Relevant learnings — show topic index so Claude knows what's there
+    # Relevant learnings — show count + pointer so Claude knows rules exist
     learnings_path = prawduct_dir / "learnings.md"
     if learnings_path.is_file():
         try:
             learnings_content = learnings_path.read_text()
-            topics = []
             rule_count = 0
             for line in learnings_content.splitlines():
-                stripped = line.strip()
-                # Collect section headers as topic names
-                if stripped.startswith("## "):
-                    topic = stripped[3:].strip()
-                    # Skip the top-level "Learnings" header and resolved topics
-                    if topic.lower().startswith("learnings") or "(RESOLVED)" in topic:
-                        continue
-                    topics.append(topic)
                 # Count bullet-point rules
-                elif stripped.startswith("- "):
+                if line.strip().startswith("- "):
                     rule_count += 1
+            # Collapse to a count + pointer. The full topic index re-printed
+            # unchanged every session — a static table of contents is tax; the
+            # /learnings skill is the intended lookup path.
             if rule_count > 0:
-                if topics:
-                    topic_list = " | ".join(topics)
-                    lines.append(f"Learnings ({rule_count} rules): {topic_list}")
-                else:
-                    lines.append(f"Learnings ({rule_count} rules): read .prawduct/learnings.md for active rules")
+                lines.append(f"Learnings ({rule_count} rules): /learnings <topic> or read .prawduct/learnings.md")
         except Exception:  # prawduct:ok-broad-except — briefing must never block session start
             pass
 
@@ -1630,13 +1529,9 @@ def assemble_session_briefing(
                         if item_text:
                             pending_items.append(item_text)
             if pending_items:
-                lines.append(f"Backlog: {len(pending_items)} pending items (.prawduct/backlog.md)")
-                for item in pending_items[:5]:  # Show up to 5, truncate long ones
-                    if len(item) > 120:
-                        item = item[:117] + "..."
-                    lines.append(f"  - {item}")
-                if len(pending_items) > 5:
-                    lines.append(f"  ... and {len(pending_items) - 5} more")
+                # One count line, not a 5-item dump every session. /backlog is
+                # the triage path; dumping arbitrary items here was tax.
+                lines.append(f"Backlog: {len(pending_items)} pending (/backlog to triage)")
         except Exception:  # prawduct:ok-broad-except — briefing must never block session start
             pass
 
@@ -2176,7 +2071,10 @@ def cmd_clear(project_dir: Path) -> int:
             pass
 
     if prefs_missing or prefs_unfilled:
-        # Only warn if there's source code (not a brand-new project)
+        # Only warn if there's source code (not a brand-new project). Framework
+        # tooling (tools/product-hook, tools/lib/*.py) is infrastructure shipped
+        # by sync, NOT the product's own code — counting it would fire this
+        # CRITICAL on a freshly-initialized empty repo.
         has_code = any(
             f.suffix in (".py", ".js", ".ts", ".go", ".rs", ".java", ".rb", ".swift", ".kt", ".c", ".cpp", ".h")
             for f in project_dir.rglob("*")
@@ -2184,6 +2082,7 @@ def cmd_clear(project_dir: Path) -> int:
             and ".prawduct" not in f.parts
             and "node_modules" not in f.parts
             and f.name != "conftest.py"
+            and not _is_framework_tooling(f, project_dir)
         )
         if has_code:
             print(
@@ -3874,7 +3773,18 @@ def cmd_regen_views(project_dir: Path) -> int:
     tools_dir = str(Path(__file__).resolve().parent)
     if tools_dir not in sys.path:
         sys.path.insert(0, tools_dir)
-    from lib import views  # noqa: PLC0415 — lazy import keeps top-level cheap
+    try:
+        from lib import views  # noqa: PLC0415 — lazy import keeps top-level cheap
+    except ImportError:
+        # Old repo that predates tools/lib propagation — degrade gracefully
+        # rather than crash. Views derivation is a convenience; Status can be
+        # updated by hand until the next framework sync ships tools/lib.
+        print(
+            "NOTE: regen-views needs tools/lib (not present in this repo). "
+            "Run a framework sync to install it; Status not auto-regenerated.",
+            file=sys.stderr,
+        )
+        return 0
 
     prawduct_dir = get_prawduct_dir(project_dir)
     try:
@@ -3919,7 +3829,18 @@ def cmd_check_operator_verification(project_dir: Path) -> int:
     tools_dir = str(Path(__file__).resolve().parent)
     if tools_dir not in sys.path:
         sys.path.insert(0, tools_dir)
-    from lib import operator_verification as ov  # noqa: PLC0415 — lazy import
+    try:
+        from lib import operator_verification as ov  # noqa: PLC0415 — lazy import
+    except ImportError:
+        # Fail OPEN: this gate cannot evaluate a queue it can't load. In a repo
+        # that predates tools/lib, operator-verification isn't active anyway, so
+        # blocking /pr here would be a false positive. Surface a note, allow.
+        print(
+            "NOTE: check-operator-verification needs tools/lib (not present); "
+            "gate skipped. Run a framework sync to install it.",
+            file=sys.stderr,
+        )
+        return 0
 
     result = ov.run_check_operator_verification(project_dir)
     if not result["required"]:
@@ -3943,7 +3864,17 @@ def cmd_accept_operator_verification(
     tools_dir = str(Path(__file__).resolve().parent)
     if tools_dir not in sys.path:
         sys.path.insert(0, tools_dir)
-    from lib import operator_verification as ov  # noqa: PLC0415 — lazy import
+    try:
+        from lib import operator_verification as ov  # noqa: PLC0415 — lazy import
+    except ImportError:
+        # Honest failure: this command mutates the queue, so it must not claim
+        # success when its machinery is absent. Tell the user to sync.
+        print(
+            "error: accept-operator-verification needs tools/lib (not present "
+            "in this repo). Run a framework sync to install it.",
+            file=sys.stderr,
+        )
+        return 1
 
     if rationale is None or not rationale.strip():
         print(


### PR DESCRIPTION
## Summary

- Bumps Prawduct framework files to upstream **v1.8.0** (skipping past v1.7.0 in one go: brookstalley/prawduct PRs #46 + #47).
- **Adds `tools/lib/` directory (13 modules)** — fixes the `ModuleNotFoundError` introduced by v1.6.0's product-hook that depended on `tools/lib/*` modules the framework didn't yet ship to product repos.
- **`tools/product-hook`**: -183/+114 lines (logic moved into `tools/lib/` modules; net simpler).
- All new files are byte-identical to the framework source.

## Why this is the buttons fix

TC-v3's `tools/product-hook` (after yesterday's #263 sync to v1.6.0) had 9+ lazy imports — `from lib import views`, `from lib import operator_verification`, `from lib import advisory_cmd`, `from lib import infer_mode` — depending on a `tools/lib/` directory **that did not exist in this repo**. Validate explicitly flagged it: `! hook_library: tools/lib missing or incomplete — regen-views / operator-verification will crash`.

This explains all three broken buttons reported by the operator:
- **Wrap** → `regen-views` and `operator-verification` steps were crashing
- **Run Critic** → `critic_mode.infer_mode` was crashing
- **Mark Critic Run** → `advisory_cmd` was crashing

v1.8.0's PR description confirms this is a known cross-product bug: *"Tooling works. `tools/lib/` now ships to product repos — fixes the `ModuleNotFoundError` that blocked hallucinote (~6 PRs) and forced war-castle to hand-vendor `lib`. Existing repos self-heal on next sync (dynamic `MANAGED_DIRS`, no static list to drift)."*

## What else lands

- **v1.7.0 contents**: structured `/backlog` skill, first production post-sync probe (`legacy-backlog-format`), backward-compatible.
- **v1.8.0 contents**: governance-tax reduction, quieter session briefings, anti-reinflation guards, Critic read-only git allow-list (CRT-2M5P).
- 1597 tests passing upstream, 0 blocking Critic findings, PR-reviewer recommendation: `merge`.

## Test plan

- [x] Framework source pulled clean to v1.8.0 (no merge conflicts).
- [x] `tools/lib/` files byte-identical to framework source.
- [x] `tools/product-hook` matches framework source.
- [x] New skills (`backlog`) loaded into the active session at session-start sync without restart.
- [ ] **After merge**: in this session, test "Run Critic" button (read-only — should spawn a review and complete cleanly, possibly with "nothing to review" on a clean tree).
- [ ] **After merge**: in this session, test "Mark Critic Run" button (state update only — should toggle state without crash).
- [ ] **After merge**: in a freshly-opened session of another Prawduct project, test "Wrap" button on minor trivial change (verifies fix propagates via session-start sync to other repos, and verifies Wrap pipeline now runs without `regen-views` crash).
- [ ] **After merge**: confirm `.prawduct/backlog.md` legacy-format advisory appears at next session start (expected, harmless, resolvable via `/backlog migrate` later).

## Related

- Framework PRs: brookstalley/prawduct#46 (v1.7.0) + #47 (v1.8.0)
- Yesterday's incomplete sync: #263 (v1.6.0 — introduced the `tools/lib/` dependency without shipping the directory)
- Open issues this might close as fixed-by-upgrade:
  - **#264** (session-wrap commits to main + bypasses blocking Critic) — root cause may have been `tools/lib/` crash silencing the pipeline; needs post-merge verification before closing.
  - Pending issue (not yet filed) about three broken buttons — likely no longer needed if post-merge testing confirms they work.
- Follow-up: #262 (machine-wide sync sweep — eager update across all TC projects)