### PR TITLE
Teach buildCaddyfileContent the tailnet HTTPS site + case-sensitive gate (#434 Chunk 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Security
+
+- **`buildCaddyfileContent` gates with a case-sensitive `path_regexp` matcher instead of the case-insensitive `path` matcher (#434, folds in #472 Critic residual-risk #2).** Caddy's `path` matcher is case-insensitive, so a request to `/OPENCLAW-DIRECT/x` (or `/API/HEALTH`) slipped past the `not path` bypass gate; TC's case-sensitive router then missed the proxy route and served the unauthenticated SPA shell. The bypass is now an anchored RE2 regex (`^(/api/health|/openclaw-direct/.*|/manifest\.json)$`, case-sensitive, `.` escaped literal) applied to every gated site block, so only exact-cased bypass paths are exempt. Verified with a live `caddy run` probe: uppercase variants → 401, correctly-cased paths bypass, path traversal (`/openclaw-direct/../api/system`) still 401 (Caddy canonicalizes before matching), authed requests reach the upstream. Tests in `test/caddy.test.js`.
+
+### Internal
+
+- **`buildCaddyfileContent` can now emit the tailnet HTTPS site + http→https redirect (#434, generator half).** New `tailnetHost` option: when set (with basic_auth — fail-closed guard, an ungated remote HTTPS site throws), the generator emits a gated HTTPS site for the tailnet FQDN (reusing the local mkcert cert, whose SAN must include the FQDN) plus an `http://<host>` → `https://<host>:<port>{uri}` redirect, and adds `auto_https disable_redirects` so the explicit redirect governs. This codifies the 2026-07-04 hand-edit that unblocked remote OpenClaw access (OpenClaw 2026.6.11+ Control UI requires a secure context). Not yet wired into config adoption or the cutover — that is #434 Chunk 2 — so no operator-visible behavior change yet; the generator is capability-only. Tests in `test/caddy.test.js`.
+
 ## [4.2.0] - 2026-07-04
 
 ### Added

--- a/lib/caddy.js
+++ b/lib/caddy.js
@@ -127,6 +127,29 @@ function detectCaddy() {
 const AUTH_BYPASS_PATHS = ['/api/health', '/openclaw-direct/*', '/manifest.json'];
 
 /**
+ * Build a case-SENSITIVE anchored regex (RE2 syntax) matching exactly the
+ * AUTH_BYPASS_PATHS globs, for Caddy's `path_regexp` matcher.
+ *
+ * Caddy's `path` matcher is case-INSENSITIVE, so `/OPENCLAW-DIRECT/x` slips past
+ * a `not path /openclaw-direct/*` gate; TC's case-sensitive router then misses
+ * the proxy route and serves the SPA shell UNAUTHENTICATED (#472 Critic
+ * residual-risk #2, folded into #434). `path_regexp` uses RE2, case-sensitive by
+ * default, so the bypass matches only the exact casing. A trailing `/*` glob
+ * becomes a `/.*` prefix match; every other char is regex-escaped (so the `.` in
+ * `/manifest.json` stays literal, not "any char"). Anchored `^(...)$` for
+ * exactness. Caddy canonicalizes the request path before matching (traversal like
+ * `/openclaw-direct/../api/system` is normalized first), so the gate is preserved.
+ * @returns {string} e.g. `^(/api/health|/openclaw-direct/.*|/manifest\.json)$`
+ */
+function _bypassPathRegexp() {
+  const esc = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const alts = AUTH_BYPASS_PATHS.map((p) =>
+    p.endsWith('/*') ? `${esc(p.slice(0, -1))}.*` : esc(p)
+  );
+  return `^(${alts.join('|')})$`;
+}
+
+/**
  * Append a Caddy site block to `lines`. Emits an optional `tls` directive and an
  * optional `basic_auth` gate, then the `reverse_proxy` upstream. With no `auth`
  * the block is byte-for-byte what AUTH-1 emitted, so an ungated Caddyfile is
@@ -152,8 +175,10 @@ function _pushSiteBlock(lines, siteHeader, block) {
     // own-auth proxy, credential-less manifest fetch — see AUTH_BYPASS_PATHS).
     // `basic_auth` runs before `reverse_proxy` in Caddy's directive order, so
     // unauthenticated requests to any other path are challenged before they
-    // reach the upstream.
-    lines.push(`\t@protected not path ${AUTH_BYPASS_PATHS.join(' ')}`);
+    // reach the upstream. Uses `path_regexp` (case-sensitive RE2), NOT `path`
+    // (case-insensitive) — otherwise `/OPENCLAW-DIRECT/x` bypasses the gate and
+    // leaks the unauthenticated SPA shell (#472 Critic residual-risk #2).
+    lines.push(`\t@protected not path_regexp ${_bypassPathRegexp()}`);
     lines.push('\tbasic_auth @protected {');
     lines.push(`\t\t${block.auth.user} ${block.auth.hash}`);
     lines.push('\t}');
@@ -168,6 +193,25 @@ function _pushSiteBlock(lines, siteHeader, block) {
   } else {
     lines.push(`\treverse_proxy ${block.upstream}`);
   }
+  lines.push('}');
+}
+
+/**
+ * Append a plain-HTTP → HTTPS redirect site block for a single host. Used for the
+ * tailnet host: a browser landing on `http://<host>:<httpPort>` is bounced to the
+ * secure-context HTTPS origin. OpenClaw 2026.6.11+ Control UI requires a secure
+ * context, and a split http/https origin fractures the Basic-Auth credential
+ * cache (2026-07-04 popup-loop incident) — one HTTPS origin avoids both. The
+ * more-specific `http://<host>` block wins over any `http://` catch-all for this
+ * host, so both coexist. No gate here — `redir` fires before auth would run, and
+ * a redirect leaks nothing (the HTTPS destination still gates).
+ * @param {string[]} lines - Accumulator, mutated in place.
+ * @param {string} host - Bare hostname (the tailnet FQDN).
+ * @param {number} httpsPort - Destination HTTPS port.
+ */
+function _pushRedirectBlock(lines, host, httpsPort) {
+  lines.push(`http://${host} {`);
+  lines.push(`\tredir https://${host}:${httpsPort}{uri}`);
   lines.push('}');
 }
 
@@ -210,6 +254,14 @@ function _pushSiteBlock(lines, siteHeader, block) {
  *   ungated plain-HTTP catch-all would be an open door, so it throws. Also adds
  *   `auto_https disable_redirects` so Caddy serves the HTTP site instead of
  *   308-redirecting it to HTTPS before auth runs.
+ * @param {string|null} [options.tailnetHost=null] - Tailnet FQDN (e.g.
+ *   `cursatory.tail123678.ts.net`). When set, emits a gated HTTPS site for it
+ *   (reusing the local mkcert cert, whose SAN must include the FQDN) plus an
+ *   `http://<host>` → HTTPS redirect (#434 codification of the 2026-07-04
+ *   hand-edit; OpenClaw 2026.6.11+ needs a secure context). Requires basic_auth —
+ *   an ungated remote HTTPS site is an open door, so it throws. Also adds
+ *   `auto_https disable_redirects` (the explicit redirect must govern, not Caddy's
+ *   automatic one).
  * @returns {string} Caddyfile content.
  */
 function buildCaddyfileContent(options = {}) {
@@ -221,6 +273,7 @@ function buildCaddyfileContent(options = {}) {
   const basicAuthUser = options.basicAuthUser || null;
   const basicAuthHash = options.basicAuthHash || null;
   const remoteHttpCatchAll = options.remoteHttpCatchAll === true;
+  const tailnetHost = options.tailnetHost || null;
 
   if (!serverPort || typeof serverPort !== 'number') {
     throw new Error('buildCaddyfileContent: serverPort (number) is required');
@@ -238,6 +291,11 @@ function buildCaddyfileContent(options = {}) {
   if (remoteHttpCatchAll && !(basicAuthUser && basicAuthHash)) {
     throw new Error('buildCaddyfileContent: remoteHttpCatchAll requires basicAuthUser and basicAuthHash (an ungated plain-HTTP catch-all is an open door)');
   }
+  // A remote-reachable HTTPS site with no gate exposes the whole app to the
+  // tailnet — same fail-closed posture as the catch-all guard above.
+  if (tailnetHost && !(basicAuthUser && basicAuthHash)) {
+    throw new Error('buildCaddyfileContent: tailnetHost requires basicAuthUser and basicAuthHash (an ungated remote HTTPS site is an open door)');
+  }
 
   const upstream = `127.0.0.1:${serverPort}`;
   const auth = basicAuthUser && basicAuthHash ? { user: basicAuthUser, hash: basicAuthHash } : null;
@@ -251,9 +309,11 @@ function buildCaddyfileContent(options = {}) {
   lines.push(`\thttps_port ${httpsPort}`);
   lines.push(`\thttp_port ${httpPort}`);
   lines.push('\tadmin off');
-  if (remoteHttpCatchAll) {
+  if (remoteHttpCatchAll || tailnetHost) {
     // Without this Caddy 308-redirects the plain-HTTP catch-all to HTTPS before
-    // basic_auth runs, breaking the WireGuard-transport remote path.
+    // basic_auth runs, breaking the WireGuard-transport remote path; and for the
+    // tailnet host it would pre-empt our explicit `http://<host>` redirect with
+    // Caddy's automatic one. Disabling auto-redirects lets both blocks govern.
     lines.push('\tauto_https disable_redirects');
   }
   lines.push('}');
@@ -262,10 +322,26 @@ function buildCaddyfileContent(options = {}) {
   // Local site — reuse the mkcert cert so local HTTPS is unchanged for the operator.
   _pushSiteBlock(lines, localSite, { tls: { certPath, keyPath }, upstream, auth });
 
+  // Tailnet HTTPS site — same mkcert cert (its SAN must include the tailnet FQDN),
+  // gated. OpenClaw 2026.6.11+ Control UI requires a secure context, so remote
+  // access must be HTTPS (#434 codification of the 2026-07-04 hand-edit).
+  if (tailnetHost) {
+    lines.push('');
+    _pushSiteBlock(lines, tailnetHost, { tls: { certPath, keyPath }, upstream, auth });
+  }
+
   // Public site — no tls directive ⇒ Caddy auto-provisions Let's Encrypt (ACME).
   if (publicDomain) {
     lines.push('');
     _pushSiteBlock(lines, publicDomain, { upstream, auth });
+  }
+
+  // Tailnet http→https redirect — bounces plain-HTTP on the tailnet host to the
+  // secure-context HTTPS origin. More-specific than the http:// catch-all below,
+  // so it wins for this host while the catch-all still serves other hosts.
+  if (tailnetHost) {
+    lines.push('');
+    _pushRedirectBlock(lines, tailnetHost, httpsPort);
   }
 
   // Remote plain-HTTP catch-all — Basic-Auth-gated (enforced above). The tailnet

--- a/test/caddy.test.js
+++ b/test/caddy.test.js
@@ -178,6 +178,10 @@ describe('caddy', () => {
     // a real bcrypt-shaped token; the stubbed `caddy validate` doesn't check it,
     // real `caddy validate` syntax is exercised in verification.
     const AUTH = { basicAuthUser: 'jason', basicAuthHash: '$2a$14$wThequ7Ahgg6dT3KZ8x9KuOk0o0gO3pQF1m6Xq9r4tFz8sJgVn3bC' };
+    // Case-sensitive RE2 bypass matcher emitted by _bypassPathRegexp() (#472
+    // residual-risk #2 fix): exact-cased /api/health, /openclaw-direct/* prefix,
+    // /manifest.json — anchored, `.` in manifest escaped.
+    const BYPASS_MATCHER = '@protected not path_regexp ^(/api/health|/openclaw-direct/.*|/manifest\\.json)$';
 
     it('emits no basic_auth gate by default (ungated ingress unchanged)', () => {
       const out = caddy.buildCaddyfileContent(opts);
@@ -187,34 +191,32 @@ describe('caddy', () => {
 
     it('injects a basic_auth gate over the local site when user+hash are set', () => {
       const out = caddy.buildCaddyfileContent({ ...opts, ...AUTH });
-      assert.match(out, /\t@protected not path \/api\/health/);
+      assert.ok(out.includes(`\t${BYPASS_MATCHER}`));
       assert.match(out, /\tbasic_auth @protected \{/);
       assert.match(out, /\t\tjason \$2a\$14\$wThequ7Ahgg6dT3KZ8x9KuOk0o0gO3pQF1m6Xq9r4tFz8sJgVn3bC/);
       // basic_auth must precede reverse_proxy so the gate runs before the upstream.
       assert.ok(out.indexOf('basic_auth') < out.indexOf('reverse_proxy'));
     });
 
-    it('keeps /api/health out of the gate (health probe needs no credentials)', () => {
+    it('gates with a case-SENSITIVE path_regexp matcher, not case-insensitive path (#472 residual-risk #2)', () => {
       const out = caddy.buildCaddyfileContent({ ...opts, ...AUTH });
-      // The gate references "@protected = not path <bypass list>", so health is open.
-      assert.match(out, /@protected not path \/api\/health /);
+      // `path` is case-insensitive in Caddy, so /OPENCLAW-DIRECT/x would slip the
+      // gate and leak the unauthenticated SPA shell. path_regexp (RE2) is
+      // case-sensitive. Behavioral proof (case-variant → 401) is in the live probe.
+      assert.ok(out.includes('@protected not path_regexp '));
+      assert.doesNotMatch(out, /@protected not path \//);
     });
 
-    it('keeps /openclaw-direct/* out of the gate (OpenClaw sends its own Authorization header; a basic_auth 401 there poisons the browser credential cache → prompt loop)', () => {
+    it('bypasses exactly /api/health, /openclaw-direct/*, /manifest.json (probe, OpenClaw own-auth, credential-less manifest)', () => {
       const out = caddy.buildCaddyfileContent({ ...opts, ...AUTH });
-      assert.match(out, /@protected not path \/api\/health \/openclaw-direct\/\* \/manifest\.json/);
+      assert.ok(out.includes(`\t${BYPASS_MATCHER}`));
     });
 
-    it('keeps /manifest.json out of the gate (browsers fetch PWA manifests credential-less — a gated manifest pops an auth prompt per page load)', () => {
-      const out = caddy.buildCaddyfileContent({ ...opts, ...AUTH });
-      assert.match(out, / \/manifest\.json$/m);
-    });
-
-    it('applies the same bypass list to every gated site block (local + public + remote catch-all)', () => {
+    it('applies the same bypass matcher to every gated site block (local + public + remote catch-all)', () => {
       const out = caddy.buildCaddyfileContent({
         ...opts, ...AUTH, publicDomain: 'tc.example.com', remoteHttpCatchAll: true
       });
-      const matcherLines = out.match(/@protected not path \/api\/health \/openclaw-direct\/\* \/manifest\.json/g) || [];
+      const matcherLines = out.split('\n').filter((l) => l.trim() === BYPASS_MATCHER);
       assert.equal(matcherLines.length, 3);
     });
 
@@ -259,6 +261,41 @@ describe('caddy', () => {
     it('forwards identity on BOTH the local and public sites when gated + publicDomain', () => {
       const out = caddy.buildCaddyfileContent({ ...opts, ...AUTH, publicDomain: 'tc.example.com' });
       assert.equal((out.match(/header_up X-Auth-User \{http\.auth\.user\.id\}/g) || []).length, 2);
+    });
+
+    // #434 — tailnet HTTPS site + http→https redirect (codifies the 2026-07-04 hand-edit).
+    const TAILNET = 'cursatory.tail123678.ts.net';
+
+    it('emits a gated tailnet HTTPS site reusing the mkcert cert when tailnetHost + auth are set', () => {
+      const out = caddy.buildCaddyfileContent({ ...opts, ...AUTH, tailnetHost: TAILNET });
+      assert.match(out, /^cursatory\.tail123678\.ts\.net \{$/m);
+      const siteBlock = out.slice(out.indexOf(`${TAILNET} {`));
+      assert.match(siteBlock, /\ttls \/c\/cert\.pem \/c\/key\.pem/);
+      assert.ok(siteBlock.includes(BYPASS_MATCHER));
+      assert.match(siteBlock, /header_up X-Auth-User \{http\.auth\.user\.id\}/);
+    });
+
+    it('emits an http→https redirect block for the tailnet host, pointing at the https port', () => {
+      const out = caddy.buildCaddyfileContent({ ...opts, ...AUTH, tailnetHost: TAILNET, httpsPort: 9443 });
+      assert.match(out, /^http:\/\/cursatory\.tail123678\.ts\.net \{$/m);
+      assert.match(out, /\tredir https:\/\/cursatory\.tail123678\.ts\.net:9443\{uri\}/);
+    });
+
+    it('adds auto_https disable_redirects when tailnetHost is set (so the explicit redirect governs)', () => {
+      const out = caddy.buildCaddyfileContent({ ...opts, ...AUTH, tailnetHost: TAILNET });
+      assert.match(out, /\tauto_https disable_redirects/);
+    });
+
+    it('throws when tailnetHost is set without basic_auth (fail closed — no ungated remote HTTPS site)', () => {
+      assert.throws(() => caddy.buildCaddyfileContent({ ...opts, tailnetHost: TAILNET }),
+        /tailnetHost requires basicAuthUser and basicAuthHash/);
+    });
+
+    it('emits no tailnet site, redirect, or auto_https when tailnetHost is unset (output unchanged)', () => {
+      const out = caddy.buildCaddyfileContent({ ...opts, ...AUTH });
+      assert.doesNotMatch(out, /ts\.net/);
+      assert.doesNotMatch(out, /\tredir /);
+      assert.doesNotMatch(out, /auto_https disable_redirects/);
     });
   });
 

--- a/test/ingress-cutover.test.js
+++ b/test/ingress-cutover.test.js
@@ -158,7 +158,8 @@ describe('ingress-cutover', () => {
 
     it('gates the Caddyfile when authEnabled with a user + hash', () => {
       const plan = cutover.planCutover('caddy', makeCtx({ config: { authEnabled: true, basicAuthUser: 'jason', basicAuthHash: BCRYPT } }));
-      assert.match(plan.caddyfile.content, /@protected not path \/api\/health/);
+      // Case-sensitive path_regexp gate (#472/#434) — see caddy.test.js for the full matcher contract.
+      assert.match(plan.caddyfile.content, /@protected not path_regexp \^\(\/api\/health\|/);
       assert.match(plan.caddyfile.content, /basic_auth @protected \{/);
       assert.match(plan.caddyfile.content, /jason \$2a\$14\$/);
     });


### PR DESCRIPTION
## What

Generator half of #434 (`buildCaddyfileContent` only — adoption + cutover wiring is Chunk 2), plus a security hardening folded in from #472's Critic:

1. **Security — case-sensitive `path_regexp` bypass matcher.** The `basic_auth` bypass switches from Caddy's case-insensitive `path` matcher to an anchored case-sensitive RE2 regex (`^(/api/health|/openclaw-direct/.*|/manifest\.json)$`). `path` is case-insensitive, so `/OPENCLAW-DIRECT/x` (or `/API/HEALTH`) slipped the gate; TC's case-sensitive router then missed the proxy route and served the **unauthenticated SPA shell** (#472 Critic residual-risk #2). Applies to every gated site block.
2. **Capability — `tailnetHost` option.** When set (with basic_auth — fail-closed guard, an ungated remote HTTPS site throws), emits a gated HTTPS site for the tailnet FQDN (reusing the local mkcert cert, whose SAN must include the FQDN) + an `http://<host>` → `https://<host>:<port>{uri}` redirect, and adds `auto_https disable_redirects` so the explicit redirect governs. Codifies the live 2026-07-04 hand-edit.

## Why

Part of #434 (the generator half; see scope note). A `node scripts/ingress-cutover.js` run regenerates the live Cursatory Caddyfile from `buildCaddyfileContent`, which could not reproduce the tailnet HTTPS site + redirect (added by hand 2026-07-04 to unblock remote OpenClaw access — OpenClaw 2026.6.11+ Control UI requires a secure context). Without this, a cutover drops those blocks and breaks remote access. The case-sensitivity fix closes a real unauthenticated-shell leak in the shipped gate.

## Scope / not in this PR

- **Chunk 2** (separate): config default `caddyTailnetHost`, boot adoption (`extractTailnetHost`), cutover wiring, docs/memory reconciliation. So `tailnetHost` is capability-only here — **no operator-visible behavior change yet** (CHANGELOG entry under `### Internal`; the security fix under `### Security`).
- The live cutover on Cursatory stays off; the hand-edited Caddyfile remains load-bearing until Chunk 2 + a ratified cutover (VRF'd on elkaholic first).

## Test plan

- `node --test test/caddy.test.js` — 72 pass (new: tailnet HTTPS site, redirect + port, auto_https, fail-closed guard, unset-is-noop, case-sensitive matcher, per-block matcher parity). Updated `test/ingress-cutover.test.js` matcher assertion.
- Full suite `node --test 'test/*.test.js'` — **3759 pass / 0 fail / 1 skipped**.
- **Live `caddy run` probe** (ephemeral ports, echo upstream): `/` → 401; `/api/health`, `/openclaw-direct/x`, `/manifest.json` → 200 (bypassed); `/API/HEALTH`, `/OPENCLAW-DIRECT/x` → 401 (case-fix); `/manifestXjson` → 401 (dot literal); `/openclaw-direct/../api/system` → 401 (canonicalized); authed reaches upstream; tailnet `http://` host → 302 https. All pass.
- `caddy validate` on generated output with `tailnetHost` — valid.

## Critic

Independent Critic PASS (0 blocking). WARNING (stale test-evidence) resolved — evidence rebound to HEAD. NOTE (path-normalization parity beyond the case axis: percent-encoding, duplicate slashes) filed as #473.

Part of #434 (Chunk 1 — generator half; Chunk 2 wires adoption + cutover and will close it).
