### PR TITLE
Fix auth chip false-positive on direct-loopback loads (AUTH-5N2J)

### DIFF
--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -19,6 +19,12 @@ Tag-line conventions (ART-4K9M, ratified 2026-07-17):
 -->
 
 
+## 2026-07-17: Fix — auth chip false-positive on direct-loopback loads: proxy-evidence split (AUTH-5N2J)
+
+<!-- prawduct: type=fix | chunks=01 | scope=auth-5n2j -->
+
+**Why:** Janitor-filed AUTH-5N2J (surfaced during the AUTH-2K9D VRF): in caddy mode, any direct-loopback dashboard load (`localhost:3102` bypassing caddy) ambered the `configured-no-identity` chip against a healthy gate — the AUTH-2K9D design assumed all browser traffic traverses Caddy, which holds remotely but not locally (the 127.0.0.1 bind accepts direct connections). **Discovery (stage was `idea`):** root cause is that Caddy proxies from loopback too, so remote address can't discriminate; the decided contract is proxy evidence — Caddy's `reverse_proxy` sets `X-Forwarded-For` unconditionally (verified against the live hand-edited Caddyfile: every block proxies), a direct client sends none. Decision recorded as an amendment in `docs/auth-status-surfacing.md`. **What:** `resolveAuthStatus` (`lib/auth-identity.js`) splits the no-identity branch: `x-forwarded-for` present → `configured-no-identity` (real AUTH-3 warning preserved); absent → new `configured-bypassed` status, which the chip deliberately renders as nothing (`_authStatusWarning` unchanged — unknown states already map to null; JSDoc documents the silence as intentional). `PROXY_EVIDENCE_HEADER` exported; enum extended. **Spoof wall:** the header classifies the diagnostic only — `resolveRequestUser`'s config-gated trust is untouched; spoofed XFF at worst shows the spoofer an amber chip (pinned by test). **Tests:** unit bypass regression (incl. empty/whitespace/array XFF edges), live-socket API regression (the exact former false-positive request shape now reports `configured-bypassed`), proxied-no-identity coverage, spoof-direction pins, and a frontend structural pin that exactly two states warn.
+
 ## 2026-07-17: Chore — FEATURES.md symbol-anchor convention + stub fold-in + citation contract test (DOC-3K7Q)
 
 <!-- prawduct: type=chore | chunks=01 | scope=doc-3k7q | status=shipped -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The dashboard auth chip no longer false-positives the amber `configured-no-identity` warning on direct-loopback loads (backlog AUTH-5N2J).** In caddy mode a request hitting `localhost:3102` directly (local browser, AI-session `curl`) carries no `X-Auth-User` — the chip read that as a broken identity gate even when caddy auth was healthy. Since Caddy also connects from loopback, the remote address can't distinguish the two paths; the discriminator is proxy evidence: Caddy's `reverse_proxy` always sets `X-Forwarded-For`, a direct client sends none. `resolveAuthStatus` now returns a new `configured-bypassed` status (chip renders nothing — gate health is unknowable from a request that never traversed it) when identity AND `X-Forwarded-For` are both absent; a proxied request without identity still warns `configured-no-identity` (the real AUTH-3 signal, preserved). `X-Forwarded-For` is consulted only to classify the diagnostic — `resolveRequestUser`'s spoof defense is untouched, so spoofing it can at most show the spoofer a warning chip. Design amendment recorded in `docs/auth-status-surfacing.md`. Tests: bypass regression (unit + live-socket API), proxied-no-identity preserved, spoof-direction pins, frontend mapper pinned to exactly two warning states.
+
 ## [4.20.0] - 2026-07-17
 
 ### Added

--- a/docs/auth-status-surfacing.md
+++ b/docs/auth-status-surfacing.md
@@ -1,6 +1,6 @@
 # Auth status surfacing (AUTH-2K9D)
 
-**Status: built (2026-07-08). `/api/server-info.authStatus` + dashboard warning chip.**
+**Status: built (2026-07-08). `/api/server-info.authStatus` + dashboard warning chip. Amended 2026-07-17 (AUTH-5N2J): direct-loopback bypass split out of `configured-no-identity`.**
 
 Related: [ADR 0003 — Ingress model](adr/0003-ingress-model.md), [ADR 0004 — AUTH-2 basic_auth gate](adr/0004-auth-2-basic-auth-gate.md), `lib/auth-identity.js`, `lib/server-info.js`.
 
