### PR TITLE
OpenClaw tunnels self-heal: periodic liveness monitor + auto-recreate (#294)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **OpenClaw tunnels self-heal — periodic liveness check + auto-recreate (closes #294).** A background monitor (`lib/tunnel-monitor.js`, started at server boot) end-to-end probes each tunnel TC has established this process lifetime (`oc-direct-<connId>`, every 45s via `httpRoundTrip`) and rebuilds any that died via `ensureTunnel({force:true})` — re-resolving the connection config and re-picking the IPv4/IPv6 forward target (#291). This fixes the "tunnel connects, then doesn't persist → Web UI black-screens" loop: when an `ssh -f -N -L` tunnel dropped (transport flap, or the remote gateway container being restarted) nothing rebuilt it, so the connection stayed dead until a manual re-launch. Per-connection **exponential backoff** (45s → capped 10min) keeps a genuinely-down gateway from hot-looping and clears the moment a probe succeeds. Scope is intentionally narrow: only currently-tracked `oc-direct` tunnels (ones the operator opened) are monitored — never auto-establishing a tunnel nobody asked for. The interval is `unref`'d (never holds the process open) and `stop()`ped on graceful shutdown. **Tests.** New `test/tunnel-monitor.test.js` (9): key parsing, healthy→no-rebuild, dead→recreate-with-force+bridge-forward, recreate-failure→backoff→skip-in-window, backoff escalation + cap, recovery-clears-backoff, `tick` filters to known oc-direct connections, start-idempotent/stop-clears. Full suite 2675/2676 (1 pre-existing skip).
+
 ## [3.24.0] - 2026-06-02
 
 ### Added

--- a/lib/tunnel-monitor.js
+++ b/lib/tunnel-monitor.js
@@ -1,0 +1,166 @@
+'use strict';
+
+// #294 — periodic OpenClaw tunnel liveness check + auto-recreate.
+//
+// An `ssh -f -N -L` tunnel can die on its own (transport drop under
+// ExitOnForwardFailure, or the remote gateway container being restarted) while
+// the operator isn't looking, and nothing rebuilds it — so the connection
+// reads dead until someone manually re-launches it (the "tunnel doesn't
+// persist" complaint). This monitor walks the tunnels TC has established this
+// process lifetime, end-to-end probes each (#288 `httpRoundTrip`), and rebuilds
+// any that died via `ensureTunnel({force:true})` — which re-resolves the
+// connection config and re-picks the right forward target (#291). Per-connection
+// exponential backoff keeps a genuinely-down gateway from hot-looping.
+//
+// Scope: only tunnels currently TRACKED as `oc-direct-<connId>` (i.e. ones the
+// operator opened) are monitored — we never auto-establish a tunnel nobody
+// asked for. A dead tunnel stays tracked (nothing prunes the map on ssh exit),
+// so it remains visible to the monitor and gets rebuilt. On server restart the
+// in-memory tracking resets; the operator's next open re-tracks it.
+
+const tunnel = require('./tunnel');
+const { createLogger } = require('./logger');
+
+const log = createLogger('tunnel-monitor');
+
+const DEFAULT_INTERVAL_MS = 45 * 1000;
+const BASE_BACKOFF_MS = 45 * 1000;
+const MAX_BACKOFF_MS = 10 * 60 * 1000;
+const KEY_PREFIX = 'oc-direct-';
+
+const _backoff = new Map(); // connId -> { failures, nextAttemptAt }
+let _timer = null;
+
+/**
+ * Extract a connection id from a tunnel tracking key, or null if it isn't an
+ * operator-opened OpenClaw connection tunnel.
+ * @param {string} key
+ * @returns {string|null}
+ */
+function _connIdFromKey(key) {
+  return typeof key === 'string' && key.startsWith(KEY_PREFIX) ? key.slice(KEY_PREFIX.length) : null;
+}
+
+/**
+ * Whether a connection is eligible for a recreate attempt right now (not inside
+ * its backoff window).
+ * @param {string} connId
+ * @param {number} now - epoch ms
+ * @returns {boolean}
+ */
+function _eligible(connId, now) {
+  const bo = _backoff.get(connId);
+  return !bo || bo.nextAttemptAt <= now;
+}
+
+/**
+ * Check one connection's tunnel and recreate it if dead. Pure of timers —
+ * `now` is injected so tests are deterministic.
+ * @param {object} conn - OpenClaw connection record
+ * @param {number} now - epoch ms
+ * @returns {Promise<{outcome:string, error?:string}>}
+ */
+async function _checkOne(conn, now) {
+  if (!conn || !conn.localPort) return { outcome: 'skip:no-conn' };
+  if (!_eligible(conn.id, now)) return { outcome: 'skip:backoff' };
+
+  const alive = await _internal.roundTrip(conn.localPort);
+  if (alive) {
+    _backoff.delete(conn.id); // healthy → clear any backoff
+    return { outcome: 'healthy' };
+  }
+
+  log.warn('Tunnel down — auto-recreating', { connId: conn.id, localPort: conn.localPort });
+  const extraForwards = conn.bridgePort
+    ? [{ localPort: conn.bridgePort, remotePort: conn.bridgePort }]
+    : [];
+  let res;
+  try {
+    res = await _internal.ensure(`${KEY_PREFIX}${conn.id}`, {
+      host: conn.host,
+      port: conn.port,
+      localPort: conn.localPort,
+      sshUser: conn.sshUser,
+      sshKeyPath: conn.sshKeyPath,
+      force: true,
+      extraForwards
+    });
+  } catch (err) {
+    res = { ok: false, error: err.message };
+  }
+
+  if (res && res.ok) {
+    _backoff.delete(conn.id);
+    log.info('Tunnel auto-recreated', { connId: conn.id, localPort: conn.localPort, forwardTarget: res.forwardTarget });
+    return { outcome: 'recreated' };
+  }
+
+  // Failed — back off so a truly-down gateway doesn't hot-loop.
+  const failures = (_backoff.get(conn.id)?.failures || 0) + 1;
+  const delay = Math.min(BASE_BACKOFF_MS * Math.pow(2, failures - 1), MAX_BACKOFF_MS);
+  _backoff.set(conn.id, { failures, nextAttemptAt: now + delay });
+  log.warn('Tunnel recreate failed — backing off', { connId: conn.id, failures, delayMs: delay, error: res && res.error });
+  return { outcome: 'failed', error: res && res.error };
+}
+
+/**
+ * One monitor pass over all tracked oc-direct tunnels.
+ * @param {number} now - epoch ms (injected for tests)
+ * @returns {Promise<object[]>} per-connection results
+ */
+async function tick(now) {
+  const results = [];
+  let tracked;
+  try {
+    tracked = _internal.listTunnels();
+  } catch (err) {
+    log.warn('tunnel-monitor tick: listTunnels failed', { error: err.message });
+    return results;
+  }
+  for (const t of tracked) {
+    const connId = _connIdFromKey(t && t.projectName);
+    if (!connId) continue;
+    const conn = _internal.getConn(connId);
+    if (!conn) continue;
+    try {
+      results.push({ connId, ...(await _checkOne(conn, now)) });
+    } catch (err) {
+      log.warn('tunnel-monitor: check threw', { connId, error: err.message });
+    }
+  }
+  return results;
+}
+
+/**
+ * Start the periodic monitor. Idempotent. The timer is unref'd so it never
+ * keeps the process alive on its own.
+ * @param {number} [intervalMs]
+ */
+function start(intervalMs = DEFAULT_INTERVAL_MS) {
+  if (_timer) return;
+  _timer = setInterval(() => { tick(Date.now()).catch(() => {}); }, intervalMs);
+  if (_timer.unref) _timer.unref();
+  log.info('tunnel-monitor started', { intervalMs });
+}
+
+/**
+ * Stop the monitor and clear backoff state.
+ */
+function stop() {
+  if (_timer) {
+    clearInterval(_timer);
+    _timer = null;
+  }
+  _backoff.clear();
+}
+
+// Injectable seam for tests.
+const _internal = {
+  roundTrip: (port) => tunnel.httpRoundTrip(port),
+  ensure: (name, cfg) => tunnel.ensureTunnel(name, cfg),
+  listTunnels: () => tunnel.listTunnels(),
+  getConn: (id) => require('./store').openclawConnections.get(id)
+};
+
+module.exports = { start, stop, tick, _checkOne, _connIdFromKey, _eligible, _backoff, _internal,
+  DEFAULT_INTERVAL_MS, BASE_BACKOFF_MS, MAX_BACKOFF_MS };

--- a/server.js
+++ b/server.js
@@ -26,6 +26,7 @@ const evalAudit = require('./lib/eval-audit');
 const pidfile = require('./lib/pidfile');
 const sidecar = require('./lib/sidecar');
 const openclawVersion = require('./lib/openclaw-version');
+const tunnelMonitor = require('./lib/tunnel-monitor');
 const httpsSetup = require('./lib/https-setup');
 const ttydWatcher = require('./lib/ttyd-watcher');
 
@@ -3337,6 +3338,10 @@ if (require.main === module) {
     });
     // Start ttyd zombie-child watcher (#94). macOS-only; no-op elsewhere.
     ttydWatcher.start();
