### PR TITLE
Fix #557: prime cap no longer drops Resume guard on Medusa launches

### DIFF
--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -2,6 +2,12 @@
 
 <!-- Append new entries at the top. -->
 
+## 2026-07-14: Fix — prime truncation dropped the Resume wait-guard + wrap sentinel on medusaEnabled launches (#557)
+
+<!-- prawduct: type=fix | chunks=557 | scope=med-2k9p-v2 | status=merged -->
+
+**Why:** Operator-reported live regression during the T4 VRF sweep: a freshly-relaunched bypass-mode Gemini session "went to town" at boot (unprompted switchboard/continuity exploration — "thought I was hacked"), while interactive mode sat inert. Root cause reproduced offline against the live store: T1's consumer-contract embed (~14K chars) blows the methodology template's prime cap (`prime.maxTokens * 4`; prawduct 16000, minimal 8000), and `generatePrimePrompt`'s blind tail-truncation silently cut every section after the contract — the Resume block's wait-for-confirmation guard, Active Learnings, and the wrap-sentinel instruction (typed "wrap" dead too). The session booted with a mission-shaped prime and no wait directive; permission mode was the only thing separating quiet from chaos. **What:** bulk reference yields to directives (`lib/sessions.js`) — `_medusaPrimeSection` now carries identity + role only; new `_medusaContractSection` appends the contract LAST, budgeted to the space the cap leaves (full / trimmed with an honest `[contract truncated to fit the prime size budget — full doc at <path>]` note / omitted-with-pointer below a 400-char floor); the blind slice survives only as a safety net the medusa path can no longer trip. Plus an explicit "**context, not a task**" line — participation is event-driven, never a boot mission, truncated or not. Live re-render: portfolio prime 15,996/16,000 chars, every directive present. **Tests:** #557 regression pin (oversized contract + continuity index + cap → all directives survive, honest trim note, blind slice must NOT fire; verified failing pre-fix), budget-floor omission, infinite-budget full embed, guard-line presence (`test/sessions.test.js`); full suite 4186/0/1. **Critic:** verify-resolutions chain (0 blocking, 1 warning — stale test evidence, refreshed) extending cumulative `ce1d1359` to HEAD `62f625c`.
+
 ## 2026-07-14: Feat — banner loop view + force-done + boot listener re-sync (MED-2K9P v2 Slice 1, chunk T4 — TC side complete; Round-3 e2e RAN LIVE)
 
 <!-- prawduct: type=feat | chunks=T4 | scope=med-2k9p-v2 | status=merged -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Prime truncation no longer silently drops the Resume wait-guard and wrap instructions on `medusaEnabled` launches (#557).** Since v4.15.0 (T1), the embedded Medusa consumer contract (~14K chars) blew the methodology template's prime size cap (`prime.maxTokens * 4`), and the blind tail-truncation in `generatePrimePrompt` cut every section after it — the Resume block's "MUST NOT start the work until the operator confirms" guard, Active Learnings, and the wrap-sentinel instruction (typed "wrap" stopped opening the drawer). Observed live 2026-07-14: a bypass-mode Gemini session booted with a mission-shaped prime and no wait directive and went straight into unprompted switchboard exploration. Fix (`lib/sessions.js`): the contract is bulk reference material and now **yields to directives** — `_medusaPrimeSection` carries identity + role only, and new `_medusaContractSection` appends the contract LAST, budgeted to the space the cap leaves: full when it fits, trimmed with an honest `[contract truncated to fit the prime size budget — full doc at <path>]` note, or omitted with a pointer when the remaining budget can't hold a useful fragment (< 400 chars); the blind slice survives only as a safety net that the medusa path can no longer trip. The switchboard section also gains an explicit **"context, not a task"** line — participation is event-driven (act when a message arrives or the operator asks), never a boot mission, regardless of truncation. Tests (`test/sessions.test.js`): the #557 regression pin (oversized contract + continuity index + template cap → Resume guard, wrap sentinel, identity, and honest trim note all present; blind slice must not fire; verified failing pre-fix), budget-floor omission, no-cap full embed, event-driven guard line.
+
 ## [4.17.0] - 2026-07-13
 
 ### Added

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -509,8 +509,10 @@ function generatePrimePrompt(project, engineProfile, options = {}) {
   // couldn't reach TC's own plugin-governed CLAUDE.md anyway, which would
   // silently exclude the primary dogfood session. Only the launch path passes
   // `medusaWorkspaceId`, so re-generation from other callers never fabricates
-  // an identity no listener registered.
-  if (projConfig.medusaEnabled === true && options.medusaWorkspaceId) {
+  // an identity no listener registered. Identity + role only — the bulk
+  // consumer contract is appended after the cap math at the bottom (#557).
+  const medusaActive = projConfig.medusaEnabled === true && Boolean(options.medusaWorkspaceId);
+  if (medusaActive) {
     sections.push(..._medusaPrimeSection(project, options.medusaWorkspaceId));
   }
 
@@ -685,12 +687,26 @@ function generatePrimePrompt(project, engineProfile, options = {}) {
 
   let prompt = sections.join('\n');
 
-  // Respect maxTokens from template prime config (rough character estimate)
-  if (template && template.prime && template.prime.maxTokens) {
-    const maxChars = template.prime.maxTokens * 4; // rough token-to-char ratio
-    if (prompt.length > maxChars) {
-      prompt = prompt.slice(0, maxChars) + '\n\n[Prime prompt truncated]';
-    }
+  // Respect maxTokens from template prime config (rough character estimate).
+  const maxChars = (template && template.prime && template.prime.maxTokens)
+    ? template.prime.maxTokens * 4 // rough token-to-char ratio
+    : Infinity;
+
+  // Medusa consumer contract — appended LAST and budgeted to the space the
+  // cap leaves (#557). Bulk reference material must yield to the directive
+  // sections above (Resume wait-guard, wrap sentinel, scope guard), never
+  // displace them: when the contract was embedded mid-prime, the blind tail
+  // truncation below silently cut every directive after it, and a bypass-mode
+  // session booted with a mission-shaped prime and no wait-for-confirmation.
+  if (medusaActive) {
+    prompt += '\n' + _medusaContractSection(maxChars - prompt.length - 1).join('\n');
+  }
+
+  // Safety net for any other section growth; the contract budgeting above
+  // keeps the medusa path under the cap, so this firing means a NON-yielding
+  // section overflowed — blunt, but directives-first ordering bounds the loss.
+  if (Number.isFinite(maxChars) && prompt.length > maxChars) {
+    prompt = prompt.slice(0, maxChars) + '\n\n[Prime prompt truncated]';
   }
 
   return prompt;
@@ -698,13 +714,14 @@ function generatePrimePrompt(project, engineProfile, options = {}) {
 
 /**
  * Build the Medusa switchboard participation section of the prime prompt
- * (MED-2K9P v2 T1): the session's workspace identity, the participant role
- * instruction, and Medusa's public consumer contract (design §3 — "the agent
- * is the client": identity + role + contract is everything an LLM needs to
- * participate natively). The contract is embedded, not referenced, so the
- * session can participate without a file read; when it can't be resolved the
- * section says so honestly (never a silent omission) — identity + role still
- * inject, since TC's own API endpoints cover inbox/send without the doc.
+ * (MED-2K9P v2 T1): the session's workspace identity and the participant role
+ * instruction (design §3 — "the agent is the client"). The consumer contract
+ * — the third leg of identity + role + contract — is NOT rendered here: it is
+ * bulk reference material appended at the END of the prime by
+ * `_medusaContractSection`, budgeted against the template's prime size cap so
+ * it can never displace directive sections (#557 — before the split, the
+ * embedded contract blew the cap mid-prime and the tail truncation silently
+ * cut the Resume wait-guard and wrap instructions).
  * @param {object} project - Project record (needs `name`).
  * @param {string} workspaceId - The pre-minted workspace id for this launch.
  * @returns {string[]} Prime section lines.
@@ -726,6 +743,12 @@ function _medusaPrimeSection(project, workspaceId) {
     + 'never you.'
   );
   lines.push(
+    '- **This section is context, not a task:** do NOT act on it at session '
+    + 'start — no inbox checks, roster fetches, or switchboard exploration '
+    + 'unprompted. Participate only when a message actually arrives '
+    + '(TangleClaw nudges you when one does) or when the operator asks.'
+  );
+  lines.push(
     '- **How to interact:** TangleClaw already runs your WebSocket listener — '
     + 'do NOT register your own WS connection for this workspace id (two '
     + 'consumers on one id fight over the queue). Use the TangleClaw API '
@@ -733,33 +756,70 @@ function _medusaPrimeSection(project, workspaceId) {
     + `\`GET /api/sessions/${proj}/medusa/messages\`, mark read `
     + `\`POST /api/sessions/${proj}/medusa/read\`, send `
     + `\`POST /api/sessions/${proj}/medusa/send\` (\`{"to","message"}\`), peers `
-    + `\`GET /api/sessions/${proj}/medusa/roster\`.`
+    + `\`GET /api/sessions/${proj}/medusa/roster\`. The full consumer contract `
+    + 'is appended at the end of this prime.'
   );
   lines.push('');
+  return lines;
+}
 
+/** Below this many chars a contract fragment is useless — omit the body and
+ * point at the source doc instead of shipping a misleading stub (#557). */
+const MEDUSA_CONTRACT_MIN_CHARS = 400;
+
+/**
+ * Build the Medusa consumer-contract section, budgeted to the space the
+ * template's prime size cap leaves (#557). Rendered LAST in the prime so bulk
+ * reference material yields to directive sections, never the reverse. Three
+ * honest outcomes: the full contract when it fits; a trimmed contract ending
+ * in a truncation note naming the source doc; or — when the remaining budget
+ * can't hold a useful fragment (< MEDUSA_CONTRACT_MIN_CHARS) — no body at
+ * all, just a pointer to the source. An unresolvable contract keeps the T1
+ * UNAVAILABLE note (never a silent omission).
+ * @param {number} budget - Characters available (Infinity when the template
+ *   sets no `prime.maxTokens` cap).
+ * @returns {string[]} Prime section lines.
+ */
+function _medusaContractSection(budget) {
+  const lines = [];
   const contract = medusa.readContract({ medusaProjectPath: _medusaProjectPath() });
-  if (contract.text) {
-    lines.push(`### Medusa consumer contract (from \`${contract.source}\`)`);
-    lines.push(
-      'The public protocol reference — read it to understand envelopes, '
-      + 'delivery semantics, and how non-TC consumers participate. Remember: '
-      + 'inside this TC-managed session you interact via the TangleClaw API '
-      + 'above, not by opening your own registration.'
-    );
-    lines.push('');
-    lines.push(contract.text.trim());
-  } else {
+  if (!contract.text) {
     const tried = contract.tried.length > 0 ? ` (tried: ${contract.tried.join(', ')})` : ' (no local Medusa checkout registered and MEDUSA_CONTRACT_PATH unset)';
-    lines.push(
-      '### Medusa consumer contract — UNAVAILABLE'
-    );
+    lines.push('### Medusa consumer contract — UNAVAILABLE');
     lines.push(
       `The contract doc could not be resolved at launch${tried}. The TangleClaw `
       + 'API endpoints above still work for inbox/send; for full protocol '
       + 'details see `docs/CONSUMER-CONTRACT.md` in the Medusa repository.'
     );
+    lines.push('');
+    return lines;
   }
-  lines.push('');
+
+  const heading = `### Medusa consumer contract (from \`${contract.source}\`)`;
+  const guidance =
+    'The public protocol reference — read it to understand envelopes, '
+    + 'delivery semantics, and how non-TC consumers participate. Remember: '
+    + 'inside this TC-managed session you interact via the TangleClaw API '
+    + 'above, not by opening your own registration.';
+  const trimNote = `[contract truncated to fit the prime size budget — full doc at ${contract.source}]`;
+  const text = contract.text.trim();
+  // Chars the section costs beyond the contract text itself: heading,
+  // guidance, blank separator lines, and the joining newlines.
+  const overhead = heading.length + guidance.length + 8;
+
+  if (text.length + overhead <= budget) {
+    lines.push(heading, guidance, '', text, '');
+  } else if (budget - overhead - trimNote.length >= MEDUSA_CONTRACT_MIN_CHARS) {
+    const keep = Math.floor(budget - overhead - trimNote.length - 2);
+    lines.push(heading, guidance, '', text.slice(0, keep), '', trimNote, '');
+  } else {
+    lines.push(
+      heading,
+      `Omitted to fit the prime size budget — read the full doc at ${contract.source}. `
+      + 'The TangleClaw API endpoints above cover inbox/send without it.',
+      ''
+    );
+  }
   return lines;
 }
 
@@ -1954,6 +2014,7 @@ module.exports = {
   launchSession,
   launchWebuiSession,
   generatePrimePrompt,
+  _medusaContractSection,
   _writePrimeFile,
   _removePrimeFile,
   _maybeAutoStartMedusa,

--- a/test/sessions.test.js
+++ b/test/sessions.test.js
@@ -105,6 +105,11 @@ describe('sessions', () => {
         if (savedEnv === undefined) delete process.env.MEDUSA_CONTRACT_PATH;
         else process.env.MEDUSA_CONTRACT_PATH = savedEnv;
         store.projectConfig.save(projDir, {});
+        // #557 fixtures — continuity index + oversized contract must never
+        // leak into sibling tests (readIndex flips the prime into its Resume
+        // branch for every later generatePrimePrompt call).
+        fs.rmSync(path.join(projDir, '.tangleclaw'), { recursive: true, force: true });
+        fs.rmSync(path.join(projDir, 'fixture-contract.md'), { force: true });
       });
 
       it('injects contract + identity + role for an opted-in launch', () => {
@@ -152,6 +157,91 @@ describe('sessions', () => {
         assert.ok(prompt.includes('`prime-test-cafe0123`'), 'identity still injects');
         assert.ok(prompt.includes('consumer contract — UNAVAILABLE'), 'missing contract is surfaced, not silent');
         assert.ok(prompt.includes('no-such-contract.md'), 'the tried path is named');
+      });
+
+      it('tells the session participation is event-driven, not a boot task (#557)', () => {
+        const contractFile = path.join(projDir, 'fixture-contract.md');
+        fs.writeFileSync(contractFile, '# Fixture Consumer Contract\nRegister then drain.\n');
+        process.env.MEDUSA_CONTRACT_PATH = contractFile;
+        store.projectConfig.save(projDir, { medusaEnabled: true });
+
+        const project = store.projects.getByName('prime-test');
+        const engine = store.engines.get('claude');
+        const prompt = sessions.generatePrimePrompt(project, engine, { medusaWorkspaceId: 'prime-test-cafe0123' });
+
+        assert.ok(
+          prompt.includes('This section is context, not a task'),
+          'the switchboard section must not read as a boot mission'
+        );
+      });
+
+      it('#557 regression: directive sections survive the template cap — the contract yields, honestly', () => {
+        const wrapSentinel = require('../lib/wrap-sentinel');
+        // An oversized contract: alone it exceeds the minimal template's
+        // 2000-token (8000-char) prime cap several times over. Pre-fix, the
+        // blind tail truncation cut the Resume wait-guard and the wrap
+        // instructions out of the prime — the #557 live regression.
+        const contractFile = path.join(projDir, 'fixture-contract.md');
+        fs.writeFileSync(contractFile, '# Big Consumer Contract\n' + 'protocol detail line\n'.repeat(1500));
+        process.env.MEDUSA_CONTRACT_PATH = contractFile;
+        store.projectConfig.save(projDir, { medusaEnabled: true });
+        const continuityDir = path.join(projDir, '.tangleclaw', 'continuity');
+        fs.mkdirSync(continuityDir, { recursive: true });
+        fs.writeFileSync(path.join(continuityDir, 'index.md'), [
+          '# Continuity Index — prime-test',
+          '',
+          '## Current state',
+          'Mid-build on the fixture feature.',
+          '',
+          '## Next action',
+          '- finish the fixture feature',
+          ''
+        ].join('\n'));
+
+        const project = store.projects.getByName('prime-test');
+        const engine = store.engines.get('claude');
+        const prompt = sessions.generatePrimePrompt(project, engine, { medusaWorkspaceId: 'prime-test-cafe0123' });
+
+        // Every load-bearing directive survives the cap.
+        assert.ok(prompt.includes('## Resume'), 'Resume block survives the cap');
+        assert.ok(prompt.includes('MUST NOT start the work'), 'the wait-for-confirmation guard survives the cap');
+        assert.ok(prompt.includes('## Wrapping this session'), 'wrap instructions survive the cap');
+        assert.ok(prompt.includes(wrapSentinel.SENTINEL_TOKEN), 'the wrap sentinel token survives the cap');
+        assert.ok(prompt.includes('`prime-test-cafe0123`'), 'the workspace identity survives the cap');
+        // The contract yields — trimmed with an honest note, never a blind slice.
+        assert.ok(
+          prompt.includes('truncated to fit the prime size budget'),
+          'the contract trim is announced honestly'
+        );
+        assert.ok(prompt.includes(contractFile), 'the trim note names the source doc');
+        assert.equal(
+          prompt.includes('[Prime prompt truncated]'), false,
+          'the blind tail truncation must not fire on the medusa path'
+        );
+        assert.ok(prompt.length <= 2000 * 4, 'the prime respects the template cap');
+      });
+
+      it('#557: contract body is omitted (with a pointer) when the budget cannot hold a useful fragment', () => {
+        const contractFile = path.join(projDir, 'fixture-contract.md');
+        fs.writeFileSync(contractFile, '# Fixture Consumer Contract\n' + 'line\n'.repeat(200));
+        process.env.MEDUSA_CONTRACT_PATH = contractFile;
+
+        const lines = sessions._medusaContractSection(100);
+        const section = lines.join('\n');
+        assert.ok(section.includes('Omitted to fit the prime size budget'), 'omission is announced');
+        assert.ok(section.includes(contractFile), 'the pointer names the source doc');
+        assert.equal(section.includes('line\nline'), false, 'no contract body ships');
+      });
+
+      it('#557: the full contract still embeds when no cap constrains it', () => {
+        const contractFile = path.join(projDir, 'fixture-contract.md');
+        const body = '# Fixture Consumer Contract\n' + 'protocol detail line\n'.repeat(50);
+        fs.writeFileSync(contractFile, body);
+        process.env.MEDUSA_CONTRACT_PATH = contractFile;
+
+        const section = sessions._medusaContractSection(Infinity).join('\n');
+        assert.ok(section.includes(body.trim()), 'the whole contract embeds under an infinite budget');
+        assert.equal(section.includes('truncated'), false, 'no trim note when nothing was trimmed');
       });
     });
 


### PR DESCRIPTION
## What

Splits the Medusa consumer contract (~14K chars) out of `_medusaPrimeSection` into a new `_medusaContractSection` appended LAST in `generatePrimePrompt`, budgeted to the space the template's prime cap leaves — full when it fits, trimmed with an honest source-naming note, or omitted with a pointer below a 400-char floor. Adds an explicit "context, not a task" line so switchboard participation is event-driven, never a boot mission.

## Why

Since v4.15.0 (T1), the embedded contract blew the prime cap (`prime.maxTokens * 4`) and the blind tail-truncation silently cut every section after it — the Resume wait-for-confirmation guard, Active Learnings, and the wrap-sentinel instruction. Observed live 2026-07-14: a bypass-mode Gemini session booted with a mission-shaped prime and no wait directive and went straight into unprompted switchboard exploration. Bulk reference material now yields to directives, never the reverse; the blind slice survives only as a safety net the medusa path can no longer trip.

## Test plan

- #557 regression pin: oversized contract + continuity index + template cap → Resume wait-guard, wrap sentinel, workspace identity, and honest trim note all present; blind slice must NOT fire; prime ≤ cap. **Verified failing pre-fix** (independently reproduced by the PR reviewer in a clean worktree).
- Budget-floor omission (pointer, no body), infinite-budget full embed, event-driven guard line.
- Full suite green: 4186 pass / 0 fail / 1 skipped.
- Live re-render against the real store: portfolio prime 15,996/16,000 chars, every directive present.

## Review

Critic: verify-resolutions chain, 0 blocking (1 warning — stale test evidence — resolved). Independent PR review (fable, escalate tier): 0 blocking, 0 warnings, 1 note (status stamp convention — addressed).

Fixes #557