### PR TITLE
Add tc-cleanroom first-run acceptance gate (Phase A Chunk 08)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to TangleClaw are documented in this file.
 
 ### Internal
 
-- **tc-cleanroom first-run acceptance gate** (`deploy/cleanroom/`): compose + provisioner + runbook for exercising TangleClaw's first-time-install experience in a zero-egress Docker container on the habitat host, driven entirely over `ssh` + `docker exec`; `test/cleanroom-compose.test.js` pins the ratified lockdown constraints (internal-only network, no published ports, never pull, compose project pinned to `tc-cleanroom`). First run of the gate filed #614, #615, #616, #617; #613 (PortHub lease silent overwrite) surfaced in the surrounding session.
+- **tc-cleanroom first-run acceptance gate** (`deploy/cleanroom/`): compose + provisioner + tracked image bake recipe + runbook for exercising TangleClaw's first-time-install experience in a zero-egress Docker container on the habitat host, driven entirely over `ssh` + `docker exec`; `test/cleanroom-compose.test.js` pins the ratified lockdown constraints (internal-only network, no published ports, never pull, compose project pinned to `tc-cleanroom`). First run of the gate filed #614, #615, #616, #617; #613 (PortHub lease silent overwrite) surfaced in the surrounding session.
 
 ## [4.25.0] - 2026-07-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Internal
+
+- **tc-cleanroom first-run acceptance gate** (`deploy/cleanroom/`): compose + provisioner + runbook for exercising TangleClaw's first-time-install experience in a zero-egress Docker container on the habitat host, driven entirely over `ssh` + `docker exec`; `test/cleanroom-compose.test.js` pins the ratified lockdown constraints (internal-only network, no published ports, never pull, compose project pinned to `tc-cleanroom`). First run of the gate filed #614, #615, #616, #617; #613 (PortHub lease silent overwrite) surfaced in the surrounding session.
+
 ## [4.25.0] - 2026-07-18
 
 ### Added

