### PR TITLE
Stop the wrap stubbing Feature Index entries for deleted files (#637)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,18 @@ All notable changes to TangleClaw are documented in this file.
 ### Fixed
 
 - **The wrap no longer stubs Feature Index entries for files the session deleted (#637).**
-  `features-toc` built its auto-stub list from `git diff --name-only`, which reports deleted
-  paths alongside added ones, and filtered only on path shape — extension, prefix, basename —
-  never on whether the file still existed. So a session that removed a file got a
-  `- **TBD** — touched in this session: \`<deleted path>\`` entry pointing at nothing. That is
-  not merely noise: `FEATURES.md`'s citation contract asserts every cited path exists on disk,
-  so the stub failed the required test gate and blocked the wrap's *own* PR from merging,
-  stranding that wrap's version bump on an unmerged branch while every step still reported
-  success. The diff now uses `--diff-filter=d` to exclude deletions. Renames arrive as
-  delete+add, so the stale path drops out and the new one is still stubbed.
+  `features-toc` built its auto-stub list from `git diff --name-only` and filtered only on path
+  shape — extension, prefix, basename — never on whether the file still existed. So a session
+  that removed a file got a `- **TBD** — touched in this session: \`<deleted path>\`` entry
+  pointing at nothing. That is not merely noise: `FEATURES.md`'s citation contract asserts every
+  cited path exists on disk, so the stub failed the required test gate and blocked the wrap's
+  *own* PR from merging, stranding that wrap's version bump on an unmerged branch while every
+  step still reported success. The step now checks that each candidate still exists before
+  citing it — the same question the citation contract asks, so the two cannot disagree. That
+  also closes a second route a range-level filter would have missed: a file added earlier in the
+  session and deleted in the working tree still reports as *added* by any range diff, yet the
+  wrap's own `git add -A` commits its deletion moments later. A wrap whose session only deleted
+  files now reports that honestly rather than claiming everything was already indexed.
 
 ## [4.27.0] - 2026-07-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The wrap no longer stubs Feature Index entries for files the session deleted (#637).**
+  `features-toc` built its auto-stub list from `git diff --name-only`, which reports deleted
+  paths alongside added ones, and filtered only on path shape — extension, prefix, basename —
+  never on whether the file still existed. So a session that removed a file got a
+  `- **TBD** — touched in this session: \`<deleted path>\`` entry pointing at nothing. That is
+  not merely noise: `FEATURES.md`'s citation contract asserts every cited path exists on disk,
+  so the stub failed the required test gate and blocked the wrap's *own* PR from merging,
+  stranding that wrap's version bump on an unmerged branch while every step still reported
+  success. The diff now uses `--diff-filter=d` to exclude deletions. Renames arrive as
+  delete+add, so the stale path drops out and the new one is still stubbed.
+
 ## [4.27.0] - 2026-07-19
 
 ### Added

--- a/lib/wrap-steps/features-toc.js
+++ b/lib/wrap-steps/features-toc.js
@@ -60,6 +60,16 @@
  * "every diff line", broader than "lib/ only" — and meant to be
  * tightened against dogfood feedback in Chunk 4 if it produces churn.
  *
+ * **Deleted files are never stubbed.** The diff is taken with
+ * `--diff-filter=d`, so a file the session touched and then removed
+ * does not become an entry. Beyond being meaningless as a feature
+ * pointer, a stub for a deleted file is a *dangling citation*:
+ * `FEATURES.md`'s citation contract asserts every cited path exists on
+ * disk, so such a stub fails the required test gate and blocks the
+ * wrap's own PR — stranding that wrap's version bump on an unmerged
+ * branch while every step still reports success. See
+ * {@link _diffNameOnly}.
+ *
  * **Drift extraction.** Existing index entries are tokenized by a
  * single regex that scans for path tokens with the same extension
  * allowlist. The matcher is intentionally permissive (matches inside
@@ -377,12 +387,21 @@ function _resolveBaseBranch(cwd) {
  * `<lastWrapSha>..HEAD` (this session's merged commits) or `<baseBranch>...HEAD`
  * (the current branch's divergence, the first-wrap fallback).
  *
+ * `--diff-filter=d` (lower-case `d` = *exclude* deletions) drops paths whose
+ * final state in the range is "deleted". A file the session touched and then
+ * removed is not a feature to describe, and stubbing it actively breaks the
+ * wrap: `FEATURES.md`'s citation contract asserts that every cited path still
+ * exists on disk, so a stub for a deleted file fails that check, reddens the
+ * required test gate, and blocks the wrap's own PR from merging — leaving the
+ * version bump stranded on an unmerged branch. Renames arrive as delete+add
+ * (no `-M`), so the stale path drops out and the new one is still stubbed.
+ *
  * @param {string} cwd
  * @param {string} range - A git revision range (e.g. `abc123..HEAD`, `main...HEAD`).
  * @returns {string[]}
  */
 function _diffNameOnly(cwd, range) {
-  const stdout = _internal.execSync(`git diff --name-only ${range}`, {
+  const stdout = _internal.execSync(`git diff --name-only --diff-filter=d ${range}`, {
     cwd,
     encoding: 'utf8',
     timeout: GIT_EXEC_TIMEOUT_MS,

--- a/lib/wrap-steps/features-toc.js
+++ b/lib/wrap-steps/features-toc.js
@@ -60,15 +60,22 @@
  * "every diff line", broader than "lib/ only" — and meant to be
  * tightened against dogfood feedback in Chunk 4 if it produces churn.
  *
- * **Deleted files are never stubbed.** The diff is taken with
- * `--diff-filter=d`, so a file the session touched and then removed
- * does not become an entry. Beyond being meaningless as a feature
- * pointer, a stub for a deleted file is a *dangling citation*:
- * `FEATURES.md`'s citation contract asserts every cited path exists on
- * disk, so such a stub fails the required test gate and blocks the
- * wrap's own PR — stranding that wrap's version bump on an unmerged
- * branch while every step still reports success. See
- * {@link _diffNameOnly}.
+ * **Only paths that still exist are stubbed.** A stub for a file the
+ * session removed is a *dangling citation*: `FEATURES.md`'s citation
+ * contract asserts every cited path exists on disk, so such a stub
+ * fails the required test gate and blocks the wrap's own PR — stranding
+ * that wrap's version bump on an unmerged branch while every step still
+ * reports success.
+ *
+ * The guard is an existence check on the write path
+ * ({@link _stillExists}), deliberately not a `--diff-filter` on the
+ * range. Two distinct routes produce a doomed path, and only the
+ * existence check closes both: a file deleted *within* the range, and a
+ * file added earlier in the range then deleted in the *working tree* —
+ * the latter still reports as added by any range diff, yet the wrap's
+ * own `git add -A` commits its deletion moments later. Checking what is
+ * on disk at write time asks the same question the citation contract
+ * asks, so the two cannot disagree.
  *
  * **Drift extraction.** Existing index entries are tokenized by a
  * single regex that scans for path tokens with the same extension
@@ -208,7 +215,8 @@ async function run(context) {
     return _skipped(`git diff failed: ${err.message}`);
   }
 
-  const candidates = touchedFiles.filter(_isIndexableCandidate);
+  const indexable = touchedFiles.filter(_isIndexableCandidate);
+  const candidates = indexable.filter((f) => _stillExists(project.path, f));
   const indexedSet = _extractIndexedPaths(indexContent);
   const drifted = candidates.filter((f) => !indexedSet.has(f));
 
@@ -217,7 +225,14 @@ async function run(context) {
     // this is the steady-state "everything already indexed" skip.
     if (created) return _stageCreate(featuresPath, indexContent, staged, project, log);
     if (touchedFiles.length === 0) return _skipped(`no files touched in ${sessionRange.range}`);
-    if (candidates.length === 0) return _skipped('no indexable candidates after filtering');
+    if (candidates.length === 0) {
+      // Distinguish the two empty-candidate causes rather than reporting the
+      // generic filter skip — "every touched file was deleted" is a materially
+      // different session from "nothing touched was indexable".
+      return _skipped(indexable.length > 0
+        ? 'no indexable candidates — every touched file was deleted'
+        : 'no indexable candidates after filtering');
+    }
     return _skipped('no drift — every touched file already in FEATURES.md');
   }
 
@@ -387,21 +402,18 @@ function _resolveBaseBranch(cwd) {
  * `<lastWrapSha>..HEAD` (this session's merged commits) or `<baseBranch>...HEAD`
  * (the current branch's divergence, the first-wrap fallback).
  *
- * `--diff-filter=d` (lower-case `d` = *exclude* deletions) drops paths whose
- * final state in the range is "deleted". A file the session touched and then
- * removed is not a feature to describe, and stubbing it actively breaks the
- * wrap: `FEATURES.md`'s citation contract asserts that every cited path still
- * exists on disk, so a stub for a deleted file fails that check, reddens the
- * required test gate, and blocks the wrap's own PR from merging — leaving the
- * version bump stranded on an unmerged branch. Renames arrive as delete+add
- * (no `-M`), so the stale path drops out and the new one is still stubbed.
+ * Deletions are NOT filtered here. The range says what changed between two
+ * commits, which is the wrong question for "does this path still exist" — the
+ * wrap commits the working tree with `git add -A`, so a path's fate is decided
+ * after this diff is taken. Existence is checked once, on the write path, by
+ * {@link _stillExists}.
  *
  * @param {string} cwd
  * @param {string} range - A git revision range (e.g. `abc123..HEAD`, `main...HEAD`).
  * @returns {string[]}
  */
 function _diffNameOnly(cwd, range) {
-  const stdout = _internal.execSync(`git diff --name-only --diff-filter=d ${range}`, {
+  const stdout = _internal.execSync(`git diff --name-only ${range}`, {
     cwd,
     encoding: 'utf8',
     timeout: GIT_EXEC_TIMEOUT_MS,
@@ -437,6 +449,25 @@ function _isIndexableCandidate(relativePath) {
   const base = path.basename(relativePath);
   if (EXCLUDED_BASENAMES.has(base)) return false;
   return true;
+}
+
+/**
+ * Whether a diffed path still exists in the working tree — i.e. whether it will
+ * survive into the commit this wrap is about to make.
+ *
+ * This is the guard against dangling citations. `FEATURES.md`'s citation
+ * contract asserts that every cited path exists on disk; asking exactly that
+ * question here means a stub can never contradict it. A range diff cannot
+ * answer it — the wrap commits the working tree with `git add -A` after the
+ * diff is taken, so a path reported as "added" may be deleted on disk and
+ * about to be committed as such.
+ *
+ * @param {string} projectPath - Absolute project root.
+ * @param {string} relativePath - Repo-relative path from the diff.
+ * @returns {boolean}
+ */
+function _stillExists(projectPath, relativePath) {
+  return _internal.existsSync(path.join(projectPath, relativePath));
 }
 
 /**
@@ -517,6 +548,7 @@ module.exports = {
   _resolveBaseBranch,
   _diffNameOnly,
   _isIndexableCandidate,
+  _stillExists,
   _extractIndexedPaths,
   _appendTodoSection,
   _stageCreate,

--- a/test/wrap-step-features-toc.test.js
+++ b/test/wrap-step-features-toc.test.js
@@ -929,9 +929,11 @@ describe('wrap-step features-toc (#207 Chunk 3)', () => {
     let createdProject;
     let firstSha;
 
-    // Driven against a REAL git repo, not a stubbed execSync: the behavior under
-    // test IS git's `--diff-filter=d` semantics, and a stub could only prove the
-    // flag string was passed, never that it excludes what we think it excludes.
+    // Driven against a REAL git repo, not a stubbed execSync. The bug is a
+    // disagreement between what a range diff reports and what is actually on
+    // disk, so a stub that hand-writes the diff output would be asserting the
+    // very relationship under test — it could show the guard filtering a list,
+    // never that the list git really produces contains a doomed path.
     before(() => {
       tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-features-toc-deleted-'));
       store._setBasePath(path.join(tmpDir, 'tangleclaw'));
@@ -1049,6 +1051,11 @@ describe('wrap-step features-toc (#207 Chunk 3)', () => {
       assert.equal(result.ok, true, 'never blocks');
       assert.equal(result.status, 'skipped');
       assert.equal(staged['features-toc:append'], undefined, 'nothing staged when there is no drift');
+      // Pin the specific reason, not just the shared prefix: reporting an
+      // all-deletions session as "already indexed" would be a false statement
+      // about why nothing happened.
+      assert.match(result.output.reason, /every touched file was deleted/,
+        'the skip reason must name deletion as the cause');
     });
   });
 });

--- a/test/wrap-step-features-toc.test.js
+++ b/test/wrap-step-features-toc.test.js
@@ -20,6 +20,25 @@ const store = require('../lib/store');
 const featuresToc = require('../lib/wrap-steps/features-toc');
 const commitStep = require('../lib/wrap-steps/commit');
 
+/**
+ * Materialize repo-relative fixture paths inside a project dir.
+ *
+ * A stubbed `git diff` must be backed by real files: the handler only stubs
+ * paths that still exist on disk, because FEATURES.md's citation contract
+ * asserts every cited path exists and a dangling stub blocks the wrap's own PR.
+ * Without this, a stubbed diff would describe a tree that could never occur.
+ *
+ * @param {string} projectPath - Absolute project root.
+ * @param {...string} relativePaths - Repo-relative paths to create.
+ */
+function materialize(projectPath, ...relativePaths) {
+  for (const rel of relativePaths) {
+    const abs = path.join(projectPath, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, '// fixture\n');
+  }
+}
+
 describe('wrap-step features-toc (#207 Chunk 3)', () => {
   describe('_todayIsoLocal (#205 parity — local-zoned date)', () => {
     // Mirrors the version-bump fix in PR #216. The bundled
@@ -252,6 +271,7 @@ describe('wrap-step features-toc (#207 Chunk 3)', () => {
         engine: 'claude',
         methodology: 'minimal'
       });
+      materialize(projectPath, 'lib/new-thing.js', 'lib/foo.js', 'lib/bar.js');
     });
 
     after(() => {
@@ -492,6 +512,8 @@ describe('wrap-step features-toc (#207 Chunk 3)', () => {
         methodology: 'minimal',
         featureIndexEnabled: true
       });
+      materialize(projectPath,
+        'lib/pill.js', 'lib/new-foo.js', 'lib/new-bar.ts', 'lib/some-new.js', 'lib/idempo.js');
     });
 
     after(() => {
@@ -697,6 +719,7 @@ describe('wrap-step features-toc (#207 Chunk 3)', () => {
       createdProject = store.projects.create({
         name: 'features-toc-465', path: projectPath, engine: 'claude', methodology: 'minimal'
       });
+      materialize(projectPath, 'lib/merged-a.js', 'lib/merged-b.js');
     });
 
     after(() => {
@@ -978,10 +1001,42 @@ describe('wrap-step features-toc (#207 Chunk 3)', () => {
       }
     });
 
-    it('skips entirely when the session only deleted files (nothing left to describe)', async () => {
-      // Second session: delete the file the first one added, touching nothing else.
+    it('does NOT stub a file deleted in the WORKING TREE after being added in the range', async () => {
+      // The route a range-level `--diff-filter` cannot close: `transient.js` is
+      // ADDED by a commit inside the session range, so every range diff reports
+      // it as added — but it is gone from the working tree, and the wrap's own
+      // `git add -A` (lib/wrap-steps/commit.js) commits that deletion moments
+      // after this step runs. Stubbing it would dangle by the time CI looks.
       const headBefore = execSync('git rev-parse HEAD', { cwd: projectPath, encoding: 'utf8' }).trim();
-      fs.rmSync(path.join(projectPath, 'lib', 'kept.js'));
+      fs.writeFileSync(path.join(projectPath, 'lib', 'transient.js'), '// added then removed\n');
+      execSync('git add -A && git commit -q -m "add transient"', { cwd: projectPath, stdio: 'ignore' });
+      fs.rmSync(path.join(projectPath, 'lib', 'transient.js')); // uncommitted deletion
+
+      store.projectConfig.save(projectPath, {
+        engine: 'claude', methodology: 'minimal', featureIndexEnabled: true, lastWrapSha: headBefore
+      });
+
+      const rangeSawIt = execSync(`git diff --name-only ${headBefore}..HEAD`, { cwd: projectPath, encoding: 'utf8' });
+      assert.match(rangeSawIt, /transient\.js/,
+        'precondition: the range reports it as added, so only an on-disk check can catch it');
+
+      const staged = {};
+      const result = await featuresToc.run({ project: createdProject, staged });
+
+      assert.equal(result.ok, true, 'never blocks');
+      assert.equal(result.status, 'skipped', 'nothing survives to stub');
+      assert.equal(staged['features-toc:append'], undefined);
+
+      execSync('git add -A && git commit -q -m "commit the deletion"', { cwd: projectPath, stdio: 'ignore' });
+    });
+
+    it('skips entirely when the session only deleted files (nothing left to describe)', async () => {
+      // Self-contained: create and commit this test's own file, then delete it,
+      // so the case does not depend on a sibling test having run first.
+      fs.writeFileSync(path.join(projectPath, 'lib', 'solo.js'), '// this test owns this file\n');
+      execSync('git add -A && git commit -q -m "add solo"', { cwd: projectPath, stdio: 'ignore' });
+      const headBefore = execSync('git rev-parse HEAD', { cwd: projectPath, encoding: 'utf8' }).trim();
+      fs.rmSync(path.join(projectPath, 'lib', 'solo.js'));
       execSync('git add -A && git commit -q -m "delete only"', { cwd: projectPath, stdio: 'ignore' });
 
       store.projectConfig.save(projectPath, {

--- a/test/wrap-step-features-toc.test.js
+++ b/test/wrap-step-features-toc.test.js
@@ -716,9 +716,9 @@ describe('wrap-step features-toc (#207 Chunk 3)', () => {
       featuresToc._internal.execSync = (cmd) => {
         if (cmd.includes(`${SHA}^{commit}`)) return Buffer.from(''); // SHA resolves
         // The OLD (branch) range is empty — this is the wrap-on-main bug condition.
-        if (cmd.includes('git diff --name-only main...HEAD')) return Buffer.from('');
+        if (cmd.includes('main...HEAD')) return Buffer.from('');
         // The NEW (session) range captures everything merged since the last wrap.
-        if (cmd.includes(`git diff --name-only ${SHA}..HEAD`)) {
+        if (cmd.includes(`${SHA}..HEAD`)) {
           sawSessionDiff = true;
           return 'lib/merged-a.js\nlib/merged-b.js\n';
         }
@@ -897,6 +897,103 @@ describe('wrap-step features-toc (#207 Chunk 3)', () => {
       const lines = commitStep._buildBodyLines(staged);
       assert.ok(lines.includes('- Feature Index: created (3 stub(s) appended)'),
         'self-heal create with drift reports the appended count');
+    });
+  });
+
+  describe('deleted files are never stubbed (dangling-citation regression)', () => {
+    let tmpDir;
+    let projectPath;
+    let createdProject;
+    let firstSha;
+
+    // Driven against a REAL git repo, not a stubbed execSync: the behavior under
+    // test IS git's `--diff-filter=d` semantics, and a stub could only prove the
+    // flag string was passed, never that it excludes what we think it excludes.
+    before(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-features-toc-deleted-'));
+      store._setBasePath(path.join(tmpDir, 'tangleclaw'));
+      store.init();
+      const projectsDir = path.join(tmpDir, 'projects');
+      fs.mkdirSync(projectsDir, { recursive: true });
+      const cfg = store.config.load();
+      cfg.projectsDir = projectsDir;
+      store.config.save(cfg);
+
+      projectPath = path.join(projectsDir, 'features-toc-deleted');
+      fs.mkdirSync(path.join(projectPath, 'lib'), { recursive: true });
+
+      const git = (cmd) => execSync(`git ${cmd}`, { cwd: projectPath, stdio: 'ignore' });
+      git('init -q');
+      git('config user.email test@example.com');
+      git('config user.name Test');
+      git('config commit.gpgsign false');
+
+      // Baseline commit — this is where the previous wrap left off.
+      fs.writeFileSync(path.join(projectPath, 'FEATURES.md'), '# Feature Index\n\n## UI\n');
+      fs.writeFileSync(path.join(projectPath, 'lib', 'doomed.js'), '// removed later\n');
+      git('add -A');
+      git('commit -q -m baseline');
+      firstSha = execSync('git rev-parse HEAD', { cwd: projectPath, encoding: 'utf8' }).trim();
+
+      // The session: add one file, delete another. Mirrors the real #637 trigger
+      // (a wrap-step file disposed of mid-session), which stubbed the deleted
+      // path and blocked that wrap's own PR on the citation contract.
+      fs.writeFileSync(path.join(projectPath, 'lib', 'kept.js'), '// still here\n');
+      fs.rmSync(path.join(projectPath, 'lib', 'doomed.js'));
+      git('add -A');
+      git('commit -q -m session');
+
+      createdProject = store.projects.create({
+        name: 'features-toc-deleted', path: projectPath, engine: 'claude', methodology: 'minimal'
+      });
+    });
+
+    after(() => {
+      store.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('stubs a file added this session but NOT one deleted this session', async () => {
+      store.projectConfig.save(projectPath, {
+        engine: 'claude', methodology: 'minimal', featureIndexEnabled: true, lastWrapSha: firstSha
+      });
+
+      const origToday = featuresToc._internal.todayIso;
+      featuresToc._internal.todayIso = () => '2026-07-19';
+      try {
+        const staged = {};
+        const result = await featuresToc.run({ project: createdProject, staged });
+
+        assert.equal(result.status, 'done');
+        assert.deepEqual(result.output.addedFiles, ['lib/kept.js'],
+          'the added file is stubbed; the deleted file must not appear');
+        assert.equal(result.output.addedCount, 1);
+
+        const { newContent } = staged['features-toc:append'];
+        assert.match(newContent, /lib\/kept\.js/);
+        assert.doesNotMatch(newContent, /doomed/,
+          'a stub for a deleted path is a dangling citation — it fails the FEATURES.md citation contract and blocks the wrap PR');
+      } finally {
+        featuresToc._internal.todayIso = origToday;
+      }
+    });
+
+    it('skips entirely when the session only deleted files (nothing left to describe)', async () => {
+      // Second session: delete the file the first one added, touching nothing else.
+      const headBefore = execSync('git rev-parse HEAD', { cwd: projectPath, encoding: 'utf8' }).trim();
+      fs.rmSync(path.join(projectPath, 'lib', 'kept.js'));
+      execSync('git add -A && git commit -q -m "delete only"', { cwd: projectPath, stdio: 'ignore' });
+
+      store.projectConfig.save(projectPath, {
+        engine: 'claude', methodology: 'minimal', featureIndexEnabled: true, lastWrapSha: headBefore
+      });
+
+      const staged = {};
+      const result = await featuresToc.run({ project: createdProject, staged });
+
+      assert.equal(result.ok, true, 'never blocks');
+      assert.equal(result.status, 'skipped');
+      assert.equal(staged['features-toc:append'], undefined, 'nothing staged when there is no drift');
     });
   });
 });


### PR DESCRIPTION
## What

`features-toc` built its auto-stub list from `git diff --name-only` and filtered only on path *shape* — extension, prefix, basename — never on whether the file still existed. A session that removed a file got a stub citing a path that resolves to nothing.

The guard is now an existence check on the write path (`_stillExists`), asking exactly the question `FEATURES.md`'s citation contract asks, so the two cannot disagree.

## Why

Not just index noise. The citation contract (`DOC-3K7Q`) asserts every cited path exists on disk, so the stub failed the required `test` check and blocked **the wrap's own PR** from merging — stranding that wrap's version bump on an unmerged branch while every step in the drawer still reported `[Done]`. Hit live on #636: `main` sat at 4.26.0 while the wrap reported `4.26.0 → 4.27.0`.

A first pass used `git diff --diff-filter=d` to exclude deletions. Critic review found that closes only one of two routes: a file added earlier in the session range and deleted in the **working tree** still reports as *added* by any range diff, and the wrap's own `git add -A` (`lib/wrap-steps/commit.js:681`) commits that deletion moments after the step runs — reproducing #637 exactly, silent symptom included. The range filter was removed in favor of the existence check, which closes both routes and is robust to future changes in how the session range is computed.

Also: a wrap whose session only deleted files now reports `every touched file was deleted` instead of the generic `no drift — every touched file already in FEATURES.md`, which was simply false.

## Test plan

- Full suite green: **4573 passed, 0 failed** (`node --test 'test/*.test.js'`). Test evidence recorded.
- Three new regression tests, driven against a **real git repo** rather than a stubbed `execSync` — the bug is a disagreement between what a range diff reports and what is on disk, so a hand-written diff stub would assert the very relationship under test:
  - deleted within the range → not stubbed
  - **added in range, deleted in working tree** → not stubbed (includes a precondition assertion that the range *does* report it as added, so the test proves the right thing)
  - all-deletions session → skips, with the reason pinned
- Verified non-vacuous: with the guard removed, all three fail; the first reproduces the exact `lib/doomed.js` dangling stub.
- Existing fixtures now materialize the paths their stubbed diffs name — a stubbed diff naming files that exist nowhere describes a tree that cannot occur.

## Review

`/prawduct:critic cumulative` → 0 blocking, 2 warnings → both resolved → `verify-resolutions` → 0 blocking. Notes on the stale comment and unpinned skip reason also fixed.

Known gap, deliberately not in scope: *pre-existing* citations to files deleted in an earlier session still dangle with the identical outcome. Filed separately.

Fixes #637