### PR TITLE
Always render OpenClaw Version row in connection detail (#306)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **OpenClaw Version row always renders in the connection detail list (#306).** Previously the `Version` row in an expanded OpenClaw connection card (`public/ui.js`) only appeared when the connection had an `instanceDir` configured — so connections without it showed no Version row at all, making the #296 version display look absent. The row is now unconditional: when `instanceDir` is set it shows the async-fetched OpenClaw image tag (unchanged), and when it isn't it shows a muted, actionable **"Set Instance Dir to enable"** hint with a tooltip explaining how to turn it on. The async version fetch still only runs for connections that have an `instanceDir` (the hint branch has no value to populate). New `.oc-detail-muted` style for the hint. **Tests.** New `test/openclaw-version-row.test.js` (5) locks the always-render label, both value branches, the fetch-guard, and the CSS rule.
+
 ### Fixed
 
 - **OpenClaw version display works for locally-built / custom-tagged images (#308).** `parseVersion` (`lib/openclaw-version.js`) required the `OPENCLAW_IMAGE` value to contain the canonical `openclaw/openclaw:` registry path, so an image like `openclaw:qmd` (a local build) failed to parse and the connection showed "unknown". It now extracts the tag generically — the substring after the reference's last `:`, unless that substring contains a `/` (a registry host:port, not a tag) — handling `ghcr.io/openclaw/openclaw:<tag>`, `openclaw:qmd`, `openclaw:latest`, and `registry:5000/openclaw:tag`. **Tests.** +4 regression cases (bare tag, custom registry, host:port guard, untagged ref).

--- a/public/style.css
+++ b/public/style.css
@@ -684,6 +684,13 @@ body {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+/* #306: muted hint shown in the Version row when a connection has no
+   instanceDir configured, so the row is always present (discoverable)
+   rather than silently omitted. */
+.oc-detail-value.oc-detail-muted {
+  color: var(--text-muted);
+  font-style: italic;
+}
 .oc-tunnel-status {
   display: flex;
   align-items: center;

--- a/public/ui.js
+++ b/public/ui.js
@@ -1821,7 +1821,9 @@ function renderOpenclawConnections() {
       <span class="oc-detail-label">SSH Key</span><span class="oc-detail-value" style="font-family:monospace;font-size:0.85em">${esc(conn.sshKeyPath)}</span>
       <span class="oc-detail-label">CLI Command</span><span class="oc-detail-value" style="font-family:monospace;font-size:0.85em">${esc(conn.cliCommand || 'openclaw-cli')}</span>
       <span class="oc-detail-label">Local Port</span><span class="oc-detail-value">${conn.localPort}</span>
-      ${conn.instanceDir ? `<span class="oc-detail-label">Version</span><span class="oc-detail-value" id="ocVer-${esc(conn.id)}" title="OpenClaw instance image tag (${esc(conn.instanceDir)}/.env)">checking…</span>` : ''}
+      <span class="oc-detail-label">Version</span>${conn.instanceDir
+        ? `<span class="oc-detail-value" id="ocVer-${esc(conn.id)}" title="OpenClaw instance image tag (${esc(conn.instanceDir)}/.env)">checking…</span>`
+        : `<span class="oc-detail-value oc-detail-muted" title="Set this connection's Instance Dir (Edit → Instance Dir) to read its OpenClaw image tag over SSH">Set Instance Dir to enable</span>`}
       <span class="oc-detail-label">Engine</span><span class="oc-detail-value">${conn.availableAsEngine ? 'Yes' : 'No'}</span>
     </div>`;
     // Tunnel status + kill button
@@ -1845,7 +1847,9 @@ function renderOpenclawConnections() {
 
   // #296: populate each connection's OpenClaw version asynchronously (the
   // endpoint reads the instance .env over SSH; server-side cached, so repeated
-  // renders are cheap). Only connections with instanceDir render a Version row.
+  // renders are cheap). Every connection renders a Version row (#306), but only
+  // those with an instanceDir have a fetchable `ocVer-<id>` value to populate —
+  // the rest already show a static "Set Instance Dir to enable" hint.
   for (const conn of state.openclawConnections) {
     if (!conn.instanceDir) continue;
     const el = document.getElementById(`ocVer-${conn.id}`);

--- a/test/openclaw-version-row.test.js
+++ b/test/openclaw-version-row.test.js
@@ -1,0 +1,74 @@
+'use strict';
+
+/*
+ * Frontend regression tests for #306 — the OpenClaw Version row in the
+ * connection detail list (public/ui.js renderOpenclawConnections) is now
+ * ALWAYS rendered, not gated behind `conn.instanceDir`.
+ *
+ * Before #306 the entire `Version` label+value was wrapped in
+ * `${conn.instanceDir ? ... : ''}`, so a connection without an Instance Dir
+ * showed no Version row at all — making the #296 version-display feature look
+ * absent. Now the label is unconditional; only the *value* branches:
+ *   - instanceDir set   → async-fetched `ocVer-<id>` value (current behavior)
+ *   - instanceDir unset → muted "Set Instance Dir to enable" hint
+ *
+ * ui.js renders DOM via innerHTML strings and has many top-level deps, so
+ * source-level structural assertions are the pragmatic contract lock-in —
+ * the same pattern used in test/settings-modal-silentprime.test.js and
+ * test/session-wrapper.test.js.
+ */
+
+const { describe, it, before } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+describe('OpenClaw connection detail — Version row always renders (#306)', () => {
+  let src;
+  let css;
+
+  before(() => {
+    src = fs.readFileSync(path.join(__dirname, '..', 'public', 'ui.js'), 'utf8');
+    css = fs.readFileSync(path.join(__dirname, '..', 'public', 'style.css'), 'utf8');
+  });
+
+  it('renders the Version label unconditionally (not wrapped in a conn.instanceDir guard)', () => {
+    // The label must NOT be inside `${conn.instanceDir ? <label+value> : ''}`.
+    // Regression guard: the pre-#306 form gated the whole label away.
+    assert.doesNotMatch(
+      src,
+      /\$\{conn\.instanceDir\s*\?\s*`<span class="oc-detail-label">Version<\/span>/,
+      'the Version label must not be gated behind conn.instanceDir (pre-#306 bug)'
+    );
+    // The label is emitted before the value branch.
+    assert.match(
+      src,
+      /<span class="oc-detail-label">Version<\/span>\$\{conn\.instanceDir/,
+      'Version label should be unconditional, immediately followed by the instanceDir value branch'
+    );
+  });
+
+  it('keeps the async-fetched value (ocVer-<id> + "checking…") on the instanceDir-set branch', () => {
+    assert.match(src, /id="ocVer-\$\{esc\(conn\.id\)\}"/);
+    assert.match(src, /checking…/);
+    // The fetchable value still carries the instance .env tooltip.
+    assert.match(src, /OpenClaw instance image tag \(\$\{esc\(conn\.instanceDir\)\}\/\.env\)/);
+  });
+
+  it('shows a muted, actionable hint when instanceDir is unset', () => {
+    assert.match(src, /oc-detail-value oc-detail-muted/);
+    assert.match(src, /Set Instance Dir to enable/);
+    // The hint's tooltip tells the operator how to enable it.
+    assert.match(src, /Set this connection's Instance Dir.*to read its OpenClaw image tag over SSH/);
+  });
+
+  it('still only async-fetches versions for connections with an instanceDir', () => {
+    // The hint branch has no ocVer-<id> element to populate, so the fetch loop
+    // must keep skipping connections without an instanceDir.
+    assert.match(src, /for \(const conn of state\.openclawConnections\)\s*\{\s*\n\s*if \(!conn\.instanceDir\) continue;/);
+  });
+
+  it('defines the .oc-detail-muted style used by the hint', () => {
+    assert.match(css, /\.oc-detail-value\.oc-detail-muted\s*\{[^}]*var\(--text-muted\)/);
+  });
+});


### PR DESCRIPTION
## What

Makes the **Version** row in the expanded OpenClaw connection detail list always render. When the connection has an Instance Dir set it shows the OpenClaw image tag (existing async-over-SSH behavior); when it doesn't, it shows a muted *"Set Instance Dir to enable"* hint instead of omitting the row.

![where it shows](n/a)

## Why

The #296 version display was gated behind `conn.instanceDir` (`public/ui.js`), so connections without that field configured showed **no Version row at all** — which reads as the feature having been lost. Always showing the row (with an actionable hint when unconfigured) makes the capability discoverable and self-documenting, matching the rest of the always-present detail fields (Host, Port, Engine, …).

Note: actual version *values* still require the connection's Instance Dir to be set (the version is read from `<instanceDir>/.env`'s `OPENCLAW_IMAGE` tag over SSH). This PR is about the row's presence + discoverability; the hint tells operators how to populate it.

## Test plan

- `node --test test/openclaw-version-row.test.js` → **5/5 pass**.
- New structural tests (same source-assertion pattern as `settings-modal-silentprime.test.js`) lock: the unconditional Version label, the instanceDir-set value branch (`ocVer-<id>` + tooltip), the muted-hint branch, the async fetch-guard still skipping connections without instanceDir, and the new `.oc-detail-muted` CSS rule.

Fixes #306