--- a/deploy/cleanroom/README.md
+++ b/deploy/cleanroom/README.md
@@ -1,0 +1,47 @@
+# tc-cleanroom — first-run acceptance gate
+
+A disposable, fully isolated Docker environment for exercising TangleClaw's
+first-time-install experience the way a stranger would: fresh clone, follow the
+README, and record every broken or dishonest moment as a GitHub issue. Run it
+before declaring any install-affecting campaign done.
+
+## Where it runs
+
+On the `habitat` Docker host, driven over SSH from the dev machine. The
+container uses the pre-baked `tc-cleanroom-base` image (tmux, git, ttyd, node —
+TangleClaw's runtime deps) on an `internal: true` network: zero egress, no
+published ports, no reach to the host or the production stacks that share the
+box. Everything is driven through `docker exec`. See the header comments in
+`compose.yaml` and `provision.sh` for the binding constraints and their
+rationale.
+
+The image was baked from `.prawduct/artifacts/tc-cleanroom-bake.sh` (local,
+untracked) during an operator-opened network window; re-baking needs another
+window — the provisioner itself never pulls.
+
+## Run the gate
+
+```bash
+./deploy/cleanroom/provision.sh     # bundle HEAD, ship, compose up, clone inside
+# drive the walkthrough:
+ssh habitat 'export PATH="/usr/local/bin:/Applications/Docker.app/Contents/Resources/bin:$PATH"; \
+  docker exec -w /root/TangleClaw tc-cleanroom-tc <cmd>'
+./deploy/cleanroom/provision.sh --down   # teardown (image + staging dir remain)
+```
+
+Walkthrough spine (add anything the README's Quick Start promises):
+
+1. `./deploy/install.sh` — observe how it fails or succeeds; error text must be honest.
+2. `node server.js` — first boot: config/DB creation, the *effective* listen URL vs what the logs and README claim.
+3. Setup wizard flow via API: `GET /api/config` (`setupComplete`), `GET /api/setup/https-check`, `POST /api/setup/scan {"directory": …}`, `POST /api/setup/complete`.
+4. `POST /api/projects/attach {"name": …}` against a seeded git repo in the projects dir.
+5. `POST /api/sessions/<name>` with no engine binary installed — the failure must name the real problem.
+
+Every gap between what docs/logs claim and what actually happens becomes a
+filed issue (`[bug] …`, labeled). The gate passes when a run produces zero new
+issues. Port 3310 is PortHub-reserved for this environment should a
+127.0.0.1-only publish ever be needed (requires moving off the internal-only
+network — a deliberate, operator-ratified change, not a default).
+
+Findings from the 2026-07-18 run: #614, #615, #616, #617 (plus #613 found in
+the surrounding session).

--- a/deploy/cleanroom/README.md
+++ b/deploy/cleanroom/README.md
@@ -15,9 +15,9 @@ box. Everything is driven through `docker exec`. See the header comments in
 `compose.yaml` and `provision.sh` for the binding constraints and their
 rationale.
 
-The image was baked from `.prawduct/artifacts/tc-cleanroom-bake.sh` (local,
-untracked) during an operator-opened network window; re-baking needs another
-window — the provisioner itself never pulls.
+The image is baked from `bake.sh` (tracked here) during an operator-opened
+network window; re-baking needs another window — the provisioner itself never
+pulls.
 
 ## Run the gate
 

--- a/deploy/cleanroom/bake.sh
+++ b/deploy/cleanroom/bake.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+# tc-cleanroom bake — the ONE egress batch for the tc-cleanroom acceptance-gate image.
+# Run INSIDE an open rc-research-mode window, on habitat (ssh habitat 'sh -s' < this,
+# or by RentalClaw verbatim if the TC session is not live when the window opens).
+# Everything after this script completes needs ZERO egress: TC source arrives via
+# scp + docker cp, and TC has no npm dependencies.
+#
+# ttyd is installed from the upstream static aarch64 binary because the `ttyd`
+# apt package exists only in Debian sid — bookworm has none (RentalClaw verified
+# against packages.debian.org, 2026-07-18). Release pinned for reproducibility;
+# the trailing --version makes a bad fetch fail loudly INSIDE the window.
+set -eux
+# Non-interactive ssh gets the docker CLI but NOT Docker Desktop's credential
+# helper (docker-credential-desktop lives in Docker.app's Resources/bin and is
+# invoked even for anonymous Hub pulls) — without this export the first pull
+# dies with "executable file not found in $PATH". Applies to EVERY ssh-driven
+# docker command on habitat, not just this script. (RentalClaw, 2026-07-18.)
+export PATH="/usr/local/bin:/Applications/Docker.app/Contents/Resources/bin:$PATH"
+DOCKER=/usr/local/bin/docker
+
+# 1. Base pulls (linux/arm64 — habitat's Docker Desktop VM is aarch64)
+$DOCKER pull node:22-bookworm
+$DOCKER pull node:22-slim
+
+# 2. Bake tc-cleanroom-base:latest
+BUILDDIR=$(mktemp -d)
+cat > "$BUILDDIR/Dockerfile" <<'DF'
+FROM node:22-bookworm
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends tmux git curl ca-certificates procps \
+ && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL -o /usr/local/bin/ttyd https://github.com/tsl0922/ttyd/releases/download/1.7.7/ttyd.aarch64 \
+ && chmod +x /usr/local/bin/ttyd \
+ && ttyd --version
+DF
+$DOCKER build -t tc-cleanroom-base:latest "$BUILDDIR"
+rm -rf "$BUILDDIR"
+
+# 3. Self-verify — if this passes, the image is provably complete and we are
+#    egress-free for the rest of Chunk 08.
+$DOCKER run --rm tc-cleanroom-base:latest sh -c 'tmux -V && git --version && ttyd --version && node -v && curl --version | head -1'
+echo "BAKE-OK"

--- a/deploy/cleanroom/compose.yaml
+++ b/deploy/cleanroom/compose.yaml
@@ -1,0 +1,34 @@
+# tc-cleanroom — TangleClaw first-run acceptance-gate environment.
+#
+# Runs on the habitat Docker host as compose project `tc-cleanroom`. Binding
+# constraints (operator-ratified lockdown, 2026-07-18):
+#   - Dedicated network with `internal: true` — zero egress, no reach to the
+#     host or other stacks. Because Docker ignores published ports on
+#     internal-only networks, this file publishes NOTHING; the walkthrough is
+#     driven entirely through `docker exec`. If a host publish is ever
+#     enabled, it must bind 127.0.0.1 only and use the PortHub-reserved port
+#     (3310, leased to TangleClaw / tc-cleanroom-server).
+#   - Never attach to existing networks; never rely on host.docker.internal.
+#   - The image is pre-baked (tc-cleanroom-base); no pulls at up-time.
+#
+# The TangleClaw repo arrives as a git bundle mounted read-only at /bundle;
+# the walkthrough clones from it inside the container to simulate a fresh
+# `git clone` without any network egress.
+name: tc-cleanroom
+
+services:
+  tc:
+    image: tc-cleanroom-base:latest
+    pull_policy: never
+    container_name: tc-cleanroom-tc
+    init: true
+    command: ["sleep", "infinity"]
+    working_dir: /root
+    networks:
+      - cleanroom
+    volumes:
+      - ./bundle:/bundle:ro
+
+networks:
+  cleanroom:
+    internal: true

--- a/deploy/cleanroom/provision.sh
+++ b/deploy/cleanroom/provision.sh
@@ -27,12 +27,21 @@ readonly REMOTE_DIR="tc-cleanroom"
 readonly DOCKER_PATH_EXPORT='export PATH="/usr/local/bin:/Applications/Docker.app/Contents/Resources/bin:$PATH"'
 readonly COMPOSE="${DOCKER_PATH_EXPORT}; docker compose -f ~/${REMOTE_DIR}/compose.yaml -p tc-cleanroom"
 
-if [ "${1:-}" = "--down" ]; then
-  # shellcheck disable=SC2029
-  ssh "$HABITAT" "${COMPOSE} down"
-  echo "tc-cleanroom is down (image and ~/${REMOTE_DIR} left in place)."
-  exit 0
-fi
+# Strict argument gate: habitat hosts production stacks, so a typoed teardown
+# flag must fail loudly here — never fall through to a surprise provision.
+case "${1:-}" in
+  --down)
+    # shellcheck disable=SC2029
+    ssh "$HABITAT" "${COMPOSE} down"
+    echo "tc-cleanroom is down (image and ~/${REMOTE_DIR} left in place)."
+    exit 0
+    ;;
+  '') ;; # no args → provision
+  *)
+    echo "usage: $0 [--down]   (unrecognized argument: $1)" >&2
+    exit 2
+    ;;
+esac
 
 echo "==> Bundling repo (HEAD of current branch)"
 BUNDLE="$(mktemp -d)/tc.bundle"