@@ -26,9 +26,19 @@ Derived from config `{authEnabled, ingressMode}` and the request-resolved `curre
 | `off` | `authEnabled` falsy | Auth not configured (expected) | none |
 | `live` | `authEnabled` && `ingressMode='caddy'` && `currentUser` present | Gate enforcing, identity flowing | existing 👤 chip |
 | `configured-inert` | `authEnabled` && `ingressMode !== 'caddy'` (i.e. direct or any non-caddy mode) | AUTH-2: config claims auth, no gate enforces it | ⚠ warning |
-| `configured-no-identity` | `authEnabled` && `ingressMode='caddy'` && `currentUser` null | AUTH-3: gate up but no identity arriving (missing `header_up`, or request didn't traverse Caddy) | ⚠ warning |
+| `configured-no-identity` | `authEnabled` && `ingressMode='caddy'` && `currentUser` null && `x-forwarded-for` present | AUTH-3: request traversed Caddy but no identity arrived (missing `header_up`) | ⚠ warning |
+| `configured-bypassed` | `authEnabled` && `ingressMode='caddy'` && `currentUser` null && no `x-forwarded-for` | AUTH-5N2J: request hit TC's loopback bind directly without traversing Caddy — gate health unknowable from this request | none |
 
-The `configured-no-identity` state is not a false positive: in `caddy` mode TC binds `127.0.0.1`, so a browser reaching `/api/server-info` should traverse Caddy and carry `x-auth-user`. A `null` there means the identity forwarding is broken — exactly the state to flag. The brief window after flipping to `caddy` mode but before the cutover regenerates the Caddyfile also lands here, which is correct ("configured but not live").
+### The loopback-bypass split (AUTH-5N2J, 2026-07-17)
+
+The original design claimed `configured-no-identity` could not false-positive because "a browser reaching `/api/server-info` should traverse Caddy." That held for the intended remote access path but not for local access: TC's `127.0.0.1` bind in caddy mode still accepts direct connections from the machine itself (`localhost:3102` in a local browser, AI-session `curl` checks), and those legitimately carry no identity — the chip went amber against a perfectly healthy gate on every such load (surfaced during the AUTH-2K9D VRF, 2026-07-09).
+
+**Discriminator: proxy evidence, not remote address.** Caddy connects to TC from loopback exactly like a direct local client, so `req.socket.remoteAddress` cannot tell the two apart. What does distinguish them: Caddy's `reverse_proxy` sets `X-Forwarded-For` on every upstream request (Caddy 2.x default, all blocks in the live Caddyfile included), while a direct client sends none. So with no trusted identity:
+
+- `x-forwarded-for` present → the request traversed a proxy that failed to forward identity → **`configured-no-identity`** (the real AUTH-3 warning, preserved).
+- `x-forwarded-for` absent → the request never passed the gate → **`configured-bypassed`**, and the chip deliberately renders nothing: this request proves nothing about gate health, and the operator's actual access path (through Caddy) still reports truthfully.
+
+**Spoof direction is safe.** `X-Forwarded-For` is consulted only to *classify the diagnostic*, never for identity trust — `resolveRequestUser`'s config-gated spoof defense is unchanged. A direct client spoofing `X-Forwarded-For` can at most show *itself* a false amber chip; it gains no identity and no access. The residual fail-silent case — a proxied request arriving with `X-Forwarded-For` stripped — would suppress a real warning, but Caddy sets the header unconditionally, so that requires a deliberately misconfigured non-Caddy proxy, outside this design's ingress model (ADR 0003).
 
 ### Signal — `/api/server-info`
 

--- a/docs/auth-status-surfacing.md
+++ b/docs/auth-status-surfacing.md
@@ -40,11 +40,13 @@ The original design claimed `configured-no-identity` could not false-positive be
 
 **Spoof direction is safe.** `X-Forwarded-For` is consulted only to *classify the diagnostic*, never for identity trust — `resolveRequestUser`'s config-gated spoof defense is unchanged. A direct client spoofing `X-Forwarded-For` can at most show *itself* a false amber chip; it gains no identity and no access. The residual fail-silent case — a proxied request arriving with `X-Forwarded-For` stripped — would suppress a real warning, but Caddy sets the header unconditionally, so that requires a deliberately misconfigured non-Caddy proxy, outside this design's ingress model (ADR 0003).
 
+**Trade-off accepted: the mid-cutover window goes quiet on loopback.** The original design noted that the window after flipping to `caddy` mode but before the cutover regenerates the Caddyfile landed in `configured-no-identity` ("configured but not live" — a useful nudge). In that window the only reachable path is direct loopback, which now classifies as `configured-bypassed` (silent) — by construction indistinguishable, from the request alone, from a deliberate loopback load against a healthy gate. The nudge isn't lost entirely: the API still reports the distinct `configured-bypassed` value, and any through-proxy load during a broken cutover still warns. Accepted as the cost of killing the standing false positive on an access path operators and AI sessions use routinely.
+
 ### Signal — `/api/server-info`
 
 Add an `authStatus` field (enum above) to the `GET /api/server-info` response, computed server-side from the loaded config + the same `resolveRequestUser(req.headers, config)` call the route already makes for `currentUser`. Pure derivation, single source of truth, unit-testable. Backward-compatible additive field; older clients ignore it.
 
-Derivation lives in a small pure helper (e.g. `authIdentity.resolveAuthStatus(headers, config)` or a `server-info` helper) so the four-state logic is tested independently of the route.
+Derivation lives in a small pure helper (e.g. `authIdentity.resolveAuthStatus(headers, config)` or a `server-info` helper) so the state logic is tested independently of the route.
 
 **Exposure note:** in direct mode `/api/server-info` is already reachable unauthenticated, and every endpoint already responds — so revealing `configured-inert` leaks nothing an attacker couldn't determine by probing. In caddy mode the endpoint is behind the gate. No new exposure.
 

--- a/lib/auth-identity.js
+++ b/lib/auth-identity.js
@@ -29,6 +29,18 @@
 const IDENTITY_HEADER = 'x-auth-user';
 
 /**
+ * Header whose presence marks a request as having traversed a reverse proxy.
+ * Caddy's `reverse_proxy` sets `X-Forwarded-For` on every upstream request, so
+ * in caddy mode its absence means the client reached TC's loopback bind
+ * directly (e.g. `curl localhost:3102`, a local browser) without passing the
+ * gate — a legitimate access path, not evidence the gate is broken. Used ONLY
+ * to classify the `authStatus` diagnostic; never consulted for identity trust
+ * (spoofing it can at most show the spoofer a warning chip).
+ * @type {string}
+ */
+const PROXY_EVIDENCE_HEADER = 'x-forwarded-for';
+
+/**
  * Resolve the authenticated user for a request.
  *
  * @param {object} headers - The request headers (`req.headers`; keys lower-cased
@@ -61,7 +73,7 @@ function resolveRequestUser(headers, config) {
  * Valid `authStatus` values (AUTH-2K9D). See `resolveAuthStatus`.
  * @type {string[]}
  */
-const AUTH_STATUSES = ['off', 'live', 'configured-inert', 'configured-no-identity'];
+const AUTH_STATUSES = ['off', 'live', 'configured-inert', 'configured-no-identity', 'configured-bypassed'];
 
 /**
  * Classify the effective auth-enforcement state for a request (AUTH-2K9D) so the
@@ -74,22 +86,35 @@ const AUTH_STATUSES = ['off', 'live', 'configured-inert', 'configured-no-identit
  * | `off` | `authEnabled` falsy | auth not configured (expected) |
  * | `configured-inert` | `authEnabled` && `ingressMode !== 'caddy'` | AUTH-2: settable-but-inert — direct mode has no in-process gate; only the Caddy cutover reads `authEnabled` |
  * | `live` | `authEnabled` && caddy && identity present | gate enforcing, identity flowing |
- * | `configured-no-identity` | `authEnabled` && caddy && identity null | AUTH-3: gate up but no identity arriving (missing `header_up X-Auth-User`, or the request didn't traverse Caddy / cutover not yet run) |
+ * | `configured-no-identity` | `authEnabled` && caddy && identity null && request traversed a proxy | AUTH-3: gate up but no identity arriving (missing `header_up X-Auth-User`) |
+ * | `configured-bypassed` | `authEnabled` && caddy && identity null && no proxy evidence | request reached TC's loopback bind directly without traversing Caddy — gate health unknowable from this request, no warning warranted |
+ *
+ * The proxy-evidence split (AUTH-5N2J) exists because Caddy connects to TC from
+ * loopback just like a direct local client, so the remote address can't tell the
+ * two apart — but Caddy always sets `X-Forwarded-For` and a direct client sends
+ * none. Without the split, every direct-loopback dashboard load false-positived
+ * the amber `configured-no-identity` warning against a healthy gate.
  *
  * @param {object} headers - Request headers (`req.headers`). May be undefined/null.
  * @param {object} config - Merged TC config; reads `ingressMode` + `authEnabled`.
  *   May be undefined/null.
- * @returns {'off'|'live'|'configured-inert'|'configured-no-identity'}
+ * @returns {'off'|'live'|'configured-inert'|'configured-no-identity'|'configured-bypassed'}
  */
 function resolveAuthStatus(headers, config) {
   if (!config || !config.authEnabled) return 'off';
   // authEnabled is true. In any non-caddy ingress the flag is inert — only the
   // Caddy cutover installs a gate, so direct mode enforces nothing (AUTH-2).
   if (config.ingressMode !== 'caddy') return 'configured-inert';
-  // Caddy mode: the gate should be live. A trust-gated identity ⇒ healthy; null ⇒
-  // gate up but identity not arriving (AUTH-3), which resolveRequestUser reports
-  // as null under the same live-gate precondition checked above.
-  return resolveRequestUser(headers, config) ? 'live' : 'configured-no-identity';
+  // Caddy mode: the gate should be live. A trust-gated identity ⇒ healthy.
+  if (resolveRequestUser(headers, config)) return 'live';
+  // No identity. Only a request that demonstrably traversed a proxy can testify
+  // that identity forwarding is broken (AUTH-3); a direct-loopback request
+  // simply never passed the gate (AUTH-5N2J) — flagging it would be a false
+  // positive. Any non-empty X-Forwarded-For (string or duplicated array header)
+  // counts as traversal evidence.
+  const forwarded = headers && headers[PROXY_EVIDENCE_HEADER];
+  const traversedProxy = Array.isArray(forwarded) ? forwarded.length > 0 : typeof forwarded === 'string' && forwarded.trim().length > 0;
+  return traversedProxy ? 'configured-no-identity' : 'configured-bypassed';
 }
 
-module.exports = { resolveRequestUser, resolveAuthStatus, IDENTITY_HEADER, AUTH_STATUSES };
+module.exports = { resolveRequestUser, resolveAuthStatus, IDENTITY_HEADER, PROXY_EVIDENCE_HEADER, AUTH_STATUSES };

--- a/public/landing.js
+++ b/public/landing.js
@@ -124,7 +124,9 @@ async function loadServerInfo() {
 
 /**
  * Human-readable warning for an auth config-vs-live mismatch (AUTH-2K9D), or null
- * for the healthy/expected states (`off`, `live`, or an older server that omits
+ * for the healthy/expected states (`off`, `live`, `configured-bypassed` — a
+ * direct-loopback load that never traversed the gate says nothing about gate
+ * health, so it deliberately renders no warning — or an older server that omits
  * `authStatus`). Text carries the meaning so the chip is not color-only (a11y).
  * @param {string|null|undefined} authStatus
  * @returns {string|null}

--- a/test/api-auth-identity.test.js
+++ b/test/api-auth-identity.test.js
@@ -105,10 +105,22 @@ describe('AUTH-3 — /api/server-info currentUser (proxy identity over HTTP)', (
     assert.equal(res.body.currentUser, null);
   });
 
-  it("reports authStatus 'configured-no-identity' when caddy gate up but no identity (AUTH-3)", async () => {
+  it("reports authStatus 'configured-no-identity' when a proxied request lacks identity (AUTH-3)", async () => {
     setConfig({ ingressMode: 'caddy', authEnabled: true });
-    const res = await get(server, '/api/server-info');
+    // X-Forwarded-For marks the request as having traversed Caddy, so the
+    // missing identity is real evidence of broken header_up forwarding.
+    const res = await get(server, '/api/server-info', { 'X-Forwarded-For': '100.64.0.7' });
     assert.equal(res.body.authStatus, 'configured-no-identity');
+  });
+
+  it("reports authStatus 'configured-bypassed' on a direct loopback request (AUTH-5N2J regression)", async () => {
+    setConfig({ ingressMode: 'caddy', authEnabled: true });
+    // This request really does hit the server's loopback listener with no proxy
+    // in front — exactly the dashboard-on-localhost load that used to
+    // false-positive the amber configured-no-identity warning.
+    const res = await get(server, '/api/server-info');
+    assert.equal(res.body.authStatus, 'configured-bypassed');
+    assert.equal(res.body.currentUser, null);
   });
 
   it("reports authStatus 'off' when auth is disabled", async () => {

--- a/test/auth-identity.test.js
+++ b/test/auth-identity.test.js
@@ -2,7 +2,7 @@
 
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
-const { resolveRequestUser, resolveAuthStatus, IDENTITY_HEADER, AUTH_STATUSES } = require('../lib/auth-identity');
+const { resolveRequestUser, resolveAuthStatus, IDENTITY_HEADER, PROXY_EVIDENCE_HEADER, AUTH_STATUSES } = require('../lib/auth-identity');
 
 const CADDY_AUTH = { ingressMode: 'caddy', authEnabled: true };
 
@@ -70,17 +70,42 @@ describe('auth-identity.resolveAuthStatus (AUTH-2K9D)', () => {
     assert.equal(resolveAuthStatus({ [IDENTITY_HEADER]: 'jason' }, CADDY_AUTH), 'live');
   });
 
-  it("returns 'configured-no-identity' when caddy+authEnabled but no identity arrives (AUTH-3)", () => {
-    assert.equal(resolveAuthStatus({}, CADDY_AUTH), 'configured-no-identity');
-    assert.equal(resolveAuthStatus({ [IDENTITY_HEADER]: '' }, CADDY_AUTH), 'configured-no-identity');
+  it("returns 'configured-no-identity' when a proxied request arrives without identity (AUTH-3)", () => {
+    // X-Forwarded-For proves the request traversed Caddy, so a missing identity
+    // header there is real evidence the header_up forwarding is broken.
+    const proxied = { [PROXY_EVIDENCE_HEADER]: '100.64.0.7' };
+    assert.equal(resolveAuthStatus(proxied, CADDY_AUTH), 'configured-no-identity');
+    assert.equal(resolveAuthStatus({ ...proxied, [IDENTITY_HEADER]: '' }, CADDY_AUTH), 'configured-no-identity');
     // Ambiguous duplicate header fails closed in resolveRequestUser → still no identity.
-    assert.equal(resolveAuthStatus({ [IDENTITY_HEADER]: ['jason', 'attacker'] }, CADDY_AUTH), 'configured-no-identity');
+    assert.equal(resolveAuthStatus({ ...proxied, [IDENTITY_HEADER]: ['jason', 'attacker'] }, CADDY_AUTH), 'configured-no-identity');
+    // A duplicated X-Forwarded-For (array) is still traversal evidence.
+    assert.equal(resolveAuthStatus({ [PROXY_EVIDENCE_HEADER]: ['1.2.3.4', '5.6.7.8'] }, CADDY_AUTH), 'configured-no-identity');
+  });
+
+  it("returns 'configured-bypassed' on a direct-loopback request in caddy mode (AUTH-5N2J regression)", () => {
+    // The false-positive scenario: `localhost:3102` bypassing caddy carries no
+    // X-Forwarded-For and no identity — gate health is unknowable, not broken.
+    assert.equal(resolveAuthStatus({}, CADDY_AUTH), 'configured-bypassed');
+    // Empty/whitespace X-Forwarded-For is not traversal evidence.
+    assert.equal(resolveAuthStatus({ [PROXY_EVIDENCE_HEADER]: '' }, CADDY_AUTH), 'configured-bypassed');
+    assert.equal(resolveAuthStatus({ [PROXY_EVIDENCE_HEADER]: '   ' }, CADDY_AUTH), 'configured-bypassed');
+    assert.equal(resolveAuthStatus({ [PROXY_EVIDENCE_HEADER]: [] }, CADDY_AUTH), 'configured-bypassed');
+  });
+
+  it('never trusts identity based on proxy evidence — spoof defense unchanged (AUTH-5N2J)', () => {
+    // A direct client spoofing X-Forwarded-For gains nothing: identity trust is
+    // config-gated in resolveRequestUser, and the worst outcome is the spoofer
+    // showing itself the amber warning chip.
+    const spoofed = { [PROXY_EVIDENCE_HEADER]: '9.9.9.9', [IDENTITY_HEADER]: 'attacker' };
+    assert.equal(resolveRequestUser(spoofed, { ingressMode: 'direct', authEnabled: true }), null);
+    assert.equal(resolveAuthStatus(spoofed, { ingressMode: 'direct', authEnabled: true }), 'configured-inert');
   });
 
   it('tolerates missing headers / config without throwing', () => {
     assert.equal(resolveAuthStatus(null, null), 'off');
     assert.equal(resolveAuthStatus(undefined, undefined), 'off');
-    assert.equal(resolveAuthStatus(null, CADDY_AUTH), 'configured-no-identity');
+    // No headers object at all ⇒ no proxy evidence ⇒ bypassed, not a warning.
+    assert.equal(resolveAuthStatus(null, CADDY_AUTH), 'configured-bypassed');
   });
 
   it('only ever returns a value from the AUTH_STATUSES enum', () => {
@@ -88,7 +113,8 @@ describe('auth-identity.resolveAuthStatus (AUTH-2K9D)', () => {
       [{}, { authEnabled: false }],
       [{}, { ingressMode: 'direct', authEnabled: true }],
       [{ [IDENTITY_HEADER]: 'jason' }, CADDY_AUTH],
-      [{}, CADDY_AUTH]
+      [{}, CADDY_AUTH],
+      [{ [PROXY_EVIDENCE_HEADER]: '1.2.3.4' }, CADDY_AUTH]
     ];
     for (const [h, c] of cases) {
       assert.ok(AUTH_STATUSES.includes(resolveAuthStatus(h, c)), `${resolveAuthStatus(h, c)} in enum`);

--- a/test/auth-status-warning.test.js
+++ b/test/auth-status-warning.test.js
@@ -50,6 +50,13 @@ describe('AUTH-2K9D dashboard warning surface', () => {
     // Both warning texts name the concrete remediation.
     assert.match(landing, /run the Caddy cutover/i);
     assert.match(landing, /header_up X-Auth-User/);
+    // Exactly two states produce a warning: a direct-loopback load that never
+    // traversed the gate ('configured-bypassed') must stay silent — it was the
+    // AUTH-5N2J false-positive.
+    const mapperBody = landing.slice(landing.indexOf('function _authStatusWarning('));
+    const fnBody = mapperBody.slice(0, mapperBody.indexOf('\n}\n') + 2);
+    assert.equal((fnBody.match(/return '⚠/g) || []).length, 2);
+    assert.doesNotMatch(fnBody, /authStatus === 'configured-bypassed'/);
   });
 
   it('is state-driven: shows on a message, hides (clears) otherwise — no dismiss/timer', () => {


### PR DESCRIPTION
## What

Fixes the dashboard auth chip false-positiving the amber `configured-no-identity` warning on direct-loopback loads (backlog AUTH-5N2J, janitor-filed during the AUTH-2K9D VRF).

`lib/auth-identity.js` `resolveAuthStatus` now splits the caddy-mode no-identity branch on proxy evidence:

| condition (caddy mode, auth on, no trusted identity) | status | chip |
|---|---|---|
| `X-Forwarded-For` present — request traversed Caddy | `configured-no-identity` | ⚠ amber (unchanged) |
| no `X-Forwarded-For` — request hit the loopback bind directly | `configured-bypassed` *(new)* | none |

The frontend needed no behavior change (unknown statuses already render nothing); a JSDoc note documents the silence as intentional and a new structural pin asserts exactly two states warn.

## Why

In caddy mode TC binds `127.0.0.1`, but that bind still accepts direct connections from the machine itself (`localhost:3102` in a local browser, AI-session `curl` checks). Those legitimately carry no `X-Auth-User`, and the chip read that as a broken identity gate against perfectly healthy caddy auth. Remote address can't discriminate — Caddy proxies from loopback exactly like a direct client — but Caddy's `reverse_proxy` sets `X-Forwarded-For` unconditionally (verified against every block of the live Caddyfile) while a direct client sends none.

**Spoof direction is safe:** `X-Forwarded-For` classifies the diagnostic only; `resolveRequestUser`'s config-gated spoof defense is untouched. A direct client spoofing the header can at most show *itself* a false amber chip (pinned by test). Design amendment recorded in `docs/auth-status-surfacing.md`.

## Test plan

- Unit regression: bypass scenario (`{}` headers) → `configured-bypassed`, incl. empty/whitespace/array `X-Forwarded-For` edges (`test/auth-identity.test.js`).
- Live-socket API regression: the exact former false-positive request shape (direct loopback `GET /api/server-info`, no proxy headers) now reports `configured-bypassed`; proxied-no-identity still warns (`test/api-auth-identity.test.js`).
- Spoof-direction pins: spoofed XFF + identity header in direct mode grants nothing.
- Frontend structural pin: `_authStatusWarning` returns a warning for exactly two states (`test/auth-status-warning.test.js`).
- Full suite green: 4328 tests, 0 failures. Revert-verified: neutering the split fails exactly the 3 regression pins.
