### PR TITLE
Fix: dashboard wrap trigger is single-flight (UI-3B8N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The dashboard (landing.js) wrap trigger is now single-flight — no concurrent wraps, no mid-wrap dismissal (UI-3B8N).** `landing.js` `confirmWrap` (the project-card wrap trigger, distinct from the in-session one fixed in #519) awaited `POST /wrap` *without* disabling the confirm button, so a second click during the in-flight wrap launched a **concurrent** wrap (double commit / pipeline race), and Cancel or a backdrop click could dismiss the modal mid-wrap. Applied the same fix #519 landed on `public/session.js`: the first click sets a `wrapInFlight` flag, disables **both** Confirm and Cancel, flips the label to **"Wrapping…"**, and blocks every close path (`closeWrapModal` guards on a strict `force !== true`, so the Cancel handler's event-arg and the backdrop's no-arg close can't slip through) until the request resolves — all restored in `finally` so a failed or hung wrap re-enables cleanly. Driven purely by the request lifecycle, no timers (per the no-timer-UI rule, #98/#268). Regression pin in `test/landing-wrap-single-flight.test.js` (structural, matching the `session-wrapper.test.js` convention).
+
 ## [4.9.0] - 2026-07-09
 
 ### Added

--- a/public/landing.js
+++ b/public/landing.js
@@ -1189,6 +1189,13 @@ function wrapProject(name) {
 
 let wrapTarget = null;
 
+/**
+ * True while a wrap `POST` is in flight, so a second confirm can't fire a
+ * concurrent wrap and no close path can dismiss the modal mid-wrap. Reset in
+ * `confirmWrap`'s `finally`. Mirrors the session-page fix (#519 / UI-3B8N).
+ */
+let wrapInFlight = false;
+
 function openWrapModal(name) {
   wrapTarget = name;
   document.getElementById('wrapText').innerHTML =
@@ -1204,24 +1211,63 @@ function openWrapModal(name) {
   document.getElementById('wrapModal').classList.add('open');
 }
 
-function closeWrapModal() {
+/**
+ * Close the wrap modal. Blocked while a wrap is in flight unless forced:
+ * the Cancel handler passes the click Event (not `true`) and the backdrop
+ * handler passes nothing, so a strict `force !== true` check stops both from
+ * dismissing the modal mid-wrap; `confirmWrap` passes `force:true` on success.
+ * @param {boolean} [force] `true` to close past the in-flight guard.
+ */
+function closeWrapModal(force) {
+  if (wrapInFlight && force !== true) return;
   document.getElementById('wrapModal').classList.remove('open');
   wrapTarget = null;
 }
 
+/**
+ * Confirm and execute a wrap for the targeted project (dashboard trigger).
+ * Single-flight: the first click sets an in-flight flag, disables both
+ * buttons, and flips the confirm label to "Wrapping…", so a second click
+ * (or Cancel / backdrop) is a no-op until the request resolves — preventing
+ * a double-click from firing two concurrent wraps. All state is restored in
+ * `finally` so a failed or hung wrap re-enables cleanly. No timers — the
+ * state tracks the request lifecycle (no timer-driven UI lifecycle).
+ */
 async function confirmWrap() {
   if (!wrapTarget) return;
+  // Re-entrancy guard: ignore a second confirm while the first wrap POST is
+  // still in flight, so a double-click can't fire two concurrent wraps.
+  if (wrapInFlight) return;
+
   const pw = document.getElementById('wrapPassword').value;
   const body = {};
   if (pw) body.password = pw;
-  const data = await apiMutate(`/api/sessions/${encodeURIComponent(wrapTarget)}/wrap`, 'POST', body);
-  if (!data) {
-    document.getElementById('wrapError').textContent = 'Wrap failed. Check password.';
-    document.getElementById('wrapError').classList.remove('hidden');
-    return;
+
+  const confirmBtn = document.getElementById('wrapConfirmBtn');
+  const cancelBtn = document.getElementById('wrapCancelBtn');
+  const priorLabel = confirmBtn.textContent;
+  wrapInFlight = true;
+  confirmBtn.disabled = true;
+  cancelBtn.disabled = true;
+  confirmBtn.textContent = 'Wrapping…';
+
+  try {
+    const data = await apiMutate(`/api/sessions/${encodeURIComponent(wrapTarget)}/wrap`, 'POST', body);
+    if (!data) {
+      // Failure — surface inline and let `finally` re-enable so the operator
+      // can fix (e.g. wrong password) and retry without reopening.
+      document.getElementById('wrapError').textContent = 'Wrap failed. Check password.';
+      document.getElementById('wrapError').classList.remove('hidden');
+      return;
+    }
+    closeWrapModal(true); // force-close past the in-flight guard on success
+    await loadProjects();
+  } finally {
+    wrapInFlight = false;
+    confirmBtn.disabled = false;
+    cancelBtn.disabled = false;
+    confirmBtn.textContent = priorLabel;
   }
-  closeWrapModal();
-  await loadProjects();
 }
 
 // ── Theme ──

--- a/test/landing-wrap-single-flight.test.js
+++ b/test/landing-wrap-single-flight.test.js
@@ -1,0 +1,83 @@
+'use strict';
+
+/*
+ * UI-3B8N — the dashboard (landing.js) wrap trigger must be single-flight,
+ * mirroring the session.js fix (#519 / VRF-wrap-single-flight).
+ *
+ * Regression: landing.js `confirmWrap` awaited `POST /wrap` without disabling
+ * the confirm button, so a double-click fired two concurrent wraps (double
+ * commit / pipeline race), and Cancel or a backdrop click could dismiss the
+ * modal mid-wrap. This pins the guard structurally — landing.js is a browser
+ * global script, not a require()-able module, so we assert against source the
+ * same way test/session-wrapper.test.js pins the session-page fix and
+ * test/auth-status-warning.test.js pins its landing surface.
+ */
+
+const { describe, it, before } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+/**
+ * Slice out a top-level function body by brace-matching from its declaration.
+ * @param {string} src full source text
+ * @param {string} decl the function declaration to find (e.g. `async function confirmWrap()`)
+ * @returns {string} the function body including its braces
+ */
+function functionBody(src, decl) {
+  const start = src.indexOf(decl);
+  assert.ok(start !== -1, `${decl} must exist`);
+  const bodyStart = src.indexOf('{', start);
+  let depth = 0;
+  for (let i = bodyStart; i < src.length; i++) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}') {
+      depth--;
+      if (depth === 0) return src.slice(bodyStart, i + 1);
+    }
+  }
+  assert.fail(`${decl} body must close`);
+}
+
+describe('UI-3B8N dashboard wrap trigger is single-flight', () => {
+  let landing;
+
+  before(() => {
+    const root = path.resolve(__dirname, '..');
+    landing = fs.readFileSync(path.join(root, 'public/landing.js'), 'utf8');
+  });
+
+  it('tracks an in-flight flag', () => {
+    assert.ok(landing.includes('let wrapInFlight = false'),
+      'landing.js must track an in-flight flag');
+  });
+
+  it('confirmWrap guards re-entrancy, locks both buttons, and resets in finally', () => {
+    const body = functionBody(landing, 'async function confirmWrap()');
+    assert.ok(body.includes('if (wrapInFlight) return'),
+      'confirmWrap must bail when a wrap is already in flight');
+    assert.ok(body.includes('wrapInFlight = true'),
+      'must set the flag before the POST');
+    assert.ok(/confirmBtn\.disabled = true/.test(body) && /cancelBtn\.disabled = true/.test(body),
+      'must disable both Confirm and Cancel while wrapping');
+    assert.ok(/Wrapping/.test(body),
+      'must show a Wrapping… label');
+    assert.ok(body.includes('} finally {') && /wrapInFlight = false/.test(body),
+      'must reset the in-flight flag in finally (so a failed/hung wrap re-enables)');
+  });
+
+  it('closeWrapModal blocks user closes while a wrap is in flight (strict force check)', () => {
+    assert.ok(landing.includes('if (wrapInFlight && force !== true) return'),
+      'closeWrapModal must block Cancel/backdrop closes mid-wrap via a strict force check');
+    // The success path must force-close past that guard.
+    const body = functionBody(landing, 'async function confirmWrap()');
+    assert.ok(body.includes('closeWrapModal(true)'),
+      'confirmWrap must force-close the modal on success');
+  });
+
+  it('has no timer-driven lifecycle (state tracks the request, not a clock)', () => {
+    const body = functionBody(landing, 'async function confirmWrap()');
+    assert.ok(!/setTimeout|setInterval/.test(body),
+      'confirmWrap must not use timers (no timer-driven UI lifecycle)');
+  });
+});


### PR DESCRIPTION
## What

Makes the **dashboard** (landing.js project-card) wrap trigger single-flight — the same re-entrancy fix #519 landed on the in-session trigger (`public/session.js`).

`landing.js` `confirmWrap` awaited `POST /wrap` without disabling the confirm button, so:
- a second click during the in-flight wrap launched a **concurrent** wrap (double commit / pipeline race), and
- Cancel or a backdrop click could dismiss the modal mid-wrap.

Now the first click sets a `wrapInFlight` flag, disables **both** Confirm and Cancel, flips the label to **"Wrapping…"**, and blocks every close path (`closeWrapModal` guards on a strict `force !== true`, catching both the Cancel handler's event-arg and the backdrop's no-arg close) until the request resolves — all restored in `finally` so a failed or hung wrap re-enables cleanly. No timers (per the no-timer-UI rule, #98/#268).

## Why

Backlog UI-3B8N — the twin defect the Critic flagged while fixing #519. The dashboard trigger carried the identical bug.

## Test plan

- New structural regression pin: `test/landing-wrap-single-flight.test.js` (4 assertions — flag, re-entrancy guard, both-button lock + `finally` restore, strict `force !== true` close guard, no-timer). Matches the `session-wrapper.test.js` convention (landing.js is a browser global, not require()-able).
- Full suite green (0 failed); event wiring verified in `public/ui.js` (Cancel → Event arg, backdrop → no arg, both stopped by the guard; success path force-closes with `closeWrapModal(true)`).
- Independent Critic: 0 blocking, 0 warning (test-evidence refreshed).