--- a/deploy/cleanroom/provision.sh
+++ b/deploy/cleanroom/provision.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# tc-cleanroom provisioner — stands up (or tears down) the TangleClaw
+# first-run acceptance-gate container on the habitat Docker host.
+#
+# Run FROM the TangleClaw repo on cursatory:
+#   ./deploy/cleanroom/provision.sh          # bundle repo, ship, compose up, clone inside
+#   ./deploy/cleanroom/provision.sh --down   # compose down tc-cleanroom ONLY
+#
+# Safety rails (habitat runs production stacks — openclaw-*, tiltclaw-*, uci-*):
+#   - Every docker/compose invocation is pinned to project `tc-cleanroom` via
+#     an explicit -f/-p; nothing here can list, stop, or remove anything else.
+#   - The image is pre-baked on habitat (pull_policy: never in compose.yaml);
+#     this script performs no pulls, honoring the no-egress lockdown.
+#   - The repo travels as a git bundle over scp — the container needs no
+#     network to "clone" it, preserving the internal-only network.
+#
+# The PATH export below is mandatory for ssh-driven docker on habitat: the
+# non-interactive PATH lacks /usr/local/bin, and credential helpers live in
+# the Docker.app bundle.
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly REPO_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+readonly HABITAT="habitat"
+readonly REMOTE_DIR="tc-cleanroom"
+readonly DOCKER_PATH_EXPORT='export PATH="/usr/local/bin:/Applications/Docker.app/Contents/Resources/bin:$PATH"'
+readonly COMPOSE="${DOCKER_PATH_EXPORT}; docker compose -f ~/${REMOTE_DIR}/compose.yaml -p tc-cleanroom"
+
+if [ "${1:-}" = "--down" ]; then
+  # shellcheck disable=SC2029
+  ssh "$HABITAT" "${COMPOSE} down"
+  echo "tc-cleanroom is down (image and ~/${REMOTE_DIR} left in place)."
+  exit 0
+fi
+
+echo "==> Bundling repo (HEAD of current branch)"
+BUNDLE="$(mktemp -d)/tc.bundle"
+git -C "$REPO_DIR" bundle create "$BUNDLE" HEAD --quiet
+
+echo "==> Shipping compose.yaml + bundle to ${HABITAT}:~/${REMOTE_DIR}/"
+ssh "$HABITAT" "mkdir -p ~/${REMOTE_DIR}/bundle"
+scp -q "${SCRIPT_DIR}/compose.yaml" "${HABITAT}:${REMOTE_DIR}/compose.yaml"
+scp -q "$BUNDLE" "${HABITAT}:${REMOTE_DIR}/bundle/tc.bundle"
+rm -rf "$(dirname "$BUNDLE")"
+
+echo "==> compose up (project tc-cleanroom, pre-baked image, no pulls)"
+# shellcheck disable=SC2029
+ssh "$HABITAT" "${COMPOSE} up -d"
+
+echo "==> Fresh clone inside the container (simulates git clone, zero egress)"
+# shellcheck disable=SC2029
+ssh "$HABITAT" "${DOCKER_PATH_EXPORT}; docker exec tc-cleanroom-tc sh -c 'rm -rf /root/TangleClaw && git clone -q /bundle/tc.bundle /root/TangleClaw && cd /root/TangleClaw && git log --oneline -1'"
+
+echo "==> Ready. Drive the walkthrough with:"
+echo "    ssh ${HABITAT} '${DOCKER_PATH_EXPORT}; docker exec -w /root/TangleClaw tc-cleanroom-tc <cmd>'"

