### PR TITLE
Add engine-aware wake: nudge antigravity/Gemini-CLI switchboard targets (#560)

### DIFF
--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -2,6 +2,12 @@
 
 <!-- Append new entries at the top. -->
 
+## 2026-07-14: Feat — engine-aware wake nudge (TC#560, first chunk of Switchboard v2 Slice 2)
+
+<!-- prawduct: type=feat | chunks=560 | scope=med-2k9p-v2 | status=branch -->
+
+**Why:** The idle-gated switchboard wake (`lib/medusa-wake.js`) hard-skipped `engineId !== 'claude'` and used Claude-only TUI markers, so a `medusaWake:true` non-Claude target (antigravity/Gemini-CLI) received inbox mail but was never nudged — supervised/autonomous loops against it were structurally dead without a manual `tmux send-keys` nudge (observed live 2026-07-14, loop `80b935a2` sat at round 0 until its wall-time guard halted it). **What:** replaced the Claude-only gate + module-level markers with a per-engine `ENGINE_WAKE_PROFILES` registry (`{busyMarker, promptRe, idleMarker}`) keyed by `engineId`; `_assessPane` takes a profile. Claude's path is byte-for-byte unchanged (`esc to interrupt` + bare `❯`, no idle marker). The antigravity profile (`esc to cancel` + bare `>` + a required `? for shortcuts` at-rest marker) was derived from a LIVE pane capture (Medusa builder pane, 2026-07-14) — which surfaced the load-bearing finding that Gemini-CLI keeps its bare `>` prompt rendered mid-turn, so the busy-marker gate can't be the sole guard and a positive at-rest marker is required. That positive marker also makes the (unforceable, auto-approve builder) permission-dialog case fail-safe by construction (a dialog drops `? for shortcuts` → reads non-idle). webui and unprofiled engines (codex, aider — no live signature captured) stay skipped-and-logged, never woken against a guessed idle signature. **Tests:** antigravity idle/busy/dialog/typing `_assessPane` matrix, cross-profile non-match (Claude pane not idle under the antigravity profile and vice-versa), full idle→nudge tick for an antigravity session, unprofiled-engine/webui skip gate; all Claude pins preserved (`test/medusa-wake.test.js`); full suite 0-fail. **Critic:** verify-resolutions chain (0 blocking/warning, 1 note) — the note (real-dialog capture unforceable on the auto-approve builder) anticipated and enqueued. **VRF queued:** VRF-560-engine-aware-wake.
+
 ## 2026-07-14: Fix — prime truncation dropped the Resume wait-guard + wrap sentinel on medusaEnabled launches (#557)
 
 <!-- prawduct: type=fix | chunks=557 | scope=med-2k9p-v2 | status=merged -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Engine-aware wake nudge — the idle-gated switchboard wake now fires for antigravity/Gemini-CLI targets, not just Claude (#560, first chunk of Switchboard v2 Slice 2).** `lib/medusa-wake.js` no longer hard-skips `engineId !== 'claude'`; idle/busy detection is driven by a per-engine `ENGINE_WAKE_PROFILES` registry, each entry carrying live-probed markers (`{ busyMarker, promptRe, idleMarker }`). Claude's path is byte-for-byte unchanged (`esc to interrupt` + bare `❯`, no positive idle marker). The antigravity profile (`esc to cancel` + bare `>` + a required `? for shortcuts` at-rest marker) was derived from a live pane capture (2026-07-14), which surfaced the load-bearing finding that **Gemini-CLI keeps its bare `>` prompt rendered mid-turn** — so unlike Claude the busy-marker gate can't be the sole guard, and a positive at-rest marker is required. That positive marker also makes the (auto-approve builder → unforceable) permission-dialog case **fail-safe by construction**: a dialog drops `? for shortcuts`, so it reads non-idle even though the bare `>` persists. webui/gateway sessions and engines with no live-captured profile (codex, aider) are skipped and logged once per session, never silently woken against a guessed idle signature. Before this, a `medusaWake:true` non-Claude target received inbox mail but was never nudged, so supervised/autonomous loops against it were structurally dead without a manual `tmux send-keys` nudge (observed live 2026-07-14). Tests (`test/medusa-wake.test.js`): antigravity idle/busy/dialog/typing `_assessPane` matrix, cross-profile non-match (Claude pane not idle under the antigravity profile and vice-versa), full idle→nudge tick for an antigravity session, and the unprofiled-engine/webui skip gate; all existing Claude pins preserved.
+
 ## [4.17.1] - 2026-07-13
 
 ### Fixed

--- a/lib/medusa-wake.js
+++ b/lib/medusa-wake.js
@@ -19,13 +19,19 @@
  *    carries a deterministic busy marker: `esc to interrupt` is present iff a
  *    turn is in flight — strictly more truthful than the 3-line output-age
  *    heuristic in `sessions.detectIdle` (a long quiet tool call reads
- *    false-idle under output-age alone). A pane is judged idle only when BOTH
- *    the busy marker is absent AND a bare `❯` input-prompt line is present
- *    (a pending permission dialog replaces the bare prompt with `❯ 1. Yes`
- *    option rows, so requiring a BARE prompt line also refuses to type into a
- *    dialog — where injected text could answer it — or over an operator's
- *    half-typed input). Two consecutive idle ticks are required (debounce
- *    against capture races at turn boundaries).
+ *    false-idle under output-age alone). A pane is judged idle only when the
+ *    engine's `busyMarker` is absent AND a bare input-prompt line matching the
+ *    engine's `promptRe` is present (a pending permission dialog replaces the
+ *    bare prompt with option rows — Claude's `❯ 1. Yes` — so requiring a BARE
+ *    prompt line also refuses to type into a dialog, where injected text could
+ *    answer it, or over an operator's half-typed input). An engine whose bare
+ *    prompt PERSISTS during a turn (antigravity/Gemini-CLI keeps `>` while
+ *    "Generating…", #560 live spike) also carries a positive `idleMarker` that
+ *    must be present — its at-rest status hint (`? for shortcuts`), absent
+ *    during both generation and any dialog/menu — so the busy-marker gate is
+ *    never the only thing standing between a nudge and a busy pane. Two
+ *    consecutive idle ticks are required (debounce against capture races at
+ *    turn boundaries).
  * 2. **Zero attacker-controlled bytes.** The nudge is a fixed template — the
  *    inbound message text is NEVER typed into the pane (cross-session text
  *    typed into a terminal is an injection surface; the agent fetches it over
@@ -41,10 +47,15 @@
  *    passive badge never did — upgrading TC must not change what an inbound
  *    message costs without the operator choosing it. Requires the listener
  *    already `listening` (i.e. `medusaEnabled`/banner opt-in) on top.
- * 5. **Claude/tmux only (Slice 1).** The idle signature is Claude Code's TUI;
- *    other engines and webui/gateway sessions are skipped (injection is
- *    unsupported for webui; other engines are a later slice). Skips are
- *    logged once per session, never silent.
+ * 5. **Profiled tmux engines only (#560 — engine-aware).** Each supported
+ *    engine has an entry in `ENGINE_WAKE_PROFILES` carrying its live-probed
+ *    idle/busy markers: Claude (`esc to interrupt` + bare `❯`) and antigravity/
+ *    Gemini-CLI (`esc to cancel` + bare `>` + the `? for shortcuts` at-rest
+ *    marker). webui/gateway sessions (no tmux pane — injection unsupported) and
+ *    engines with no profile (e.g. codex, aider — no live idle signature
+ *    captured yet) are skipped and logged once per session, never silent.
+ *    Guessing an unprofiled engine's idle signature is exactly the false-idle
+ *    hazard property 1 forbids, so an unknown engine stays off until probed.
  *
  * Lifecycle mirrors the other boot-time monitors (`wrap-sentinel`,
  * `tunnel-monitor`): `start()` arms a `setInterval` tick wired in `server.js`;
@@ -62,10 +73,35 @@ const DEFAULT_INTERVAL_MS = 5000;
 const IDLE_TICKS_REQUIRED = 2;
 /** Pane tail depth — enough to see the input box + status line. */
 const TMUX_TAIL_LINES = 15;
-/** Claude Code's in-flight-turn marker (T2 spike finding — see header). */
-const BUSY_MARKER = 'esc to interrupt';
-/** A bare input-prompt line: `❯` alone (whitespace-padded), no dialog row. */
-const BARE_PROMPT_RE = /^\s*❯\s*$/;
+
+/**
+ * Per-engine idle/busy detection profiles (#560 — engine-aware wake). Each
+ * value's markers were derived from a LIVE pane capture, never guessed — a
+ * false-idle read is the core injection hazard (header, safety property 1), so
+ * an engine with no live signature stays absent here (→ skipped-and-logged).
+ *
+ * - `busyMarker` (string): substring present iff a turn is in flight; its
+ *   presence blocks a nudge. Load-bearing when the prompt persists during a turn.
+ * - `promptRe` (RegExp): matches a BARE input-prompt line (no dialog/menu row,
+ *   no operator half-typed text). At least one line must match for idle.
+ * - `idleMarker` (string|null): a POSITIVE at-rest signal that must be present
+ *   for idle. Set only for engines whose bare prompt persists during a turn
+ *   (antigravity keeps `>` while "Generating…"), so the busy-marker gate is
+ *   never the sole guard; also excludes dialog/menu states that drop the hint.
+ *   `null` for engines (Claude) where a busy turn already hides the bare prompt.
+ *
+ * @type {Object<string, {busyMarker: string, promptRe: RegExp, idleMarker: (string|null)}>}
+ */
+const ENGINE_WAKE_PROFILES = {
+  // Claude Code (T2 spike, 2026-07-11): `esc to interrupt` in the status line
+  // iff busy; a busy turn hides the bare `❯`, so no positive idle marker needed.
+  claude: { busyMarker: 'esc to interrupt', promptRe: /^\s*❯\s*$/, idleMarker: null },
+  // antigravity / Gemini CLI (#560 spike, 2026-07-14): status flips to
+  // `esc to cancel` (from `? for shortcuts`) while a spinner shows "Generating…"
+  // — but the bare `>` input line is STILL rendered mid-turn, so `? for
+  // shortcuts` is required as the positive at-rest signal.
+  antigravity: { busyMarker: 'esc to cancel', promptRe: /^\s*>\s*$/, idleMarker: '? for shortcuts' }
+};
 
 // CSI escape sequences + bare CR (same construction as wrap-sentinel.js:
 // explicit unicode escapes, newlines preserved so line structure survives).
@@ -91,18 +127,29 @@ function _strip(text) {
 }
 
 /**
- * Judge a captured pane tail: is the session safe to type into right now?
+ * Judge a captured pane tail against an engine profile: is the session safe to
+ * type into right now?
  *
  * Pure — the whole idle policy lives here so tests can pin it byte-for-byte.
+ * Gate order (each blocks alone): busy marker present → `turn-in-flight`;
+ * a positive `idleMarker` required-but-absent → `not-at-rest` (covers an
+ * engine whose prompt persists mid-turn, and any dialog/menu that drops the
+ * at-rest hint); no bare `promptRe` line → `no-bare-prompt`; else idle.
  * @param {string[]} lines - Pane tail lines (raw, may carry ANSI).
+ * @param {{busyMarker: string, promptRe: RegExp, idleMarker: (string|null)}} profile
+ *   - The engine's detection profile (from `ENGINE_WAKE_PROFILES`).
  * @returns {{idle: boolean, reason: string}} `idle` true only when the busy
- *   marker is absent AND a bare `❯` prompt line is present; `reason` is one of
- *   `turn-in-flight` | `no-bare-prompt` | `at-prompt`.
+ *   marker is absent, any required idle marker is present, AND a bare prompt
+ *   line is present; `reason` is one of
+ *   `turn-in-flight` | `not-at-rest` | `no-bare-prompt` | `at-prompt`.
  */
-function _assessPane(lines) {
+function _assessPane(lines, profile) {
   const text = _strip((lines || []).join('\n'));
-  if (text.includes(BUSY_MARKER)) return { idle: false, reason: 'turn-in-flight' };
-  const hasBarePrompt = text.split('\n').some((l) => BARE_PROMPT_RE.test(l));
+  if (text.includes(profile.busyMarker)) return { idle: false, reason: 'turn-in-flight' };
+  if (profile.idleMarker && !text.includes(profile.idleMarker)) {
+    return { idle: false, reason: 'not-at-rest' };
+  }
+  const hasBarePrompt = text.split('\n').some((l) => profile.promptRe.test(l));
   if (!hasBarePrompt) return { idle: false, reason: 'no-bare-prompt' };
   return { idle: true, reason: 'at-prompt' };
 }
@@ -151,12 +198,16 @@ function _scanSession(session) {
     _sessions.set(sessionId, st);
   }
 
-  // Transport + engine gates (Slice 1: Claude over tmux only). Logged once per
-  // session so an unsupported-but-opted-in session is never a silent no-op.
-  if (session.sessionMode === 'webui' || !session.tmuxSession || session.engineId !== 'claude') {
+  // Transport + engine gates (#560 — engine-aware): a live tmux pane and a
+  // known wake profile for the session's engine. webui has no pane; an
+  // unprofiled engine has no live-captured idle signature to type against
+  // safely. Logged once per session so an unsupported-but-opted-in session is
+  // never a silent no-op.
+  const profile = ENGINE_WAKE_PROFILES[session.engineId];
+  if (session.sessionMode === 'webui' || !session.tmuxSession || !profile) {
     if (!st.skipLogged) {
       st.skipLogged = true;
-      log.info('medusa-wake: session skipped (unsupported transport/engine for Slice 1)', {
+      log.info('medusa-wake: session skipped (unsupported transport or unprofiled engine)', {
         sessionId, sessionMode: session.sessionMode, engineId: session.engineId
       });
     }
@@ -223,7 +274,7 @@ function _scanSession(session) {
     st.idleTicks = 0; // pane vanished mid-poll (session dying) — prune pass drops it
     return;
   }
-  const verdict = _assessPane(cap.lines || []);
+  const verdict = _assessPane(cap.lines || [], profile);
   if (!verdict.idle) {
     st.idleTicks = 0;
     return;
@@ -318,7 +369,7 @@ const _internal = {
 module.exports = {
   start,
   stop,
-  BUSY_MARKER,
+  ENGINE_WAKE_PROFILES,
   IDLE_TICKS_REQUIRED,
   _assessPane,
   _nudgeLine,

--- a/test/medusa-wake.test.js
+++ b/test/medusa-wake.test.js
@@ -1,15 +1,18 @@
 'use strict';
 
-// Tests for lib/medusa-wake.js (MED-2K9P v2 Slice 1, chunk T2) — the idle-gated
-// wake-nudge monitor. Drives `_internal.tick()` deterministically with stubbed
-// seams (no tmux, no Bridge, no store); `stop()` between tests clears state.
+// Tests for lib/medusa-wake.js (MED-2K9P v2 Slice 1 chunk T2, extended by #560
+// engine-aware wake) — the idle-gated wake-nudge monitor. Drives
+// `_internal.tick()` deterministically with stubbed seams (no tmux, no Bridge,
+// no store); `stop()` between tests clears state.
 //
 // The safety contract under test, in order:
 //   1. a busy turn is NEVER interrupted (busy marker / no bare prompt / dialog)
 //   2. the nudge carries only TC-controlled bytes (message text never injected)
 //   3. one nudge per fresh-mail edge (watermark; burst = single wake)
 //   4. explicit `medusaWake: true` only; listener must be `listening`
-//   5. Slice-1 transport/engine gates (webui / non-claude skipped, logged once)
+//   5. engine-aware transport/engine gates (#560): webui + engines with no
+//      `ENGINE_WAKE_PROFILES` entry skipped and logged once; profiled engines
+//      (claude, antigravity) each judged against their own live-probed markers
 
 const { describe, it, beforeEach, afterEach } = require('node:test');
 const assert = require('node:assert/strict');

--- a/test/medusa-wake.test.js
+++ b/test/medusa-wake.test.js
@@ -19,7 +19,11 @@ setLevel('error');
 
 const wake = require('../lib/medusa-wake');
 
-// ── Pane fixtures (from the 2026-07-11 live spike captures) ──
+/** The live-probed detection profiles the module ships (#560). */
+const CLAUDE = wake.ENGINE_WAKE_PROFILES.claude;
+const ANTIGRAVITY = wake.ENGINE_WAKE_PROFILES.antigravity;
+
+// ── Claude pane fixtures (from the 2026-07-11 live spike captures) ──
 
 /** An idle Claude Code pane: bare prompt, no busy marker. */
 const IDLE_PANE = [
@@ -46,9 +50,55 @@ const TYPING_PANE = [
   '  ⏵⏵ bypass permissions on (shift+tab to cycle)'
 ];
 
+// ── antigravity / Gemini-CLI pane fixtures (#560 live spike, 2026-07-14) ──
+// The bare `>` prompt persists mid-turn, so idle turns on the positive
+// `? for shortcuts` at-rest marker, not the prompt alone.
+
+/** Idle antigravity pane: bare `>` between rules + the at-rest status hint. */
+const AG_IDLE_PANE = [
+  '  DONE: #51 — PR#56',
+  '─────────────────────',
+  '>',
+  '─────────────────────',
+  '? for shortcuts                                    Gemini 3.5 Flash (Medium)'
+];
+/** Busy antigravity pane: bare `>` STILL rendered, but generating + `esc to cancel`. */
+const AG_BUSY_PANE = [
+  '⣷  Generating...',
+  '─────────────────────',
+  '>',
+  '─────────────────────',
+  'esc to cancel                                      Gemini 3.5 Flash (Medium)'
+];
+/**
+ * A dialog/menu analog with NO busy marker present — bare `>` still rendered,
+ * but the at-rest `? for shortcuts` hint is gone. Deliberately omits
+ * `esc to cancel` to isolate that the POSITIVE idle marker (not the busy gate)
+ * is what refuses it — the fail-safe that covers the unverified real dialog UI.
+ */
+const AG_DIALOG_PANE = [
+  '  Apply this change?  ● Yes   ○ No',
+  '─────────────────────',
+  '>',
+  '─────────────────────',
+  'enter to confirm · ↑↓ to select                    Gemini 3.5 Flash (Medium)'
+];
+/** Operator mid-typing in antigravity: prompt line is non-bare. */
+const AG_TYPING_PANE = [
+  '─────────────────────',
+  '> what is the status',
+  '─────────────────────',
+  '? for shortcuts                                    Gemini 3.5 Flash (Medium)'
+];
+
 /** A live tmux Claude session record. */
 function claudeSession(id = 1) {
   return { id, projectId: id * 10, sessionMode: 'tmux', tmuxSession: `tc-${id}`, engineId: 'claude' };
+}
+
+/** A live tmux antigravity session record. */
+function antigravitySession(id = 1) {
+  return { id, projectId: id * 10, sessionMode: 'tmux', tmuxSession: `tc-${id}`, engineId: 'antigravity' };
 }
 
 /**
@@ -85,26 +135,50 @@ function tickThroughDebounce() {
   for (let i = 0; i < wake.IDLE_TICKS_REQUIRED; i++) wake._internal.tick();
 }
 
-describe('medusa-wake — _assessPane (the idle policy, pinned byte-for-byte)', () => {
+describe('medusa-wake — _assessPane (Claude idle policy, pinned byte-for-byte)', () => {
   it('judges a bare-prompt pane with no busy marker idle', () => {
-    assert.deepEqual(wake._assessPane(IDLE_PANE), { idle: true, reason: 'at-prompt' });
+    assert.deepEqual(wake._assessPane(IDLE_PANE, CLAUDE), { idle: true, reason: 'at-prompt' });
   });
   it('judges a turn-in-flight pane busy even though the bare prompt is rendered', () => {
-    assert.deepEqual(wake._assessPane(BUSY_PANE), { idle: false, reason: 'turn-in-flight' });
+    assert.deepEqual(wake._assessPane(BUSY_PANE, CLAUDE), { idle: false, reason: 'turn-in-flight' });
   });
   it('refuses a permission dialog (selector row is not a bare prompt)', () => {
-    assert.deepEqual(wake._assessPane(DIALOG_PANE), { idle: false, reason: 'no-bare-prompt' });
+    assert.deepEqual(wake._assessPane(DIALOG_PANE, CLAUDE), { idle: false, reason: 'no-bare-prompt' });
   });
   it('refuses to type over an operator\'s half-typed input', () => {
-    assert.deepEqual(wake._assessPane(TYPING_PANE), { idle: false, reason: 'no-bare-prompt' });
+    assert.deepEqual(wake._assessPane(TYPING_PANE, CLAUDE), { idle: false, reason: 'no-bare-prompt' });
   });
   it('strips ANSI before judging (a colored busy marker still blocks)', () => {
     const colored = ['❯ ', '[2mesc to interrupt[0m'];
-    assert.deepEqual(wake._assessPane(colored), { idle: false, reason: 'turn-in-flight' });
+    assert.deepEqual(wake._assessPane(colored, CLAUDE), { idle: false, reason: 'turn-in-flight' });
   });
   it('judges an empty/unknown pane not-idle (fail closed)', () => {
-    assert.equal(wake._assessPane([]).idle, false);
-    assert.equal(wake._assessPane(['some random TUI']).idle, false);
+    assert.equal(wake._assessPane([], CLAUDE).idle, false);
+    assert.equal(wake._assessPane(['some random TUI'], CLAUDE).idle, false);
+  });
+});
+
+describe('medusa-wake — _assessPane (antigravity idle policy, #560)', () => {
+  it('judges a bare `>` pane with the at-rest hint idle', () => {
+    assert.deepEqual(wake._assessPane(AG_IDLE_PANE, ANTIGRAVITY), { idle: true, reason: 'at-prompt' });
+  });
+  it('judges a generating pane busy EVEN THOUGH the bare `>` prompt persists', () => {
+    // The load-bearing #560 finding: antigravity keeps `>` mid-turn, so the
+    // busy marker (not the prompt) is what blocks a nudge here.
+    assert.deepEqual(wake._assessPane(AG_BUSY_PANE, ANTIGRAVITY), { idle: false, reason: 'turn-in-flight' });
+  });
+  it('refuses a dialog/menu: bare `>` present but the at-rest hint is gone → not-at-rest', () => {
+    // Fail-safe by construction — the positive `? for shortcuts` marker is
+    // absent during a dialog, so an unverified dialog UI still reads non-idle.
+    assert.deepEqual(wake._assessPane(AG_DIALOG_PANE, ANTIGRAVITY), { idle: false, reason: 'not-at-rest' });
+  });
+  it('refuses to type over half-typed antigravity input (prompt non-bare)', () => {
+    assert.deepEqual(wake._assessPane(AG_TYPING_PANE, ANTIGRAVITY), { idle: false, reason: 'no-bare-prompt' });
+  });
+  it('a Claude-idle pane is NOT idle under the antigravity profile (markers do not cross)', () => {
+    // The bug this chunk fixes, from the other direction: Claude's `❯` never
+    // matches antigravity's `>` promptRe, and Claude lacks `? for shortcuts`.
+    assert.equal(wake._assessPane(IDLE_PANE, ANTIGRAVITY).idle, false);
   });
 });
 
@@ -273,11 +347,28 @@ describe('medusa-wake — gates (each one blocks alone)', () => {
     assert.equal(world.injected.length, 1, 'same session nudges once active again');
   });
 
-  it('skips webui sessions and non-claude engines (Slice-1 gate)', () => {
+  it('skips webui sessions and unprofiled engines (#560 gate)', () => {
+    // webui has no pane; codex/gemini(retired) have no live-captured profile.
     const webui = { id: 2, projectId: 20, sessionMode: 'webui', tmuxSession: null, engineId: 'openclaw:c1' };
-    const gemini = { id: 3, projectId: 30, sessionMode: 'tmux', tmuxSession: 'tc-3', engineId: 'gemini' };
-    const world = installWorld({ sessions: [webui, gemini] });
+    const codex = { id: 3, projectId: 30, sessionMode: 'tmux', tmuxSession: 'tc-3', engineId: 'codex' };
+    const gemini = { id: 4, projectId: 40, sessionMode: 'tmux', tmuxSession: 'tc-4', engineId: 'gemini' };
+    const world = installWorld({ sessions: [webui, codex, gemini] });
     tickThroughDebounce();
+    assert.equal(world.injected.length, 0);
+  });
+
+  it('nudges an idle antigravity session using its own profile (#560)', () => {
+    // The bug fix, end-to-end: a profiled non-Claude engine wakes on fresh mail.
+    const world = installWorld({ sessions: [antigravitySession(1)], pane: AG_IDLE_PANE });
+    wake._internal.tick();
+    assert.equal(world.injected.length, 0, 'first idle tick is debounce');
+    wake._internal.tick();
+    assert.equal(world.injected.length, 1, 'second idle tick nudges the antigravity pane');
+  });
+
+  it('never nudges a generating antigravity pane (bare `>` persists mid-turn)', () => {
+    const world = installWorld({ sessions: [antigravitySession(1)], pane: AG_BUSY_PANE });
+    for (let i = 0; i < 5; i++) wake._internal.tick();
     assert.equal(world.injected.length, 0);
   });
 


### PR DESCRIPTION
## What
Makes the idle-gated Medusa switchboard wake nudge fire for **antigravity/Gemini-CLI** targets, not just Claude — the first chunk of Switchboard v2 Slice 2.

## Why
`lib/medusa-wake.js` hard-skipped `engineId !== 'claude'` and used Claude-only TUI markers, so a `medusaWake:true` non-Claude target received inbox mail but was **never nudged** — supervised/autonomous loops against it were structurally dead without a manual `tmux send-keys` nudge (observed live 2026-07-14: loop `80b935a2` sat at round 0 until its wall-time guard halted it).

## How
- Replaced the Claude-only gate + module-level markers with a per-engine `ENGINE_WAKE_PROFILES` registry (`{busyMarker, promptRe, idleMarker}`); `_assessPane` takes a profile.
- **Claude path byte-for-byte unchanged** (`esc to interrupt` + bare `❯`, no idle marker).
- Antigravity profile (`esc to cancel` + bare `>` + a required `? for shortcuts` at-rest marker) was **derived from a live pane capture**, which surfaced the load-bearing finding that Gemini-CLI keeps its bare `>` prompt rendered mid-turn — so the busy-marker gate can't be the sole guard, and the positive at-rest marker is required. That marker also makes the (unforceable, auto-approve builder) permission-dialog case **fail-safe by construction** (a dialog drops `? for shortcuts` → reads non-idle).
- webui + unprofiled engines (codex, aider) stay **skipped-and-logged**, never woken against a guessed idle signature.

## Test plan
- `test/medusa-wake.test.js`: antigravity idle/busy/dialog/typing `_assessPane` matrix, cross-profile non-match (both directions), full idle→nudge tick for an antigravity session, unprofiled-engine/webui skip gate; all Claude pins preserved.
- Full suite **0-fail**.
- Live verification queued as `VRF-560-engine-aware-wake` (post-merge + restart — the monitor runs in the TC server).

## Review
Critic: cumulative + verify-resolutions chain, **0 blocking / 0 warning** (1 note: real-dialog capture unforceable on the auto-approve builder — anticipated, enqueued in the VRF). Independent PR reviewer: **0 blocking / 0 warning / 0 notes**, Critic record audited (3 spot-checks passed).

Fixes #560