### PR TITLE
Reconcile PortHub leases when a connection's port changes via PUT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`PUT /api/openclaw/connections/:id` now reconciles the PortHub leases when a connection's port changes (#483, backlog PH-4B7N, surfaced by the #352 Critic pass).** The create path leases `local_port`/`bridge_port` under `oc-direct-<id>` and DELETE releases them, but an update used to leave the old lease held forever and the new port unleased — reopening the #352 allocate→bind race for edited connections (a later create's `nextFreePort` could hand the edited connection's live port to someone else, while the abandoned port stayed blocked until DELETE). The PUT handler now mirrors the create/delete lifecycle: it 404s early on unknown ids, conflict-checks a *changed* `localPort` (as before) **and** a changed `bridgePort` (previously unchecked — parity with POST), then after a successful store update kills the now-misconfigured standalone tunnel (`tunnel.killTunnel('oc-direct-<id>')` — it was still bound to the old port while the record and HTTP/WS proxy pointed at the new one) and releases the stale lease(s) before re-leasing the connection's current ports. `bridgePort: "auto"` is now also honored on PUT (previously the literal string `"auto"` was written to the DB) with *idempotent* semantics: a connection that already has a bridge port keeps it — re-saving an edit form must not churn ports — and only a bridge-less connection allocates from `[3201, 3300)`. Lease reconciliation only runs when a port actually changed, so non-port edits touch nothing. Tests: `test/api-openclaw.test.js` (+8 — local/bridge swap release+re-lease incl. the bridge-only-change case guarding the killTunnel/localPort interaction, clear-to-null release, PUT-side conflict 409s for both ports, `"auto"` allocate + `"auto"` keep-existing, and no-port-change lease preservation; 6 of the 8 fail without the fix, the other 2 pin pre-existing contracts).
+
 ## [4.4.0] - 2026-07-04
 
 ### Added

--- a/server.js
+++ b/server.js
@@ -2466,18 +2466,64 @@ route('PUT', '/api/openclaw/connections/:id', (_req, res, params, body) => {
   if (!body || typeof body !== 'object') {
     return errorResponse(res, 400, 'Request body must be a JSON object', 'BAD_REQUEST');
   }
+  const existing = store.openclawConnections.get(params.id);
+  if (!existing) {
+    return errorResponse(res, 404, `Connection "${params.id}" not found`, 'NOT_FOUND');
+  }
   // Check for port conflicts if localPort is being changed
-  if (body.localPort !== undefined) {
-    const existing = store.openclawConnections.get(params.id);
-    if (existing && body.localPort !== existing.localPort) {
-      const portCheck = porthub.checkPort(body.localPort);
-      if (!portCheck.available) {
-        return errorResponse(res, 409, `Port ${body.localPort} is already in use by ${portCheck.leasedBy || 'system process'}`, 'PORT_CONFLICT');
+  if (body.localPort !== undefined && body.localPort !== existing.localPort) {
+    const portCheck = porthub.checkPort(body.localPort);
+    if (!portCheck.available) {
+      return errorResponse(res, 409, `Port ${body.localPort} is already in use by ${portCheck.leasedBy || 'system process'}`, 'PORT_CONFLICT');
+    }
+  }
+  // Resolve bridgePort the same way POST does (#483). 'auto' is idempotent on
+  // update: a connection that already has a bridge port keeps it (re-saving an
+  // edit form must not churn ports); only a bridge-less connection allocates.
+  if (body.bridgePort === 'auto') {
+    if (existing.bridgePort) {
+      body.bridgePort = existing.bridgePort;
+    } else {
+      try {
+        body.bridgePort = porthub.nextFreePort({ range: [3201, 3300] });
+      } catch (err) {
+        return errorResponse(res, 409, err.message, 'PORT_EXHAUSTED');
       }
+    }
+  } else if (body.bridgePort !== undefined && body.bridgePort !== null && body.bridgePort !== ''
+      && body.bridgePort !== existing.bridgePort) {
+    const bridgeCheck = porthub.checkPort(body.bridgePort);
+    if (!bridgeCheck.available) {
+      return errorResponse(res, 409, `Bridge port ${body.bridgePort} is already in use by ${bridgeCheck.leasedBy || 'system process'}`, 'PORT_CONFLICT');
     }
   }
   try {
     const connection = store.openclawConnections.update(params.id, body);
+    // Lease reconciliation (#483): the create path leases local/bridge ports
+    // under oc-direct-<id> and DELETE releases them, but a port change via PUT
+    // used to leave the old lease held forever and the new port unleased —
+    // reopening the #352 allocate→bind race for edited connections. Mirror the
+    // create/delete lifecycle: kill the now-misconfigured standalone tunnel
+    // (killTunnel also releases its tracked localPort), release the stale
+    // leases, then re-lease the connection's current ports.
+    const localChanged = connection.localPort !== existing.localPort;
+    const bridgeChanged = connection.bridgePort !== existing.bridgePort;
+    if (localChanged || bridgeChanged) {
+      const leaseName = `oc-direct-${connection.id}`;
+      tunnel.killTunnel(leaseName);
+      if (localChanged && existing.localPort) {
+        porthub.releasePort(existing.localPort);
+      }
+      if (bridgeChanged && existing.bridgePort) {
+        porthub.releasePort(existing.bridgePort);
+      }
+      if (connection.localPort) {
+        porthub.registerPort(connection.localPort, leaseName, 'openclaw-tunnel', { permanent: true });
+      }
+      if (connection.bridgePort) {
+        porthub.registerPort(connection.bridgePort, leaseName, 'openclaw-bridge', { permanent: true });
+      }
+    }
     openclawVersion.invalidate(params.id); // #296: instanceDir may have changed → drop stale cache
     jsonResponse(res, 200, connection);
   } catch (err) {

--- a/test/api-openclaw.test.js
+++ b/test/api-openclaw.test.js
@@ -463,6 +463,139 @@ describe('API /api/openclaw/connections', () => {
     assert.equal(created.data.code, 'PORT_CONFLICT');
     assert.ok(created.data.error.includes('3290'));
   });
+
+  // ── #483: PUT reconciles the oc-direct-<id> leases when a port changes ──
+
+  it('PUT changing localPort releases the old lease and leases the new port (#483)', async () => {
+    const created = await request(server, 'POST', '/api/openclaw/connections', {
+      name: 'PutLocalSwap', host: '10.0.0.100', sshUser: 'user', sshKeyPath: '/key',
+      localPort: 19501
+    });
+    assert.equal(created.status, 201);
+    const id = created.data.id;
+    assert.ok(store.portLeases.get(19501), 'old port leased at create');
+
+    const updated = await request(server, 'PUT', `/api/openclaw/connections/${id}`, { localPort: 19502 });
+    assert.equal(updated.status, 200);
+    assert.equal(updated.data.localPort, 19502);
+    assert.equal(store.portLeases.get(19501), null, 'old localPort lease is released on update');
+    const lease = store.portLeases.get(19502);
+    assert.ok(lease, 'new localPort is leased on update');
+    assert.equal(lease.project, `oc-direct-${id}`);
+    assert.equal(lease.service, 'openclaw-tunnel');
+  });
+
+  it('PUT rejects a localPort leased by another project (#483)', async () => {
+    const porthub = require('../lib/porthub');
+    porthub.registerPort(19504, 'someone-else', 'svc');
+    const created = await request(server, 'POST', '/api/openclaw/connections', {
+      name: 'PutLocalConflict', host: '10.0.0.101', sshUser: 'user', sshKeyPath: '/key',
+      localPort: 19505
+    });
+    assert.equal(created.status, 201);
+
+    const updated = await request(server, 'PUT', `/api/openclaw/connections/${created.data.id}`, { localPort: 19504 });
+    assert.equal(updated.status, 409);
+    assert.equal(updated.data.code, 'PORT_CONFLICT');
+    assert.ok(store.portLeases.get(19505), 'own lease is untouched after a rejected update');
+  });
+
+  it('PUT changing bridgePort releases the old bridge lease and leases the new one (#483)', async () => {
+    const created = await request(server, 'POST', '/api/openclaw/connections', {
+      name: 'PutBridgeSwap', host: '10.0.0.102', sshUser: 'user', sshKeyPath: '/key',
+      localPort: 19506, bridgePort: 3270
+    });
+    assert.equal(created.status, 201);
+    const id = created.data.id;
+
+    const updated = await request(server, 'PUT', `/api/openclaw/connections/${id}`, { bridgePort: 3271 });
+    assert.equal(updated.status, 200);
+    assert.equal(updated.data.bridgePort, 3271);
+    assert.equal(store.portLeases.get(3270), null, 'old bridgePort lease is released on update');
+    const bridgeLease = store.portLeases.get(3271);
+    assert.ok(bridgeLease, 'new bridgePort is leased on update');
+    assert.equal(bridgeLease.project, `oc-direct-${id}`);
+    assert.equal(bridgeLease.service, 'openclaw-bridge');
+    // The unchanged localPort lease must survive the reconciliation (guards the
+    // killTunnel-releases-localPort interaction).
+    const localLease = store.portLeases.get(19506);
+    assert.ok(localLease, 'unchanged localPort lease survives a bridge-only update');
+    assert.equal(localLease.project, `oc-direct-${id}`);
+  });
+
+  it('PUT clearing bridgePort releases the old bridge lease (#483)', async () => {
+    const created = await request(server, 'POST', '/api/openclaw/connections', {
+      name: 'PutBridgeClear', host: '10.0.0.103', sshUser: 'user', sshKeyPath: '/key',
+      localPort: 19507, bridgePort: 3272
+    });
+    assert.equal(created.status, 201);
+
+    const updated = await request(server, 'PUT', `/api/openclaw/connections/${created.data.id}`, { bridgePort: null });
+    assert.equal(updated.status, 200);
+    assert.equal(updated.data.bridgePort, null);
+    assert.equal(store.portLeases.get(3272), null, 'cleared bridgePort lease is released');
+  });
+
+  it('PUT rejects a bridgePort leased by another project (#483)', async () => {
+    const porthub = require('../lib/porthub');
+    porthub.registerPort(3273, 'someone-else', 'svc');
+    const created = await request(server, 'POST', '/api/openclaw/connections', {
+      name: 'PutBridgeConflict', host: '10.0.0.104', sshUser: 'user', sshKeyPath: '/key',
+      localPort: 19508
+    });
+    assert.equal(created.status, 201);
+
+    const updated = await request(server, 'PUT', `/api/openclaw/connections/${created.data.id}`, { bridgePort: 3273 });
+    assert.equal(updated.status, 409);
+    assert.equal(updated.data.code, 'PORT_CONFLICT');
+    assert.ok(updated.data.error.includes('3273'));
+  });
+
+  it('PUT bridgePort:"auto" on a bridge-less connection allocates and leases (#483)', async () => {
+    const created = await request(server, 'POST', '/api/openclaw/connections', {
+      name: 'PutBridgeAuto', host: '10.0.0.105', sshUser: 'user', sshKeyPath: '/key',
+      localPort: 19509
+      // bridgePort omitted — persists null
+    });
+    assert.equal(created.status, 201);
+    assert.equal(created.data.bridgePort, null);
+
+    const updated = await request(server, 'PUT', `/api/openclaw/connections/${created.data.id}`, { bridgePort: 'auto' });
+    assert.equal(updated.status, 200);
+    assert.ok(Number.isInteger(updated.data.bridgePort),
+      'the literal string "auto" must never reach the DB');
+    assert.ok(updated.data.bridgePort >= 3201 && updated.data.bridgePort < 3300,
+      'auto-allocated bridgePort falls inside the bridge range');
+    assert.ok(store.portLeases.get(updated.data.bridgePort), 'auto-allocated bridgePort is leased');
+  });
+
+  it('PUT bridgePort:"auto" keeps an existing bridge port — no churn (#483)', async () => {
+    const created = await request(server, 'POST', '/api/openclaw/connections', {
+      name: 'PutBridgeAutoKeep', host: '10.0.0.106', sshUser: 'user', sshKeyPath: '/key',
+      localPort: 19510, bridgePort: 3274
+    });
+    assert.equal(created.status, 201);
+
+    const updated = await request(server, 'PUT', `/api/openclaw/connections/${created.data.id}`, { bridgePort: 'auto' });
+    assert.equal(updated.status, 200);
+    assert.equal(updated.data.bridgePort, 3274, 're-saving with "auto" keeps the assigned port');
+    assert.ok(store.portLeases.get(3274), 'existing bridge lease is untouched');
+  });
+
+  it('PUT with no port change leaves the leases untouched (#483)', async () => {
+    const created = await request(server, 'POST', '/api/openclaw/connections', {
+      name: 'PutNoPortChange', host: '10.0.0.107', sshUser: 'user', sshKeyPath: '/key',
+      localPort: 19511
+    });
+    assert.equal(created.status, 201);
+    const id = created.data.id;
+
+    const updated = await request(server, 'PUT', `/api/openclaw/connections/${id}`, { name: 'PutNoPortChange2' });
+    assert.equal(updated.status, 200);
+    const lease = store.portLeases.get(19511);
+    assert.ok(lease, 'localPort lease survives a non-port update');
+    assert.equal(lease.project, `oc-direct-${id}`);
+  });
 });
 
 describe('API /api/openclaw/test', () => {


### PR DESCRIPTION
## What

`PUT /api/openclaw/connections/:id` now mirrors the create/delete PortHub lease lifecycle when a port changes:

- Early 404 on unknown ids (behavior-equivalent to the prior late-404 from the store).
- Conflict-checks a **changed** `bridgePort` (parity with POST — previously entirely unchecked).
- Honors `bridgePort: "auto"` with **idempotent** semantics: a connection that already has a bridge port keeps it (re-saving an edit form must not churn ports); only a bridge-less connection allocates from `[3201, 3300)`. Previously the literal string `"auto"` was written to the DB.
- On an actual port change: kills the now-misconfigured standalone tunnel (`oc-direct-<id>` was still bound to the old port while the record and HTTP/WS proxy pointed at the new one), releases the stale lease(s), and re-leases the connection's current ports under `oc-direct-<id>`.
- Non-port edits touch no leases.

## Why

The create path leases `local_port`/`bridge_port` under `oc-direct-<id>` (#352) and DELETE releases them, but an update left the old lease held forever and the new port unleased — reopening the #352 allocate→bind race for edited connections and permanently blocking the abandoned port. Surfaced by the #352 Critic pass (backlog PH-4B7N).

Fixes #483

## Test plan

- `test/api-openclaw.test.js` +8: local/bridge swap release+re-lease (including the bridge-only-change case guarding the killTunnel↔localPort interaction), clear-to-null release, PUT-side 409s for both ports, `"auto"` allocate + `"auto"` keep-existing, and no-port-change lease preservation.
- 6 of the 8 fail without the fix; the other 2 pin pre-existing contracts.
- Full suite: 3836 tests, 0 fail, 1 skipped.

## Governance

- Independent Critic: verify-resolutions chain-extend on the CRT-4J8W anchor — 0 blocking / 0 warnings / 0 notes.
- Independent PR reviewer (opus): 0 blocking / 0 warnings / 1 note (mark backlog PH-4B7N shipped at merge — will do).
- Change-log entry added to `.prawduct/change-log.md` (manual check: the `check-change-log-entry` probe cannot evaluate in this repo because `.gitignore` excludes `.prawduct/` wholesale, so the entry never appears in the branch diff — structural gate/repo mismatch, flagged separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)