--- a/test/cleanroom-compose.test.js
+++ b/test/cleanroom-compose.test.js
@@ -1,0 +1,49 @@
+'use strict';
+
+// Guards the operator-ratified lockdown constraints of the tc-cleanroom
+// acceptance-gate environment (deploy/cleanroom/). These are textual
+// contracts on purpose — the project is zero-dependency, so there is no
+// YAML parser; the assertions pin the exact spellings compose consumes.
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const CLEANROOM_DIR = path.join(__dirname, '..', 'deploy', 'cleanroom');
+const compose = fs.readFileSync(path.join(CLEANROOM_DIR, 'compose.yaml'), 'utf8');
+const provision = fs.readFileSync(path.join(CLEANROOM_DIR, 'provision.sh'), 'utf8');
+
+describe('tc-cleanroom lockdown contract', () => {
+  test('compose project is named tc-cleanroom', () => {
+    assert.match(compose, /^name: tc-cleanroom$/m);
+  });
+
+  test('the cleanroom network is internal (zero egress)', () => {
+    assert.match(compose, /internal: true/);
+  });
+
+  test('no ports are published (internal networks ignore publishes; none may be declared)', () => {
+    assert.doesNotMatch(compose, /^\s*ports:/m);
+  });
+
+  test('image is pre-baked — compose must never pull', () => {
+    assert.match(compose, /pull_policy: never/);
+  });
+
+  test('no attachment to external/pre-existing networks', () => {
+    assert.doesNotMatch(compose, /external: true/);
+    assert.doesNotMatch(compose, /host\.docker\.internal/);
+  });
+
+  test('provisioner pins every compose invocation to the tc-cleanroom project', () => {
+    const composeLines = provision.split('\n').filter((l) => l.includes('docker compose'));
+    assert.ok(composeLines.length > 0, 'expected docker compose usage in provision.sh');
+    for (const line of composeLines) {
+      assert.ok(line.includes('-p tc-cleanroom'), `compose line missing -p tc-cleanroom: ${line}`);
+    }
+  });
+
+  test('provisioner exports the ssh docker PATH (non-interactive habitat PATH lacks /usr/local/bin)', () => {
+    assert.match(provision, /export PATH="\/usr\/local\/bin:\/Applications\/Docker\.app\/Contents\/Resources\/bin:\$PATH"/);
+  });
+});

