### PR TITLE
version-bump: bump package.json when there's no version.json (#298)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **version-bump bumps `package.json` when there's no `version.json` (closes #298).** `lib/wrap-steps/version-bump.js` now resolves the version source — preferring `version.json`, falling back to `package.json` (Node projects) — so wrapping a Node app actually bumps its version instead of skipping. Of 34 registered projects only 4 had a `version.json`; ~14 are `package.json`-versioned and were silently skipped every wrap with "version.json not found". The `package.json` write is **surgical** — only the top-level `"version"` value is swapped (anchored on the current value), byte-preserving the hand-maintained file's formatting, key order, and dependency versions; a defensive normalized-rewrite fallback covers unusual formatting. `version.json` stays preferred + normalized (TangleClaw and the other 3 `version.json` projects are unchanged). When **neither** file exists the skip reason is now the clearer "not version-tracked (no version.json or package.json …)" instead of the alarming "version.json not found", and the wrap-drawer detail names the source (e.g. `1.4.2 → 1.5.0 (minor, package.json)`). The commit-body "Bumped …" line shape-matches the staged metadata, so package.json bumps render with no commit-step change. **Tests.** New `test/version-bump-package-json.test.js`: source resolution (version.json preferred, package.json fallback, neither → skip, missing/non-semver version → skip), the surgical swap preserves siblings and does NOT touch a coinciding dependency version, and a `run()` e2e bumping package.json + promoting the CHANGELOG. Updated the "skips when missing" + detail-format pins in `test/wrap-pipeline.test.js`. Full suite 2666/2667 (1 pre-existing skip).
+
 ## [3.23.0] - 2026-06-02
 
 ### Added

--- a/lib/wrap-steps/version-bump.js
+++ b/lib/wrap-steps/version-bump.js
@@ -295,25 +295,17 @@ async function run(context) {
   }
 
   const versionPath = path.join(project.path, 'version.json');
+  const pkgPath = path.join(project.path, 'package.json');
   const changelogPath = path.join(project.path, 'CHANGELOG.md');
 
-  if (!_internal.existsSync(versionPath)) {
-    return _skipped('version.json not found');
+  // #298: resolve which file holds the version — prefer `version.json`, fall
+  // back to `package.json` (Node projects). Everything below is identical
+  // regardless; only which file is read + written differs.
+  const source = _resolveVersionSource(versionPath, pkgPath);
+  if (source.skip) {
+    return _skipped(source.skip);
   }
-  let versionJson;
-  try {
-    const txt = _internal.readFileSync(versionPath, 'utf8');
-    versionJson = JSON.parse(txt);
-  } catch (err) {
-    return _skipped(`version.json unreadable: ${err.message}`);
-  }
-  if (!versionJson || typeof versionJson !== 'object') {
-    return _skipped('version.json is not an object');
-  }
-  const currentVersion = versionJson.version;
-  if (!_parseSemver(currentVersion)) {
-    return _skipped(`version.json "version" field missing or non-semver (got ${JSON.stringify(currentVersion)})`);
-  }
+  const currentVersion = source.currentVersion;
 
   if (!_internal.existsSync(changelogPath)) {
     return _skipped('CHANGELOG.md not found');
@@ -356,11 +348,10 @@ async function run(context) {
 
   const today = _internal.todayIso();
   const newChangelogText = _promoteUnreleased(changelogText, newVersion, today);
-  const newVersionJsonText = JSON.stringify({ ...versionJson, version: newVersion }, null, 2) + '\n';
 
-  staged['version-bump:version-json'] = {
-    primingPath: versionPath,
-    newContent: newVersionJsonText,
+  staged[source.stagedKey] = {
+    primingPath: source.path,
+    newContent: source.makeContent(newVersion),
     changed: true,
     oldVersion: currentVersion,
     newVersion,
@@ -390,8 +381,9 @@ async function run(context) {
       from: currentVersion,
       to: newVersion,
       bumpLevel,
+      versionFile: source.kind,
       subsections: parsed.subsections,
-      detail: `${currentVersion} → ${newVersion} (${bumpLevel})`
+      detail: `${currentVersion} → ${newVersion} (${bumpLevel}, ${source.kind})`
     },
     blockers: []
   };
@@ -407,6 +399,77 @@ function _skipped(reason) {
     output: { reason, detail: reason },
     blockers: []
   };
+}
+
+/**
+ * Resolve which file holds the project version (#298): prefer `version.json`,
+ * fall back to `package.json` (Node projects). Returns `{skip:<reason>}` when
+ * neither is usable, else `{kind, path, currentVersion, stagedKey, makeContent}`.
+ * `version.json` is rewritten normalized; `package.json`'s write is surgical —
+ * only the top-level `"version"` value is swapped, byte-preserving the rest of
+ * the hand-maintained file.
+ * @param {string} versionPath - <project>/version.json
+ * @param {string} pkgPath - <project>/package.json
+ * @returns {{skip:string}|{kind:string, path:string, currentVersion:string, stagedKey:string, makeContent:(nv:string)=>string}}
+ */
+function _resolveVersionSource(versionPath, pkgPath) {
+  if (_internal.existsSync(versionPath)) {
+    let json;
+    try {
+      json = JSON.parse(_internal.readFileSync(versionPath, 'utf8'));
+    } catch (err) {
+      return { skip: `version.json unreadable: ${err.message}` };
+    }
+    if (!json || typeof json !== 'object') {
+      return { skip: 'version.json is not an object' };
+    }
+    if (!_parseSemver(json.version)) {
+      return { skip: `version.json "version" field missing or non-semver (got ${JSON.stringify(json.version)})` };
+    }
+    return {
+      kind: 'version.json',
+      path: versionPath,
+      currentVersion: json.version,
+      stagedKey: 'version-bump:version-json',
+      makeContent: (nv) => JSON.stringify({ ...json, version: nv }, null, 2) + '\n'
+    };
+  }
+
+  if (_internal.existsSync(pkgPath)) {
+    let raw;
+    let json;
+    try {
+      raw = _internal.readFileSync(pkgPath, 'utf8');
+      json = JSON.parse(raw);
+    } catch (err) {
+      return { skip: `package.json unreadable: ${err.message}` };
+    }
+    const cv = json && json.version;
+    if (!_parseSemver(cv)) {
+      return { skip: `package.json "version" field missing or non-semver (got ${JSON.stringify(cv)})` };
+    }
+    return {
+      kind: 'package.json',
+      path: pkgPath,
+      currentVersion: cv,
+      stagedKey: 'version-bump:package-json',
+      // Surgical swap of ONLY the top-level "version" value — preserves the
+      // file's formatting, key order, and remaining bytes. `"version":` is a
+      // top-level-only key in package.json (dependencies key on package name),
+      // so the match anchored on the current value is the package version.
+      // Defensive fallback to a normalized rewrite if the regex doesn't match.
+      makeContent: (nv) => {
+        const escaped = String(cv).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const re = new RegExp('("version"\\s*:\\s*")' + escaped + '(")');
+        const out = raw.replace(re, `$1${nv}$2`);
+        return out === raw ? JSON.stringify({ ...json, version: nv }, null, 2) + '\n' : out;
+      }
+    };
+  }
+
+  // Clearer than the old "version.json not found" — this project simply isn't
+  // version-tracked in a form this step bumps.
+  return { skip: 'not version-tracked (no version.json or package.json with a semver version)' };
 }
 
 // `_todayIsoLocal` previously lived inline here (PR #216); extracted
@@ -432,6 +495,7 @@ module.exports = {
   _parseUnreleased,
   _decideBumpLevel,
   _promoteUnreleased,
+  _resolveVersionSource,
   _todayIsoLocal,
   _internal
 };

--- a/test/version-bump-package-json.test.js
+++ b/test/version-bump-package-json.test.js
@@ -1,0 +1,123 @@
+'use strict';
+
+// #298 — version-bump falls back to package.json (Node projects) when there's
+// no version.json. The package.json write is surgical (only the top-level
+// "version" value changes); version.json stays preferred + normalized.
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const { setLevel } = require('../lib/logger');
+
+setLevel('error');
+
+const vb = require('../lib/wrap-steps/version-bump');
+
+const PKG = `{
+  "name": "rentalclaw",
+  "version": "1.4.2",
+  "private": true,
+  "scripts": { "build": "next build" },
+  "dependencies": { "next": "14.0.0" }
+}
+`;
+const CHANGELOG = `# Changelog
+
+## [Unreleased]
+
+### Added
+- **A new feature.**
+
+## [1.4.2] - 2026-05-01
+
+### Fixed
+- something old
+`;
+
+describe('version-bump package.json support (#298)', () => {
+  let saved;
+  beforeEach(() => { saved = { ...vb._internal }; });
+  afterEach(() => { Object.assign(vb._internal, saved); });
+
+  describe('_resolveVersionSource', () => {
+    it('prefers version.json when present (unchanged behavior)', () => {
+      vb._internal.existsSync = (p) => p.endsWith('version.json');
+      vb._internal.readFileSync = () => '{"version":"3.0.0"}';
+      const s = vb._resolveVersionSource('/p/version.json', '/p/package.json');
+      assert.equal(s.kind, 'version.json');
+      assert.equal(s.currentVersion, '3.0.0');
+      assert.equal(s.stagedKey, 'version-bump:version-json');
+      assert.equal(s.makeContent('3.1.0'), '{\n  "version": "3.1.0"\n}\n');
+    });
+
+    it('falls back to package.json when there is no version.json', () => {
+      vb._internal.existsSync = (p) => p.endsWith('package.json');
+      vb._internal.readFileSync = () => PKG;
+      const s = vb._resolveVersionSource('/p/version.json', '/p/package.json');
+      assert.equal(s.kind, 'package.json');
+      assert.equal(s.currentVersion, '1.4.2');
+      assert.equal(s.stagedKey, 'version-bump:package-json');
+      const out = s.makeContent('1.5.0');
+      // Surgical: ONLY the top-level version value changed; rest byte-identical.
+      assert.equal(out, PKG.replace('"version": "1.4.2"', '"version": "1.5.0"'));
+      assert.ok(out.includes('"name": "rentalclaw"'));
+      assert.ok(out.includes('"next": "14.0.0"'), 'dependency untouched');
+    });
+
+    it('does NOT touch a dependency version that coincides with the package version', () => {
+      const pkg = '{\n  "version": "14.0.0",\n  "dependencies": { "next": "14.0.0" }\n}\n';
+      vb._internal.existsSync = (p) => p.endsWith('package.json');
+      vb._internal.readFileSync = () => pkg;
+      const out = vb._resolveVersionSource('/p/version.json', '/p/package.json').makeContent('15.0.0');
+      assert.ok(out.includes('"version": "15.0.0"'), 'top-level version bumped');
+      assert.ok(out.includes('"next": "14.0.0"'), 'matching dependency value untouched');
+    });
+
+    it('skips with a clear message when neither file exists', () => {
+      vb._internal.existsSync = () => false;
+      const s = vb._resolveVersionSource('/p/version.json', '/p/package.json');
+      assert.match(s.skip, /not version-tracked/);
+    });
+
+    it('skips when package.json has no semver version', () => {
+      vb._internal.existsSync = (p) => p.endsWith('package.json');
+      vb._internal.readFileSync = () => '{"name":"x"}';
+      const s = vb._resolveVersionSource('/p/version.json', '/p/package.json');
+      assert.match(s.skip, /package\.json "version" field missing or non-semver/);
+    });
+  });
+
+  describe('run() end-to-end on a package.json project', () => {
+    it('bumps package.json + promotes CHANGELOG (no version.json present)', async () => {
+      vb._internal.existsSync = (p) => p.endsWith('package.json') || p.endsWith('CHANGELOG.md');
+      vb._internal.readFileSync = (p) => (p.endsWith('package.json') ? PKG : CHANGELOG);
+      vb._internal.todayIso = () => '2026-06-02';
+
+      const ctx = { project: { path: '/proj', name: 'rentalclaw' }, staged: {}, options: {} };
+      const r = await vb.run(ctx);
+
+      assert.equal(r.ok, true);
+      assert.equal(r.status, 'done');
+      assert.equal(r.output.from, '1.4.2');
+      assert.equal(r.output.to, '1.5.0', 'minor bump driven by ### Added');
+      assert.equal(r.output.versionFile, 'package.json');
+
+      const pkgStaged = ctx.staged['version-bump:package-json'];
+      assert.ok(pkgStaged, 'package.json write staged');
+      assert.equal(pkgStaged.primingPath, '/proj/package.json');
+      assert.equal(pkgStaged.newContent, PKG.replace('"version": "1.4.2"', '"version": "1.5.0"'));
+      assert.ok(!ctx.staged['version-bump:version-json'], 'no version-json entry for a package.json project');
+
+      assert.match(ctx.staged['version-bump:changelog'].newContent, /## \[1\.5\.0\] - 2026-06-02/);
+    });
+
+    it('still skips cleanly on a project with neither file', async () => {
+      vb._internal.existsSync = (p) => p.endsWith('CHANGELOG.md'); // CHANGELOG only, no version files
+      vb._internal.readFileSync = () => CHANGELOG;
+      const ctx = { project: { path: '/proj', name: 'x' }, staged: {}, options: {} };
+      const r = await vb.run(ctx);
+      assert.equal(r.status, 'skipped');
+      assert.match(r.output.reason, /not version-tracked/);
+      assert.deepEqual(ctx.staged, {}, 'nothing staged on skip');
+    });
+  });
+});

--- a/test/wrap-pipeline.test.js
+++ b/test/wrap-pipeline.test.js
@@ -4469,12 +4469,12 @@ describe('wrap-step version-bump — handler (open-queue #3, post-#139)', () => 
     assert.match(result.output.reason, /no project path/i);
   });
 
-  it('skips when version.json is missing', async () => {
+  it('skips when neither version.json nor package.json is present (#298)', async () => {
     const project = makeProject('no-version-json');
     fs.writeFileSync(path.join(project.path, 'CHANGELOG.md'), '## [Unreleased]\n### Added\n- x\n');
     const result = await versionBump.run(freshContext(project));
     assert.equal(result.status, 'skipped');
-    assert.match(result.output.reason, /version\.json not found/i);
+    assert.match(result.output.reason, /not version-tracked/i);
   });
 
   it('skips when version.json is malformed JSON', async () => {
@@ -4537,7 +4537,8 @@ describe('wrap-step version-bump — handler (open-queue #3, post-#139)', () => 
     assert.equal(result.output.from, '3.16.2');
     assert.equal(result.output.to, '3.17.0', 'Added subsection → minor bump');
     assert.equal(result.output.bumpLevel, 'minor');
-    assert.equal(result.output.detail, '3.16.2 → 3.17.0 (minor)');
+    assert.equal(result.output.versionFile, 'version.json', '#298: source file surfaced');
+    assert.equal(result.output.detail, '3.16.2 → 3.17.0 (minor, version.json)');
 
     // Two staged writes under composite keys
     assert.ok(ctx.staged['version-bump:version-json'], 'version-json staging missing');


### PR DESCRIPTION
## What
Teaches the wrap version-bump step to bump **`package.json`** when a project has no `version.json` — so your Node apps actually version on wrap instead of skipping.

## Why
Of 34 registered projects, only 4 have a `version.json`; ~14 are `package.json`-versioned (RentalClaw, Medusa, ClawBridge, PortHub, …) and were silently skipped every wrap with "version.json not found". (TangleClaw itself uses `version.json` and was fine — this closes the gap for everything else.)

## How
- `_resolveVersionSource()` picks the source: **prefer `version.json`**, fall back to `package.json`, else skip with a clearer "not version-tracked …" message.
- `package.json` write is **surgical** — only the top-level `"version"` value is swapped (anchored on the current value), byte-preserving formatting/key-order/dependencies; normalized-rewrite fallback on no-match.
- `output.versionFile` + drawer detail name the source (e.g. `1.4.2 → 1.5.0 (minor, package.json)`).
- No commit-step change: `_buildBodyLines` shape-matches the staged metadata, so the new `version-bump:package-json` key renders the "Bumped …" line identically.

## Test plan
- Full suite **2666 pass / 0 fail / 1 pre-existing skip**.
- New `test/version-bump-package-json.test.js`: source resolution (version.json preferred / package.json fallback / neither→skip / missing-or-non-semver→skip), surgical swap preserves siblings **and** a coinciding dependency version, run() e2e bumps package.json + promotes CHANGELOG.
- Updated the "skips when missing" + detail-format pins in `test/wrap-pipeline.test.js`.
- **Critic** (cumulative): 0 blocking, 0 warning, 1 low-probability note (first-match regex; covered by the coinciding-dependency test) — accepted.

Fixes #298