### PR TITLE
Fix priming-roll blocking clean wraps when all plans are archived (#302)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **priming-roll wrap step no longer BLOCKS a clean wrap when `.claude/plans/` has no active plan (#302).** When every build plan has been archived to `.claude/plans/archive/` (per CLAUDE.md's plan-archiving rule), the active plans dir is empty — there is no pointer to roll. `_resolvePlanPath` already treated the conceptually-identical "several plans, none in-progress" case as a clean **skip** (`priming-roll.js`), but the zero-plans branch returned a bare error with no `skip` flag, so the handler fell through to **BLOCKED**. Every clean wrap on a fully-shipped project showed a spurious red BLOCKED row. The empty-dir branch now mirrors its sibling and skips with a "nothing to roll" reason. The non-recursive `.md` filter already ignored the `archive/` subdir, so archived plans were never miscounted — the only defect was the missing skip flag. **Tests.** Updated the now-inverted "empty plans dir" case and added a regression test reproducing the exact reported scenario (all plans under `archive/`, empty top level → skips).
+
 ## [3.25.0] - 2026-06-02
 
 ### Added

--- a/lib/wrap-steps/priming-roll.js
+++ b/lib/wrap-steps/priming-roll.js
@@ -280,6 +280,10 @@ function _readActivePlan(projectPath) {
  *   4. several plans → the single in-progress one (auto-disambiguation);
  *      zero in-progress → skip ("all plans complete"); more than one
  *      in-progress → block with `remediation`.
+ *   5. zero `.md` plans in `.claude/plans/` → skip ("nothing to roll"):
+ *      same meaning as zero-in-progress, the well-behaved all-archived
+ *      end state (#302). The `.md` filter is non-recursive, so an
+ *      `archive/` subdir of shipped plans does not count.
  *
  * @param {string} projectPath
  * @param {object} step - Step spec
@@ -354,7 +358,17 @@ function _resolvePlanPath(projectPath, step) {
   }
   const entries = _internal.readdirSync(plansDir).filter((f) => f.endsWith('.md'));
   if (entries.length === 0) {
-    return { ok: false, error: `No .md plans found in ${DEFAULT_PLANS_DIR}` };
+    // No active plan to roll — same meaning as "several plans, none
+    // in-progress" below, so skip cleanly rather than block (#302). This
+    // is the well-behaved end state: a project that has shipped and
+    // archived all its plans (per CLAUDE.md's archive rule) leaves the
+    // active `.claude/plans/` dir empty (the `.md` filter above ignores
+    // the `archive/` subdir). Blocking that state failed every clean wrap.
+    return {
+      ok: false,
+      skip: true,
+      reason: `No .md plans found in ${DEFAULT_PLANS_DIR} (all plans archived or none authored) — nothing to roll`
+    };
   }
   if (entries.length === 1) {
     return { ok: true, planPath: path.join(plansDir, entries[0]) };

--- a/test/wrap-pipeline.test.js
+++ b/test/wrap-pipeline.test.js
@@ -1567,11 +1567,31 @@ describe('wrap-step priming-roll — handler (#139 Chunk 6)', () => {
     assert.match(result.blockers[0], /No plans directory/);
   });
 
-  it('blocks when .claude/plans is empty', async () => {
+  it('skips (not blocks) when .claude/plans is empty (#302)', async () => {
+    // An empty active plans dir means "no plan to roll" — same as the
+    // all-complete case below. Must skip cleanly, not block the wrap.
     fs.mkdirSync(path.join(projectPath, '.claude', 'plans'), { recursive: true });
     const result = await primingRoll.run(buildContext({ id: 'next-session-prime' }));
-    assert.equal(result.ok, false);
-    assert.match(result.blockers[0], /No \.md plans found/);
+    assert.equal(result.ok, true, 'an empty active plans dir must not block the wrap');
+    assert.equal(result.status, 'skipped');
+    assert.match(result.output.reason, /No \.md plans found/i);
+    assert.deepEqual(result.blockers, []);
+  });
+
+  it('skips when all plans are archived under .claude/plans/archive/ (#302 repro)', async () => {
+    // The exact reported scenario: every shipped plan has been moved to
+    // the archive subdir (per CLAUDE.md's archive rule), leaving the
+    // active dir holding only `archive/`. The non-recursive `.md` filter
+    // must ignore the subdir's plans, so the step skips rather than
+    // mistaking 20 archived plans for active ones.
+    const archiveDir = path.join(projectPath, '.claude', 'plans', 'archive');
+    fs.mkdirSync(archiveDir, { recursive: true });
+    fs.writeFileSync(path.join(archiveDir, 'shipped-a.md'), '### Chunk 1: A ✅\n');
+    fs.writeFileSync(path.join(archiveDir, 'shipped-b.md'), '### Chunk 1: B\n'); // undone, but archived
+    const result = await primingRoll.run(buildContext({ id: 'next-session-prime' }));
+    assert.equal(result.ok, true, 'archived plans must not count as active');
+    assert.equal(result.status, 'skipped');
+    assert.match(result.output.reason, /nothing to roll/i);
   });
 
   it('blocks when multiple plans are in progress and none can be auto-picked (#226)', async () => {


### PR DESCRIPTION
## What

Makes the `priming-roll` wrap step **SKIP** (not BLOCK) when `.claude/plans/` has no active `.md` plan — the state you reach when every shipped plan has been moved to `.claude/plans/archive/` per CLAUDE.md's archive rule.

## Why

`_resolvePlanPath` (`lib/wrap-steps/priming-roll.js`) already treats the conceptually-identical *"several plans, none in-progress"* case as a clean skip, with the comment *"a project that finished its plans shouldn't fail its wrap."* But the **zero-plans-in-directory** branch returned a bare `error` with no `skip: true` flag, so the handler fell through to BLOCKED.

Result: every clean Session Wrap on a fully-shipped project (all plans archived) showed a spurious red **BLOCKED** row for *Roll priming pointer — next-session-prime*. This is exactly what surfaced in the 2026-06-02 wrap. The empty-dir branch simply forgot to set the skip flag; this PR makes it mirror its sibling.

The non-recursive `.md` filter already ignored the `archive/` subdir, so the 20 archived plans were never miscounted — the only defect was the missing skip flag.

## Test plan

- `node --test --test-name-pattern="priming-roll" test/wrap-pipeline.test.js` → **49/49 pass**.
- Inverted the now-stale `'blocks when .claude/plans is empty'` test to assert `ok:true` / `status:skipped`.
- Added a regression test reproducing the exact reported scenario: all plans under `archive/`, empty top level → skips with a "nothing to roll" reason.

Fixes #302