### PR TITLE
Extract shared adoption-computation core for caddy real + dry-run paths

### DIFF
--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -2,6 +2,12 @@
 
 <!-- Append new entries at the top. -->
 
+## 2026-07-06: Refactor — shared adoption-computation core for caddy real + dry-run paths (#494, CAD-7X4V)
+
+<!-- prawduct: type=refactor | chunks=494 | scope=caddy-adoption-helper -->
+
+**Why:** backlog CAD-7X4V (PR-reviewer-filed on #476): `applyDryRunAdoptionPreview` (`scripts/ingress-cutover.js`) hand-mirrored the 3 adoption concerns of `adoptCredentialIntoConfig` (`lib/caddy.js`) — the dry-run/real divergence this invites was itself the Critic-caught bug on #476, and each future adoption shape adds another mirror obligation. **What:** pure `caddy.computeCaddyfileAdoption(config, content)` extracted as the single core (in-memory mutation, full `{adopted, changed, user, remoteHttp, tailnetHost, reason}` return incl. the pre-#434 `remoteHttp`-reflects-the-file contract); `adoptCredentialIntoConfig` keeps mode gate + file read + persist/log; `applyDryRunAdoptionPreview` keeps its exported signature (null-text guard + boolean return) but delegates. Behavior-preserving: zero existing assertions touched. **Tests:** `test/auth-credential-durability.test.js` +5 — direct helper coverage (result shape, never-overwrite + no-op reasons, idempotence, publicDomain exclusion) + an anti-drift structural pin (cutover script must reference `computeCaddyfileAdoption` and must NOT reference the three concern extractors — the #476 bug class cannot silently return).
+
 ## 2026-07-06: Feat — Bridge Port row on the OpenClaw connection card (#491, OUI-4T9M)
 
 <!-- prawduct: type=feat | chunks=491 | scope=openclaw-ui-bridge-card-row | status=merged -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Internal
+
+- **The caddy adoption computation now has a single implementation shared by the real and dry-run paths (#494, backlog CAD-7X4V).** `applyDryRunAdoptionPreview` (`scripts/ingress-cutover.js`) was a hand-maintained 3-concern mirror of `adoptCredentialIntoConfig` (`lib/caddy.js`) — credential, remote-HTTP catch-all, and tailnet-host adoption duplicated across two files, with the original dry-run/real divergence itself a Critic-caught bug on the #476 review. The computation is extracted to a pure `caddy.computeCaddyfileAdoption(config, content)` (mutates the in-memory config, returns the `{adopted, changed, user, remoteHttp, tailnetHost, reason}` shape); `adoptCredentialIntoConfig` keeps the ingress-mode gate, Caddyfile read, and persist+log around it, and the dry-run preview delegates behind its unchanged exported signature. Pure refactor — no behavior change; all pre-existing adoption/preview contracts pass unmodified. Tests: `test/auth-credential-durability.test.js` +5 (direct helper coverage: full result shape, never-overwrite + no-op reasons, idempotence, publicDomain exclusion; plus an anti-drift structural pin that the cutover script no longer references the three concern extractors).
+
 ## [4.5.0] - 2026-07-06
 
 ### Added

--- a/lib/caddy.js
+++ b/lib/caddy.js
@@ -742,9 +742,75 @@ function extractTailnetHost(content) {
 }
 
 /**
+ * Compute Caddyfile→config adoption on an IN-MEMORY config — the shared pure
+ * core of `adoptCredentialIntoConfig` (real path: loads, persists, logs) and
+ * the cutover script's `applyDryRunAdoptionPreview` (dry-run path: previews
+ * only, nothing saved). Extracted per CAD-7X4V so the two paths cannot drift —
+ * the original dry-run/real divergence was itself a Critic-caught bug on #476.
+ *
+ * Three concerns, each applied only where config lacks the value (config is
+ * never overwritten):
+ * - basic_auth credential (+ `authEnabled`) when config carries neither
+ *   `basicAuthUser` nor `basicAuthHash` and the file's credential is unambiguous
+ * - `caddyRemoteHttp` when the file carries the remote plain-HTTP catch-all
+ * - `caddyTailnetHost` when the file carries exactly one tls-bearing FQDN site
+ *   that isn't `publicDomain` (that site is the ACME block's job)
+ *
+ * Shape adoption is INDEPENDENT of credential adoption (#434 Chunk 2) — a
+ * credential already in config must not block adopting a shape the file
+ * carries but the config doesn't.
+ *
+ * @param {object} config - Loaded config object, mutated in place.
+ * @param {string} content - Live Caddyfile text.
+ * @returns {{ adopted: boolean, changed: boolean, user?: string,
+ *   remoteHttp?: boolean, tailnetHost?: string, reason?: string }} `adopted` =
+ *   credential adopted this call; `changed` = ANY adoption applied (credential
+ *   or shape); `reason` set when credential adoption no-oped.
+ */
+function computeCaddyfileAdoption(config, content) {
+  const result = { adopted: false, changed: false };
+
+  if (config.basicAuthUser || config.basicAuthHash) {
+    result.reason = 'config-already-has-credential';
+  } else {
+    const cred = extractBasicAuthCredential(content);
+    if (!cred) {
+      result.reason = 'no-unambiguous-credential';
+    } else {
+      config.authEnabled = true;
+      config.basicAuthUser = cred.user;
+      config.basicAuthHash = cred.hash;
+      result.adopted = true;
+      result.changed = true;
+      result.user = cred.user;
+    }
+  }
+
+  if (config.caddyRemoteHttp !== true && hasRemoteHttpCatchAll(content)) {
+    config.caddyRemoteHttp = true;
+    result.changed = true;
+  }
+  // Surface the shape's presence on the credential-adopted path even when it
+  // was already in config (pre-#434 return contract: adopted ⇒ remoteHttp
+  // reflects the file).
+  if (hasRemoteHttpCatchAll(content)) result.remoteHttp = true;
+
+  const tailnetHost = extractTailnetHost(content);
+  if (tailnetHost && !config.caddyTailnetHost && tailnetHost !== config.publicDomain) {
+    config.caddyTailnetHost = tailnetHost;
+    result.changed = true;
+    result.tailnetHost = tailnetHost;
+  }
+
+  return result;
+}
+
+/**
  * Adopt the live Caddyfile's basic_auth credential and ingress SHAPES (remote
  * plain-HTTP catch-all, tailnet HTTPS site) into the canonical config —
- * READ-ONLY on the Caddyfile, writes config only.
+ * READ-ONLY on the Caddyfile, writes config only. The adoption computation
+ * itself lives in `computeCaddyfileAdoption`; this wrapper owns the ingress-mode
+ * gate, the Caddyfile read, and persistence + logging.
  *
  * Root-cause hardening for the 2026-07-03 lockout (#397): the working credential
  * existed ONLY inside the hand-edited Caddyfile, so (a) any regeneration lost it
@@ -788,39 +854,7 @@ function adoptCredentialIntoConfig(opts = {}) {
     if (!fs.existsSync(caddyfilePath)) return { adopted: false, changed: false, reason: 'no-caddyfile' };
     const content = fs.readFileSync(caddyfilePath, 'utf8');
 
-    const result = { adopted: false, changed: false };
-
-    if (config.basicAuthUser || config.basicAuthHash) {
-      result.reason = 'config-already-has-credential';
-    } else {
-      const cred = extractBasicAuthCredential(content);
-      if (!cred) {
-        result.reason = 'no-unambiguous-credential';
-      } else {
-        config.authEnabled = true;
-        config.basicAuthUser = cred.user;
-        config.basicAuthHash = cred.hash;
-        result.adopted = true;
-        result.changed = true;
-        result.user = cred.user;
-      }
-    }
-
-    if (config.caddyRemoteHttp !== true && hasRemoteHttpCatchAll(content)) {
-      config.caddyRemoteHttp = true;
-      result.changed = true;
-    }
-    // Surface the shape's presence on the credential-adopted path even when it
-    // was already in config (pre-#434 return contract: adopted ⇒ remoteHttp
-    // reflects the file).
-    if (hasRemoteHttpCatchAll(content)) result.remoteHttp = true;
-
-    const tailnetHost = extractTailnetHost(content);
-    if (tailnetHost && !config.caddyTailnetHost && tailnetHost !== config.publicDomain) {
-      config.caddyTailnetHost = tailnetHost;
-      result.changed = true;
-      result.tailnetHost = tailnetHost;
-    }
+    const result = computeCaddyfileAdoption(config, content);
 
     if (result.changed) {
       store.config.save(config);
@@ -930,6 +964,7 @@ module.exports = {
   caddyCanonicalPath,
   isCaddyAuthBypassPath,
   extractTailnetHost,
+  computeCaddyfileAdoption,
   adoptCredentialIntoConfig,
   ADMIN_PASSWORD_MIN_LENGTH,
   BCRYPT_HASH_RE,

--- a/scripts/ingress-cutover.js
+++ b/scripts/ingress-cutover.js
@@ -201,34 +201,16 @@ function parseArgs(argv) {
  * the IN-MEMORY config only — nothing is saved — so the previewed plan reflects
  * the post-adoption state instead of crashing on the refuse-to-ungate guard
  * (Critic-caught: dry-run and real-run diverged on exactly the #397 recovery
- * scenario). Mirrors the real function's #434 decoupling: shapes preview even
- * when the credential is already in config, and never overwrite a set field.
+ * scenario). Delegates to `caddy.computeCaddyfileAdoption` — the same pure core
+ * the real path runs (CAD-7X4V) — so dry-run and real adoption cannot drift;
+ * this wrapper only owns the no-Caddyfile guard and the boolean return.
  * @param {object} config - Loaded config, mutated in place (in-memory only).
  * @param {string|null} existingCaddyfileText - Live Caddyfile text, if any.
  * @returns {boolean} Whether any adoption was previewed.
  */
 function applyDryRunAdoptionPreview(config, existingCaddyfileText) {
   if (typeof existingCaddyfileText !== 'string') return false;
-  let previewed = false;
-  if (!config.basicAuthUser && !config.basicAuthHash) {
-    const cred = caddy.extractBasicAuthCredential(existingCaddyfileText);
-    if (cred) {
-      config.authEnabled = true;
-      config.basicAuthUser = cred.user;
-      config.basicAuthHash = cred.hash;
-      previewed = true;
-    }
-  }
-  if (config.caddyRemoteHttp !== true && caddy.hasRemoteHttpCatchAll(existingCaddyfileText)) {
-    config.caddyRemoteHttp = true;
-    previewed = true;
-  }
-  const tailnetHost = caddy.extractTailnetHost(existingCaddyfileText);
-  if (tailnetHost && !config.caddyTailnetHost && tailnetHost !== config.publicDomain) {
-    config.caddyTailnetHost = tailnetHost;
-    previewed = true;
-  }
-  return previewed;
+  return caddy.computeCaddyfileAdoption(config, existingCaddyfileText).changed;
 }
 
 /**

--- a/test/auth-credential-durability.test.js
+++ b/test/auth-credential-durability.test.js
@@ -347,6 +347,67 @@ describe('auth credential durability (#397 / 2026-07-03 lockout)', () => {
     });
   });
 
+  describe('computeCaddyfileAdoption — shared pure core of real + dry-run adoption (CAD-7X4V)', () => {
+    it('adopts credential + shapes into an empty in-memory config and reports the full result shape', () => {
+      const config = {};
+      const result = caddy.computeCaddyfileAdoption(config, liveShapedCaddyfile());
+      assert.equal(result.adopted, true);
+      assert.equal(result.changed, true);
+      assert.equal(result.user, 'jason');
+      assert.equal(result.remoteHttp, true);
+      assert.equal(config.authEnabled, true);
+      assert.equal(config.basicAuthUser, 'jason');
+      assert.equal(config.basicAuthHash, HASH_A);
+      assert.equal(config.caddyRemoteHttp, true);
+    });
+
+    it('never overwrites config values and reports the credential no-op reason', () => {
+      const config = { basicAuthUser: 'ops', basicAuthHash: HASH_B, caddyRemoteHttp: true };
+      const result = caddy.computeCaddyfileAdoption(config, liveShapedCaddyfile());
+      assert.equal(result.adopted, false);
+      assert.equal(result.changed, false);
+      assert.equal(result.reason, 'config-already-has-credential');
+      assert.equal(result.remoteHttp, true, 'pre-#434 contract: remoteHttp reflects the file');
+      assert.equal(config.basicAuthUser, 'ops');
+      assert.equal(config.basicAuthHash, HASH_B);
+    });
+
+    it('is idempotent on the same config — the second pass adopts nothing', () => {
+      const config = {};
+      assert.equal(caddy.computeCaddyfileAdoption(config, liveTailnetCaddyfile()).changed, true);
+      const second = caddy.computeCaddyfileAdoption(config, liveTailnetCaddyfile());
+      assert.equal(second.changed, false);
+      assert.equal(second.reason, 'config-already-has-credential');
+      assert.equal(config.caddyTailnetHost, TAILNET_HOST);
+    });
+
+    it('skips a tailnet host equal to publicDomain (that site is the ACME block\'s job)', () => {
+      const config = {
+        publicDomain: TAILNET_HOST,
+        basicAuthUser: 'ops', basicAuthHash: HASH_B, caddyRemoteHttp: true
+      };
+      const result = caddy.computeCaddyfileAdoption(config, liveTailnetCaddyfile());
+      assert.equal(result.changed, false);
+      assert.equal(config.caddyTailnetHost, undefined);
+    });
+
+    it('is the ONLY adoption implementation — the cutover script delegates instead of mirroring it', () => {
+      const src = fs.readFileSync(path.join(__dirname, '..', 'scripts', 'ingress-cutover.js'), 'utf8');
+      assert.ok(
+        src.includes('computeCaddyfileAdoption'),
+        'applyDryRunAdoptionPreview must delegate to the shared helper'
+      );
+      // The pre-CAD-7X4V hand-maintained mirror called these three directly; any
+      // reappearance means the dry-run/real paths can drift again (#476 bug class).
+      for (const fn of ['extractBasicAuthCredential', 'hasRemoteHttpCatchAll', 'extractTailnetHost']) {
+        assert.ok(
+          !src.includes(fn),
+          `ingress-cutover.js must not re-implement adoption via caddy.${fn}`
+        );
+      }
+    });
+  });
+
   describe('extractTailnetHost (#434 Chunk 2)', () => {
     it('extracts the host from the live 2026-07-04 hand-edited shape', () => {
       assert.equal(caddy.extractTailnetHost(liveTailnetCaddyfile()), TAILNET_HOST);


### PR DESCRIPTION
## What

Extracts the 3-concern caddy adoption computation (basic_auth credential, remote-HTTP catch-all, tailnet HTTPS host) into a single pure helper, `caddy.computeCaddyfileAdoption(config, content)`. `adoptCredentialIntoConfig` keeps the ingress-mode gate, Caddyfile read, and persist+log around it; the cutover script's `applyDryRunAdoptionPreview` keeps its exported signature but delegates.

## Why

`applyDryRunAdoptionPreview` was a hand-maintained mirror of `adoptCredentialIntoConfig` — the dry-run/real divergence this invites was itself a Critic-caught bug on the #476 review, and every future adoption shape added another mirror obligation. One shared pure core makes the two paths structurally unable to drift.

Fixes #494 (backlog CAD-7X4V).

## Test plan

- Behavior-preserving: zero existing assertions touched; the extracted block is verbatim the prior inline code (dry-run's `.changed` ≡ old `previewed` by construction).
- +5 tests in `test/auth-credential-durability.test.js`: full result shape, never-overwrite + no-op reasons, idempotence, publicDomain exclusion, and an anti-drift structural pin (the cutover script must delegate and must not reference the three concern extractors).
- Full suite: 1881 passed / 0 failed / 1 skipped (junit testcases 3864 → 3869, exactly the +5).

## Governance

- Critic (cumulative): 0 blocking / 0 warnings / 2 notes (post-merge backlog stamp; accepted trade-off on the whole-file structural pin).
- Independent PR review (opus, standard tier): 0 blocking / 0 warnings / 1 note (same backlog stamp). Critic record audited with 3 adversarial spot-checks, all passed.