### PR TITLE
Exempt /openclaw-direct/* and /manifest.json from the caddy basic_auth gate (fix the password-prompt loop)

### DIFF
--- a/lib/caddy.js
+++ b/lib/caddy.js
@@ -110,10 +110,21 @@ function detectCaddy() {
   }
 }
 
-// Named matcher for the auth-bypass: every request EXCEPT the health endpoint is
-// gated. `/api/health` stays open so the ingress cutover's health probe — and any
-// launchd/liveness check — reaches TC without credentials (the probe has none).
-const AUTH_BYPASS_PATH = '/api/health';
+// Named matcher for the auth-bypass: every request EXCEPT these paths is gated.
+// - `/api/health` stays open so the ingress cutover's health probe — and any
+//   launchd/liveness check — reaches TC without credentials (the probe has none).
+// - `/openclaw-direct/*` stays open because the OpenClaw web UI sends its OWN
+//   Authorization header (gateway token) on its API/WS calls. A request carries
+//   only one Authorization header, so the token displaces the browser's cached
+//   basic_auth credential; basic_auth then 401s the token as a bad password,
+//   and that 401 makes the browser discard the cached credential for the whole
+//   origin and re-prompt in a loop (2026-07-04 popup-loop incident). The
+//   OpenClaw gateway enforces its own token + device-identity auth on these
+//   paths, so bypassing the caddy gate does not leave them open.
+// - `/manifest.json` stays open because browsers fetch PWA manifests in
+//   anonymous mode (no credentials), so a gated manifest pops one extra auth
+//   prompt per page load. The manifest is static, public-safe app metadata.
+const AUTH_BYPASS_PATHS = ['/api/health', '/openclaw-direct/*', '/manifest.json'];
 
 /**
  * Append a Caddy site block to `lines`. Emits an optional `tls` directive and an
@@ -137,10 +148,12 @@ function _pushSiteBlock(lines, siteHeader, block) {
     lines.push(`\ttls ${block.tls.certPath} ${block.tls.keyPath}`);
   }
   if (block.auth) {
-    // Gate everything except the health endpoint. `basic_auth` runs before
-    // `reverse_proxy` in Caddy's directive order, so unauthenticated requests to
-    // any other path are challenged before they reach the upstream.
-    lines.push(`\t@protected not path ${AUTH_BYPASS_PATH}`);
+    // Gate everything except the bypass paths (health probe, OpenClaw's
+    // own-auth proxy, credential-less manifest fetch — see AUTH_BYPASS_PATHS).
+    // `basic_auth` runs before `reverse_proxy` in Caddy's directive order, so
+    // unauthenticated requests to any other path are challenged before they
+    // reach the upstream.
+    lines.push(`\t@protected not path ${AUTH_BYPASS_PATHS.join(' ')}`);
     lines.push('\tbasic_auth @protected {');
     lines.push(`\t\t${block.auth.user} ${block.auth.hash}`);
     lines.push('\t}');
@@ -172,7 +185,8 @@ function _pushSiteBlock(lines, siteHeader, block) {
  * Let's Encrypt (ACME) certificate for it.
  *
  * When `basicAuthUser` + `basicAuthHash` are supplied (AUTH-2), every site block
- * gains a `basic_auth` gate over all paths except `/api/health`. The gate is the
+ * gains a `basic_auth` gate over all paths except AUTH_BYPASS_PATHS
+ * (`/api/health`, `/openclaw-direct/*`, `/manifest.json`). The gate is the
  * stored bcrypt hash (never a plaintext password); the wizard hashes via
  * `caddy hash-password` and persists only the hash. Both are required together —
  * a half-set pair throws, so a misconfigured gate can never silently produce an

--- a/test/caddy.test.js
+++ b/test/caddy.test.js
@@ -196,8 +196,26 @@ describe('caddy', () => {
 
     it('keeps /api/health out of the gate (health probe needs no credentials)', () => {
       const out = caddy.buildCaddyfileContent({ ...opts, ...AUTH });
-      // The gate references "@protected = not path /api/health", so health is open.
-      assert.match(out, /@protected not path \/api\/health/);
+      // The gate references "@protected = not path <bypass list>", so health is open.
+      assert.match(out, /@protected not path \/api\/health /);
+    });
+
+    it('keeps /openclaw-direct/* out of the gate (OpenClaw sends its own Authorization header; a basic_auth 401 there poisons the browser credential cache → prompt loop)', () => {
+      const out = caddy.buildCaddyfileContent({ ...opts, ...AUTH });
+      assert.match(out, /@protected not path \/api\/health \/openclaw-direct\/\* \/manifest\.json/);
+    });
+
+    it('keeps /manifest.json out of the gate (browsers fetch PWA manifests credential-less — a gated manifest pops an auth prompt per page load)', () => {
+      const out = caddy.buildCaddyfileContent({ ...opts, ...AUTH });
+      assert.match(out, / \/manifest\.json$/m);
+    });
+
+    it('applies the same bypass list to every gated site block (local + public + remote catch-all)', () => {
+      const out = caddy.buildCaddyfileContent({
+        ...opts, ...AUTH, publicDomain: 'tc.example.com', remoteHttpCatchAll: true
+      });
+      const matcherLines = out.match(/@protected not path \/api\/health \/openclaw-direct\/\* \/manifest\.json/g) || [];
+      assert.equal(matcherLines.length, 3);
     });
 
     it('gates the public ACME site too when publicDomain + auth are set', () => {


### PR DESCRIPTION
## What

Widens the `basic_auth` bypass matcher emitted by `buildCaddyfileContent` from `/api/health` alone to:

```
@protected not path /api/health /openclaw-direct/* /manifest.json
```

`AUTH_BYPASS_PATH` (string) becomes `AUTH_BYPASS_PATHS` (list); the matcher is applied identically to every gated site block (local, public ACME, remote plain-HTTP catch-all).

## Why

Fixes #471 — the 2026-07-04 password-prompt loop:

- The OpenClaw UI at `/openclaw-direct/*` sends its own `Authorization` header (gateway token). caddy's gate 401'd it as a bad Basic password, which made the browser drop its cached credential for the whole origin and re-prompt endlessly. The gateway does its own token + device-identity auth on these paths, so they are not left open by the bypass.
- Browsers fetch `/manifest.json` credential-less, so the gated manifest added one extra prompt per page load.

The equivalent hand-edit is live on Cursatory and verified: the loop stopped immediately (see #471 for the access-log forensics).

## Testing

- `node --test test/caddy.test.js` — 68 pass, including 3 new cases: `/openclaw-direct/*` bypass, `/manifest.json` bypass, and identical matcher on all three gated site blocks.
- `node --test test/auth-credential-durability.test.js test/ingress-cutover.test.js test/contracts.test.js` — all pass.
- `caddy validate` on generated output (localhost + remote catch-all + auth): `Valid configuration`.

## Notes

- Does not touch #470 (WS proxy forwarding browser Basic auth to the gateway) — that remains the proper server-side fix for the other direction of the same collision.
- Does not make the live tailnet HTTPS site / blanket redirect reproducible (#434 scope); the live Caddyfile on Cursatory is still hand-edited beyond what the generator emits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
