### PR TITLE
Sweep vendored Prawduct V1 remnants from the fleet (Phase A Chunk 04)

### DIFF
--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -28,7 +28,7 @@ Tag-line conventions (ART-4K9M, ratified 2026-07-17):
 
 ## 2026-07-18: Chore — fleet remnant sweep: vendored V1 product-hook eradicated (Chunk 04)
 
-<!-- prawduct: type=chore | chunks=04 | scope=prawduct-v2-sunset -->
+<!-- prawduct: type=chore | chunks=04 | scope=prawduct-v2-sunset | status=shipped -->
 
 **Why:** Phase A Chunk 04 — the 2026-07-14 plugin rollup left the V1 file-sync install's
 vendored artifacts behind across the fleet. **Pre-build verification corrected the spec:**

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -38,9 +38,10 @@ stranded outer dir (not "9 repos"); the codextest settings claim was STALE (alre
 only the TC prime hook remains); and **CLITS** (unregistered repo) was a missed live carrier
 with active product-hook SessionStart/Stop wiring. **Decisions (operator):** write-mode =
 TC-direct sweep + scoped per-repo commits + push where clean; prawduct-test = full retirement.
-**What:** (1) Hook artifacts deleted in all 13 carriers — 10 scoped chore commits (WhitePapers,
+**What:** (1) Hook artifacts deleted in all 13 carriers — 9 scoped carrier commits (WhitePapers,
 Medusa+lib, TangleWeb+lib, JasonVaughanComPortfolio, Notse, RentalClaw-Project+lib, UCI, CLITS,
-TangleClaw-migrate-sandbox+lib, Kobold); 3 untracked-only carriers needed no commit (ScrapeGoat,
+TangleClaw-migrate-sandbox+lib) plus Kobold's separate orphan-CLAUDE.md commit (item 3) = 10
+commits total; 3 untracked-only carriers needed no commit (ScrapeGoat,
 ClawCode-x, codextest); pushed where the branch had no unrelated commits ahead (Medusa,
 TangleWeb, JasonVaughanComPortfolio); settings de-wired in the same commit as the hook delete
 (CLITS + sandbox settings.json were 100% V1-generated → removed whole; sandbox's also pointed

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -26,6 +26,37 @@ Tag-line conventions (ART-4K9M, ratified 2026-07-17):
 -->
 
 
+## 2026-07-18: Chore — fleet remnant sweep: vendored V1 product-hook eradicated (Chunk 04)
+
+<!-- prawduct: type=chore | chunks=04 | scope=prawduct-v2-sunset -->
+
+**Why:** Phase A Chunk 04 — the 2026-07-14 plugin rollup left the V1 file-sync install's
+vendored artifacts behind across the fleet. **Pre-build verification corrected the spec:**
+`tools/product-hook` is a single ~178KB bundled executable (not a tree; 4 repos also carried
+the vendored `tools/lib/` python hook lib); the real inventory was 12 live carriers + TiLT v2's
+stranded outer dir (not "9 repos"); the codextest settings claim was STALE (already clean —
+only the TC prime hook remains); and **CLITS** (unregistered repo) was a missed live carrier
+with active product-hook SessionStart/Stop wiring. **Decisions (operator):** write-mode =
+TC-direct sweep + scoped per-repo commits + push where clean; prawduct-test = full retirement.
+**What:** (1) Hook artifacts deleted in all 13 carriers — 10 scoped chore commits (WhitePapers,
+Medusa+lib, TangleWeb+lib, JasonVaughanComPortfolio, Notse, RentalClaw-Project+lib, UCI, CLITS,
+TangleClaw-migrate-sandbox+lib, Kobold); 3 untracked-only carriers needed no commit (ScrapeGoat,
+ClawCode-x, codextest); pushed where the branch had no unrelated commits ahead (Medusa,
+TangleWeb, JasonVaughanComPortfolio); settings de-wired in the same commit as the hook delete
+(CLITS + sandbox settings.json were 100% V1-generated → removed whole; sandbox's also pointed
+its prime hook at the dead `TangleClaw-v3` path). (2) TiLT v2 stranded outer dir: `.claude/`
+(V1 skills tree + settings pair) and `tools/` deleted (non-git). (3) Orphan engine configs from
+the Chunk 03 boundary: `Kobold/CLAUDE.md` (git rm + commit), `codextest/CLAUDE.md` (untracked rm).
+(4) prawduct-test RETIRED: no git remote, so archived by move to
+`~/Backups/prawduct-test-archive-2026-07-18` + deregistered via `DELETE /api/projects` (rows
+gone, files kept). (5) Two backups deliberately untouched (`TangleClaw-v3-backup-pre-bfg`,
+`~/Backups/TangleClaw-v3-2026-03-16`). **Verified:** `find` over Projects shows product-hook
+only in the untouched backup; fleet-wide settings grep clean; TC's own
+`GET /api/projects/stranded-configs-scan` (the Chunk 02 guard) returns `stranded: []` — the
+TiLT v2 straggler it found is resolved. **TC repo diff is bookkeeping only** (plan, change-log,
+CHANGELOG) — no product code changed; the chunk's substance lives in the foreign-repo commits
+listed above.
+
 ## 2026-07-18: Feat — TiLT template retired + fleet downgrades to minimal (Chunk 03)
 
 <!-- prawduct: type=feat | chunks=03 | scope=prawduct-v2-sunset | status=shipped -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Internal
+
+- **Fleet remnant sweep: the vendored Prawduct V1 `tools/product-hook` bundle is eradicated from every live repo on this machine (V1 Sunset Phase A, Chunk 04).** No TangleClaw code changed — this entry records cross-repo fleet maintenance for audit history. 13 carriers swept (the plan's "9 repos" undercounted; CLITS — an unregistered repo with *active* product-hook SessionStart/Stop wiring — was a missed carrier): hook executable + vendored python `tools/lib/` deleted, settings de-wired in the same commit where wired (dangling-hook loop hazard), 10 scoped per-repo chore commits, pushed where branches were clean. TiLT v2's stranded outer `.claude/` + `tools/` (the #592 straggler) deleted; `Kobold/CLAUDE.md` and `codextest/CLAUDE.md` orphan engine configs removed; prawduct-test retired (archived to `~/Backups/prawduct-test-archive-2026-07-18`, deregistered — it had no git remote). Verified clean via filesystem sweep + `GET /api/projects/stranded-configs-scan` returning zero stranded files. Backups deliberately untouched.
+
 ## [4.22.0] - 2026-07-18
 
 ### Changed


### PR DESCRIPTION
## What

TC-side bookkeeping for **Prawduct V1 Sunset Phase A, Chunk 04** (fleet remnant sweep): CHANGELOG `### Internal` entry + prawduct change-log entry (stamped `status=shipped` for this trunk merge). No TangleClaw code changed — the chunk's substance is cross-repo fleet work recorded by these entries:

- Vendored V1 `tools/product-hook` bundle (+ vendored python lib where present) deleted from all **13 live carriers** — 9 scoped carrier commits + Kobold's orphan-CLAUDE.md commit; 3 untracked-only carriers needed no commit; pushed where branches were clean (Medusa, TangleWeb, JasonVaughanComPortfolio).
- Settings de-wired in the same commit as the hook delete where wired (CLITS, migrate-sandbox — both files 100% V1-generated, removed whole; dangling-hook loop hazard avoided).
- TiLT v2 stranded outer `.claude/` + `tools/` deleted (the #592 straggler found by Chunk 02's scan).
- Orphan engine configs removed: Kobold + codextest root CLAUDE.md.
- prawduct-test **retired**: no git remote → archived to `~/Backups/prawduct-test-archive-2026-07-18`, deregistered from TC.
- Backups deliberately untouched.

## Why

The 2026-07-14 plugin rollup left the V1 file-sync install's artifacts behind fleet-wide. Pre-build verification corrected the plan's spec: 13 carriers (not 9), the codextest settings claim was stale, and CLITS (an unregistered repo) was a missed carrier with *active* product-hook SessionStart/Stop wiring.

## Test plan

- Doc-only PR — `check-pr-doc-only` green; review gates skippable, but per-chunk Critic ran anyway: cumulative (1 blocking: plan-ref formatting; 1 warning: stale test evidence; 1 note) → fixes → verify-resolutions **0/0/0**.
- Fleet verified clean: filesystem sweep shows product-hook only in the untouched backup; `GET /api/projects/stranded-configs-scan` returns `stranded: []`; test evidence current (2232/0/1).

Part of the #538 remnant-sweep tail (Phase A build plan, scope `prawduct-v2-sunset`).