### PR TITLE
Fix priming-roll blocking the wrap on a chunk-less plan (#515)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The `priming-roll` wrap step (`next-session-prime`) now skips — instead of blocking the wrap — when the resolved plan has no `### Chunk N:` headings (#515).** `lib/wrap-steps/priming-roll.js` treated a chunk-less plan asymmetrically: the single-plan resolve path (`.claude/plans/` holds exactly one `.md`) returned it and let `run()` hard-**block** on zero chunks, while the multi-plan path already **skipped** such a plan via `_isPlanInProgress`. So the same spec/design doc (or a not-yet-chunked plan) failed the wrap when it stood alone but was silently dropped when it had company — the `feedback_symmetric_capability_gates` class of gate asymmetry. Observed live 2026-07-09: TC's own wrap went BLOCKED on `.claude/plans/continuity-contract.md` (a Phase-0 spec doc, zero chunks) once the real build plan was archived. The `run()` zero-chunk gate now returns `status:'skipped'` with a reason (`… no ### Chunk N: headings — nothing to roll (add chunk headings if this is meant to be an active build plan)`) and stages no priming write — honest and visible in the drawer, never halting. Applies to explicitly-configured `step.planPath`s too (a pointer at a chunk-less file is a visible skip, not a wrap failure). Re-specified the prior block-asserting test to the new contract and added regression tests pinning single-plan/multi-plan symmetry and the explicit-planPath case (`test/wrap-pipeline.test.js`).
+
 ## [4.8.0] - 2026-07-09
 
 ### Added

--- a/lib/wrap-steps/priming-roll.js
+++ b/lib/wrap-steps/priming-roll.js
@@ -12,7 +12,11 @@
  * Chunk ids tolerate dotted / lettered sub-chunk numbering (e.g.
  * `### Chunk 10c.2: …` parses to id `10c.2`). The "current" chunk is
  * the first un-done heading in document order; the "next" chunk is
- * whatever follows it (or `null` when current is the tail).
+ * whatever follows it (or `null` when current is the tail). A resolved
+ * plan with **no** `### Chunk N:` headings (a spec/design doc, or a
+ * plan not yet chunked) is **skipped with a reason**, not blocked —
+ * nothing to roll, and blocking on it was asymmetric with the
+ * multi-plan path (#515).
  *
  * **Blocker annotations.** A line in a chunk body matching
  * `**Blocked on:** <text>` (case-insensitive) is captured and carried
@@ -477,13 +481,26 @@ async function run(context) {
 
   const chunks = _parseChunks(planContent);
   if (chunks.length === 0) {
+    // No `### Chunk N:` headings — the resolved plan is a spec/design doc
+    // (or a plan not yet chunked), so there is no chunk pointer to roll.
+    // SKIP (not block): this mirrors the multi-plan path, where a chunk-less
+    // plan is dropped by `_isPlanInProgress` rather than failing the wrap.
+    // Blocking here was asymmetric — the same chunk-less plan blocked when it
+    // was the only `.md` in the dir but skipped when it had company (#515).
+    // The skip carries a reason so the drawer still surfaces the "add chunk
+    // headings if this is an active build plan" signal without halting the
+    // wrap. Applies to explicitly-configured planPaths too: an explicit
+    // pointer at a chunk-less file is a visible skip-with-reason, not a hard
+    // wrap failure — honest and non-blocking beats loud-and-blocking here.
+    const rel = path.relative(project.path, planRes.planPath) || planRes.planPath;
+    const reason =
+      `Resolved plan \`${rel}\` has no \`### Chunk N:\` headings — nothing to ` +
+      'roll (add chunk headings if this is meant to be an active build plan)';
     return {
-      ok: false,
-      status: 'blocked',
-      output: {
-        remediation: 'The resolved plan has no `### Chunk N: Title` headings, so there is no chunk to roll the priming pointer to. Add chunk headings to the plan, or point `step.planPath` at the correct plan file.'
-      },
-      blockers: [`No "### Chunk N: Title" headings found in ${planRes.planPath}`]
+      ok: true,
+      status: 'skipped',
+      output: { reason, detail: `No "### Chunk N: Title" headings in ${planRes.planPath}` },
+      blockers: []
     };
   }
 

--- a/test/wrap-pipeline.test.js
+++ b/test/wrap-pipeline.test.js
@@ -1762,14 +1762,65 @@ describe('wrap-step priming-roll — handler (#139 Chunk 6)', () => {
     assert.equal(result.output.pointer.current.id, '7');
   });
 
-  it('blocks when the plan has no ### Chunk headings at all', async () => {
+  it('skips (not blocks) when the single plan has no ### Chunk headings (#515)', async () => {
+    // Behavior change (#515): a resolved plan with zero `### Chunk N:`
+    // headings is a spec/design doc (or a not-yet-chunked plan) — there is
+    // nothing to roll, so the step SKIPS with a reason rather than blocking
+    // the whole wrap. Re-specified from the old block assertion because the
+    // *contract* changed, not to make code pass: blocking here was
+    // asymmetric with the multi-plan path (a chunk-less plan among several
+    // is already skipped via `_isPlanInProgress`). Repro of the live
+    // 2026-07-09 wrap failure on `continuity-contract.md`.
     writePlan('plan.md', '# Just a header, no chunks here.\n');
-    const result = await primingRoll.run(buildContext({ id: 'next-session-prime' }));
-    assert.equal(result.ok, false);
-    assert.match(result.blockers[0], /No "### Chunk N: Title" headings/);
-    // #223 — blocked output carries operator remediation for the drawer.
-    assert.equal(typeof result.output.remediation, 'string');
-    assert.match(result.output.remediation, /Chunk/);
+    const ctx = buildContext({ id: 'next-session-prime' });
+    const result = await primingRoll.run(ctx);
+    assert.equal(result.ok, true, 'a chunk-less single plan must not block the wrap');
+    assert.equal(result.status, 'skipped');
+    assert.deepEqual(result.blockers, []);
+    // The skip stays honest — the drawer surfaces why + the recovery hint.
+    assert.match(result.output.reason, /no `### Chunk N:` headings/i);
+    assert.match(result.output.reason, /nothing to roll/i);
+    assert.match(result.output.reason, /add chunk headings/i);
+    // No pointer is staged — the "field" is null, nothing for commit to flush.
+    assert.equal(ctx.staged['next-session-prime'], undefined,
+      'a skip must not stage a priming-roll write');
+  });
+
+  it('skip-on-no-chunks is symmetric between the single-plan and multi-plan paths (#515)', async () => {
+    // The core of #515: the SAME chunk-less plan must resolve to `skipped`
+    // whether it is the only `.md` in the dir or sits among others. Guards
+    // against the single-plan branch regressing back to a block while the
+    // multi-plan branch skips.
+    const chunkless = '# Design notes\n\nProse, no chunks.\n';
+
+    // (a) alone in the dir → single-plan resolve path
+    writePlan('solo-spec.md', chunkless);
+    const solo = await primingRoll.run(buildContext({ id: 'next-session-prime' }));
+    assert.equal(solo.status, 'skipped', 'lone chunk-less plan skips');
+
+    // (b) among a completed (chunked, all-done) plan → multi-plan resolve path,
+    //     which drops the chunk-less candidate as not-in-progress and finds no
+    //     in-progress plan → also skips. Same end state, different branch.
+    writePlan('shipped.md', '### Chunk 1: A ✅\n');
+    const multi = await primingRoll.run(buildContext({ id: 'next-session-prime' }));
+    assert.equal(multi.status, 'skipped', 'chunk-less plan among others also skips');
+    assert.equal(solo.ok, multi.ok, 'both paths agree on ok=true');
+  });
+
+  it('skips (not blocks) when an explicit step.planPath has no ### Chunk headings (#515)', async () => {
+    // An explicitly-configured pointer at a chunk-less file is a deliberate
+    // visible skip-with-reason, not a hard wrap failure — the operator still
+    // sees it in the drawer, but a doc with nothing to roll never halts.
+    fs.mkdirSync(path.join(projectPath, 'custom'), { recursive: true });
+    fs.writeFileSync(path.join(projectPath, 'custom', 'spec.md'), '# Spec, no chunks.\n');
+    const result = await primingRoll.run(buildContext({
+      id: 'next-session-prime',
+      planPath: 'custom/spec.md'
+    }));
+    assert.equal(result.ok, true);
+    assert.equal(result.status, 'skipped');
+    assert.match(result.output.reason, /custom\/spec\.md/);
+    assert.match(result.output.reason, /nothing to roll/i);
   });
 
   it('rolls a fresh priming file (creates managed block) when none exists', async () => {


### PR DESCRIPTION
## What

`lib/wrap-steps/priming-roll.js` `run()` now **skips with a reason** (instead of hard-**blocking** the wrap) when the resolved plan has no `### Chunk N:` headings.

## Why

The zero-chunk gate was asymmetric with the rest of the resolver:
- **Single-plan path** (`.claude/plans/` holds exactly one `.md`) → returned the plan, and `run()` **blocked** on zero chunks.
- **Multi-plan path** → already **skipped** a chunk-less plan via `_isPlanInProgress`.

So the same spec/design doc (or a not-yet-chunked plan) *failed* the wrap when it stood alone but was *silently dropped* when it had company — the `feedback_symmetric_capability_gates` class of gate asymmetry.

Observed live 2026-07-09: TC's own `next-session-prime` wrap step went **BLOCKED** on `.claude/plans/continuity-contract.md` (a Phase-0 spec doc, zero chunks) once the real build plan was archived.

## How

`run()`'s `chunks.length === 0` branch returns `ok:true / status:'skipped'` with a reason (`… no ### Chunk N: headings — nothing to roll (add chunk headings if this is meant to be an active build plan)`) and stages no priming write. The wrap runner only halts on `!ok && blocker`, so this stops the false wrap failure while keeping the skip **visible and honest** in the drawer. Applies to explicitly-configured `step.planPath`s too (a pointer at a chunk-less file is a visible skip, not a wrap failure).

## Test plan

- Re-specified the prior block-asserting test to the new skip contract (legitimate contract change — documented in-comment, and strengthened: asserts skip + no staging).
- Added regression tests: single-plan/multi-plan **symmetry** and the **explicit-`planPath`** case.
- Full suite green (0 fail); `prawduct-hook test-status` current.
- Critic `final` mode: **0 BLOCKING**, 1 WARNING (stale test-evidence — resolved by recording).

Fixes #515