+    // Start OpenClaw tunnel liveness monitor (#294) — auto-recreates tunnels
+    // that die out from under an open Web UI so they self-heal without a
+    // manual re-launch.
+    tunnelMonitor.start();
   });
 
   // Graceful shutdown
@@ -3350,6 +3355,7 @@ if (require.main === module) {
     evalAudit.stopWatchdog();
     sidecar.stopAllPolling();
     ttydWatcher.stop();
+    tunnelMonitor.stop();
     clearInterval(_lockExpiryInterval);
     server.close();
     store.close();

--- a/test/tunnel-monitor.test.js
+++ b/test/tunnel-monitor.test.js
@@ -1,0 +1,125 @@
+'use strict';
+
+// #294 — periodic tunnel liveness + auto-recreate. Exercised through the
+// `_internal` seam (injected roundTrip/ensure/listTunnels/getConn) and an
+// injected `now`, so it's deterministic with no real timers, ssh, or sockets.
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const { setLevel } = require('../lib/logger');
+
+setLevel('error');
+
+const mon = require('../lib/tunnel-monitor');
+
+const conn = (over = {}) => ({
+  id: 'c1', host: 'h', port: 18789, localPort: 18789, sshUser: 'u', sshKeyPath: '~/.ssh/k', bridgePort: null, ...over
+});
+
+describe('tunnel-monitor (#294)', () => {
+  let saved;
+  beforeEach(() => { saved = { ...mon._internal }; mon._backoff.clear(); });
+  afterEach(() => { Object.assign(mon._internal, saved); mon._backoff.clear(); mon.stop(); });
+
+  describe('_connIdFromKey', () => {
+    it('extracts the connId from an oc-direct- key', () => {
+      assert.equal(mon._connIdFromKey('oc-direct-abc-123'), 'abc-123');
+    });
+    it('returns null for non-oc-direct keys', () => {
+      assert.equal(mon._connIdFromKey('some-project'), null);
+      assert.equal(mon._connIdFromKey(null), null);
+    });
+  });
+
+  describe('_checkOne', () => {
+    it('healthy tunnel → no recreate, backoff cleared', async () => {
+      let ensured = false;
+      mon._internal.roundTrip = async () => true;
+      mon._internal.ensure = async () => { ensured = true; return { ok: true }; };
+      const r = await mon._checkOne(conn(), 1000);
+      assert.equal(r.outcome, 'healthy');
+      assert.equal(ensured, false, 'a healthy tunnel is never rebuilt');
+    });
+
+    it('dead tunnel → recreates with force + the bridge forward', async () => {
+      let calledWith = null;
+      mon._internal.roundTrip = async () => false;
+      mon._internal.ensure = async (name, cfg) => { calledWith = { name, cfg }; return { ok: true, forwardTarget: '127.0.0.1' }; };
+      const r = await mon._checkOne(conn({ bridgePort: 3201 }), 1000);
+      assert.equal(r.outcome, 'recreated');
+      assert.equal(calledWith.name, 'oc-direct-c1');
+      assert.equal(calledWith.cfg.force, true);
+      assert.deepEqual(calledWith.cfg.extraForwards, [{ localPort: 3201, remotePort: 3201 }]);
+      assert.equal(mon._backoff.has('c1'), false);
+    });
+
+    it('dead + recreate fails → backs off, then skips inside the window', async () => {
+      mon._internal.roundTrip = async () => false;
+      mon._internal.ensure = async () => ({ ok: false, error: 'ssh failed' });
+      const r1 = await mon._checkOne(conn(), 1000);
+      assert.equal(r1.outcome, 'failed');
+      const bo = mon._backoff.get('c1');
+      assert.equal(bo.failures, 1);
+      assert.ok(bo.nextAttemptAt > 1000);
+
+      let touched = false;
+      mon._internal.roundTrip = async () => { touched = true; return false; };
+      const r2 = await mon._checkOne(conn(), 1001); // still inside backoff window
+      assert.equal(r2.outcome, 'skip:backoff');
+      assert.equal(touched, false, 'no probe/ensure while backing off');
+    });
+
+    it('backoff escalates and is capped at MAX_BACKOFF_MS', async () => {
+      mon._internal.roundTrip = async () => false;
+      mon._internal.ensure = async () => ({ ok: false, error: 'down' });
+      let now = 0;
+      const delays = [];
+      for (let i = 0; i < 12; i++) {
+        await mon._checkOne(conn(), now);
+        const bo = mon._backoff.get('c1');
+        delays.push(bo.nextAttemptAt - now);
+        now = bo.nextAttemptAt; // advance past the window for the next attempt
+      }
+      assert.ok(delays[1] > delays[0], 'delay escalates');
+      assert.ok(delays[delays.length - 1] <= mon.MAX_BACKOFF_MS, 'capped');
+    });
+
+    it('recovery after failures clears backoff', async () => {
+      mon._internal.roundTrip = async () => false;
+      mon._internal.ensure = async () => ({ ok: false });
+      await mon._checkOne(conn(), 0);
+      assert.ok(mon._backoff.has('c1'));
+      mon._internal.roundTrip = async () => true; // gateway back
+      const r = await mon._checkOne(conn(), mon._backoff.get('c1').nextAttemptAt);
+      assert.equal(r.outcome, 'healthy');
+      assert.equal(mon._backoff.has('c1'), false);
+    });
+  });
+
+  describe('tick', () => {
+    it('checks only oc-direct tunnels backed by a known connection', async () => {
+      mon._internal.listTunnels = () => [
+        { projectName: 'oc-direct-c1', localPort: 18789 },
+        { projectName: 'some-project', localPort: 4000 },    // not oc-direct → skip
+        { projectName: 'oc-direct-gone', localPort: 18800 }  // unknown conn → skip
+      ];
+      mon._internal.getConn = (id) => (id === 'c1' ? conn() : null);
+      const probed = [];
+      mon._internal.roundTrip = async (p) => { probed.push(p); return true; };
+      const results = await mon.tick(1000);
+      assert.deepEqual(probed, [18789], 'only the known oc-direct connection is probed');
+      assert.equal(results.length, 1);
+      assert.equal(results[0].connId, 'c1');
+    });
+  });
+
+  describe('start/stop', () => {
+    it('start is idempotent and stop clears state', () => {
+      mon._internal.listTunnels = () => [];
+      mon.start(10000);
+      mon.start(10000); // no-op (already running)
+      mon.stop();
+      assert.equal(mon._backoff.size, 0);
+    });
+  });
+});


### PR DESCRIPTION
## What
A background monitor that keeps OpenClaw tunnels alive — fixes the "tunnel connects, then doesn't persist → Web UI black-screens" loop you hit repeatedly.

## Why
An `ssh -f -N -L` tunnel dies on its own (transport flap, or the remote gateway container restarting) and **nothing rebuilds it** — so the connection reads dead until a manual re-launch. Observed live: opening the Web UI worked only when the tunnel happened to be up; when it had dropped, black page + "test connection" fails.

## How
`lib/tunnel-monitor.js` (started at server boot, stopped on shutdown):
- Every 45s, end-to-end probes each **tracked** `oc-direct-<connId>` tunnel via `httpRoundTrip` (#288).
- Rebuilds any that died via `ensureTunnel({force:true})` — re-resolving the connection config and re-picking the IPv4/`[::1]` forward target (#291).
- **Per-connection exponential backoff** (45s → capped 10min, clears on recovery) so a genuinely-down gateway doesn't hot-loop.
- Scope-limited to tunnels the operator actually opened (never auto-establishes an unopened one); `unref`'d timer; `stop()` on graceful shutdown.

## Test plan
- Full suite **2675 pass / 0 fail / 1 pre-existing skip**.
- New `test/tunnel-monitor.test.js` (9, via an injectable `_internal` seam + injected `now`, no real timers/ssh): key parsing, healthy→no-rebuild, dead→recreate-with-force+bridge-forward, recreate-failure→backoff→skip-in-window, backoff escalation + cap, recovery clears backoff, `tick` filters to known oc-direct connections, start-idempotent/stop-clears.
- **Critic** (cumulative): 0 blocking, 0 warning, 0 note.

## Note
Takes effect after a server restart (loads the new code + starts the monitor).

Fixes #294