### PR TITLE
Reconcile .gitignore with prawduct session-file contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,9 +52,16 @@ __pycache__/
 .prawduct/.gates-waived
 .prawduct/reflections.md
 .prawduct/sync-manifest.json
-.prawduct/artifacts/build-plan.md
 .prawduct/.sync-pending
 .prawduct/.advisories.json
 
 # Prawduct plugin version marker (per-repo last-seen)
 .prawduct/.prawduct-version
+
+# Prawduct session files
+.prawduct/.bug-inbox
+.prawduct/.critic-active
+.prawduct/.critic-partials/
+.prawduct/.governance-ledger.jsonl
+.prawduct/.session-base-tree
+.prawduct/.work-model-index.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to TangleClaw are documented in this file.
 
 - **The version-bump wrap step now stamps the prawduct change-log at release time (backlog WRP-9F2K).** When the step promotes `[Unreleased]` into a dated release, it also flips every `<!-- prawduct: ... status=merged ... -->` tag line in that project's `.prawduct/change-log.md` to `status=shipped` — staged through the same single-transaction flush as the version bump, so the ledger and the release change state in one wrap commit. This mechanizes the manual release-checklist flip whose omission let 29 entries rot at `status=merged` across ~15 releases (the ART-4K9M back-stamp); `regen-views` derives build-plan Status checkboxes from `status=shipped` only, so the rot silently un-ticked genuinely shipped chunks. Blanket by design (a promote means everything merged is in the release); statusless tag lines are counted but never flipped (a missing `status=` is the missed-merge-stamp diagnostic); projects without a `.prawduct/change-log.md` are untouched; a flip failure degrades to a step-output warning, honoring the step's never-blocks contract. The step output reports the flip count (wrap drawer + wrap commit body). Tests: pure flip matrix (prose immunity, statusless preservation), handler staging/no-promote/no-file/read-failure gates, flush round-trip, commit-body line — revert-verified (4 pins fail with the stamp neutered).
 
+### Internal
+
+- **Reconciled `.gitignore` with the prawduct session-file contract** (post-sync advisory `gitignore-contract-drift-v1`). Added the six missing session-file entries (`.bug-inbox`, `.critic-active`, `.critic-partials/`, `.governance-ledger.jsonl`, `.session-base-tree`, `.work-model-index.json`) and dropped the `.prawduct/artifacts/build-plan.md` ignore — build plans are tracked-by-contract now. Mechanical `prawduct-hook update-gitignore` run; no code changes.
+
 ## [4.19.1] - 2026-07-17
 
 ### Fixed


### PR DESCRIPTION
## What
Mechanical `prawduct-hook update-gitignore` run to clear the active post-sync advisory (`gitignore-contract-drift-v1`): adds six missing prawduct session-file ignore entries and un-ignores `.prawduct/artifacts/build-plan.md` (tracked-by-contract under the plugin).

## Why
Un-ignored session files risk accidental commits of per-session state; the stale build-plan ignore would silently hide a real build plan from git.

## Test plan
- `git diff` reviewed — ignore-list + CHANGELOG only, no code.
- `grep -E '^## \[' CHANGELOG.md` verified release headings intact after the edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)