--- a/test/cleanroom-compose.test.js
+++ b/test/cleanroom-compose.test.js
@@ -4,46 +4,92 @@
 // acceptance-gate environment (deploy/cleanroom/). These are textual
 // contracts on purpose — the project is zero-dependency, so there is no
 // YAML parser; the assertions pin the exact spellings compose consumes.
-const { test, describe } = require('node:test');
-const assert = require('node:assert');
+// Negative assertions run against comment-stripped content so prose in
+// header comments can name the very patterns being forbidden.
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
+const { spawnSync } = require('node:child_process');
 
 const CLEANROOM_DIR = path.join(__dirname, '..', 'deploy', 'cleanroom');
 const compose = fs.readFileSync(path.join(CLEANROOM_DIR, 'compose.yaml'), 'utf8');
 const provision = fs.readFileSync(path.join(CLEANROOM_DIR, 'provision.sh'), 'utf8');
 
+/**
+ * Strip full-line and trailing comments from YAML/shell-style text so
+ * assertions see only effective configuration, not documentation prose.
+ * @param {string} text - raw file content
+ * @returns {string} content with comment text removed
+ */
+function stripComments(text) {
+  return text
+    .split('\n')
+    .map((line) => line.replace(/(^|\s)#.*$/, ''))
+    .join('\n');
+}
+
+const effective = stripComments(compose);
+
 describe('tc-cleanroom lockdown contract', () => {
-  test('compose project is named tc-cleanroom', () => {
-    assert.match(compose, /^name: tc-cleanroom$/m);
+  it('names the compose project tc-cleanroom', () => {
+    assert.match(effective, /^name: tc-cleanroom$/m);
   });
 
-  test('the cleanroom network is internal (zero egress)', () => {
-    assert.match(compose, /internal: true/);
+  it('declares exactly one network, and it is internal (zero egress)', () => {
+    // A second, non-internal network attached to the service would restore
+    // egress while an "internal: true exists somewhere" check still passed —
+    // so pin the whole networks topology, not just the flag's presence.
+    const topLevelBlocks = effective.match(/^networks:$/gm) || [];
+    assert.equal(topLevelBlocks.length, 1, 'expected exactly one top-level networks block');
+    const topLevel = effective.slice(effective.lastIndexOf('\nnetworks:\n'));
+    const definedNetworks = [...topLevel.matchAll(/^ {2}(\w[\w-]*):/gm)].map((m) => m[1]);
+    assert.deepEqual(definedNetworks, ['cleanroom'], 'only the cleanroom network may be defined');
+    assert.match(topLevel, /internal: true/);
+    const serviceNets = compose.match(/networks:\n( {6}- .+\n)+/);
+    assert.ok(serviceNets, 'service must list its networks explicitly');
+    assert.deepEqual(
+      serviceNets[0].split('\n').filter((l) => l.trim().startsWith('- ')).map((l) => l.trim().slice(2)),
+      ['cleanroom'],
+      'the service may attach only to the cleanroom network'
+    );
   });
 
-  test('no ports are published (internal networks ignore publishes; none may be declared)', () => {
-    assert.doesNotMatch(compose, /^\s*ports:/m);
+  it('publishes no ports (internal networks ignore publishes; none may be declared)', () => {
+    assert.doesNotMatch(effective, /^\s*ports:/m);
   });
 
-  test('image is pre-baked — compose must never pull', () => {
-    assert.match(compose, /pull_policy: never/);
+  it('never pulls — the image is pre-baked', () => {
+    assert.match(effective, /pull_policy: never/);
   });
 
-  test('no attachment to external/pre-existing networks', () => {
-    assert.doesNotMatch(compose, /external: true/);
-    assert.doesNotMatch(compose, /host\.docker\.internal/);
+  it('attaches to no external or pre-existing networks', () => {
+    assert.doesNotMatch(effective, /external: true/);
+    assert.doesNotMatch(effective, /host\.docker\.internal/);
   });
 
-  test('provisioner pins every compose invocation to the tc-cleanroom project', () => {
-    const composeLines = provision.split('\n').filter((l) => l.includes('docker compose'));
+  it('pins every compose invocation in the provisioner to the tc-cleanroom project', () => {
+    const composeLines = stripComments(provision).split('\n').filter((l) => l.includes('docker compose'));
     assert.ok(composeLines.length > 0, 'expected docker compose usage in provision.sh');
     for (const line of composeLines) {
       assert.ok(line.includes('-p tc-cleanroom'), `compose line missing -p tc-cleanroom: ${line}`);
     }
   });
 
-  test('provisioner exports the ssh docker PATH (non-interactive habitat PATH lacks /usr/local/bin)', () => {
+  it('exports the ssh docker PATH (non-interactive habitat PATH lacks /usr/local/bin)', () => {
     assert.match(provision, /export PATH="\/usr\/local\/bin:\/Applications\/Docker\.app\/Contents\/Resources\/bin:\$PATH"/);
+  });
+
+  it('rejects unrecognized provisioner arguments before touching the remote host', () => {
+    const run = spawnSync('bash', [path.join(CLEANROOM_DIR, 'provision.sh'), '--dwon'], {
+      encoding: 'utf8',
+      timeout: 10000,
+    });
+    assert.notEqual(run.status, 0, 'a typoed flag must not fall through to provisioning');
+    assert.match(run.stderr + run.stdout, /usage/i);
+  });
+
+  it('tracks the image bake recipe beside the compose file (reproducible from a fresh clone)', () => {
+    assert.ok(fs.existsSync(path.join(CLEANROOM_DIR, 'bake.sh')), 'deploy/cleanroom/bake.sh must exist');
   });
 });


### PR DESCRIPTION
## What

The `deploy/cleanroom/` toolkit: compose file, provisioner, tracked image bake recipe, and runbook for standing up TangleClaw in a zero-egress Docker container on the habitat host and walking the first-time-install experience as a stranger would. `test/cleanroom-compose.test.js` pins the operator-ratified lockdown contract (single internal-only network with the service attached to nothing else, no published ports, `pull_policy: never`, every compose call pinned to `-p tc-cleanroom`, provisioner rejects unrecognized args before touching the remote host).

## Why

Phase A's acceptance gate (re-runs at Phase B exit): the first-run experience had never been exercised in a clean environment. The gate's first run filed #614 (install.sh has no platform guard), #615 (Homebrew bootstrap failure masked → dishonest error), #616 (listen log claims https while serving HTTP), #617 (README port 3102 vs fresh default 3101).

## Test plan

- Full suite green with in-session machine-backed evidence (2275 top-level / 4405 subtests, 0 fail).
- Gate executed live on habitat 2026-07-18 (provision → walkthrough → teardown); prod stacks untouched.
- Critic: cumulative review + verify-resolutions — 0 unresolved findings.