### PR TITLE
Fix the flaky rule-ordering test that turns main red

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Internal
+
+- **Fixed a flaky test that turned `main` red without any code being wrong.** The startup
+  session-rule ordering test built its own precondition by racing the clock: it created six
+  rules and assumed all six would land inside one tick of SQLite's second-resolution
+  `datetime('now')`, giving them the tied timestamps the ordering contract is about. On a
+  loaded CI runner the burst straddled a second boundary, the timestamps differed, and the
+  run failed on the precondition — without ever exercising the ordering it exists to check.
+  The tie is now forced directly, so the assertion runs every time. No production behavior
+  changed; the query already ordered by `created_at, id`.
+
 ### Fixed
 
 - **The wrap no longer stubs Feature Index entries for files the session deleted (#637).**

--- a/test/session-rule-delivery.test.js
+++ b/test/session-rule-delivery.test.js
@@ -147,6 +147,21 @@ describe('startup session-rule delivery (#595)', () => {
       for (let i = 0; i < 6; i++) {
         ids.push(store.sessionRules.create({ content: `burst rule ${i}`, projectId: project.id }).id);
       }
+      // Force the tie rather than racing the clock for it. Relying on all six
+      // inserts landing inside one tick of datetime('now') makes the test's own
+      // precondition timing-dependent: on a loaded machine the burst straddles a
+      // second boundary, the timestamps differ, and the run fails without the
+      // ordering contract ever being exercised. Pinning created_at guarantees
+      // the tie every run, so the assertion below always tests what it claims to.
+      //
+      // Scope of the guard, measured by reverting the query: flipping the sort to
+      // `id DESC` fails this test, so it does read the order. Dropping the `, id`
+      // tiebreaker entirely does NOT fail it — SQLite's unspecified scan order
+      // happens to coincide with ascending id here. Absence of unspecified
+      // behavior isn't testable; this pins the contract, not the SQL.
+      store.getDb()
+        .prepare(`UPDATE session_rules SET created_at = '2000-01-01 00:00:00' WHERE id IN (${ids.map(() => '?').join(',')})`)
+        .run(...ids);
       const stamps = new Set(store.sessionRules.listActiveForProject(project.id).map((r) => r.createdAt));
       assert.equal(stamps.size, 1, 'precondition: the burst must share one timestamp for this test to mean anything');
 


### PR DESCRIPTION
## What

`test/session-rule-delivery.test.js` built its own precondition by racing the clock. It creates six session rules and asserts they share one `created_at` — tied timestamps being the exact condition the ordering contract is about — but obtained that tie by hoping all six inserts landed inside one tick of SQLite's second-resolution `datetime('now')`.

The tie is now forced directly via `UPDATE session_rules SET created_at = ...`.

## Why

On a loaded CI runner the burst straddles a second boundary, the timestamps differ, and the run fails on the **precondition** (`2 !== 1`) — without the ordering assertion ever executing. That is what turned `main` red in run 29700467369: a false red with nothing actually broken, and simultaneously a silent hole, since the check the test exists for didn't run.

No production behavior changed. `listActiveForProject` already ordered by `created_at, id` (`lib/store.js:3232-3236`).

## Guard scope (measured, not assumed)

Reverted the production query two ways to see what this test actually catches:

- `ORDER BY created_at, id DESC` → **test fails.** It genuinely reads the order.
- `ORDER BY created_at` (tiebreaker dropped) → **test still passes.** SQLite's unspecified scan order happens to coincide with ascending id.

So the test pins the observable contract, not the SQL. Absence of unspecified behavior isn't testable through this seam; that limitation is now recorded in the test rather than left implied.

## Test plan

- `node --test test/session-rule-delivery.test.js` → 31 pass, 0 fail
- `node --test 'test/*.test.js'` → 4573 pass, 0 fail, 1 skipped
- Falsification runs above, with `lib/store.js` restored verbatim afterward (diff is test + CHANGELOG only)