### PR TITLE
Fix priming-roll resolving the wrong plan and misreading done-state

### DIFF
--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -63,7 +63,7 @@ an un-ticked source veto a ticked one would resurrect shipped chunks. A roster-o
 plan (the compact format this plan shipped with before anchors were added) supplies
 the chunk list itself. `TITLE_SEPARATOR_RE` covers em/en dash and hyphen.
 
-**Tests:** `test/wrap-step-priming-roll.test.js` +29 (53→82 in-file): #620 repro,
+**Tests:** `test/wrap-step-priming-roll.test.js` +34 (48→82 in-file): #620 repro,
 precedence-preservation for both operator hatches, dangling-pointer skip, traversal
 block, column-0 contract, roster union/scoping/roster-only, separator forms, and the
 Critic-caught edges below. Revert-verified — 13 fail against the pre-fix module, 0

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -26,6 +26,58 @@ Tag-line conventions (ART-4K9M, ratified 2026-07-17):
 -->
 
 
+## 2026-07-19: Fix — priming-roll resolved the wrong plan and misread done-state (#620)
+
+<!-- prawduct: type=bugfix | scope=wrap-620 -->
+
+**Why:** The `next-session-prime` wrap step reported **Done** while priming the next
+session onto unrelated, stale work. Found by auditing the 2026-07-18 wrap (PR #619,
+`10a355e`), which closed Phase A Chunk 08 of the prawduct-v2-sunset plan and then wrote
+`**Active:** Chunk 01 — — One-way auto-inject` pointing at
+`.claude/plans/switchboard-v2-autoinject-loop.md`. Three defects, one family — TC's
+plan machinery encodes conventions that plugin-governed plans do not use:
+
+1. **Wrong plan.** `_resolvePlanPath` knew only `.claude/plans/`. A governed project
+   keeps its plan under `.prawduct/artifacts/` and names it via column-0
+   `active_build_plan:` in `.prawduct/project-state.yaml`. With one unrelated `.md`
+   in `.claude/plans/`, the "only file in the dir" rule matched and the step declared
+   success. Reproduces on every plugin-governed project — now the fleet default.
+2. **Wrong chunk.** Done-state was read only from `✅` on `### Chunk NN:` headings.
+   Governed plans declare their `## Status` checkbox roster the cross-session tracker
+   (this plan says so in its own header comment) and leave the heading anchors — which
+   exist for `verify-chunk-refs` — un-ticked. So a plan with all 8 chunks `[x]` parsed
+   as zero-done and pointed at chunk 01.
+3. **Doubled separator.** The title strip handled `:` but not the em-dash form the
+   plan uses, rendering `Chunk 01 — — Title`.
+
+**What:** `_readGovernedPlan` reads the column-0 pointer (line regex, not a YAML dep;
+indented keys deliberately ignored to match the framework's own reader) and slots into
+the precedence ladder BELOW `step.planPath` and the operator's `activePlan` pick, so
+neither is overridden — the multi-plan picker (#428) persists to `activePlan` and must
+keep winning. A declared-but-missing pointer SKIPS with a reason rather than falling
+through to the heuristic, since falling through is precisely what manufactured the
+confidently-wrong pointer. `_parseRoster` reads the `## Status` section (scoped
+heading → next `##`, so stray prose checkboxes can't mark chunks done); done-state is
+the UNION of roster tick and heading `✅` — both are affirmative markers, and letting
+an un-ticked source veto a ticked one would resurrect shipped chunks. A roster-only
+plan (the compact format this plan shipped with before anchors were added) supplies
+the chunk list itself. `TITLE_SEPARATOR_RE` covers em/en dash and hyphen.
+
+**Tests:** `test/wrap-step-priming-roll.test.js` +22 (65→75 in-file plus the governed
+suite): #620 repro, precedence-preservation for both hatches, dangling-pointer skip,
+traversal block, column-0 contract, roster union/scoping/roster-only, separator forms.
+Revert-verified — 13 fail against the pre-fix module, 0 after. Also fixed a
+pre-existing harness leak: the handler suite installed a throwing `readFileSync` stub
+on the shared `_internal` singleton and never restored it, so any suite declared after
+it captured the poisoned fn as its "originals" (it silently corrupted the new suite on
+first run). Full suite 4433 tests / 0 fail, exit 0.
+
+**Verified:** ran the step against this repo — resolves
+`.prawduct/artifacts/prawduct-v2-sunset-build-plan.md`, `allDone: true`, renders
+"All chunks … are marked done." Matches reality (Phase A complete). The stale priming
+block left by the bad wrap was corrected in the same commit.
+
+
 ## 2026-07-18: Feature — Master settings surface v1 (Chunk 07)
 
 <!-- prawduct: type=feature | chunks=07 | scope=prawduct-v2-sunset | status=shipped -->

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -26,7 +26,7 @@ Tag-line conventions (ART-4K9M, ratified 2026-07-17):
 -->
 
 
-## 2026-07-19: Fix — priming-roll resolved the wrong plan and misread done-state (#620)
+## 2026-07-18: Fix — priming-roll resolved the wrong plan and misread done-state (#620)
 
 <!-- prawduct: type=bugfix | scope=wrap-620 -->
 
@@ -63,14 +63,28 @@ an un-ticked source veto a ticked one would resurrect shipped chunks. A roster-o
 plan (the compact format this plan shipped with before anchors were added) supplies
 the chunk list itself. `TITLE_SEPARATOR_RE` covers em/en dash and hyphen.
 
-**Tests:** `test/wrap-step-priming-roll.test.js` +22 (65→75 in-file plus the governed
-suite): #620 repro, precedence-preservation for both hatches, dangling-pointer skip,
-traversal block, column-0 contract, roster union/scoping/roster-only, separator forms.
-Revert-verified — 13 fail against the pre-fix module, 0 after. Also fixed a
-pre-existing harness leak: the handler suite installed a throwing `readFileSync` stub
-on the shared `_internal` singleton and never restored it, so any suite declared after
-it captured the poisoned fn as its "originals" (it silently corrupted the new suite on
-first run). Full suite 4433 tests / 0 fail, exit 0.
+**Tests:** `test/wrap-step-priming-roll.test.js` +29 (53→82 in-file): #620 repro,
+precedence-preservation for both operator hatches, dangling-pointer skip, traversal
+block, column-0 contract, roster union/scoping/roster-only, separator forms, and the
+Critic-caught edges below. Revert-verified — 13 fail against the pre-fix module, 0
+after. Also fixed a pre-existing harness leak: the handler suite installed a throwing
+`readFileSync` stub on the shared `_internal` singleton and never restored it, so any
+suite declared after it captured the poisoned fn as its "originals" (it silently
+corrupted the new governed suite on its first run). Full suite exit 0 — 2291 top-level
+cases / 0 fail per the JUnit report ingested as test evidence; 4440 / 0 counting
+subtests.
+
+**Critic (cumulative `rev-20260719T022842Z-ea9618af`, 1 blocking / 3 warning / 2 note):**
+BLOCKING — asserted suite results with no recorded evidence at this tree (verbatim
+recurrence of learning WRP-9F2K); resolved by ingesting a JUnit report rather than
+hand-typed counts. W-1 future-dated entry (UTC had rolled, local had not) — corrected.
+W-2 the roster↔heading join keyed on the raw id string, so a plan writing `- [x] Chunk 1`
+against `### Chunk 01:` would miss the lookup and park the pointer on chunk 01 — the very
+failure this fix exists to kill; `_chunkIdKey` now normalizes leading zeros per dotted
+segment, with the raw id preserved for display. W-3 doc drift at 3 sites still calling
+`### Chunk N:` headings the only chunk source, including an operator-facing skip reason
+that misdirected roster-only authors — all reworded. N-1 a `.prawduct/`-prefixed pointer
+value double-prefixed and silently skipped — both spellings now honoured.
 
 **Verified:** ran the step against this repo — resolves
 `.prawduct/artifacts/prawduct-v2-sunset-build-plan.md`, `allDone: true`, renders

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`next-session-prime` primed the next session onto the wrong plan and the wrong chunk** (#620). The `priming-roll` wrap step resolved the build plan from `.claude/plans/` only, so on a plugin-governed project — where the plan lives under `.prawduct/artifacts/` and is named by `active_build_plan` in `.prawduct/project-state.yaml` — it fell through to its "the only `.md` in the directory" heuristic and rolled the pointer onto an unrelated plan, reporting success. It now reads that declared pointer (ranked below `step.planPath` and the operator's `activePlan` pick, so neither is overridden); a declared-but-missing pointer skips with a reason rather than falling through to the heuristic that caused the misfire. Done-state is additionally read from a plan's `## Status` checkbox roster, which governed plans declare their cross-session tracker while leaving the `### Chunk NN:` spec anchors un-ticked — previously every such plan reported chunk 01 as active no matter how much had shipped. A roster-only plan (no anchor sections) now supplies the chunk list itself. Chunk titles written with an em-dash separator (`### Chunk 01 — Title`) no longer render a doubled separator.
+
 ## [4.25.1] - 2026-07-18
 
 ### Internal

--- a/lib/wrap-steps/priming-roll.js
+++ b/lib/wrap-steps/priming-roll.js
@@ -10,7 +10,11 @@
  * own #139 build plan already uses: `### Chunk N: Title` headings,
  * with a `✅` anywhere on the heading line marking that chunk as done.
  * Chunk ids tolerate dotted / lettered sub-chunk numbering (e.g.
- * `### Chunk 10c.2: …` parses to id `10c.2`). The "current" chunk is
+ * `### Chunk 10c.2: …` parses to id `10c.2`). A `## Status` checkbox
+ * roster (`- [x] Chunk NN: Title`) is honoured as a second done-source
+ * and, on a plan that has no `### Chunk` headings, as the chunk list
+ * itself — governed plans declare that roster their tracker and leave
+ * the heading sections un-ticked (#620). The "current" chunk is
  * the first un-done heading in document order; the "next" chunk is
  * whatever follows it (or `null` when current is the tail). A resolved
  * plan with **no** `### Chunk N:` headings (a spec/design doc, or a
@@ -45,9 +49,10 @@
  * **Step config.**
  *   - `step.planPath`    — optional. Project-relative or absolute path
  *                          to the plan markdown. If unset, the plan is
- *                          resolved by precedence (#226): `activePlan` in
- *                          `.tangleclaw/project.json` → the only `.md` in
- *                          `<project>/.claude/plans/` → among several, the
+ *                          resolved by precedence (#226/#620): `activePlan`
+ *                          in `.tangleclaw/project.json` → `active_build_plan`
+ *                          in `.prawduct/project-state.yaml` → the only `.md`
+ *                          in `<project>/.claude/plans/` → among several, the
  *                          single in-progress plan. Zero in-progress →
  *                          skip ("nothing to roll"); more than one →
  *                          blocked with `output.remediation`. See
@@ -81,12 +86,74 @@ const DEFAULT_PLANS_DIR = '.claude/plans';
 const CHUNK_HEADING_RE = /^###\s+Chunk\s+([0-9]+[a-z]?(?:\.[0-9]+[a-z]?)*)\b(.*)$/i;
 const CHUNK_LINE_LOOSE_RE = /^###\s+Chunk\b/i;
 const DONE_MARKER_RE = /✅/;
+// Leading separator between a chunk id and its title. Plans write either
+// `### Chunk 1: Title` or `### Chunk 1 — Title`; both forms must render as
+// a bare title, or the pointer reads `Chunk 1 — — Title` (the em-dash form
+// was left in by an earlier `[\s:]`-only strip). Covers colon, em dash,
+// en dash, and hyphen.
+const TITLE_SEPARATOR_RE = /^[\s:—–-]+/;
+// Column-0 `active_build_plan:` in `.prawduct/project-state.yaml`. The
+// leading `^` under /m plus the absence of any indentation allowance is
+// the column-0 requirement — see `_readGovernedPlan`.
+const GOVERNED_PLAN_RE = /^active_build_plan:[ \t]*(.*)$/m;
+const PRAWDUCT_DIR = '.prawduct';
+// `## Status` section heading, and a checkbox roster item within it
+// (`- [x] Chunk 01: Title`). Governed plans declare this roster as the
+// cross-session tracker — the `### Chunk NN:` sections below it are spec
+// anchors for the ref-verifier, not done-state. See `_parseRoster`.
+const STATUS_HEADING_RE = /^##\s+Status\b/i;
+const ANY_H2_RE = /^##\s/;
+const ROSTER_ITEM_RE = /^\s*[-*]\s*\[([ xX])\]\s*Chunk\s+([0-9]+[a-z]?(?:\.[0-9]+[a-z]?)*)\b(.*)$/i;
 // Match `**Blocked on:**` so the convention reads naturally in markdown.
 // Case-insensitive so authors can write `**blocked on:**` without surprise.
 const BLOCKED_ON_RE = /\*\*Blocked on:\*\*\s*(.+)/i;
 
 /**
+ * Parse the `## Status` checkbox roster into `{id → {done, title}}`.
+ *
+ * Governed build plans track chunk completion in a `## Status` roster of
+ * `- [x] Chunk NN: Title` items and carry a parallel set of `### Chunk NN:`
+ * spec sections further down. Only the roster is the tracker — the sections
+ * exist so a ref-verifier has parseable anchors, and they are routinely left
+ * un-ticked after a chunk ships. Reading done-state from the headings alone
+ * therefore reports a long-finished plan as sitting on chunk 01.
+ *
+ * Scoped to the `## Status` section (heading → next `##`) so a checkbox in
+ * unrelated prose can't mark a chunk done.
+ *
+ * @param {string[]} lines - Plan body split into lines
+ * @returns {Map<string, {done:boolean, title:string}>}
+ */
+function _parseRoster(lines) {
+  const roster = new Map();
+  let inStatus = false;
+  for (const line of lines) {
+    if (STATUS_HEADING_RE.test(line)) { inStatus = true; continue; }
+    if (inStatus && ANY_H2_RE.test(line)) break; // next section ends the roster
+    if (!inStatus) continue;
+    const m = line.match(ROSTER_ITEM_RE);
+    if (!m) continue;
+    const title = (m[3] || '')
+      .replace(DONE_MARKER_RE, '')
+      .replace(TITLE_SEPARATOR_RE, '')
+      .trim();
+    roster.set(m[2], { done: m[1].toLowerCase() === 'x', title });
+  }
+  return roster;
+}
+
+/**
  * Parse a plan markdown body into an ordered chunk array.
+ *
+ * Chunks come from `### Chunk N:` headings when present, else from the
+ * `## Status` roster (a plan may carry the roster alone — the spec-anchor
+ * sections were a later addition to the convention).
+ *
+ * A chunk is done when EITHER source affirms it: a `✅` on its heading or a
+ * ticked roster box. Both are affirmative done-markers and neither is used
+ * as a "definitely not done" assertion, so a union can't regress a plan that
+ * uses only one — whereas letting an un-ticked source veto a ticked one would
+ * resurrect shipped chunks.
  *
  * @param {string} planContent - Raw plan markdown
  * @returns {Array<{id:string, title:string, done:boolean, blockedOn:string|null, lineNo:number}>}
@@ -96,6 +163,7 @@ function _parseChunks(planContent) {
   // CRLF tolerance: split on either form, then strip any trailing \r
   // that survives a lone-CR file (rare but cheap to defend).
   const lines = planContent.split(/\r?\n/).map((l) => l.replace(/\r$/, ''));
+  const roster = _parseRoster(lines);
   const chunks = [];
   let current = null;
   for (let i = 0; i < lines.length; i++) {
@@ -120,12 +188,13 @@ function _parseChunks(planContent) {
       // sibling chunk.
       const rawTitle = (m[2] || '')
         .replace(DONE_MARKER_RE, '')
-        .replace(/^[\s:]+/, '')
+        .replace(TITLE_SEPARATOR_RE, '')
         .trim();
+      const rostered = roster.get(m[1]);
       current = {
         id: m[1],
         title: rawTitle,
-        done: DONE_MARKER_RE.test(line),
+        done: DONE_MARKER_RE.test(line) || Boolean(rostered && rostered.done),
         blockedOn: null,
         lineNo: i + 1
       };
@@ -135,6 +204,13 @@ function _parseChunks(planContent) {
     if (current && current.blockedOn === null) {
       const b = line.match(BLOCKED_ON_RE);
       if (b) current.blockedOn = b[1].trim();
+    }
+  }
+  if (chunks.length === 0 && roster.size > 0) {
+    // Roster-only plan (no spec-anchor sections). Insertion order is
+    // document order, so the pointer still advances correctly.
+    for (const [id, entry] of roster) {
+      chunks.push({ id, title: entry.title, done: entry.done, blockedOn: null, lineNo: 0 });
     }
   }
   return chunks;
@@ -275,17 +351,57 @@ function _readActivePlan(projectPath) {
 }
 
 /**
+ * Read the governing framework's declared build-plan pointer from
+ * `.prawduct/project-state.yaml`.
+ *
+ * A Prawduct-governed project keeps its active plan under
+ * `.prawduct/artifacts/` and names it with a column-0 `active_build_plan:`
+ * key whose value is `.prawduct/`-relative. The key MUST be at column 0 —
+ * a nested/indented pointer is deliberately not honoured, matching the
+ * framework's own reader, so a pointer buried inside another mapping
+ * doesn't silently take effect here while the framework ignores it.
+ *
+ * Parsed with a line regex rather than a YAML dependency: one scalar at a
+ * fixed column doesn't justify pulling a parser into the wrap pipeline.
+ * A `null`/empty value reads as "not declared".
+ *
+ * @param {string} projectPath
+ * @returns {string|null} `.prawduct/`-relative plan path, or null when absent/unreadable
+ */
+function _readGovernedPlan(projectPath) {
+  const statePath = path.join(projectPath, '.prawduct', 'project-state.yaml');
+  if (!_internal.existsSync(statePath)) return null;
+  let content;
+  try {
+    content = _internal.readFileSync(statePath, 'utf8');
+  } catch {
+    return null; // unreadable governance state is not this step's problem
+  }
+  const m = content.match(GOVERNED_PLAN_RE);
+  if (!m) return null;
+  const value = m[1]
+    .replace(/\s+#.*$/, '')       // strip a trailing inline comment
+    .trim()
+    .replace(/^['"]|['"]$/g, ''); // strip surrounding quotes
+  if (!value || value === 'null' || value === '~') return null;
+  return value;
+}
+
+/**
  * Resolve the canonical build plan to roll the priming pointer against.
  *
  * Precedence (#226):
  *   1. `step.planPath` (methodology config; project-relative or absolute)
  *   2. `activePlan` in `.tangleclaw/project.json` (operator escape hatch;
  *      bare filename resolves under `.claude/plans/`)
- *   3. exactly one `.md` plan in `.claude/plans/` → use it
- *   4. several plans → the single in-progress one (auto-disambiguation);
+ *   3. `active_build_plan` in `.prawduct/project-state.yaml` (the governing
+ *      framework's declared pointer, `.prawduct/`-relative). Declared but
+ *      missing → skip, never fall through to the heuristics below (#620).
+ *   4. exactly one `.md` plan in `.claude/plans/` → use it
+ *   5. several plans → the single in-progress one (auto-disambiguation);
  *      zero in-progress → skip ("all plans complete"); more than one
  *      in-progress → block with `remediation`.
- *   5. zero `.md` plans in `.claude/plans/` → skip ("nothing to roll"):
+ *   6. zero `.md` plans in `.claude/plans/` → skip ("nothing to roll"):
  *      same meaning as zero-in-progress, the well-behaved all-archived
  *      end state (#302). The `.md` filter is non-recursive, so an
  *      `archive/` subdir of shipped plans does not count.
@@ -352,6 +468,38 @@ function _resolvePlanPath(projectPath, step) {
       };
     }
     return { ok: true, planPath: abs };
+  }
+
+  // The governing framework's declared pointer outranks the plans-dir
+  // heuristic below: a project whose plan lives under `.prawduct/artifacts/`
+  // would otherwise fall through and roll the pointer onto whatever
+  // unrelated `.md` happens to sit in `.claude/plans/` — reporting success
+  // while priming the next session onto stale work. It sits BELOW the two
+  // explicit hatches above, so `step.planPath` and the operator's
+  // `activePlan` pick (which the multi-plan picker persists) still win.
+  const governedPlan = _readGovernedPlan(projectPath);
+  if (governedPlan) {
+    const abs = path.isAbsolute(governedPlan)
+      ? governedPlan
+      : path.resolve(projectPath, PRAWDUCT_DIR, governedPlan);
+    if (!path.isAbsolute(governedPlan)) {
+      const root = path.resolve(projectPath);
+      if (abs !== root && !abs.startsWith(root + path.sep)) {
+        return { ok: false, error: `active_build_plan "${governedPlan}" (in ${PRAWDUCT_DIR}/project-state.yaml) resolves outside the project root` };
+      }
+    }
+    if (_internal.existsSync(abs)) {
+      return { ok: true, planPath: abs };
+    }
+    // Declared but missing — stale governance state. Skip with the reason
+    // rather than falling through to the plans-dir heuristic: falling
+    // through is exactly what produces a confidently-wrong pointer, and a
+    // dangling pointer is not the operator's typo to be blocked on.
+    return {
+      ok: false,
+      skip: true,
+      reason: `active_build_plan "${governedPlan}" (in ${PRAWDUCT_DIR}/project-state.yaml) does not exist — nothing to roll (update or clear the pointer)`
+    };
   }
 
   const plansDir = path.join(projectPath, DEFAULT_PLANS_DIR);
@@ -589,6 +737,8 @@ module.exports = {
   _selectPointer,
   _isPlanInProgress,
   _readActivePlan,
+  _readGovernedPlan,
+  _parseRoster,
   _renderPointerBody,
   _replaceManagedBlock,
   _resolvePlanPath,

--- a/lib/wrap-steps/priming-roll.js
+++ b/lib/wrap-steps/priming-roll.js
@@ -109,7 +109,27 @@ const ROSTER_ITEM_RE = /^\s*[-*]\s*\[([ xX])\]\s*Chunk\s+([0-9]+[a-z]?(?:\.[0-9]
 const BLOCKED_ON_RE = /\*\*Blocked on:\*\*\s*(.+)/i;
 
 /**
- * Parse the `## Status` checkbox roster into `{id → {done, title}}`.
+ * Normalize a chunk id for roster↔heading joining.
+ *
+ * Plans are not internally consistent about zero-padding — a roster may say
+ * `Chunk 1` where the heading says `### Chunk 01`. Keying the join on the raw
+ * string would miss the lookup, drop the tick, and park the pointer on chunk
+ * 01: exactly the silent wrong-pointer failure this module exists to prevent.
+ * Each dotted segment loses its leading zeros (`01` → `1`, `010c.02` → `10c.2`).
+ *
+ * @param {string} id - Raw chunk id as written in the plan
+ * @returns {string} Normalized join key
+ */
+function _chunkIdKey(id) {
+  return String(id)
+    .toLowerCase()
+    .split('.')
+    .map((seg) => seg.replace(/^0+(?=\d)/, ''))
+    .join('.');
+}
+
+/**
+ * Parse the `## Status` checkbox roster into `{normalized id → entry}`.
  *
  * Governed build plans track chunk completion in a `## Status` roster of
  * `- [x] Chunk NN: Title` items and carry a parallel set of `### Chunk NN:`
@@ -122,7 +142,7 @@ const BLOCKED_ON_RE = /\*\*Blocked on:\*\*\s*(.+)/i;
  * unrelated prose can't mark a chunk done.
  *
  * @param {string[]} lines - Plan body split into lines
- * @returns {Map<string, {done:boolean, title:string}>}
+ * @returns {Map<string, {done:boolean, title:string, id:string}>}
  */
 function _parseRoster(lines) {
   const roster = new Map();
@@ -137,7 +157,7 @@ function _parseRoster(lines) {
       .replace(DONE_MARKER_RE, '')
       .replace(TITLE_SEPARATOR_RE, '')
       .trim();
-    roster.set(m[2], { done: m[1].toLowerCase() === 'x', title });
+    roster.set(_chunkIdKey(m[2]), { done: m[1].toLowerCase() === 'x', title, id: m[2] });
   }
   return roster;
 }
@@ -190,7 +210,7 @@ function _parseChunks(planContent) {
         .replace(DONE_MARKER_RE, '')
         .replace(TITLE_SEPARATOR_RE, '')
         .trim();
-      const rostered = roster.get(m[1]);
+      const rostered = roster.get(_chunkIdKey(m[1]));
       current = {
         id: m[1],
         title: rawTitle,
@@ -209,8 +229,8 @@ function _parseChunks(planContent) {
   if (chunks.length === 0 && roster.size > 0) {
     // Roster-only plan (no spec-anchor sections). Insertion order is
     // document order, so the pointer still advances correctly.
-    for (const [id, entry] of roster) {
-      chunks.push({ id, title: entry.title, done: entry.done, blockedOn: null, lineNo: 0 });
+    for (const entry of roster.values()) {
+      chunks.push({ id: entry.id, title: entry.title, done: entry.done, blockedOn: null, lineNo: 0 });
     }
   }
   return chunks;
@@ -316,10 +336,11 @@ const MULTI_PLAN_REMEDIATION =
   '(archive shipped plans under `.claude/plans/archive/`).';
 
 /**
- * A plan is "in progress" when it declares at least one `### Chunk N`
- * heading and not all of them are done — i.e. there's a chunk left to roll
- * the priming pointer to. Plans with no chunks, or all chunks done, are not
- * roll candidates. Used to auto-disambiguate when several plans coexist (#226).
+ * A plan is "in progress" when it declares at least one chunk — via a
+ * `### Chunk N` heading or a `## Status` roster item — and not all of them
+ * are done, i.e. there's a chunk left to roll the priming pointer to. Plans
+ * with no chunks, or all chunks done, are not roll candidates. Used to
+ * auto-disambiguate when several plans coexist (#226).
  *
  * @param {string} planContent
  * @returns {boolean}
@@ -479,9 +500,16 @@ function _resolvePlanPath(projectPath, step) {
   // `activePlan` pick (which the multi-plan picker persists) still win.
   const governedPlan = _readGovernedPlan(projectPath);
   if (governedPlan) {
+    // The pointer is documented as `.prawduct/`-relative, but an author
+    // may reasonably write it project-relative with the dir spelled out.
+    // Double-prefixing that into `.prawduct/.prawduct/…` would dangle and
+    // silently skip, so honour both spellings.
+    const alreadyPrefixed = governedPlan === PRAWDUCT_DIR
+      || governedPlan.startsWith(`${PRAWDUCT_DIR}/`)
+      || governedPlan.startsWith(`${PRAWDUCT_DIR}${path.sep}`);
     const abs = path.isAbsolute(governedPlan)
       ? governedPlan
-      : path.resolve(projectPath, PRAWDUCT_DIR, governedPlan);
+      : path.resolve(projectPath, alreadyPrefixed ? '' : PRAWDUCT_DIR, governedPlan);
     if (!path.isAbsolute(governedPlan)) {
       const root = path.resolve(projectPath);
       if (abs !== root && !abs.startsWith(root + path.sep)) {
@@ -641,8 +669,9 @@ async function run(context) {
 
   const chunks = _parseChunks(planContent);
   if (chunks.length === 0) {
-    // No `### Chunk N:` headings — the resolved plan is a spec/design doc
-    // (or a plan not yet chunked), so there is no chunk pointer to roll.
+    // Neither `### Chunk N:` headings nor a `## Status` roster — the
+    // resolved plan is a spec/design doc (or a plan not yet chunked), so
+    // there is no chunk pointer to roll.
     // SKIP (not block): this mirrors the multi-plan path, where a chunk-less
     // plan is dropped by `_isPlanInProgress` rather than failing the wrap.
     // Blocking here was asymmetric — the same chunk-less plan blocked when it
@@ -654,12 +683,13 @@ async function run(context) {
     // wrap failure — honest and non-blocking beats loud-and-blocking here.
     const rel = path.relative(project.path, planRes.planPath) || planRes.planPath;
     const reason =
-      `Resolved plan \`${rel}\` has no \`### Chunk N:\` headings — nothing to ` +
-      'roll (add chunk headings if this is meant to be an active build plan)';
+      `Resolved plan \`${rel}\` declares no chunks — nothing to roll (add ` +
+      '`### Chunk N:` headings or a `## Status` checkbox roster if this is ' +
+      'meant to be an active build plan)';
     return {
       ok: true,
       status: 'skipped',
-      output: { reason, detail: `No "### Chunk N: Title" headings in ${planRes.planPath}` },
+      output: { reason, detail: `No "### Chunk N: Title" headings and no "## Status" roster in ${planRes.planPath}` },
       blockers: []
     };
   }
@@ -739,6 +769,7 @@ module.exports = {
   _readActivePlan,
   _readGovernedPlan,
   _parseRoster,
+  _chunkIdKey,
   _renderPointerBody,
   _replaceManagedBlock,
   _resolvePlanPath,

--- a/test/wrap-step-priming-roll.test.js
+++ b/test/wrap-step-priming-roll.test.js
@@ -300,6 +300,12 @@ describe('wrap-step priming-roll — handler (#139 Chunk 6)', () => {
   });
 
   after(() => {
+    // `_internal` is a module singleton shared with every other suite in
+    // this file. The last test here leaves a throwing `readFileSync` stub
+    // installed, so without this restore the NEXT suite's `before` captures
+    // the poisoned fn as its "originals" and every one of its tests reads
+    // through the stub.
+    Object.assign(primingRoll._internal, originals);
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
@@ -717,5 +723,339 @@ describe('wrap-step priming-roll — handler (#139 Chunk 6)', () => {
     const result = await primingRoll.run(buildContext({ id: 'next-session-prime' }));
     assert.equal(result.ok, false);
     assert.match(result.blockers[0], /Failed to read priming file/);
+  });
+});
+
+describe('wrap-step priming-roll — governed plan pointer (#620)', () => {
+  const primingRoll = require('../lib/wrap-steps/priming-roll');
+  let tmpDir;
+  let projectPath;
+  let originals;
+
+  before(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-priming-governed-'));
+    originals = { ...primingRoll._internal };
+  });
+
+  after(() => {
+    // Restore the shared `_internal` singleton — see the handler suite's
+    // `after` for why leaving a stub installed corrupts later suites.
+    Object.assign(primingRoll._internal, originals);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    Object.assign(primingRoll._internal, originals);
+    projectPath = fs.mkdtempSync(path.join(tmpDir, 'sandbox-'));
+  });
+
+  function buildContext(step) {
+    return {
+      project: { name: 'sandbox', path: projectPath, id: 1 },
+      session: null,
+      step,
+      previousResults: [],
+      staged: {},
+      options: {}
+    };
+  }
+
+  /** Write `.prawduct/project-state.yaml` with the given raw body. */
+  function writeState(body) {
+    const dir = path.join(projectPath, '.prawduct');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'project-state.yaml'), body);
+  }
+
+  /** Write a plan under `.prawduct/artifacts/<name>`. */
+  function writeGovernedPlan(name, body) {
+    const dir = path.join(projectPath, '.prawduct', 'artifacts');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, name), body);
+  }
+
+  /** Write a plan under `.claude/plans/<name>`. */
+  function writeLegacyPlan(name, body) {
+    const dir = path.join(projectPath, '.claude', 'plans');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, name), body);
+  }
+
+  describe('_readGovernedPlan', () => {
+    it('reads a column-0 active_build_plan value', () => {
+      writeState('classification:\n  domain: [x]\n\nactive_build_plan: artifacts/plan.md\n');
+      assert.equal(primingRoll._readGovernedPlan(projectPath), 'artifacts/plan.md');
+    });
+
+    it('returns null when project-state.yaml is absent', () => {
+      assert.equal(primingRoll._readGovernedPlan(projectPath), null);
+    });
+
+    it('returns null when the key is absent', () => {
+      writeState('classification:\n  domain: [x]\n');
+      assert.equal(primingRoll._readGovernedPlan(projectPath), null);
+    });
+
+    it('ignores an INDENTED active_build_plan (column-0 contract)', () => {
+      // The framework's own reader honours only column 0; matching an
+      // indented pointer here would take effect in TC while the framework
+      // ignored it — a silent divergence.
+      writeState('state:\n  active_build_plan: artifacts/nested.md\n');
+      assert.equal(primingRoll._readGovernedPlan(projectPath), null);
+    });
+
+    it('treats null / empty / ~ as not declared', () => {
+      for (const raw of ['active_build_plan:\n', 'active_build_plan: null\n', 'active_build_plan: ~\n']) {
+        writeState(raw);
+        assert.equal(primingRoll._readGovernedPlan(projectPath), null, `raw: ${JSON.stringify(raw)}`);
+      }
+    });
+
+    it('strips surrounding quotes and a trailing inline comment', () => {
+      writeState('active_build_plan: "artifacts/quoted.md"  # the active one\n');
+      assert.equal(primingRoll._readGovernedPlan(projectPath), 'artifacts/quoted.md');
+    });
+
+    it('returns null when the state file is unreadable', () => {
+      writeState('active_build_plan: artifacts/plan.md\n');
+      primingRoll._internal.readFileSync = () => { throw new Error('disk gone'); };
+      assert.equal(primingRoll._readGovernedPlan(projectPath), null);
+    });
+  });
+
+  describe('resolution precedence', () => {
+    it('rolls to the governed plan instead of the lone .claude/plans file (#620 repro)', async () => {
+      // The exact reported failure: an unrelated plan sits in .claude/plans/
+      // and used to win by the "only .md in the dir" rule, priming the next
+      // session onto stale work.
+      writeLegacyPlan('unrelated.md', '### Chunk 01 — One-way auto-inject\n');
+      writeGovernedPlan('active.md', '### Chunk 08: Habitat clean-room ✅\n### Chunk 09: Phase B discovery\n');
+      writeState('active_build_plan: artifacts/active.md\n');
+
+      const ctx = buildContext({ id: 'next-session-prime' });
+      const result = await primingRoll.run(ctx);
+
+      assert.equal(result.ok, true);
+      assert.equal(result.status, 'done');
+      assert.match(result.output.planPath, /\.prawduct[/\\]artifacts[/\\]active\.md$/,
+        'must resolve the governed plan, not the .claude/plans file');
+      assert.equal(result.output.pointer.current.id, '09');
+      assert.equal(result.output.pointer.current.title, 'Phase B discovery');
+      assert.match(ctx.staged['next-session-prime'].newContent, /Chunk 09 — Phase B discovery/);
+    });
+
+    it('lets step.planPath outrank the governed pointer', async () => {
+      writeGovernedPlan('governed.md', '### Chunk 1: Governed\n');
+      writeState('active_build_plan: artifacts/governed.md\n');
+      writeLegacyPlan('explicit.md', '### Chunk 1: Explicit\n');
+
+      const result = await primingRoll.run(buildContext({
+        id: 'next-session-prime',
+        planPath: '.claude/plans/explicit.md'
+      }));
+      assert.equal(result.ok, true);
+      assert.equal(result.output.pointer.current.title, 'Explicit');
+    });
+
+    it("lets the operator's activePlan escape hatch outrank the governed pointer", async () => {
+      // The multi-plan picker (#428) persists the operator's choice to
+      // activePlan; an auto-derived pointer must not override a human pick.
+      writeGovernedPlan('governed.md', '### Chunk 1: Governed\n');
+      writeState('active_build_plan: artifacts/governed.md\n');
+      writeLegacyPlan('picked.md', '### Chunk 1: Picked\n');
+      const cfgDir = path.join(projectPath, '.tangleclaw');
+      fs.mkdirSync(cfgDir, { recursive: true });
+      fs.writeFileSync(path.join(cfgDir, 'project.json'), JSON.stringify({ activePlan: 'picked.md' }));
+
+      const result = await primingRoll.run(buildContext({ id: 'next-session-prime' }));
+      assert.equal(result.ok, true);
+      assert.equal(result.output.pointer.current.title, 'Picked');
+    });
+
+    it('skips (never falls through) when the governed pointer dangles', async () => {
+      // Falling back to the plans-dir heuristic here is what produced the
+      // confidently-wrong pointer in the first place.
+      writeLegacyPlan('unrelated.md', '### Chunk 1: Unrelated\n');
+      writeState('active_build_plan: artifacts/gone.md\n');
+
+      const result = await primingRoll.run(buildContext({ id: 'next-session-prime' }));
+      assert.equal(result.ok, true, 'a dangling pointer must not block the wrap');
+      assert.equal(result.status, 'skipped');
+      assert.match(result.output.reason, /does not exist/);
+      assert.doesNotMatch(result.output.reason, /unrelated\.md/);
+    });
+
+    it('blocks when the governed pointer escapes the project root', async () => {
+      writeState('active_build_plan: ../../../etc/passwd.md\n');
+      const result = await primingRoll.run(buildContext({ id: 'next-session-prime' }));
+      assert.equal(result.ok, false);
+      assert.equal(result.status, 'blocked');
+      assert.match(result.blockers[0], /resolves outside the project root/);
+    });
+
+    it('falls through to .claude/plans when no pointer is declared', async () => {
+      // Ungoverned projects keep today's behavior byte-for-byte.
+      writeState('classification:\n  domain: [x]\n');
+      writeLegacyPlan('only.md', '### Chunk 1: Legacy\n');
+      const result = await primingRoll.run(buildContext({ id: 'next-session-prime' }));
+      assert.equal(result.ok, true);
+      assert.equal(result.output.pointer.current.title, 'Legacy');
+    });
+  });
+
+  describe('chunk title separator (#620)', () => {
+    it('strips an em-dash separator so the title renders once', () => {
+      const chunks = primingRoll._parseChunks('### Chunk 01 — One-way auto-inject (+ settings scaffold)\n');
+      assert.equal(chunks[0].id, '01');
+      assert.equal(chunks[0].title, 'One-way auto-inject (+ settings scaffold)');
+    });
+
+    it('strips en-dash and hyphen separators too', () => {
+      assert.equal(primingRoll._parseChunks('### Chunk 2 – Title\n')[0].title, 'Title');
+      assert.equal(primingRoll._parseChunks('### Chunk 3 - Title\n')[0].title, 'Title');
+    });
+
+    it('preserves a colon separator and an internal dash', () => {
+      assert.equal(primingRoll._parseChunks('### Chunk 4: Auto-inject — the loop\n')[0].title,
+        'Auto-inject — the loop');
+    });
+
+    it('renders a pointer body without a doubled separator', () => {
+      const chunks = primingRoll._parseChunks('### Chunk 01 — One-way auto-inject\n');
+      const body = primingRoll._renderPointerBody(primingRoll._selectPointer(chunks), 'p.md');
+      assert.match(body, /\*\*Active:\*\* Chunk 01 — One-way auto-inject/);
+      assert.doesNotMatch(body, /— —/);
+    });
+  });
+});
+
+describe('wrap-step priming-roll — ## Status roster as done-source (#620)', () => {
+  const primingRoll = require('../lib/wrap-steps/priming-roll');
+
+  // Governed plans declare the `## Status` roster their cross-session tracker
+  // and leave the `### Chunk NN:` spec anchors un-ticked, so heading-only
+  // done-detection reports a finished plan as sitting on chunk 01.
+  const GOVERNED_PLAN = [
+    '# Build Plan — Phase A',
+    '',
+    '## Status',
+    '',
+    '- [x] Chunk 01: recordVersion require-cycle fix',
+    '- [x] Chunk 02: Stranded-config guard',
+    '- [ ] Chunk 03: Phase B discovery',
+    '',
+    '## Chunks',
+    '',
+    '### Chunk 01: recordVersion require-cycle fix (#584) — SHIPPED',
+    'Body.',
+    '',
+    '### Chunk 02: Stranded-config guard (#592) — root-cause + guard',
+    'Body.',
+    '',
+    '### Chunk 03: Phase B discovery',
+    'Body.'
+  ].join('\n');
+
+  it('marks chunks done from ticked roster boxes even with no ✅ on headings', () => {
+    const chunks = primingRoll._parseChunks(GOVERNED_PLAN);
+    assert.equal(chunks.length, 3);
+    assert.equal(chunks[0].done, true, 'roster [x] must mark chunk 01 done');
+    assert.equal(chunks[1].done, true);
+    assert.equal(chunks[2].done, false);
+  });
+
+  it('points at the first roster-unticked chunk, not chunk 01 (#620 repro)', () => {
+    const pointer = primingRoll._selectPointer(primingRoll._parseChunks(GOVERNED_PLAN));
+    assert.equal(pointer.current.id, '03');
+    assert.equal(pointer.allDone, false);
+  });
+
+  it('reports allDone when every roster box is ticked', () => {
+    const md = GOVERNED_PLAN.replace('- [ ] Chunk 03', '- [x] Chunk 03');
+    const pointer = primingRoll._selectPointer(primingRoll._parseChunks(md));
+    assert.equal(pointer.allDone, true);
+    assert.equal(pointer.current, null);
+  });
+
+  it('keeps the heading title, not the roster title, when both exist', () => {
+    const chunks = primingRoll._parseChunks(GOVERNED_PLAN);
+    assert.equal(chunks[0].title, 'recordVersion require-cycle fix (#584) — SHIPPED');
+  });
+
+  it('unions the two sources — a ✅ heading stays done with no roster entry', () => {
+    // Plans predating the roster convention must not regress.
+    const md = [
+      '## Status',
+      '- [ ] Chunk 02: Later',
+      '',
+      '## Chunks',
+      '### Chunk 01: Early ✅',
+      '### Chunk 02: Later'
+    ].join('\n');
+    const chunks = primingRoll._parseChunks(md);
+    assert.equal(chunks[0].done, true, '✅ must still count when the roster omits the chunk');
+    assert.equal(chunks[1].done, false);
+  });
+
+  it('ignores checkboxes outside the ## Status section', () => {
+    const md = [
+      '## Notes',
+      '- [x] Chunk 01: this is prose, not the tracker',
+      '',
+      '## Chunks',
+      '### Chunk 01: Real chunk'
+    ].join('\n');
+    assert.equal(primingRoll._parseChunks(md)[0].done, false,
+      'only the ## Status roster is the tracker');
+  });
+
+  it('stops reading the roster at the next ## heading', () => {
+    const md = [
+      '## Status',
+      '- [x] Chunk 01: Done',
+      '',
+      '## Appendix',
+      '- [x] Chunk 02: not part of the roster',
+      '',
+      '## Chunks',
+      '### Chunk 01: One',
+      '### Chunk 02: Two'
+    ].join('\n');
+    const chunks = primingRoll._parseChunks(md);
+    assert.equal(chunks[0].done, true);
+    assert.equal(chunks[1].done, false, 'post-Status checkbox must not leak into the roster');
+  });
+
+  it('builds the chunk list from a roster-only plan (no ### sections)', () => {
+    // The compact format this plan shipped with before spec anchors were added.
+    const md = [
+      '## Status',
+      '- [x] Chunk 01: Shipped work',
+      '- [ ] Chunk 02: Next up',
+      '',
+      '## Why',
+      'Prose.'
+    ].join('\n');
+    const chunks = primingRoll._parseChunks(md);
+    assert.equal(chunks.length, 2);
+    assert.equal(chunks[0].title, 'Shipped work');
+    const pointer = primingRoll._selectPointer(chunks);
+    assert.equal(pointer.current.id, '02');
+    assert.equal(pointer.current.title, 'Next up');
+  });
+
+  it('parses an em-dash roster item and treats [X] as ticked', () => {
+    const md = ['## Status', '- [X] Chunk 01 — Upper-case tick'].join('\n');
+    const chunks = primingRoll._parseChunks(md);
+    assert.equal(chunks[0].done, true);
+    assert.equal(chunks[0].title, 'Upper-case tick');
+  });
+
+  it('_parseRoster scopes to ## Status and reports tick state', () => {
+    const roster = primingRoll._parseRoster(GOVERNED_PLAN.split('\n'));
+    assert.equal(roster.size, 3);
+    assert.equal(roster.get('01').done, true);
+    assert.equal(roster.get('03').done, false);
+    assert.equal(roster.get('03').title, 'Phase B discovery');
   });
 });

--- a/test/wrap-step-priming-roll.test.js
+++ b/test/wrap-step-priming-roll.test.js
@@ -520,9 +520,15 @@ describe('wrap-step priming-roll — handler (#139 Chunk 6)', () => {
     assert.equal(result.status, 'skipped');
     assert.deepEqual(result.blockers, []);
     // The skip stays honest — the drawer surfaces why + the recovery hint.
-    assert.match(result.output.reason, /no `### Chunk N:` headings/i);
+    assert.match(result.output.reason, /declares no chunks/i);
+    assert.match(result.output.reason, /### Chunk N:/,
+      'reason still names the heading form as one way to chunk the plan');
     assert.match(result.output.reason, /nothing to roll/i);
-    assert.match(result.output.reason, /add chunk headings/i);
+    // Recovery hint now names BOTH chunk forms — the heading-only wording
+    // misdirected an author whose plan tracks chunks in a `## Status` roster.
+    assert.match(result.output.reason, /## Status/,
+      'reason must also point at the roster form');
+    assert.match(result.output.reason, /active build plan/i);
     // No pointer is staged — the "field" is null, nothing for commit to flush.
     assert.equal(ctx.staged['next-session-prime'], undefined,
       'a skip must not stage a priming-roll write');
@@ -1054,8 +1060,119 @@ describe('wrap-step priming-roll — ## Status roster as done-source (#620)', ()
   it('_parseRoster scopes to ## Status and reports tick state', () => {
     const roster = primingRoll._parseRoster(GOVERNED_PLAN.split('\n'));
     assert.equal(roster.size, 3);
-    assert.equal(roster.get('01').done, true);
-    assert.equal(roster.get('03').done, false);
-    assert.equal(roster.get('03').title, 'Phase B discovery');
+    // Keyed by NORMALIZED id (`01` → `1`) so a padding mismatch between the
+    // roster and the headings still joins; the entry keeps the id as written.
+    assert.equal(roster.get('1').done, true);
+    assert.equal(roster.get('3').done, false);
+    assert.equal(roster.get('3').title, 'Phase B discovery');
+    assert.equal(roster.get('3').id, '03', 'raw id preserved for display');
+  });
+});
+
+describe('wrap-step priming-roll — Critic-caught edges (#620)', () => {
+  const primingRoll = require('../lib/wrap-steps/priming-roll');
+  let tmpDir;
+  let projectPath;
+  let originals;
+
+  before(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-priming-edges-'));
+    originals = { ...primingRoll._internal };
+  });
+
+  after(() => {
+    Object.assign(primingRoll._internal, originals);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    Object.assign(primingRoll._internal, originals);
+    projectPath = fs.mkdtempSync(path.join(tmpDir, 'sandbox-'));
+  });
+
+  describe('_chunkIdKey — zero-padding mismatch', () => {
+    it('normalizes leading zeros per dotted segment', () => {
+      assert.equal(primingRoll._chunkIdKey('01'), '1');
+      assert.equal(primingRoll._chunkIdKey('1'), '1');
+      assert.equal(primingRoll._chunkIdKey('010c.02'), '10c.2');
+      assert.equal(primingRoll._chunkIdKey('12.3a.4'), '12.3a.4');
+    });
+
+    it('does not collapse a legitimate zero id', () => {
+      assert.equal(primingRoll._chunkIdKey('0'), '0');
+    });
+
+    it('joins an unpadded roster to padded headings (and vice versa)', () => {
+      // A plan writing `- [x] Chunk 1` against `### Chunk 01:` used to miss
+      // the lookup, drop the tick, and park the pointer on chunk 01 — the
+      // exact silent failure this module exists to prevent.
+      const md = [
+        '## Status',
+        '- [x] Chunk 1: Done',
+        '- [ ] Chunk 2: Next',
+        '',
+        '## Chunks',
+        '### Chunk 01: Done',
+        '### Chunk 02: Next'
+      ].join('\n');
+      const chunks = primingRoll._parseChunks(md);
+      assert.equal(chunks[0].done, true, 'unpadded roster must tick the padded heading');
+      assert.equal(primingRoll._selectPointer(chunks).current.id, '02');
+    });
+
+    it('joins a padded roster to unpadded headings', () => {
+      const md = [
+        '## Status',
+        '- [x] Chunk 01: Done',
+        '',
+        '## Chunks',
+        '### Chunk 1: Done'
+      ].join('\n');
+      assert.equal(primingRoll._parseChunks(md)[0].done, true);
+    });
+
+    it('keeps the id as written on a roster-only plan', () => {
+      const md = ['## Status', '- [ ] Chunk 07: Seven'].join('\n');
+      assert.equal(primingRoll._parseChunks(md)[0].id, '07',
+        'the displayed id must match the plan, not the normalized key');
+    });
+  });
+
+  describe('governed pointer spelled with the .prawduct/ prefix', () => {
+    it('resolves without double-prefixing', () => {
+      // Documented as `.prawduct/`-relative, but an author may reasonably
+      // spell the dir out; double-prefixing would dangle and silently skip.
+      const dir = path.join(projectPath, '.prawduct', 'artifacts');
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, 'p.md'), '### Chunk 1: Only\n');
+      fs.writeFileSync(
+        path.join(projectPath, '.prawduct', 'project-state.yaml'),
+        'active_build_plan: .prawduct/artifacts/p.md\n'
+      );
+      const res = primingRoll._resolvePlanPath(projectPath, { id: 'next-session-prime' });
+      assert.equal(res.ok, true, 'a .prawduct/-prefixed pointer must resolve');
+      assert.match(res.planPath, /\.prawduct[/\\]artifacts[/\\]p\.md$/);
+      assert.doesNotMatch(res.planPath, /\.prawduct[/\\]\.prawduct/);
+    });
+  });
+
+  describe('skip reason for a chunkless plan', () => {
+    it('mentions both the heading and roster forms', async () => {
+      // The old reason misdirected a roster-only author toward headings.
+      const dir = path.join(projectPath, '.claude', 'plans');
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, 'spec.md'), '# A design doc\n\nNo chunks here.\n');
+      const result = await primingRoll.run({
+        project: { name: 'sandbox', path: projectPath, id: 1 },
+        session: null,
+        step: { id: 'next-session-prime' },
+        previousResults: [],
+        staged: {},
+        options: {}
+      });
+      assert.equal(result.status, 'skipped');
+      assert.match(result.output.reason, /### Chunk N:/);
+      assert.match(result.output.reason, /## Status/);
+    });
   });
 });


### PR DESCRIPTION
Fixes #620.

## What

`next-session-prime` (the `priming-roll` wrap step) reported **Done** while priming the next session onto unrelated, stale work. Three defects, one family — TC's plan machinery encodes conventions that plugin-governed plans do not use.

Found by auditing the previous session's wrap (PR #619, `10a355e`), which closed Phase A Chunk 08 of the prawduct-v2-sunset plan and then wrote:

```
**Active:** Chunk 01 — — One-way auto-inject (+ settings scaffold)
Plan: `.claude/plans/switchboard-v2-autoinject-loop.md`
```

## Why

1. **Wrong plan.** `_resolvePlanPath` knew only `.claude/plans/`. A governed project keeps its plan under `.prawduct/artifacts/`, named by a column-0 `active_build_plan:` in `.prawduct/project-state.yaml`. With one unrelated `.md` in `.claude/plans/`, the "only file in the dir" rule matched and the step declared success. **This reproduces on every plugin-governed project** — now the fleet default. The failure mode is worse than a miss: it is confidently wrong.

2. **Wrong chunk.** Done-state came only from a `✅` on `### Chunk NN:` headings. Governed plans declare their `## Status` checkbox roster the cross-session tracker — this plan says so in its own header comment ("THE `## Status` ROSTER IS THE CROSS-SESSION TRACKER") — and leave the heading anchors, which exist for `verify-chunk-refs`, un-ticked. So a plan with all 8 chunks `[x]` parsed as zero-done and pointed at chunk 01.

3. **Doubled separator.** The title strip handled `:` but not the em-dash form, rendering `Chunk 01 — — Title`.

## How

- `_readGovernedPlan` reads the column-0 pointer (line regex, not a YAML dep; indented keys deliberately ignored to match the framework's own reader). It slots **below** `step.planPath` and the operator's `activePlan` pick, so neither is overridden — the multi-plan picker (#428) persists to `activePlan` and must keep winning.
- A declared-but-missing pointer **skips with a reason** rather than falling through to the heuristic — falling through is precisely what manufactured the bad pointer.
- `_parseRoster` reads the `## Status` section (scoped heading → next `##`, so stray prose checkboxes can't mark chunks done). Done-state is the **union** of roster tick and heading `✅`: both are affirmative markers, and letting an un-ticked source veto a ticked one would resurrect shipped chunks. A roster-only plan supplies the chunk list itself.
- `_chunkIdKey` normalizes leading zeros so a roster writing `Chunk 1` still joins a `### Chunk 01:` heading (Critic-caught — that mismatch would have re-created the same silent wrong-pointer failure).

## Test plan

- **Revert-verified:** 13 tests fail against the pre-fix module, 0 after.
- `test/wrap-step-priming-roll.test.js` +34 (48→82): #620 repro, precedence preservation for both operator hatches, dangling-pointer skip, traversal block, column-0 contract, roster union/scoping/roster-only, id-padding mismatch both directions, separator forms.
- **Full suite exit 0** — 2291 top-level cases / 0 fail per the JUnit report ingested as test evidence (4440/0 counting subtests).
- **Product-verified** by running the step against this repo: resolves `.prawduct/artifacts/prawduct-v2-sunset-build-plan.md` with `allDone: true`, rendering "All chunks … are marked done." That matches reality — Phase A is complete. Before the fix it named the switchboard plan and claimed chunk 01 was active.

## Also in this PR

- Corrected the stale priming block the bad wrap left behind.
- Fixed a **pre-existing test-harness leak**: the handler suite installed a throwing `readFileSync` stub on the shared `_internal` singleton and never restored it, so any suite declared after it captured the poisoned fn as its "originals".

## Review

Critic `cumulative` → 1 blocking / 3 warning / 2 note → fixes → `verify-resolutions` → **0 blocking, all 4 verified fixed**, then one further warning (a wrong hand-typed test delta) corrected. The blocking finding was mine: I asserted suite results with no evidence recorded at that tree, a verbatim recurrence of learning WRP-9F2K — resolved by ingesting a JUnit report instead of hand-typed counts.
