### PR TITLE
fix(openclaw): auto-approve broken on multi-tenant hosts + --latest is preview-only

### DIFF
--- a/server.js
+++ b/server.js
@@ -2107,12 +2107,16 @@ route('POST', '/api/openclaw/connections/:id/approve-pending', async (_req, res,
   const keyPath = conn.sshKeyPath.replace(/^~/, process.env.HOME || '');
   const { execSync } = require('node:child_process');
 
-  // List pending devices via the gateway's WebSocket CLI
+  // List pending devices via the gateway's WebSocket CLI.
+  // Filter by published gateway port so we pick the right container on multi-tenant
+  // hosts (e.g. habitat runs RentalClaw, UCI services, and TiLT Claw side-by-side).
+  // Falls back to head -1 as a safety net if multiple containers somehow publish the
+  // same port (shouldn't happen given PortHub registration).
   let pending;
   try {
     const listOutput = execSync(
       `ssh -o BatchMode=yes -o ConnectTimeout=5 -o StrictHostKeyChecking=no -i "${keyPath}" ${conn.sshUser}@${conn.host} ` +
-      `"\\$HOME/.local/bin/docker ps --format '{{.Names}}' | head -1"`,
+      `"\\$HOME/.local/bin/docker ps --filter 'publish=${conn.port}' --format '{{.Names}}' | head -1"`,
       { timeout: 10000, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }
     ).trim();
 
@@ -2137,11 +2141,11 @@ route('POST', '/api/openclaw/connections/:id/approve-pending', async (_req, res,
     return jsonResponse(res, 200, { approved: false, reason: 'No pending requests' });
   }
 
-  // Approve the latest pending request
+  // Approve the latest pending request — same publish-port filter as above.
   try {
     const containerName = execSync(
       `ssh -o BatchMode=yes -o ConnectTimeout=5 -o StrictHostKeyChecking=no -i "${keyPath}" ${conn.sshUser}@${conn.host} ` +
-      `"\\$HOME/.local/bin/docker ps --format '{{.Names}}' | head -1"`,
+      `"\\$HOME/.local/bin/docker ps --filter 'publish=${conn.port}' --format '{{.Names}}' | head -1"`,
       { timeout: 10000, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }
     ).trim();
 

--- a/server.js
+++ b/server.js
@@ -2142,6 +2142,16 @@ route('POST', '/api/openclaw/connections/:id/approve-pending', async (_req, res,
   }
 
   // Approve the latest pending request — same publish-port filter as above.
+  // `openclaw devices approve --latest` is a PREVIEW (returns which request
+  // would be approved, doesn't approve); the actual approval requires the
+  // requestId as a positional argument. Sort pending by `ts` desc and use
+  // the most recent one's requestId.
+  const latestPending = pending.slice().sort((a, b) => (b.ts || 0) - (a.ts || 0))[0];
+  const requestId = latestPending && latestPending.requestId;
+  if (!requestId) {
+    return jsonResponse(res, 200, { approved: false, reason: 'Pending entry missing requestId' });
+  }
+
   try {
     const containerName = execSync(
       `ssh -o BatchMode=yes -o ConnectTimeout=5 -o StrictHostKeyChecking=no -i "${keyPath}" ${conn.sshUser}@${conn.host} ` +
@@ -2151,7 +2161,7 @@ route('POST', '/api/openclaw/connections/:id/approve-pending', async (_req, res,
 
     execSync(
       `ssh -o BatchMode=yes -o ConnectTimeout=5 -o StrictHostKeyChecking=no -i "${keyPath}" ${conn.sshUser}@${conn.host} ` +
-      `"\\$HOME/.local/bin/docker exec ${containerName} openclaw devices approve --latest --token ${conn.gatewayToken} --json"`,
+      `"\\$HOME/.local/bin/docker exec ${containerName} openclaw devices approve ${requestId} --token ${conn.gatewayToken} --json"`,
       { timeout: 15000, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }
     );
 


### PR DESCRIPTION
## Summary

The OpenClaw auto-approve flow (`POST /api/openclaw/connections/:id/approve-pending`, polled every 3s by `public/openclaw-view.js`) had two bugs that together prevented any new pairing from completing on hosts running more than one Docker container. Caught while adding a second OpenClaw connection ("TiLT Claw") to a host that already had RentalClaw + UCI services running side-by-side.

## Bug 1 — `docker ps | head -1` picks the wrong container on multi-tenant hosts

Both `execSync` blocks in `approve-pending` did:

```
docker ps --format '{{.Names}}' | head -1
```

This works only when there's exactly one container running on the target host. On habitat (TiLTClaw stack + RentalClaw stack + 7 UCI containers), `head -1` returned `openclaw-openclaw-gateway-1` (or, more often, the CLI helper `openclaw-openclaw-cli-1`) — never `tiltclaw-gateway`. Running `openclaw devices list --json` against the CLI helper fails with `GatewayTransportError 1006 abnormal closure`, the catch turns it into `"Failed to list pending devices"`, the browser polls again, and the UI shows "pairing required" forever.

**Fix:** filter by the connection's own published gateway port, which is unique per OpenClaw stack on a given host because PortHub leases are:

```
docker ps --filter "publish=${conn.port}" --format '{{.Names}}' | head -1
```

`| head -1` stays as defense-in-depth.

## Bug 2 — `openclaw devices approve --latest` is preview-only, not approval

Even after the right container is selected, the auto-approve fired:

```
docker exec <container> openclaw devices approve --latest --token <token> --json
```

`--latest` in OpenClaw 2026.4.10 returns a **preview** of which pending request would be approved (a JSON envelope containing `"selected": {...}`, `"approveCommand": "openclaw devices approve <requestId> --json"`, `"requiresAuthFlags": {...}`). It does not actually approve anything. The actual approval requires the requestId as a positional argument:

```
docker exec <container> openclaw devices approve <requestId> --token <token> --json
```

**Fix:** the listing step already returns a `pending[]` array with `requestId` and `ts` on each entry — sort by `ts` desc and use the most recent entry's `requestId` positionally instead of `--latest`. Defensive `if (!requestId)` early return if the field is missing.

## Repro / verification (manual)

Before patch, on a host running multiple containers:
- Auto-approve response: `{"approved":false,"reason":"Failed to list pending devices"}`
- After Bug 1 fix only: `{"approved":false,"reason":"Approve failed: Command failed: ssh ... approve --latest ..."}`
- After both fixes: pending drops to 0 within one auto-approve cycle, paired count increments

Verified end-to-end against habitat (10 containers — 2 OpenClaw stacks + UCI services) and against a fresh TiLT Claw pairing. RentalClaw auto-approve still returns `"No pending requests"` (no regression — was already paired).

## Test plan

- [x] Manual: on a multi-tenant host, fresh OpenClaw pair → status flips paired
- [x] Manual: on single-tenant host (RentalClaw historical case), no regression
- [ ] Unit test for the requestId picking and the docker filter args — happy to add if you want it as a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code) alongside Lord JSON