### PR TITLE
Emit session-start banner unconditionally, engine-agnostic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Session-start banner (`*TangleClaw'd into existence.*`) now surfaces on every session, regardless of wrap tier or engine/model.** The banner lives in the hidden SessionStart prime (`lib/sessions.js` `generatePrimePrompt`); confirmed against Claude Code's hooks docs, a SessionStart hook can only inject *hidden model context* — it cannot render into the startup header or emit guaranteed-visible terminal output — so the sole visible path is the model re-printing the banner on its first turn. The "re-emit this visibly" instruction previously lived **only inside the Resume branch** (which fires only when a continuity index exists), so any session after a `mechanical-only` wrap took the legacy-summary `else` path and silently dropped the banner 100% of the time; even in the Resume branch it was coupled to a wait-for-confirmation directive, so a task-opening prompt often skipped it. Hoisted an **unconditional, engine-agnostic** banner-emit instruction into the header block every prime carries, explicitly split from any wait-for-confirmation directive (visible-output requirement only — does not authorize starting work). Regression tests in `test/sessions.test.js` assert the instruction is present in the clean/no-index path, the legacy-summary path, and the Resume path.
+
 ## [4.5.1] - 2026-07-06
 
 ### Fixed

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -445,6 +445,29 @@ function generatePrimePrompt(project, engineProfile) {
   sections.push("*TangleClaw'd into existence.*");
   sections.push('');
 
+  // Banner-visibility contract (CC-1, #342). This prime is HIDDEN model context
+  // (SessionStart hook stdout → context, never shown to the operator). Confirmed
+  // against Claude Code's hooks docs: no hook can render into the startup header
+  // or emit guaranteed-visible terminal output, so the ONLY way the branding
+  // line reaches the screen is the model re-printing it on its first turn.
+  // Make that unconditional and engine-agnostic: the instruction lives here, in
+  // the header block every prime carries, so it fires for EVERY session and
+  // EVERY model — not only when a continuity index steers us into the Resume
+  // branch below. Before this hoist the re-emit instruction lived solely inside
+  // that Resume branch, so any session after a mechanical-only wrap (the
+  // legacy-summary `else` path) silently dropped the banner 100% of the time.
+  // Deliberately split from any wait-for-confirmation directive: this is a
+  // visible-OUTPUT requirement only — it does not authorize starting work.
+  sections.push(
+    "Before anything else, begin your FIRST visible reply to the operator with "
+    + "the banner line `*TangleClaw'd into existence.*` on its own line. This is "
+    + 'unconditional: do it every session, whatever the model is driving this '
+    + 'project, even when the operator opens with a direct task. It is a '
+    + 'visible-output requirement only and does NOT authorize starting work — '
+    + 'honor any wait-for-confirmation directive below before acting.'
+  );
+  sections.push('');
+
   // Session ownership identity (#347 Slice 3). Inject the owned-project
   // identity early so a consumer (#340 scope guard) reads a reliable "what do
   // I own" fact from hidden prime context. Identity only — the wrong-tab
@@ -513,8 +536,9 @@ function generatePrimePrompt(project, engineProfile) {
       + 'written-at sha above.'
     );
     sections.push(
-      "2. Emit one visible message, leading with the banner `*TangleClaw'd into "
-      + "existence.*`, then \"We left off at <X>. Next: <Y>.\" If the freshness check "
+      "2. In that same first visible message — the one that already leads with the "
+      + "required `*TangleClaw'd into existence.*` banner (see the top of this prime) "
+      + "— follow the banner with \"We left off at <X>. Next: <Y>.\" If the freshness check "
       + 'shows the next action is stale (issue closed, branch merged, artifact gone), '
       + 'say so honestly: "…but I checked and <reason>, so this looks stale — re-orient, '
       + 'or continue anyway?"'

--- a/test/sessions.test.js
+++ b/test/sessions.test.js
@@ -284,6 +284,29 @@ describe('sessions', () => {
       assert.match(prompt, /\*TangleClaw'd into existence\.\*/, 'branding flourish present');
     });
 
+    it('carries the unconditional banner-emit instruction in the header block (fires for every session/model, no continuity index needed)', () => {
+      const project = store.projects.getByName('prime-test');
+      const engine = store.engines.get('claude');
+      const prompt = sessions.generatePrimePrompt(project, engine);
+      // The instruction must appear even on a clean project with no continuity
+      // index (i.e. outside the Resume branch) — this is the whole point of the
+      // hoist: the legacy-summary / no-index path used to drop the banner.
+      assert.match(prompt, /begin your FIRST visible reply/i, 'unconditional emit instruction present');
+      assert.ok(prompt.includes('whatever the model'), 'declared engine/model-agnostic');
+      assert.ok(
+        prompt.includes('does NOT authorize starting work'),
+        'visible-output requirement is split from any wait-for-confirmation directive'
+      );
+      // The instruction must precede the branding line it refers to being echoed,
+      // and sit in the header block before session-ownership content.
+      const emitIdx = prompt.indexOf('begin your FIRST visible reply');
+      const ownershipIdx = prompt.indexOf('Session Ownership');
+      assert.ok(emitIdx > -1, 'emit instruction found');
+      if (ownershipIdx > -1) {
+        assert.ok(emitIdx < ownershipIdx, 'emit instruction sits in the header block, before ownership');
+      }
+    });
+
     it('does not inject Project Version Recording protocol (#101 — TC owns the writer)', () => {
       const project = store.projects.getByName('prime-test');
       const engine = store.engines.get('claude');
@@ -343,6 +366,9 @@ describe('sessions', () => {
         assert.ok(prompt.includes('Freshness check FIRST'), 'mandates a freshness check');
         assert.ok(prompt.includes('We left off at'), 'gives the visible resume wording');
         assert.ok(prompt.includes("TangleClaw'd into existence"), 're-emits the banner visibly');
+        // The unconditional header-block instruction is present here too — proving
+        // the banner-emit directive is truly branch-independent (Resume path).
+        assert.match(prompt, /begin your FIRST visible reply/i, 'unconditional banner-emit instruction present in the Resume path');
         assert.ok(prompt.includes('Wait for the operator'), 'confirm-before-fire, no auto-execute');
         // Surfaces the recorded fields + freshness stamp.
         assert.ok(prompt.includes('next is CC-2'));
@@ -387,6 +413,12 @@ describe('sessions', () => {
         assert.ok(prompt.includes('## Last Session Summary'));
         assert.ok(prompt.includes('Legacy passive summary blob'));
         assert.equal(prompt.includes('## Resume — emit this'), false);
+        // Regression: the legacy (no-index) path took the `else` branch, which
+        // previously carried NO banner-emit instruction — so the banner was
+        // dropped 100% of the time after a mechanical-only wrap. The hoisted
+        // header instruction must still be present here.
+        assert.match(prompt, /begin your FIRST visible reply/i, 'unconditional banner-emit instruction survives the legacy path');
+        assert.match(prompt, /\*TangleClaw'd into existence\.\*/, 'branding flourish present on the legacy path');
       });
 
       it('does not offer a resume from a degraded, judgment-empty index', () => {


### PR DESCRIPTION
## What
Make the `*TangleClaw'd into existence.*` session-start banner surface on **every** session, regardless of wrap tier or which engine/model drives the project.

## Why
The banner lives in the hidden SessionStart prime (`lib/sessions.js` `generatePrimePrompt`). Confirmed against Claude Code's hooks docs: a SessionStart hook can only inject **hidden model context** — it cannot render into the startup header or emit guaranteed-visible terminal output. So the *only* visible path is the model re-printing the banner on its first turn.

The "re-emit this visibly" instruction previously lived **only inside the Resume branch** (which fires only when a continuity index exists). Two failure modes resulted:
- **Deterministic:** any session after a `mechanical-only` wrap took the legacy-summary `else` path, which carried no banner instruction → banner dropped 100% of the time.
- **Probabilistic:** even in the Resume branch the instruction was coupled to a wait-for-confirmation directive, so a task-opening prompt often skipped it.

Note: "before the model-info header" is **not achievable** — the header is rendered by the Claude Code binary and no hook has a slot in it. The best reachable target is deterministic re-emit on the model's first turn, which this delivers.

## How
- Hoist an **unconditional, engine-agnostic** banner-emit instruction into the header block every prime carries, explicitly split from any wait-for-confirmation directive (visible-output requirement only — does not authorize starting work).
- Rewrite the Resume-branch step 2 to reference the now-required banner instead of re-instructing it (dedup, not duplication).

## Test plan
- `test/sessions.test.js`: new/updated regression assertions that the `begin your FIRST visible reply` instruction is present in the **clean/no-index**, **legacy-summary**, and **Resume** paths, plus a header-ordering guard.
- Full suite green: 3892 pass, 0 fail.

Independent Critic: 0 blocking; 1 warning (stale evidence marker — re-ran suite), 1 note (CHANGELOG citation exactness — addressed by adding the Resume-path assertion). Both resolved.