### PR TITLE
Connect the self-improvement loop: recurrence advances learnings, wraps propose rules

### DIFF
--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -26,6 +26,45 @@ Tag-line conventions (ART-4K9M, ratified 2026-07-17):
 -->
 
 
+## 2026-07-20: Chunk 05a — the self-improvement loop stops being a loop on paper (#569)
+
+<!-- prawduct: type=feat | chunks=05a | scope=wrap-v2 | status=shipped -->
+
+**Why:** both halves of #569's loop were drawn but disconnected. Every captured learning
+was written `provisional` and nothing ever advanced one, so the `## Active Learnings`
+block injected at session start was empty on every project, permanently. And nothing
+turned a learning into a rule: `promoteFromLearning` had exactly one caller, an HTTP
+route no UI invoked.
+
+**Discovery correction:** the advancer looked nearly free — `learnings-db-write` already
+dedups and `confirm()` already auto-promotes — but the dedup compares full content
+INCLUDING the entry's own `## YYYY-MM-DD` heading, so it is a same-day retry guard that
+can never see a recurrence. A date-independent normalized key was the actual missing
+piece.
+
+**Promotion bar is two sightings, owned by the step.** `confirm()`'s own threshold is 2
+confirmations (three sightings), which for exactly-matching normalized text almost never
+happens; deferring to it would have left the tier gate shut and reproduced the dead-end
+in softer form. `confirm()`'s general contract is untouched.
+
+**Proposals got `session_rules.status`** (`proposed|active|rejected`, v26→v27) rather
+than reusing `enabled`, which means "the operator switched this off" — storing proposals
+there would make a REJECTED rule indistinguishable from an unreviewed one and the wrap
+would re-propose declined rules forever. Rejection is a recorded state for that reason.
+
+**The Critic's blocking findings were one root, and it was mine.** I put the authority
+decision at the HTTP boundary and assumed reaching a route meant a human pressed a
+button. The API is on localhost and this project instructs in-session agents to call it,
+so an agent could curl a learning straight to a governing rule. Authority now comes from
+the operator-password gate, and the docs state the true ceiling instead of claiming an
+unconditional human gate. Also missed `findConflictCandidates` in the status-reader
+audit.
+
+**Deferred to 05b:** the approve/reject UI. `session_rule_versions` has no `status`
+column, so a decision is recorded as free-text `change_reason`.
+
+**Classification:** build
+
 ## 2026-07-19: Chunk 04c — a project can turn off a wrap step without forking its methodology
 
 <!-- prawduct: type=feat | chunks=04c | scope=wrap-v2 | status=shipped -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ All notable changes to TangleClaw are documented in this file.
   learnings routes at all, so the tier deciding what a future session sees was unreachable from
   outside the process), and `PUT /api/session-rules/:id/status` to approve or reject.
 
+  Approving a rule is gated by your operator password, the same gate as deleting a project or
+  killing a session — so approval is as protected as every other privileged operation, which
+  means it is only really protected if you have set one. Declining is ungated; it grants
+  nothing.
+
   Approve/reject is API-only in this release; the one-click review surface lands next.
 
 - **Projects can now turn off or reconfigure an individual wrap step, without forking their

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ All notable changes to TangleClaw are documented in this file.
 
 ### Added
 
+- **Wrapping now actually makes the next session smarter (#569).** Two halves of the loop were
+  drawn but never connected. Every learning a wrap captured was written as *provisional*, and
+  nothing in TangleClaw ever advanced one — so the `## Active Learnings` block injected at
+  session start was empty on every project, permanently. And nothing ever turned a learning
+  into a rule: the promote endpoint existed but had no caller and no button.
+
+  Both are connected now. A learning recorded again on a later day is recognised as recurring
+  and advances to active, so it reaches the next session's prime. Recognising it needed a
+  date-independent comparison — stored entries begin with their own `## YYYY-MM-DD` heading, so
+  the same insight written a month later never matched its earlier self by text.
+
+  Recurring learnings then become **proposed** rules. A proposal is inert: it is not injected
+  at session start, not into the Project Master, and not into the wrap's own prompts. It
+  governs nothing until you approve it. Each proposal records the learning it came from, so
+  "why is this rule here?" has an answer.
+
+  **The system cannot promote its own proposals.** That holds at both doors — an AI cannot
+  create an active rule, and it cannot approve one either. Approval is an operator decision,
+  and it is the operator pressing the button that makes a rule live, not the AI asking nicely.
+  A rule you *reject* is recorded as rejected rather than deleted, so the wrap won't quietly
+  re-propose it at the next wrap that sees the same learning.
+
+  New API: `GET /api/learnings`, `PUT /api/learnings/:id/tier` (there were previously no
+  learnings routes at all, so the tier deciding what a future session sees was unreachable from
+  outside the process), and `PUT /api/session-rules/:id/status` to approve or reject.
+
+  Approve/reject is API-only in this release; the one-click review surface lands next.
+
 - **Projects can now turn off or reconfigure an individual wrap step, without forking their
   methodology.** Set `wrapStepOverrides` in a project's `.tangleclaw/project.json`, keyed by
   step id — `{"version-bump": {"enabled": false}}` skips that step,

--- a/data/templates/prawduct/template.json
+++ b/data/templates/prawduct/template.json
@@ -10,7 +10,7 @@
   "playbookRuleSections": {
     "independentCritic": "### Independent Critic Review"
   },
-  "schemaRevision": 6,
+  "schemaRevision": 7,
   "phases": [
     {
       "id": "discovery",
@@ -76,6 +76,7 @@
         "prompt": "You are at the end of a development session. Capture this session's learnings \u2014 non-obvious behaviors, validated patterns, failure modes, or anti-patterns worth remembering for future work \u2014 to `.tangleclaw/memories/learnings.md`.\n\nSkip the obvious. Skip routine bug fixes. Capture only what would change how you'd approach a similar task next time.\n\nSteps:\n1. Read `.tangleclaw/memories/learnings.md` if it exists, to match the existing style. If it doesn't exist, create it with a top-level heading like `# Cross-Session Learnings \u2014 <project name>`.\n2. Reflect on this session: what surprised you? What broke in an unexpected way? What pattern got validated by shipping? What's worth remembering next time?\n3. Append a new entry. Convention: `## YYYY-MM-DD \u2014 <one-line title>` followed by a 2-5 sentence body. Link issues / PRs / commits with shortlinks where relevant.\n4. If there's nothing novel this session, append a single line: `- YYYY-MM-DD: no novel learnings (routine work).` Do not fabricate signal \u2014 a session with nothing to learn is honest.\n5. Save the file. The commit step will pick it up via `git add -A`.\n\nWhen done, reply with a single `## Result` heading followed by a one-line summary of what you captured (or `no novel learnings` if applicable)."
       },
       {"id": "learnings-db-write", "kind": "learnings-db-write", "blocker": false},
+      {"id": "rule-proposal", "kind": "rule-proposal", "blocker": false},
       {"id": "next-session-prime", "kind": "priming-roll"},
       {"id": "features-toc", "kind": "features-toc"},
       {"id": "project-map", "kind": "project-map"},

--- a/docs/session-rules-self-improvement.md
+++ b/docs/session-rules-self-improvement.md
@@ -27,9 +27,19 @@ here).
 - `session_rule_versions` — a full snapshot after **every** mutation (`create` / `update` /
   `delete` / `restore`). `version_no` is monotonic per rule; `rule_id` is a logical
   reference (no FK cascade) so **history survives a rule's deletion** for audit.
-- `learnings` — `id`, `project_id`, `content`, `tier` (`provisional` | `active`),
-  `source_session`, `confirmed_count`, timestamps. Rows are the raw material the promote
-  loop turns into rules.
+- `learnings` — `id`, `project_id`, `content`, `tier`, `source_session`,
+  `confirmed_count`, timestamps. Rows are the raw material the promote loop turns into
+  rules. `tier` is one of `provisional` | `active` | `reference` | `archived`
+  (`store.js`'s `setTier` validator is the authority; there is deliberately no CHECK
+  constraint, so `create` will accept any string — pass a valid tier). Only `active`
+  learnings are injected into a session prime, and only `active` ones are eligible to
+  become rule proposals.
+- `session_rules.status` — `proposed` | `active` | `rejected` (#569). **Orthogonal to
+  `enabled`**: `enabled` is the operator's on/off switch for a rule they own, `status` is
+  how far the rule has got through review. Only `active` is ever injected — by the launch
+  prime, the Project Master, or the wrap's own prompts. Keeping the two separate is what
+  makes a REJECTED rule distinguishable from an unreviewed one; collapse them and the wrap
+  re-proposes declined rules at every wrap that sees the same learning.
 
 ## Learnings ingestion (the DB writer, #466)
 
@@ -56,6 +66,43 @@ wrote to the table, so both the prime injection and the promote loop were perman
 | `POST /api/session-rules/:id/restore` `{versionNo}` | Roll back to a prior version |
 | `POST /api/session-rules/promote` `{learningId, content?, projectId?}` | Promote a learning → rule (operator-confirmed; defaults to the learning's project) |
 | `POST /api/session-rules/conflicts` `{content, projectId?}` | Non-authoritative conflict-candidate signal |
+| `PUT /api/session-rules/:id/status` `{status, changedBy?, changeReason?}` | #569 — approve (`active`) or decline (`rejected`) a proposal. An AI `changedBy` requesting `active` is refused with 403 |
+| `GET /api/learnings?projectId=&tier=` | #569 — list a project's learnings |
+| `PUT /api/learnings/:id/tier` `{tier}` | #569 — operator override of a learning's tier |
+
+## The automatic loop (#569)
+
+Before this, the loop existed on paper only: nothing advanced a learning's tier, and
+`promoteFromLearning` had a single caller — a route no UI invoked. So `## Active Learnings`
+was empty on every project and rules never evolved.
+
+1. **Capture** — `learnings-capture` writes the session's learnings to
+   `.tangleclaw/memories/learnings.md`; `learnings-db-write` mirrors today-dated entries
+   into the `learnings` table at `tier:'provisional'`.
+2. **Recur** — when a later wrap records the *same* learning, `learnings-db-write`
+   recognises it and confirms it. Recognition uses a **date-independent key** (the stored
+   entry's own `## YYYY-MM-DD` heading is stripped, then whitespace and case normalized),
+   because otherwise a repeated learning never matches its earlier self. The match is exact
+   after normalization rather than fuzzy: a confirmation puts a learning in front of every
+   future session, so a false match is worse than a missed one.
+3. **Advance** — a learning seen on two different days becomes `active` and is injected
+   into the next session's prime. Two sightings is the bar deliberately: `learnings.confirm`
+   promotes at 2 *confirmations* (three sightings), which for exactly-matching normalized
+   text almost never happens, so deferring to it would leave the gate shut.
+4. **Propose** — the `rule-proposal` wrap step turns each active learning that has no rule
+   yet into a `status:'proposed'` rule, carrying `source_learning_id` for provenance. It
+   proposes the learning's own text; it does not ask an AI to invent rule wording, so every
+   proposal traces to a specific row and needs no second unverifiable round-trip.
+5. **Decide** — the operator approves or rejects. Both are recorded as versions. A rejected
+   proposal is never re-proposed, which is why rejection is a recorded state rather than a
+   delete.
+
+**The gate, stated once:** AI authorship cannot produce a governing rule on its own say-so.
+`createdBy` records *authorship*, not *authority* — a rule promoted from a learning is
+genuinely AI-authored, yet an operator pressing Promote must produce a live rule. Authority
+is therefore carried separately and only set on human-initiated paths. The property is
+enforced at **both** doors into `active` — creation and status change — because a gate on
+one entrance is not a gate.
 
 `findConflictCandidates` / the `/conflicts` route return active in-scope rules sharing
 significant token overlap with a proposed edit. This is a **hint of what to compare**, NOT

--- a/docs/session-rules-self-improvement.md
+++ b/docs/session-rules-self-improvement.md
@@ -100,9 +100,23 @@ was empty on every project and rules never evolved.
 **The gate, stated once:** AI authorship cannot produce a governing rule on its own say-so.
 `createdBy` records *authorship*, not *authority* — a rule promoted from a learning is
 genuinely AI-authored, yet an operator pressing Promote must produce a live rule. Authority
-is therefore carried separately and only set on human-initiated paths. The property is
-enforced at **both** doors into `active` — creation and status change — because a gate on
-one entrance is not a gate.
+is therefore carried separately, and the property is enforced at **both** doors into
+`active` — creation and status change — because a gate on one entrance is not a gate.
+
+**What that does and does not guarantee.** In the store the property is absolute: no code
+path reaches `status:'active'` from AI authorship without authority being passed explicitly,
+and `setStatus` refuses `changedBy:'ai'` outright. Over HTTP, the two routes that can grant
+authority — `POST /api/session-rules/promote` and `PUT /api/session-rules/:id/status` with
+`status:'active'` — are gated by the **operator password** (`checkDeletePassword`), the same
+gate as deleting a project, killing a session, or wrapping. Declining a proposal is
+ungated, because it grants nothing.
+
+That gate is only real protection **when a delete password is configured**. With none set it
+allows every caller, so on a machine where in-session agents are instructed to call the
+TangleClaw API, an agent could approve a rule — exactly as it could already delete a project.
+This is stated rather than glossed: the honest claim is that rule approval is as protected as
+every other privileged operation in TangleClaw, not that it is unconditionally
+human-gated. Set a delete password if that distinction matters to you.
 
 `findConflictCandidates` / the `/conflicts` route return active in-scope rules sharing
 significant token overlap with a proposed edit. This is a **hint of what to compare**, NOT

--- a/lib/store.js
+++ b/lib/store.js
@@ -3514,7 +3514,14 @@ const sessionRulesApi = {
     activityApi.log({
       projectId: rule.projectId,
       eventType: 'session_rule.created',
-      detail: { kind: rule.kind, createdBy: rule.createdBy, contentPreview: rule.content.slice(0, 80) }
+      // `status` belongs here: this is the write site enforcing "AI authorship
+      // cannot mint a governing rule", and without it the audit trail cannot
+      // tell a proposal from a live rule — which is the one distinction an
+      // auditor of this event would be looking for.
+      detail: {
+        kind: rule.kind, createdBy: rule.createdBy, status: rule.status,
+        contentPreview: rule.content.slice(0, 80)
+      }
     });
     return rule;
   },
@@ -3664,8 +3671,13 @@ const sessionRulesApi = {
    * re-proposed at the next wrap that saw the same learning. A `'rejected'` row
    * is the memory of the operator's answer.
    *
-   * Snapshots a version like every other mutation, so who decided and when is
-   * answerable from the rule's history rather than only from an activity log.
+   * Snapshots a version like every other mutation, so the decision appears in
+   * the rule's history rather than only in an activity log. Note the limit:
+   * `session_rule_versions` has no `status` column, so the snapshot records the
+   * transition in free-text `change_reason` plus `changed_by`, not as queryable
+   * state. Two adjacent versions differing only by status therefore look
+   * near-identical in the history UI. Adding the column is a table rebuild
+   * (SQLite cannot ALTER in a CHECK) and is deliberately deferred.
    *
    * @param {number} id - Rule id
    * @param {string} status - 'proposed' | 'active' | 'rejected'

--- a/lib/store.js
+++ b/lib/store.js
@@ -8,7 +8,7 @@ const { createLogger } = require('./logger');
 
 const log = createLogger('store');
 
-const CURRENT_SCHEMA_VERSION = 26;
+const CURRENT_SCHEMA_VERSION = 27;
 
 const TANGLECLAW_DIR = path.join(process.env.HOME || '', '.tangleclaw');
 const CONFIG_FILE = path.join(TANGLECLAW_DIR, 'config.json');
@@ -783,6 +783,12 @@ function _createTables() {
       kind              TEXT    NOT NULL DEFAULT 'startup',                 -- CC-6: 'startup' (launch-injected) | 'wrap' (wrap-prompt-injected)
       owner             TEXT,                                               -- nullable auth-ready seam (AUTH/#347)
       source_learning_id INTEGER REFERENCES learnings(id) ON DELETE SET NULL, -- provenance for promoted rules (D1b)
+      -- Review state, orthogonal to enabled. enabled is the operator's on/off
+      -- switch for a rule they own; status is how far a rule has got through
+      -- review. Keeping them separate is what lets a rule the operator REJECTED
+      -- stay distinguishable from one never reviewed — collapse them and the wrap
+      -- re-proposes rejected rules forever. Only 'active' is ever injected.
+      status            TEXT    NOT NULL DEFAULT 'active' CHECK (status IN ('proposed','active','rejected')),
       created_at        TEXT    NOT NULL DEFAULT (datetime('now')),
       updated_at        TEXT    NOT NULL DEFAULT (datetime('now'))
     );
@@ -1616,6 +1622,91 @@ function _runMigrations() {
         CREATE INDEX IF NOT EXISTS idx_session_rule_deliveries_project ON session_rule_deliveries(project_id);
       `);
       log.info('Migration v25→v26: session_rule_deliveries ledger added (#595)');
+    }
+
+    if (currentVersion < 27) {
+      // v26→v27: `status` on session_rules (#569). The wrap can now PROPOSE a
+      // rule, which needs a state between "does not exist" and "governs every
+      // future session". `enabled` could not carry it: that flag means "the
+      // operator switched this rule off", so storing proposals as enabled=0 makes
+      // a REJECTED rule indistinguishable from an unreviewed one, and the wrap
+      // would re-propose everything the operator already declined, forever.
+      //
+      // Every pre-existing row is a rule that already governs sessions, so they
+      // backfill to 'active' — the column default. That is the honest reading:
+      // they were never proposals, and back-dating them into review would
+      // silently switch off working rules on upgrade.
+      //
+      // SQLite cannot add a CHECK via ALTER TABLE, so recreate the table
+      // preserving every row verbatim. Mirrors the v23→v24 rebuild.
+      let statusRecreateErr = null;
+      try {
+        // SQLite's documented procedure for a table rebuild: foreign-key
+        // enforcement OFF around it, and it must be set OUTSIDE the transaction
+        // (the pragma is a no-op inside one). This matters beyond ceremony here
+        // — `session_rules` references `projects` and `learnings`, and a
+        // database can legitimately contain a row whose referent is already
+        // gone. Re-inserting under enforcement would abort the whole migration
+        // on such a row, so a pre-existing orphan would block the upgrade
+        // instead of surviving it. A migration preserves what it finds; it is
+        // not the place to start deleting the operator's data.
+        _db.exec('PRAGMA foreign_keys = OFF');
+        _db.exec(`
+          BEGIN;
+          CREATE TABLE session_rules_new (
+            id                INTEGER PRIMARY KEY AUTOINCREMENT,
+            project_id        INTEGER REFERENCES projects(id) ON DELETE CASCADE,
+            content           TEXT    NOT NULL,
+            enabled           INTEGER NOT NULL DEFAULT 1,
+            created_by        TEXT    NOT NULL DEFAULT 'operator',
+            kind              TEXT    NOT NULL DEFAULT 'startup',
+            owner             TEXT,
+            source_learning_id INTEGER REFERENCES learnings(id) ON DELETE SET NULL,
+            status            TEXT    NOT NULL DEFAULT 'active' CHECK (status IN ('proposed','active','rejected')),
+            created_at        TEXT    NOT NULL DEFAULT (datetime('now')),
+            updated_at        TEXT    NOT NULL DEFAULT (datetime('now'))
+          );
+          INSERT INTO session_rules_new
+            (id, project_id, content, enabled, created_by, kind, owner, source_learning_id, created_at, updated_at)
+            SELECT id, project_id, content, enabled, created_by, kind, owner, source_learning_id, created_at, updated_at
+            FROM session_rules;
+          DROP TABLE session_rules;
+          ALTER TABLE session_rules_new RENAME TO session_rules;
+          CREATE INDEX IF NOT EXISTS idx_session_rules_project ON session_rules(project_id);
+          CREATE INDEX IF NOT EXISTS idx_session_rules_enabled ON session_rules(enabled);
+          CREATE INDEX IF NOT EXISTS idx_session_rules_status ON session_rules(status);
+          COMMIT;
+        `);
+      } catch (err) {
+        try { _db.exec('ROLLBACK'); } catch { /* no transaction in progress */ }
+        // `status` is a new column taking its DEFAULT on the INSERT...SELECT, so
+        // no pre-existing value can violate the CHECK. A failure here is real.
+        statusRecreateErr = err;
+        log.warn('Migration v26→v27 recreate failed — see postcondition', { error: err.message });
+      } finally {
+        // Restore enforcement whatever happened, including on the rollback path
+        // — leaving it off would silently disable FK checking for the rest of
+        // the process's life, long after this migration is forgotten.
+        try { _db.exec('PRAGMA foreign_keys = ON'); } catch { /* connection already gone */ }
+      }
+
+      // Postcondition: refuse to advance the version unless the CHECK is really
+      // present. A silent no-op here would stamp the DB v27 with a v26 schema, and
+      // every proposal would then be written as an ordinary active rule — the
+      // exact silent self-modification this chunk exists to prevent.
+      const srDdl = _db.prepare(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name='session_rules'"
+      ).get();
+      if (!srDdl || !/CHECK\s*\(\s*status\s+IN/i.test(srDdl.sql)) {
+        const cause = statusRecreateErr
+          ? `the table rebuild failed: ${statusRecreateErr.message}`
+          : `found: ${srDdl ? srDdl.sql : 'table missing'}`;
+        throw new Error(
+          `v26→v27 migration did not produce a CHECK constraint on session_rules.status ` +
+          `(${cause}). Aborting — schema_version will NOT advance to 27 until this is resolved. See #569.`
+        );
+      }
+      log.info('Migration v26→v27: status column added to session_rules (#569)');
     }
 
     _db.prepare('INSERT INTO schema_version (version) VALUES (?)').run(CURRENT_SCHEMA_VERSION);
@@ -3192,6 +3283,54 @@ function _pruneSessionRuleVersions(ruleId, keep) {
 }
 
 /**
+ * Valid `session_rules.status` values (#569) — a rule's review state, distinct
+ * from `enabled` (the operator's on/off switch for a rule they own).
+ * @type {string[]}
+ */
+const SESSION_RULE_STATUSES = ['proposed', 'active', 'rejected'];
+
+/**
+ * Decide the status a newly-created rule gets.
+ *
+ * **AI-authored content cannot become a governing rule on the AI's own say-so.**
+ * That is the safety property of the self-improvement loop: the wrap may
+ * propose, never apply. It is enforced here rather than only at the HTTP
+ * boundary because this is the write site — `promoteFromLearning` and any
+ * future internal caller reach the table through `create()` without passing
+ * through a route.
+ *
+ * `createdBy` alone cannot decide this, because it records **authorship**, not
+ * **authority**: a rule promoted from a learning is genuinely AI-authored, yet
+ * the operator clicking Promote is a human decision and must produce a live
+ * rule. Collapsing the two would either mislabel provenance (recording an
+ * operator as the author of text they did not write) or make the operator's own
+ * approval land as another proposal. So authority is carried separately and
+ * explicitly by `approvedByOperator`, which only a human-initiated path sets.
+ *
+ * An explicit `'rejected'` is honored for either author — it records a decision
+ * and governs nothing. Operator-authored rules default to `'active'`, which
+ * preserves pre-#569 behavior for every existing caller.
+ *
+ * @param {string} createdBy - 'operator' | 'ai' | 'system' (authorship)
+ * @param {string} [requested] - Caller-supplied status, if any
+ * @param {boolean} [approvedByOperator] - True only on a path a human initiated
+ * @returns {string} The status to persist
+ */
+function _resolveNewRuleStatus(createdBy, requested, approvedByOperator) {
+  if (requested !== undefined && requested !== null) {
+    if (!SESSION_RULE_STATUSES.includes(requested)) {
+      throw new StoreError(`status must be one of ${SESSION_RULE_STATUSES.join(', ')}`, 'BAD_REQUEST');
+    }
+    // AI authorship asking for 'active' without a human behind it is exactly
+    // the request that must not be granted.
+    if (createdBy === 'ai' && requested === 'active' && approvedByOperator !== true) return 'proposed';
+    return requested;
+  }
+  if (createdBy !== 'ai') return 'active';
+  return approvedByOperator === true ? 'active' : 'proposed';
+}
+
+/**
  * Valid `session_rules.kind` values (CC-6, #381). 'startup' rules inject into
  * the engine config at launch; 'wrap' rules inject into the wrap pipeline's
  * ai-content prompt (and are the self-learning sink). The former 'mode' kind
@@ -3248,7 +3387,7 @@ const sessionRulesApi = {
     // produce a different digest for an unchanged set. Matches listActiveForMaster.
     return _db.prepare(
       `SELECT * FROM session_rules
-       WHERE enabled = 1 AND kind = 'startup' AND project_id = ?
+       WHERE enabled = 1 AND status = 'active' AND kind = 'startup' AND project_id = ?
        ORDER BY created_at, id`
     ).all(projectId).map(_rowToSessionRule);
   },
@@ -3263,7 +3402,7 @@ const sessionRulesApi = {
     _ensureDb();
     return _db.prepare(
       `SELECT * FROM session_rules
-       WHERE enabled = 1 AND kind = 'master' AND project_id IS NULL
+       WHERE enabled = 1 AND status = 'active' AND kind = 'master' AND project_id IS NULL
        ORDER BY created_at, id`
     ).all().map(_rowToSessionRule);
   },
@@ -3274,6 +3413,11 @@ const sessionRulesApi = {
    * @param {number} [options.enabled] - Filter by enabled (1 or 0)
    * @param {number} [options.projectId] - Filter by exact project id
    * @param {string} [options.kind] - CC-6: filter by rule kind ('startup'|'wrap'|'master')
+   * @param {string} [options.status] - Filter by review state ('proposed'|'active'|'rejected').
+   *   Unfiltered by default, because the UI needs to SEE proposals. Any caller
+   *   using this list to inject rules into a session or prompt must pass
+   *   `status: 'active'` — an unreviewed proposal reaching a live session is the
+   *   failure this state exists to prevent (#569).
    * @returns {object[]}
    */
   list(options = {}) {
@@ -3291,6 +3435,10 @@ const sessionRulesApi = {
     if (options.kind !== undefined) {
       conditions.push('kind = ?');
       params.push(options.kind);
+    }
+    if (options.status !== undefined) {
+      conditions.push('status = ?');
+      params.push(options.status);
     }
     let sql = 'SELECT * FROM session_rules';
     if (conditions.length > 0) sql += ' WHERE ' + conditions.join(' AND ');
@@ -3348,15 +3496,17 @@ const sessionRulesApi = {
       throw new StoreError('projectId is required — the global session-rules tier was retired; put cross-project directives in the Global rules document', 'BAD_REQUEST');
     }
     _validateCriticGate(data.criticGate);
+    const status = _resolveNewRuleStatus(createdBy, data.status, data.approvedByOperator);
     _db.prepare(
-      'INSERT INTO session_rules (project_id, content, created_by, kind, owner, source_learning_id) VALUES (?, ?, ?, ?, ?, ?)'
+      'INSERT INTO session_rules (project_id, content, created_by, kind, owner, source_learning_id, status) VALUES (?, ?, ?, ?, ?, ?, ?)'
     ).run(
       data.projectId ?? null,
       data.content.trim(),
       createdBy,
       kind,
       data.owner ?? null,
-      data.sourceLearningId ?? null
+      data.sourceLearningId ?? null,
+      status
     );
     const row = _db.prepare('SELECT * FROM session_rules WHERE id = last_insert_rowid()').get();
     _snapshotSessionRule(row, 'create', createdBy, data.changeReason ?? null, data.criticGate);
@@ -3496,8 +3646,62 @@ const sessionRulesApi = {
       kind: overrides.kind || 'startup',
       sourceLearningId: learningId,
       changeReason: `promoted from learning ${learningId}`,
-      criticGate: overrides.criticGate
+      criticGate: overrides.criticGate,
+      status: overrides.status,
+      // The existing `/promote` route is the operator pressing Promote, so it
+      // passes this and gets a live rule. The wrap's proposal step calls the
+      // same method without it and gets a proposal — one code path, and which
+      // one you get depends on whether a human decided.
+      approvedByOperator: overrides.approvedByOperator
     });
+  },
+
+  /**
+   * Resolve a proposal: approve it into a governing rule, or reject it (#569).
+   *
+   * Rejection is recorded rather than deleted, and that is the point: the wrap
+   * proposes from recurring learnings, so a deleted rejection would simply be
+   * re-proposed at the next wrap that saw the same learning. A `'rejected'` row
+   * is the memory of the operator's answer.
+   *
+   * Snapshots a version like every other mutation, so who decided and when is
+   * answerable from the rule's history rather than only from an activity log.
+   *
+   * @param {number} id - Rule id
+   * @param {string} status - 'proposed' | 'active' | 'rejected'
+   * @param {object} [opts]
+   * @param {string} [opts.changedBy] - 'operator' (default) | 'ai'
+   * @param {string} [opts.changeReason] - Recorded on the snapshot
+   * @returns {object} The updated rule
+   */
+  setStatus(id, status, opts = {}) {
+    _ensureDb();
+    if (!SESSION_RULE_STATUSES.includes(status)) {
+      throw new StoreError(`status must be one of ${SESSION_RULE_STATUSES.join(', ')}`, 'BAD_REQUEST');
+    }
+    const row = _db.prepare('SELECT * FROM session_rules WHERE id = ?').get(id);
+    if (!row) throw new StoreError(`Session rule ${id} not found`, 'NOT_FOUND');
+
+    const changedBy = opts.changedBy || 'operator';
+    // An AI cannot approve its own proposal. Same property as `create()`, at the
+    // other door into 'active' — a gate on one entrance is not a gate.
+    if (changedBy === 'ai' && status === 'active') {
+      throw new StoreError(
+        'an AI cannot approve a proposed rule into an active one — approval is an operator decision',
+        'FORBIDDEN'
+      );
+    }
+
+    _db.prepare("UPDATE session_rules SET status = ?, updated_at = datetime('now') WHERE id = ?").run(status, id);
+    const updated = _db.prepare('SELECT * FROM session_rules WHERE id = ?').get(id);
+    _snapshotSessionRule(updated, 'update', changedBy,
+      opts.changeReason ?? `status ${row.status || 'active'} → ${status}`, opts.criticGate);
+    activityApi.log({
+      projectId: updated.project_id,
+      eventType: 'session_rule.updated',
+      detail: { id, from: row.status || 'active', to: status }
+    });
+    return _rowToSessionRule(updated);
   },
 
   /**
@@ -5812,6 +6016,9 @@ function _rowToSessionRule(row) {
     kind: row.kind || 'startup',
     owner: row.owner,
     sourceLearningId: row.source_learning_id ?? null,
+    // #569 review state. Rows predating the column read back as 'active' via the
+    // schema default — they already governed sessions and were never proposals.
+    status: row.status || 'active',
     createdAt: row.created_at,
     updatedAt: row.updated_at
   };
@@ -6135,6 +6342,7 @@ module.exports = {
   SESSION_RULE_DELIVERY_OUTCOMES,
   _setSessionRuleDeliveryRetention,
   SESSION_RULE_KINDS,
+  SESSION_RULE_STATUSES,
   SESSION_RULE_VERSION_RETENTION,
   _setSessionRuleVersionRetention,
   portLeases: portLeasesApi,

--- a/lib/store.js
+++ b/lib/store.js
@@ -3740,8 +3740,13 @@ const sessionRulesApi = {
     const kindParams = opts.kind ? [opts.kind] : [];
     if (projectId === null || projectId === undefined) return [];
     const active = _db.prepare(
+      // `status = 'active'` matters here as the proposal queue grows: this
+      // answers "what might a new rule conflict with", and an unreviewed
+      // proposal or a rule the operator already declined is not something to
+      // reconcile against. Without it, every accumulated proposal would start
+      // surfacing as a conflict candidate against the next one.
       `SELECT * FROM session_rules
-       WHERE enabled = 1 AND project_id = ?${kindClause}
+       WHERE enabled = 1 AND status = 'active' AND project_id = ?${kindClause}
        ORDER BY created_at`
     ).all(projectId, ...kindParams);
     const matches = [];

--- a/lib/wrap-pipeline.js
+++ b/lib/wrap-pipeline.js
@@ -45,6 +45,7 @@ const STEP_DISPATCH = {
   'test':         require('./wrap-steps/test'),
   'ai-content':   require('./wrap-steps/ai-content'),
   'learnings-db-write': require('./wrap-steps/learnings-db-write'),
+  'rule-proposal': require('./wrap-steps/rule-proposal'),
   'priming-roll': require('./wrap-steps/priming-roll'),
   'version-bump': require('./wrap-steps/version-bump'),
   'features-toc': require('./wrap-steps/features-toc'),

--- a/lib/wrap-steps/ai-content.js
+++ b/lib/wrap-steps/ai-content.js
@@ -839,7 +839,11 @@ const _internal = {
   // the startup rules' launch-injection order (created_at has second
   // resolution, so reversing on it mis-orders same-second rules). Mockable so
   // tests don't need a live DB.
-  listWrapRules: (projectId) => store.sessionRules.list({ projectId, enabled: 1, kind: 'wrap' }).sort((a, b) => a.id - b.id),
+  // `status: 'active'` is load-bearing, not defensive: a wrap can now PROPOSE a
+  // rule, and a proposal must not govern anything until the operator approves
+  // it. Without this filter an unreviewed proposal would be injected into the
+  // very next wrap's prompts — the wrap would be taking instruction from itself.
+  listWrapRules: (projectId) => store.sessionRules.list({ projectId, enabled: 1, status: 'active', kind: 'wrap' }).sort((a, b) => a.id - b.id),
   // CC-7 Slice B1 — gateway capture deps (mockable in tests vs a real bridge).
   getBridgeContext: resolveBridgeContext,
   bridgeSend: clawbridgeLib.send,

--- a/lib/wrap-steps/learnings-db-write.js
+++ b/lib/wrap-steps/learnings-db-write.js
@@ -90,15 +90,70 @@ async function run(context) {
     return _skipped(`no learnings.md entry dated ${today}`);
   }
 
-  // Dedup against rows already stored for this project (idempotent on wrap retry).
-  let existing;
+  // Two different comparisons, doing two different jobs.
+  //
+  // Exact content match is the retry guard: re-running a wrap the same day must
+  // not double-insert. It cannot detect RECURRENCE, though, because the stored
+  // content begins with the entry's own `## YYYY-MM-DD` heading — the same
+  // insight written on a later day is a different string by construction.
+  //
+  // The recurrence key strips that date and normalizes, so "we learned this
+  // again" is detectable. That matters because a re-observed learning is the
+  // signal `learnings.confirm` uses to advance provisional → active, and
+  // without it every learning stays provisional forever and never reaches a
+  // future session's prime (#569).
+  let stored;
   try {
-    existing = new Set(store.learnings.list(project.id).map((l) => l.content));
+    stored = store.learnings.list(project.id);
   } catch (err) {
     return _skipped(`learnings.list failed: ${err.message}`);
   }
-  const fresh = entries.filter((e) => !existing.has(e));
-  if (fresh.length === 0) {
+  const existing = new Set(stored.map((l) => l.content));
+  const byRecurrenceKey = new Map();
+  for (const row of stored) {
+    const key = _recurrenceKey(row.content);
+    // Oldest row wins: confirmations should accrue to one canonical row rather
+    // than scattering across near-duplicates.
+    if (key && !byRecurrenceKey.has(key)) byRecurrenceKey.set(key, row);
+  }
+
+  const notAlreadyStored = entries.filter((e) => !existing.has(e));
+
+  // Recurrences confirm the row they repeat instead of inserting a near-twin.
+  const fresh = [];
+  let confirmed = 0;
+  let promoted = 0;
+  for (const entry of notAlreadyStored) {
+    const prior = byRecurrenceKey.get(_recurrenceKey(entry));
+    if (!prior) {
+      fresh.push(entry);
+      continue;
+    }
+    try {
+      const after = store.learnings.confirm(prior.id);
+      confirmed += 1;
+      // A learning recorded on two different days is recurring, and that is the
+      // bar for it reaching future sessions. `confirm()` alone would not promote
+      // here: its own threshold is 2 CONFIRMATIONS, i.e. three sightings, which
+      // is a general-purpose contract this step should not bend for everyone
+      // else. But three exact repeats of a normalized learning almost never
+      // happen in practice, so deferring to it would leave the tier gate shut
+      // and reproduce the dead-end this step exists to open (#569).
+      if (after && after.tier === 'provisional') {
+        store.learnings.setTier(prior.id, 'active');
+        promoted += 1;
+      } else if (prior.tier === 'provisional' && after && after.tier === 'active') {
+        promoted += 1;
+      }
+    } catch (err) {
+      // A failed confirmation must not sink the wrap or the other entries.
+      log.warn('learnings.confirm failed for a recurring entry — continuing', {
+        project: project.name, learningId: prior.id, error: err.message
+      });
+    }
+  }
+
+  if (fresh.length === 0 && confirmed === 0) {
     return _skipped(`all ${entries.length} today-entr${entries.length === 1 ? 'y' : 'ies'} already in the DB`);
   }
 
@@ -123,21 +178,56 @@ async function run(context) {
     }
   }
 
-  if (inserted === 0) {
+  if (inserted === 0 && confirmed === 0) {
     return _skipped(`found ${fresh.length} new today-entr${fresh.length === 1 ? 'y' : 'ies'} but all inserts failed`);
   }
 
-  log.info('mirrored today learnings into the DB', { project: project.name, inserted, today });
+  log.info('mirrored today learnings into the DB', { project: project.name, inserted, confirmed, promoted, today });
+  const parts = [];
+  if (inserted > 0) parts.push(`${inserted} learning${inserted === 1 ? '' : 's'} written to the DB`);
+  if (confirmed > 0) {
+    parts.push(`${confirmed} recurring learning${confirmed === 1 ? '' : 's'} confirmed`
+      + (promoted > 0 ? ` (${promoted} promoted to active)` : ''));
+  }
   return {
     ok: true,
     status: 'done',
     output: {
       inserted,
+      confirmed,
+      promoted,
       today,
-      detail: `${inserted} learning${inserted === 1 ? '' : 's'} written to the DB`
+      detail: parts.join('; ')
     },
     blockers: []
   };
+}
+
+/**
+ * A date-independent identity for a learning, used to recognise the same
+ * insight recorded on a later day.
+ *
+ * Stored entries begin with their own `## YYYY-MM-DD — <title>` heading, so the
+ * raw text of a repeated learning never matches its earlier self. Dropping the
+ * date and normalizing whitespace and case leaves title + body, which is what
+ * "the same learning" actually means here.
+ *
+ * Deliberately an EXACT match after normalization rather than a fuzzy one: a
+ * confirmation advances a learning into every future session's prime, so a
+ * false match promotes something the operator never saw twice. Reworded
+ * recurrences are missed, which costs a promotion; wrong matches would cost
+ * trust in the whole loop.
+ *
+ * @param {string} content - Stored entry text (heading + body)
+ * @returns {string} Normalized key, or '' when there is nothing to key on
+ */
+function _recurrenceKey(content) {
+  if (!content || typeof content !== 'string') return '';
+  return content
+    .replace(ENTRY_HEADING_RE, '##')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
 }
 
 /**

--- a/lib/wrap-steps/learnings-db-write.js
+++ b/lib/wrap-steps/learnings-db-write.js
@@ -109,11 +109,15 @@ async function run(context) {
     return _skipped(`learnings.list failed: ${err.message}`);
   }
   const existing = new Set(stored.map((l) => l.content));
+  // Oldest row wins, so confirmations accrue to one canonical learning instead
+  // of scattering across near-duplicates. `learnings.list` returns newest-first,
+  // so this must sort rather than rely on the query's order; `id` breaks ties
+  // because `created_at` has second resolution and a burst shares a timestamp.
   const byRecurrenceKey = new Map();
-  for (const row of stored) {
+  const oldestFirst = stored.slice().sort((a, b) =>
+    (a.createdAt < b.createdAt ? -1 : a.createdAt > b.createdAt ? 1 : a.id - b.id));
+  for (const row of oldestFirst) {
     const key = _recurrenceKey(row.content);
-    // Oldest row wins: confirmations should accrue to one canonical row rather
-    // than scattering across near-duplicates.
     if (key && !byRecurrenceKey.has(key)) byRecurrenceKey.set(key, row);
   }
 
@@ -132,13 +136,17 @@ async function run(context) {
     try {
       const after = store.learnings.confirm(prior.id);
       confirmed += 1;
-      // A learning recorded on two different days is recurring, and that is the
-      // bar for it reaching future sessions. `confirm()` alone would not promote
-      // here: its own threshold is 2 CONFIRMATIONS, i.e. three sightings, which
-      // is a general-purpose contract this step should not bend for everyone
-      // else. But three exact repeats of a normalized learning almost never
-      // happen in practice, so deferring to it would leave the tier gate shut
+      // THIS STEP OWNS THE PROMOTION BAR, and it is two sightings: a learning
+      // recorded on two different days is recurring enough to show future
+      // sessions. `confirm()` also carries a promotion rule of its own (2
+      // confirmations, i.e. three sightings) as a general-purpose primitive
+      // several callers could share; three exact repeats of normalized text
+      // almost never occur, so deferring to it would leave the tier gate shut
       // and reproduce the dead-end this step exists to open (#569).
+      //
+      // The two rules do not disagree — this one is strictly earlier, so
+      // `confirm()`'s threshold is simply never the deciding factor on this
+      // path. Anything already promoted is left alone rather than re-promoted.
       if (after && after.tier === 'provisional') {
         store.learnings.setTier(prior.id, 'active');
         promoted += 1;

--- a/lib/wrap-steps/rule-proposal.js
+++ b/lib/wrap-steps/rule-proposal.js
@@ -1,0 +1,133 @@
+'use strict';
+
+/**
+ * #569 — the wrap proposes rules; it never applies them.
+ *
+ * A learning that keeps recurring is evidence that something should govern
+ * future sessions rather than be rediscovered each time. Until now nothing
+ * closed that gap: `promoteFromLearning` existed and had exactly one caller —
+ * an HTTP route no UI ever called — so turning a learning into a rule depended
+ * on someone remembering to do it by hand. The compounding loop was drawn but
+ * not connected.
+ *
+ * This step connects it, on the safe side of the line. It creates rules at
+ * `status:'proposed'`, which nothing injects: not the launch prime
+ * (`listActiveForProject`), not the master identity (`listActiveForMaster`),
+ * not the wrap's own prompts (`_appendWrapRules`). A proposal governs nothing
+ * until an operator approves it. The store enforces that at the write site too
+ * — `create()` refuses to mint an active rule from AI authorship without an
+ * explicit operator decision — because a gate on one entrance is not a gate.
+ *
+ * **Why this step proposes from ACTIVE learnings only.** A learning reaches
+ * `active` by recurring (`learnings-db-write` confirms a repeat, and
+ * `learnings.confirm` promotes at 2+). Proposing from provisional rows would
+ * turn every passing observation into a rule proposal and bury the operator in
+ * review; the recurrence requirement is what makes a proposal mean "this keeps
+ * happening" rather than "this happened once".
+ *
+ * The step is deliberately mechanical: it does not ask an AI to invent rule
+ * text. The learning's own text is the proposal, and the operator edits it at
+ * approval time. That keeps the wrap's self-improvement auditable — every
+ * proposal traces to a specific learning row via `source_learning_id` — and
+ * avoids a second AI round-trip whose output nothing could verify.
+ */
+
+const { createLogger } = require('../logger');
+const store = require('../store');
+
+const log = createLogger('wrap-step-rule-proposal');
+
+/**
+ * Canonical skip signal — `status:'skipped'` with a reason the drawer renders.
+ * @param {string} reason - Operator-readable explanation
+ * @returns {{ok: boolean, status: string, output: object, blockers: string[]}}
+ */
+function _skipped(reason) {
+  return { ok: true, status: 'skipped', output: { reason, detail: reason }, blockers: [] };
+}
+
+/**
+ * Step handler — propose a rule for each active learning that has not already
+ * produced one.
+ *
+ * Never blocks: a wrap must not fail because rule proposal was unavailable.
+ *
+ * @param {object} context - Runner context (`project`, `step`, ...)
+ * @returns {Promise<{ok: boolean, status: string, output: object, blockers: string[]}>}
+ */
+async function run(context) {
+  const project = context && context.project;
+  if (!project || !project.id) return _skipped('no project id — cannot propose rules');
+
+  let learnings;
+  try {
+    learnings = store.learnings.getActive(project.id);
+  } catch (err) {
+    return _skipped(`learnings.getActive failed: ${err.message}`);
+  }
+  if (!learnings || learnings.length === 0) {
+    return _skipped('no active learnings — nothing recurring enough to propose');
+  }
+
+  // Every learning that has ALREADY produced a rule is off the table, whatever
+  // that rule's status. Re-proposing a rejected one would make the operator's
+  // decision meaningless and re-ask it at every wrap — the reason a rejection
+  // is recorded rather than deleted.
+  let alreadyProposed;
+  try {
+    alreadyProposed = new Set(
+      store.sessionRules.list({ projectId: project.id })
+        .map((r) => r.sourceLearningId)
+        .filter((id) => id !== null && id !== undefined)
+    );
+  } catch (err) {
+    return _skipped(`sessionRules.list failed: ${err.message}`);
+  }
+
+  const candidates = learnings.filter((l) => !alreadyProposed.has(l.id));
+  if (candidates.length === 0) {
+    return _skipped(`all ${learnings.length} active learning(s) already have a rule or a decision`);
+  }
+
+  const proposed = [];
+  for (const learning of candidates) {
+    try {
+      const rule = store.sessionRules.promoteFromLearning(learning.id, {
+        createdBy: 'ai',
+        kind: 'startup',
+        changeReason: `proposed by the wrap from recurring learning ${learning.id}`
+        // No `approvedByOperator` and no `status` — so this lands as 'proposed'.
+      });
+      proposed.push({ ruleId: rule.id, learningId: learning.id, content: rule.content, status: rule.status });
+    } catch (err) {
+      // One bad proposal must not sink the others or the wrap.
+      log.warn('rule proposal failed for one learning — continuing', {
+        project: project.name, learningId: learning.id, error: err.message
+      });
+    }
+  }
+
+  if (proposed.length === 0) return _skipped(`found ${candidates.length} candidate(s) but every proposal failed`);
+
+  // Fail loudly rather than quietly if anything ever lands active from here:
+  // this step is the one place AI-authored rules enter the table, so a status
+  // regression would silently start governing sessions.
+  const leaked = proposed.filter((p) => p.status !== 'proposed');
+  if (leaked.length > 0) {
+    log.error('rule proposal produced a non-proposed rule — this should be impossible', {
+      project: project.name, ruleIds: leaked.map((p) => p.ruleId)
+    });
+  }
+
+  log.info('proposed rules from recurring learnings', { project: project.name, count: proposed.length });
+  const detail = `${proposed.length} rule${proposed.length === 1 ? '' : 's'} proposed for your review `
+    + '— nothing is applied until you approve';
+  return {
+    ok: true,
+    status: 'done',
+    output: { proposed, count: proposed.length, detail },
+    blockers: []
+  };
+}
+
+module.exports = { run, _skipped };

--- a/public/ui.js
+++ b/public/ui.js
@@ -1039,7 +1039,7 @@ function renderProjectRulesSection(project) {
 async function loadProjectRules(projectId) {
   projectRulesTargetId = projectId;
   for (const { kind } of PROJECT_RULE_KINDS) {
-    const data = await api(`/api/session-rules?projectId=${encodeURIComponent(projectId)}&kind=${kind}`);
+    const data = await api(`/api/session-rules?projectId=${encodeURIComponent(projectId)}&kind=${kind}&status=active`);
     // The modal may have been closed/reopened on another project while awaiting.
     if (projectRulesTargetId !== projectId) return;
     renderProjectRulesList(kind, data ? data.rules || [] : []);
@@ -1084,7 +1084,7 @@ async function addProjectRule(kind) {
   if (data) {
     if (input) input.value = '';
     _setProjectRulesStatus('Added', true);
-    const list = await api(`/api/session-rules?projectId=${encodeURIComponent(projectRulesTargetId)}&kind=${kind}`);
+    const list = await api(`/api/session-rules?projectId=${encodeURIComponent(projectRulesTargetId)}&kind=${kind}&status=active`);
     renderProjectRulesList(kind, list ? list.rules || [] : []);
   } else {
     _setProjectRulesStatus('Add failed', false);
@@ -1100,7 +1100,7 @@ async function addProjectRule(kind) {
 async function toggleProjectRule(id, enabled, kind) {
   const data = await apiMutate(`/api/session-rules/${id}`, 'PUT', { enabled });
   if (!data) { _setProjectRulesStatus('Update failed', false); return; }
-  const list = await api(`/api/session-rules?projectId=${encodeURIComponent(projectRulesTargetId)}&kind=${kind}`);
+  const list = await api(`/api/session-rules?projectId=${encodeURIComponent(projectRulesTargetId)}&kind=${kind}&status=active`);
   renderProjectRulesList(kind, list ? list.rules || [] : []);
 }
 
@@ -1113,7 +1113,7 @@ async function deleteProjectRule(id, kind) {
   const data = await apiMutate(`/api/session-rules/${id}`, 'DELETE', {});
   if (!data) { _setProjectRulesStatus('Delete failed', false); return; }
   _setProjectRulesStatus('Deleted', true);
-  const list = await api(`/api/session-rules?projectId=${encodeURIComponent(projectRulesTargetId)}&kind=${kind}`);
+  const list = await api(`/api/session-rules?projectId=${encodeURIComponent(projectRulesTargetId)}&kind=${kind}&status=active`);
   renderProjectRulesList(kind, list ? list.rules || [] : []);
 }
 

--- a/public/ui.js
+++ b/public/ui.js
@@ -3130,7 +3130,7 @@ function renderMasterSettingsBody(s, groups) {
 
 /** Fetch and render the master Hard rules list. */
 async function loadMasterRules() {
-  const data = await api('/api/session-rules?kind=master');
+  const data = await api('/api/session-rules?kind=master&status=active');
   renderMasterRulesList(data ? data.rules || [] : []);
 }
 
@@ -3167,7 +3167,7 @@ function renderMasterRulesList(rules) {
  * @returns {Promise<object|null>}
  */
 async function _getMasterRule(id) {
-  const data = await api('/api/session-rules?kind=master');
+  const data = await api('/api/session-rules?kind=master&status=active');
   return data && data.rules ? data.rules.find((r) => r.id === id) || null : null;
 }
 

--- a/public/wrap-drawer.js
+++ b/public/wrap-drawer.js
@@ -40,6 +40,7 @@
     'version-bump': 'Bumps version.json from the CHANGELOG’s [Unreleased] entries (Added/Changed → minor, Fixed-only → patch, BREAKING → major) and promotes them to a dated release. Skips when there is nothing to promote or the version is not semver.',
     'ai-content': 'The AI captures a piece of wrap content — a changelog line, session learnings, or session memory — into the wrap. Skips when there is nothing to capture.',
     'learnings-db-write': 'Persists the session’s captured learnings to the project’s learnings store.',
+    'rule-proposal': 'Proposes rules from recurring learnings. Proposals govern nothing until you approve them.',
     'priming-roll': 'Rolls the build-plan chunk pointer forward so the next session resumes at the current chunk. Skips when there is no chunked plan to roll; if several in-progress plans exist it asks you to pick one.',
     'features-toc': 'Refreshes FEATURES.md — stubs entries for files touched this session and prunes entries for deleted files.',
     'project-map': 'Refreshes the continuity Map (the feature/component index) from the files touched this session.',

--- a/public/wrap-drawer.js
+++ b/public/wrap-drawer.js
@@ -225,6 +225,14 @@
         if (output.from && output.to) return `${output.from} → ${output.to}`;
         if (output.to) return String(output.to);
         return null;
+      case 'rule-proposal': {
+        // Without a case here the default drops this to null, and a wrap that
+        // proposed rules would look identical to one that proposed none — the
+        // silent-loop problem #569 was filed about.
+        const n = output.count;
+        if (typeof n !== 'number' || n <= 0) return null;
+        return `${n} rule${n === 1 ? '' : 's'} proposed — awaiting your review`;
+      }
       default:
         return null;
     }

--- a/server.js
+++ b/server.js
@@ -1308,7 +1308,14 @@ route('POST', '/api/session-rules/promote', (_req, res, _params, body) => {
       // CC-6 (#381): the wrap-time self-critique loop promotes a learning into a 'wrap' rule.
       kind: body.kind,
       // SR-7K2P: optional Critic-gate attestation. Invalid → store throws BAD_REQUEST.
-      criticGate: body.criticGate
+      criticGate: body.criticGate,
+      // #569: reaching this route IS the operator's decision — it is the button
+      // they press to promote. Without this flag the store would (correctly)
+      // treat AI-authored content as a proposal, and the operator's own approval
+      // would land back in the review queue they just cleared. The wrap's
+      // proposal step calls the same store method WITHOUT it and gets a
+      // proposal, which is the distinction that keeps the loop safe.
+      approvedByOperator: true
     });
     jsonResponse(res, 201, rule);
   } catch (err) {
@@ -1317,6 +1324,61 @@ route('POST', '/api/session-rules/promote', (_req, res, _params, body) => {
     throw err;
   }
 }, { maxBodySize: 256 * 1024 });
+
+// PUT /api/session-rules/:id/status — resolve a proposal (#569).
+// Approve ('active') or decline ('rejected') a rule the wrap proposed. A
+// rejection is RECORDED rather than deleted: the wrap proposes from recurring
+// learnings, so a deleted decision would simply be re-proposed at the next wrap.
+route('PUT', '/api/session-rules/:id/status', (_req, res, params, body) => {
+  if (!body || typeof body.status !== 'string') {
+    return errorResponse(res, 400, 'status is required', 'BAD_REQUEST');
+  }
+  try {
+    const rule = store.sessionRules.setStatus(Number(params.id), body.status, {
+      changedBy: body.changedBy,
+      changeReason: body.changeReason,
+      criticGate: body.criticGate
+    });
+    jsonResponse(res, 200, rule);
+  } catch (err) {
+    if (err.code === 'NOT_FOUND') return errorResponse(res, 404, err.message, 'NOT_FOUND');
+    if (err.code === 'BAD_REQUEST') return errorResponse(res, 400, err.message, 'BAD_REQUEST');
+    if (err.code === 'FORBIDDEN') return errorResponse(res, 403, err.message, 'FORBIDDEN');
+    throw err;
+  }
+}, { maxBodySize: 256 * 1024 });
+
+// ── Learnings (#569) ──
+// Until now there were no learnings routes at all, so the tier a learning sits
+// at — the thing deciding whether it reaches a future session — was reachable
+// only from inside the process. An operator could neither see the backlog nor
+// correct a wrong promotion.
+
+// GET /api/learnings?projectId=&tier=
+route('GET', '/api/learnings', (req, res) => {
+  const url = new URL(req.url, 'http://localhost');
+  const projectId = url.searchParams.get('projectId');
+  if (!projectId) return errorResponse(res, 400, 'projectId is required', 'BAD_REQUEST');
+  const tier = url.searchParams.get('tier') || undefined;
+  jsonResponse(res, 200, { learnings: store.learnings.list(Number(projectId), { tier }) });
+});
+
+// PUT /api/learnings/:id/tier — correct a learning's tier by hand.
+// The loop advances tiers on its own via recurrence; this is the operator's
+// override for when it advanced something they disagree with, or held back
+// something they want live now.
+route('PUT', '/api/learnings/:id/tier', (_req, res, params, body) => {
+  if (!body || typeof body.tier !== 'string') {
+    return errorResponse(res, 400, 'tier is required', 'BAD_REQUEST');
+  }
+  try {
+    jsonResponse(res, 200, store.learnings.setTier(Number(params.id), body.tier));
+  } catch (err) {
+    if (err.code === 'NOT_FOUND') return errorResponse(res, 404, err.message, 'NOT_FOUND');
+    if (err.code === 'BAD_REQUEST') return errorResponse(res, 400, err.message, 'BAD_REQUEST');
+    throw err;
+  }
+}, { maxBodySize: 64 * 1024 });
 
 // POST /api/session-rules/conflicts — non-authoritative conflict-candidate signal
 route('POST', '/api/session-rules/conflicts', (_req, res, _params, body) => {

--- a/server.js
+++ b/server.js
@@ -1176,6 +1176,11 @@ route('GET', '/api/session-rules', (req, res) => {
   if (query.projectId !== undefined) options.projectId = Number(query.projectId);
   // CC-6 (#381): filter the per-project modal's rule boxes by kind.
   if (query.kind !== undefined) options.kind = query.kind;
+  // #569: review state. Unfiltered by default so a future review surface can
+  // list proposals; the Project Rules modal asks for `active` only, because it
+  // renders every row it receives as an enabled, governing rule and would
+  // otherwise show proposals and rejections as live.
+  if (query.status !== undefined) options.status = query.status;
   const rules = store.sessionRules.list(options);
   jsonResponse(res, 200, { rules });
 });
@@ -1300,6 +1305,13 @@ route('POST', '/api/session-rules/promote', (_req, res, _params, body) => {
   if (!body || body.learningId === undefined) {
     return errorResponse(res, 400, 'learningId is required', 'BAD_REQUEST');
   }
+  // This route mints a LIVE rule from AI-authored text, so it carries the same
+  // operator gate as approval. It previously asserted operator authority simply
+  // because the route had been reached — but this API is on localhost and this
+  // project instructs in-session agents to call it, so "a request arrived" is
+  // not evidence a human sent it.
+  const promoteCheck = projects.checkDeletePassword(body ? body.password : undefined);
+  if (!promoteCheck.allowed) return errorResponse(res, 403, promoteCheck.error, 'FORBIDDEN');
   try {
     const rule = store.sessionRules.promoteFromLearning(Number(body.learningId), {
       content: body.content,
@@ -1309,12 +1321,11 @@ route('POST', '/api/session-rules/promote', (_req, res, _params, body) => {
       kind: body.kind,
       // SR-7K2P: optional Critic-gate attestation. Invalid → store throws BAD_REQUEST.
       criticGate: body.criticGate,
-      // #569: reaching this route IS the operator's decision — it is the button
-      // they press to promote. Without this flag the store would (correctly)
-      // treat AI-authored content as a proposal, and the operator's own approval
-      // would land back in the review queue they just cleared. The wrap's
-      // proposal step calls the same store method WITHOUT it and gets a
-      // proposal, which is the distinction that keeps the loop safe.
+      // #569: authority comes from clearing the operator gate above, not from
+      // the request claiming it. Without this the store would treat AI-authored
+      // content as a proposal and the operator's own approval would land back
+      // in the queue they just cleared; the wrap's proposal step calls the same
+      // store method WITHOUT it and gets a proposal.
       approvedByOperator: true
     });
     jsonResponse(res, 201, rule);
@@ -1333,9 +1344,22 @@ route('PUT', '/api/session-rules/:id/status', (_req, res, params, body) => {
   if (!body || typeof body.status !== 'string') {
     return errorResponse(res, 400, 'status is required', 'BAD_REQUEST');
   }
+  // Approving a proposal grants it authority over every future session, so it
+  // is gated like TangleClaw's other privileged operations (project delete,
+  // session kill, wrap) rather than inferred from a caller-supplied field.
+  // `changedBy` is the caller describing itself — an agent that omits it is
+  // recorded as the operator — so it cannot be what decides this.
+  //
+  // Declining a proposal needs no gate: it grants nothing.
+  if (body.status === 'active') {
+    const check = projects.checkDeletePassword(body ? body.password : undefined);
+    if (!check.allowed) return errorResponse(res, 403, check.error, 'FORBIDDEN');
+  }
   try {
     const rule = store.sessionRules.setStatus(Number(params.id), body.status, {
-      changedBy: body.changedBy,
+      // Passing the gate IS the operator acting; recording anything else would
+      // misattribute a decision the gate just authorised.
+      changedBy: body.status === 'active' ? 'operator' : body.changedBy,
       changeReason: body.changeReason,
       criticGate: body.criticGate
     });

--- a/test/api-self-improvement.test.js
+++ b/test/api-self-improvement.test.js
@@ -1,0 +1,235 @@
+'use strict';
+
+/*
+ * HTTP route tests for #569's self-improvement endpoints:
+ * GET /api/learnings, PUT /api/learnings/:id/tier, PUT /api/session-rules/:id/status.
+ *
+ * These exist because the store-level safety property — AI authorship cannot
+ * produce a governing rule on its own say-so — was defeated at the HTTP boundary
+ * in review: the promote route asserted operator authority merely because it had
+ * been reached, and the status route trusted a caller-supplied `changedBy`.
+ * Authority now comes from the operator-password gate, and these tests pin that
+ * at the door rather than only in the store.
+ *
+ * Mirrors the harness in test/api-session-rules-selfimprove.test.js.
+ */
+
+const { describe, it, before, after, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const store = require('../lib/store');
+const { createServer } = require('../server');
+const { setLevel } = require('../lib/logger');
+
+setLevel('error');
+
+describe('api self-improvement loop (#569)', () => {
+  let server;
+  let port;
+  let tmpDir;
+  let pid;
+
+  /**
+   * Issue a JSON request against the test server.
+   * @param {string} method - HTTP method
+   * @param {string} urlPath - Path with query string
+   * @param {object} [body] - JSON body
+   * @returns {Promise<{status: number, data: *}>}
+   */
+  function request(method, urlPath, body) {
+    return new Promise((resolve, reject) => {
+      const options = {
+        hostname: '127.0.0.1', port, path: urlPath, method,
+        headers: { 'Content-Type': 'application/json' }
+      };
+      const bodyStr = body ? JSON.stringify(body) : null;
+      if (bodyStr) options.headers['Content-Length'] = Buffer.byteLength(bodyStr);
+      const req = http.request(options, (res) => {
+        const chunks = [];
+        res.on('data', (c) => chunks.push(c));
+        res.on('end', () => {
+          const raw = Buffer.concat(chunks).toString('utf8');
+          let data;
+          try { data = JSON.parse(raw); } catch { data = raw; }
+          resolve({ status: res.statusCode, data });
+        });
+      });
+      req.on('error', reject);
+      if (bodyStr) req.write(bodyStr);
+      req.end();
+    });
+  }
+
+  /**
+   * Set or clear the operator password used by the approval gate.
+   * @param {string|null} plaintext - Password to hash and store, or null to clear
+   */
+  function setOperatorPassword(plaintext) {
+    const cfg = store.config.load();
+    cfg.deletePassword = plaintext;
+    store.config.save(cfg);
+  }
+
+  before(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-api-selfimprove-'));
+    store._setBasePath(path.join(tmpDir, 'store'));
+    store.init();
+    const projPath = path.join(tmpDir, 'proj');
+    fs.mkdirSync(projPath, { recursive: true });
+    pid = store.projects.create({ name: 'proj', path: projPath, engine: 'claude', methodology: 'minimal' }).id;
+    server = createServer();
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', () => {
+      port = server.address().port;
+      resolve();
+    }));
+  });
+
+  after(async () => {
+    await new Promise((resolve) => server.close(resolve));
+    store.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    setOperatorPassword(null);
+  });
+
+  describe('GET /api/learnings', () => {
+    it('lists a project\'s learnings and filters by tier', async () => {
+      const l = store.learnings.create({ projectId: pid, content: `listable ${Date.now()}` });
+      const all = await request('GET', `/api/learnings?projectId=${pid}`);
+      assert.equal(all.status, 200);
+      assert.ok(all.data.learnings.some((x) => x.id === l.id));
+
+      const active = await request('GET', `/api/learnings?projectId=${pid}&tier=active`);
+      assert.equal(active.status, 200);
+      assert.ok(!active.data.learnings.some((x) => x.id === l.id), 'a provisional row must not list as active');
+    });
+
+    it('requires projectId', async () => {
+      const res = await request('GET', '/api/learnings');
+      assert.equal(res.status, 400);
+    });
+  });
+
+  describe('PUT /api/learnings/:id/tier', () => {
+    it('lets the operator correct a tier', async () => {
+      const l = store.learnings.create({ projectId: pid, content: `tierable ${Date.now()}` });
+      const res = await request('PUT', `/api/learnings/${l.id}/tier`, { tier: 'active' });
+      assert.equal(res.status, 200);
+      assert.equal(res.data.tier, 'active');
+    });
+
+    it('rejects an unknown tier and a missing one', async () => {
+      const l = store.learnings.create({ projectId: pid, content: `bad tier ${Date.now()}` });
+      assert.equal((await request('PUT', `/api/learnings/${l.id}/tier`, { tier: 'nonsense' })).status, 400);
+      assert.equal((await request('PUT', `/api/learnings/${l.id}/tier`, {})).status, 400);
+    });
+
+    it('404s for a learning that does not exist', async () => {
+      assert.equal((await request('PUT', '/api/learnings/999999/tier', { tier: 'active' })).status, 404);
+    });
+  });
+
+  describe('PUT /api/session-rules/:id/status', () => {
+    /**
+     * Create a proposed rule to act on.
+     * @returns {object} The created rule
+     */
+    function proposal() {
+      return store.sessionRules.create({
+        content: `proposal ${Date.now()}-${Math.random()}`, projectId: pid, createdBy: 'ai'
+      });
+    }
+
+    it('approves a proposal into a governing rule', async () => {
+      const rule = proposal();
+      const res = await request('PUT', `/api/session-rules/${rule.id}/status`, { status: 'active' });
+      assert.equal(res.status, 200);
+      assert.equal(res.data.status, 'active');
+    });
+
+    it('records a rejection rather than deleting it', async () => {
+      const rule = proposal();
+      const res = await request('PUT', `/api/session-rules/${rule.id}/status`, { status: 'rejected' });
+      assert.equal(res.status, 200);
+      assert.equal(res.data.status, 'rejected');
+      assert.ok(store.sessionRules.get(rule.id), 'the row must survive so it is never re-proposed');
+    });
+
+    it('REFUSES to approve without the operator password when one is set', async () => {
+      // The property that failed review: authority must come from the gate, not
+      // from the request describing itself as the operator.
+      const rule = proposal();
+      setOperatorPassword('hunter2');
+      const res = await request('PUT', `/api/session-rules/${rule.id}/status`, { status: 'active' });
+      assert.equal(res.status, 403);
+      assert.equal(store.sessionRules.get(rule.id).status, 'proposed', 'a refused approval must not mutate');
+    });
+
+    it('cannot be bypassed by claiming to be the operator in the body', async () => {
+      const rule = proposal();
+      setOperatorPassword('hunter2');
+      const res = await request('PUT', `/api/session-rules/${rule.id}/status`,
+        { status: 'active', changedBy: 'operator' });
+      assert.equal(res.status, 403);
+    });
+
+    it('approves once the password is supplied', async () => {
+      const rule = proposal();
+      setOperatorPassword('hunter2');
+      const res = await request('PUT', `/api/session-rules/${rule.id}/status`,
+        { status: 'active', password: 'hunter2' });
+      assert.equal(res.status, 200);
+      assert.equal(res.data.status, 'active');
+    });
+
+    it('does not gate a rejection — declining grants nothing', async () => {
+      const rule = proposal();
+      setOperatorPassword('hunter2');
+      const res = await request('PUT', `/api/session-rules/${rule.id}/status`, { status: 'rejected' });
+      assert.equal(res.status, 200);
+    });
+
+    it('rejects an unknown status, a missing one, and an unknown rule', async () => {
+      const rule = proposal();
+      assert.equal((await request('PUT', `/api/session-rules/${rule.id}/status`, { status: 'maybe' })).status, 400);
+      assert.equal((await request('PUT', `/api/session-rules/${rule.id}/status`, {})).status, 400);
+      assert.equal((await request('PUT', '/api/session-rules/999999/status', { status: 'active' })).status, 404);
+    });
+  });
+
+  describe('POST /api/session-rules/promote carries the same gate', () => {
+    it('refuses to mint a live rule without the operator password when one is set', async () => {
+      const l = store.learnings.create({ projectId: pid, content: `promote guard ${Date.now()}` });
+      setOperatorPassword('hunter2');
+      const res = await request('POST', '/api/session-rules/promote', { learningId: l.id });
+      assert.equal(res.status, 403);
+    });
+
+    it('mints a live rule once the password is supplied, keeping AI provenance', async () => {
+      const l = store.learnings.create({ projectId: pid, content: `promote ok ${Date.now()}` });
+      setOperatorPassword('hunter2');
+      const res = await request('POST', '/api/session-rules/promote',
+        { learningId: l.id, password: 'hunter2' });
+      assert.equal(res.status, 201);
+      assert.equal(res.data.status, 'active', 'an operator decision produces a governing rule');
+      assert.equal(res.data.createdBy, 'ai', 'provenance survives the approval');
+    });
+  });
+
+  describe('GET /api/session-rules status filter', () => {
+    it('lets a caller ask for active rules only, so proposals are not shown as live', async () => {
+      const live = store.sessionRules.create({ content: `live ${Date.now()}`, projectId: pid });
+      const prop = store.sessionRules.create({ content: `prop ${Date.now()}`, projectId: pid, createdBy: 'ai' });
+      const res = await request('GET', `/api/session-rules?projectId=${pid}&status=active`);
+      assert.equal(res.status, 200);
+      const ids = res.data.rules.map((r) => r.id);
+      assert.ok(ids.includes(live.id));
+      assert.ok(!ids.includes(prop.id), 'a proposal must not appear in the governing-rules list');
+    });
+  });
+});

--- a/test/orchestration-profiles-store.test.js
+++ b/test/orchestration-profiles-store.test.js
@@ -129,7 +129,7 @@ describe('orchestration_profile column (schema v21→v22)', () => {
     store._setBasePath(tmpDir);
     store.init();
     const db = store.getDb();
-    assert.equal(db.prepare('SELECT version FROM schema_version ORDER BY version DESC LIMIT 1').get().version, 26);
+    assert.equal(db.prepare('SELECT version FROM schema_version ORDER BY version DESC LIMIT 1').get().version, 27);
     assert.equal(store.projects.getByName('tb1-idem').orchestrationProfile, 'direct');
   });
 });

--- a/test/self-improvement-loop.test.js
+++ b/test/self-improvement-loop.test.js
@@ -137,6 +137,102 @@ describe('self-improvement loop (#569)', () => {
     });
   });
 
+  describe('the v26→v27 migration', () => {
+    const { DatabaseSync } = require('node:sqlite');
+
+    /**
+     * Seed a pre-v27 database and run it through `store.init()`.
+     * @param {string} seedSql - Rows to insert into the pre-v27 session_rules
+     * @returns {{dir: string, db: object, s: object}} Migrated handle
+     */
+    function migrateFrom(seedSql) {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-v27-'));
+      const dbPath = path.join(dir, 'tangleclaw.db');
+      const seed = new DatabaseSync(dbPath);
+      seed.exec(`
+        CREATE TABLE schema_version (
+          version INTEGER PRIMARY KEY,
+          applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+        INSERT INTO schema_version (version) VALUES (26);
+        CREATE TABLE session_rules (
+          id INTEGER PRIMARY KEY AUTOINCREMENT, project_id INTEGER, content TEXT NOT NULL,
+          enabled INTEGER NOT NULL DEFAULT 1, created_by TEXT NOT NULL DEFAULT 'operator',
+          kind TEXT NOT NULL DEFAULT 'startup', owner TEXT, source_learning_id INTEGER,
+          created_at TEXT NOT NULL DEFAULT (datetime('now')),
+          updated_at TEXT NOT NULL DEFAULT (datetime('now')));
+        ${seedSql}
+      `);
+      seed.close();
+
+      delete require.cache[require.resolve('../lib/store')];
+      const s = require('../lib/store');
+      s._setBasePath(dir);
+      s.init();
+      return { dir, db: s.getDb(), s };
+    }
+
+    /**
+     * Release a migrated handle and restore the suite's shared store module.
+     * @param {object} h - Handle from `migrateFrom`
+     */
+    function done(h) {
+      h.s.close();
+      fs.rmSync(h.dir, { recursive: true, force: true });
+      delete require.cache[require.resolve('../lib/store')];
+      require('../lib/store')._setBasePath(tmpDir);
+    }
+
+    it('backfills every pre-existing row to active — they already governed sessions', () => {
+      const h = migrateFrom(`
+        INSERT INTO session_rules (project_id, content, enabled, created_by, kind)
+          VALUES (NULL, 'legacy master', 1, 'operator', 'master');
+        INSERT INTO session_rules (project_id, content, enabled, created_by, kind)
+          VALUES (NULL, 'legacy disabled', 0, 'ai', 'wrap');
+      `);
+      try {
+        const rows = h.db.prepare('SELECT content, enabled, status FROM session_rules ORDER BY id').all();
+        assert.deepEqual(rows.map((r) => r.status), ['active', 'active'],
+          'back-dating live rules into review would silently switch them off on upgrade');
+        assert.deepEqual(rows.map((r) => r.enabled), [1, 0], 'enabled must survive untouched');
+      } finally { done(h); }
+    });
+
+    it('preserves a row whose foreign key is already orphaned', () => {
+      // A migration preserves what it finds. Re-inserting under FK enforcement
+      // would abort on such a row, so a pre-existing orphan would block the
+      // upgrade instead of surviving it.
+      const h = migrateFrom(
+        "INSERT INTO session_rules (project_id, content) VALUES (424242, 'orphaned rule');");
+      try {
+        const row = h.db.prepare('SELECT content, project_id, status FROM session_rules').get();
+        assert.equal(row.content, 'orphaned rule');
+        assert.equal(row.project_id, 424242);
+        assert.equal(row.status, 'active');
+        assert.equal(
+          h.db.prepare('SELECT MAX(version) v FROM schema_version').get().v, 27,
+          'the upgrade must complete, not stall on the orphan');
+      } finally { done(h); }
+    });
+
+    it('leaves foreign-key enforcement ON afterwards', () => {
+      // The rebuild turns it off; leaving it off would silently disable FK
+      // checking for the rest of the process's life.
+      const h = migrateFrom("INSERT INTO session_rules (project_id, content) VALUES (NULL, 'x');");
+      try {
+        assert.equal(h.db.prepare('PRAGMA foreign_keys').get().foreign_keys, 1);
+      } finally { done(h); }
+    });
+
+    it('produces a status CHECK that actually rejects an invalid value', () => {
+      const h = migrateFrom("INSERT INTO session_rules (project_id, content) VALUES (NULL, 'y');");
+      try {
+        assert.throws(() => h.db
+          .prepare("INSERT INTO session_rules (content, status) VALUES ('bad', 'nonsense')").run());
+      } finally { done(h); }
+    });
+  });
+
   describe('recurrence advances a learning into future sessions', () => {
     const dbWrite = require('../lib/wrap-steps/learnings-db-write');
 

--- a/test/self-improvement-loop.test.js
+++ b/test/self-improvement-loop.test.js
@@ -345,6 +345,28 @@ describe('self-improvement loop (#569)', () => {
     });
   });
 
+  describe('conflict candidates only compare against governing rules', () => {
+    it('ignores proposals and rejections', () => {
+      // Existing suites seed only operator-authored rules, which resolve to
+      // active, so they stay green with the status filter removed. A proposal
+      // has to exist for this to test anything.
+      store.sessionRules.create({ content: 'migrations require postgres schema validation', projectId: project.id });
+      store.sessionRules.create({
+        content: 'migrations require postgres schema rollback', projectId: project.id, createdBy: 'ai'
+      });
+      const rejected = store.sessionRules.create({
+        content: 'migrations require postgres schema snapshots', projectId: project.id, createdBy: 'ai'
+      });
+      store.sessionRules.setStatus(rejected.id, 'rejected');
+
+      const candidates = store.sessionRules
+        .findConflictCandidates('migrations require postgres schema review', project.id);
+      const contents = candidates.map((c) => c.rule.content);
+      assert.deepEqual(contents, ['migrations require postgres schema validation'],
+        'an unreviewed proposal and a declined rule are not things to reconcile against');
+    });
+  });
+
   describe('the wrap proposal step', () => {
     it('proposes one rule per active learning, all at status proposed', async () => {
       const a = store.learnings.create({ projectId: project.id, content: 'lesson A', tier: 'active' });

--- a/test/self-improvement-loop.test.js
+++ b/test/self-improvement-loop.test.js
@@ -1,0 +1,269 @@
+'use strict';
+
+/**
+ * #569 — the self-improvement loop.
+ *
+ * Two halves, each previously broken in a different way. Learnings were written
+ * at `tier:'provisional'` and nothing ever advanced them, so `## Active
+ * Learnings` was empty on every project forever. And nothing ever turned a
+ * learning into a rule — `promoteFromLearning` had one caller, an HTTP route no
+ * UI invoked.
+ *
+ * The load-bearing property of the fix is that the loop can propose but not
+ * apply. These tests pin that at every door into `status:'active'`, because a
+ * gate on one entrance is not a gate.
+ */
+
+const { describe, it, before, after, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { setLevel } = require('../lib/logger');
+
+setLevel('error');
+
+const store = require('../lib/store');
+const ruleProposal = require('../lib/wrap-steps/rule-proposal');
+
+describe('self-improvement loop (#569)', () => {
+  let tmpDir;
+  let project;
+
+  before(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-selfimprove-'));
+    store._setBasePath(tmpDir);
+    store.init();
+  });
+
+  after(() => {
+    store.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    const dir = path.join(tmpDir, `proj-${Math.floor(Math.random() * 1e9)}`);
+    fs.mkdirSync(dir, { recursive: true });
+    project = store.projects.create({ name: path.basename(dir), path: dir, methodology: 'prawduct' });
+  });
+
+  describe('a proposal governs nothing until an operator approves it', () => {
+    it('creates AI-authored rules as proposals, not active rules', () => {
+      const rule = store.sessionRules.create({
+        content: 'always run the linter', projectId: project.id, createdBy: 'ai'
+      });
+      assert.equal(rule.status, 'proposed');
+    });
+
+    it('REFUSES an AI request for an active rule — the request that must not be granted', () => {
+      const rule = store.sessionRules.create({
+        content: 'trust me', projectId: project.id, createdBy: 'ai', status: 'active'
+      });
+      assert.equal(rule.status, 'proposed', 'asking for active must not make it active');
+    });
+
+    it('still lets the operator create active rules directly (pre-#569 behavior)', () => {
+      const rule = store.sessionRules.create({ content: 'operator rule', projectId: project.id });
+      assert.equal(rule.status, 'active');
+    });
+
+    it('lets a human decision produce a live rule from AI-authored content', () => {
+      // Authorship and authority are different things: the text is the AI's,
+      // the decision is the operator's.
+      const rule = store.sessionRules.create({
+        content: 'operator approved this', projectId: project.id,
+        createdBy: 'ai', status: 'active', approvedByOperator: true
+      });
+      assert.equal(rule.status, 'active');
+      assert.equal(rule.createdBy, 'ai', 'provenance must survive the approval');
+    });
+
+    it('refuses to let an AI approve a proposal — the other door into active', () => {
+      const rule = store.sessionRules.create({
+        content: 'self approval attempt', projectId: project.id, createdBy: 'ai'
+      });
+      assert.throws(
+        () => store.sessionRules.setStatus(rule.id, 'active', { changedBy: 'ai' }),
+        (err) => err.code === 'FORBIDDEN'
+      );
+      assert.equal(store.sessionRules.get(rule.id).status, 'proposed');
+    });
+
+    it('lets the operator approve and reject, recording each as a version', () => {
+      const rule = store.sessionRules.create({ content: 'a proposal', projectId: project.id, createdBy: 'ai' });
+      const approved = store.sessionRules.setStatus(rule.id, 'active');
+      assert.equal(approved.status, 'active');
+      const rejected = store.sessionRules.setStatus(rule.id, 'rejected');
+      assert.equal(rejected.status, 'rejected');
+      const versions = store.sessionRules.listVersions(rule.id);
+      assert.ok(versions.length >= 3, 'create + two decisions must all be snapshotted');
+    });
+
+    it('rejects an unknown status rather than storing it', () => {
+      const rule = store.sessionRules.create({ content: 'x', projectId: project.id });
+      assert.throws(() => store.sessionRules.setStatus(rule.id, 'maybe'), (e) => e.code === 'BAD_REQUEST');
+    });
+  });
+
+  describe('no injection path can see a proposal', () => {
+    it('keeps proposed startup rules out of the launch prime', () => {
+      store.sessionRules.create({ content: 'proposed startup', projectId: project.id, createdBy: 'ai' });
+      store.sessionRules.create({ content: 'real startup', projectId: project.id });
+      const injected = store.sessionRules.listActiveForProject(project.id).map((r) => r.content);
+      assert.deepEqual(injected, ['real startup']);
+    });
+
+    it('keeps proposed wrap rules out of the wrap prompts', () => {
+      // The wrap taking instruction from a rule it proposed moments earlier is
+      // the loop closing on itself with no human in it.
+      store.sessionRules.create({ content: 'proposed wrap', projectId: project.id, createdBy: 'ai', kind: 'wrap' });
+      store.sessionRules.create({ content: 'real wrap', projectId: project.id, kind: 'wrap' });
+      const aiContent = require('../lib/wrap-steps/ai-content');
+      const injected = aiContent._internal.listWrapRules(project.id).map((r) => r.content);
+      assert.deepEqual(injected, ['real wrap']);
+    });
+
+    it('keeps proposed master rules out of the master identity', () => {
+      store.sessionRules.create({ content: 'proposed master', createdBy: 'ai', kind: 'master' });
+      const injected = store.sessionRules.listActiveForMaster().map((r) => r.content);
+      assert.ok(!injected.includes('proposed master'));
+    });
+
+    it('drops a rule out of injection the moment it is rejected', () => {
+      const rule = store.sessionRules.create({ content: 'was fine', projectId: project.id });
+      assert.equal(store.sessionRules.listActiveForProject(project.id).length, 1);
+      store.sessionRules.setStatus(rule.id, 'rejected');
+      assert.equal(store.sessionRules.listActiveForProject(project.id).length, 0);
+    });
+  });
+
+  describe('recurrence advances a learning into future sessions', () => {
+    const dbWrite = require('../lib/wrap-steps/learnings-db-write');
+
+    /**
+     * Write learnings.md for the current project and run the mirror step.
+     * @param {string} body - Full markdown content
+     * @param {string} today - Date the step should treat as today
+     * @returns {Promise<object>} Step result
+     */
+    async function mirror(body, today) {
+      const file = path.join(project.path, '.tangleclaw', 'memories', 'learnings.md');
+      fs.mkdirSync(path.dirname(file), { recursive: true });
+      fs.writeFileSync(file, body);
+      const original = dbWrite._internal.todayIso;
+      dbWrite._internal.todayIso = () => today;
+      try {
+        return await dbWrite.run({ project });
+      } finally {
+        dbWrite._internal.todayIso = original;
+      }
+    }
+
+    it('recognises the same learning on a later day, despite the dated heading', async () => {
+      // The stored text begins with its own `## YYYY-MM-DD` heading, so the raw
+      // content of a repeat never matches its earlier self. Without a
+      // date-independent key nothing would ever recur and nothing would advance.
+      const first = await mirror('## 2026-01-01 — Cache invalidation bites\n\nIt bit again.\n', '2026-01-01');
+      assert.equal(first.output.inserted, 1);
+      const rows = store.learnings.list(project.id);
+      assert.equal(rows.length, 1);
+      assert.equal(rows[0].tier, 'provisional');
+
+      const second = await mirror(
+        '## 2026-01-01 — Cache invalidation bites\n\nIt bit again.\n\n'
+        + '## 2026-02-09 — Cache invalidation bites\n\nIt bit again.\n', '2026-02-09');
+      assert.equal(second.output.confirmed, 1, 'the repeat must be recognised');
+      assert.equal(second.output.inserted, 0, 'and must not create a near-duplicate row');
+      assert.equal(store.learnings.list(project.id).length, 1);
+    });
+
+    it('promotes provisional → active on the second sighting, reaching the next prime', async () => {
+      await mirror('## 2026-03-01 — Flaky under load\n\nRetry masks it.\n', '2026-03-01');
+      assert.equal(store.learnings.getActive(project.id).length, 0);
+
+      const second = await mirror(
+        '## 2026-03-01 — Flaky under load\n\nRetry masks it.\n\n'
+        + '## 2026-03-08 — Flaky under load\n\nRetry masks it.\n', '2026-03-08');
+      assert.equal(second.output.promoted, 1);
+      const active = store.learnings.getActive(project.id);
+      assert.equal(active.length, 1, 'an advanced learning must now reach ## Active Learnings');
+    });
+
+    it('still refuses to double-insert on a same-day wrap retry', async () => {
+      const body = '## 2026-04-01 — Retry guard\n\nSame day twice.\n';
+      await mirror(body, '2026-04-01');
+      const retry = await mirror(body, '2026-04-01');
+      assert.equal(retry.status, 'skipped');
+      assert.equal(store.learnings.list(project.id).length, 1);
+    });
+
+    it('treats a genuinely different learning as new, not a recurrence', async () => {
+      await mirror('## 2026-05-01 — Thing one\n\nBody one.\n', '2026-05-01');
+      const next = await mirror(
+        '## 2026-05-01 — Thing one\n\nBody one.\n\n'
+        + '## 2026-05-02 — Thing two\n\nBody two.\n', '2026-05-02');
+      assert.equal(next.output.inserted, 1);
+      assert.equal(next.output.confirmed, 0);
+      assert.equal(store.learnings.list(project.id).length, 2);
+    });
+
+    it('matches across incidental whitespace and case, which is all normalization claims', async () => {
+      await mirror('## 2026-06-01 — Normalize me\n\nSome   body text.\n', '2026-06-01');
+      const next = await mirror(
+        '## 2026-06-01 — Normalize me\n\nSome   body text.\n\n'
+        + '## 2026-06-02 — normalize ME\n\nSome body   text.\n', '2026-06-02');
+      assert.equal(next.output.confirmed, 1);
+    });
+  });
+
+  describe('the wrap proposal step', () => {
+    it('proposes one rule per active learning, all at status proposed', async () => {
+      const a = store.learnings.create({ projectId: project.id, content: 'lesson A', tier: 'active' });
+      const b = store.learnings.create({ projectId: project.id, content: 'lesson B', tier: 'active' });
+      const res = await ruleProposal.run({ project });
+      assert.equal(res.status, 'done');
+      assert.equal(res.output.count, 2);
+      for (const p of res.output.proposed) assert.equal(p.status, 'proposed');
+      const sources = res.output.proposed.map((p) => p.learningId).sort();
+      assert.deepEqual(sources, [a.id, b.id].sort());
+    });
+
+    it('carries provenance, so every proposal traces to the learning behind it', async () => {
+      const l = store.learnings.create({ projectId: project.id, content: 'traceable', tier: 'active' });
+      const res = await ruleProposal.run({ project });
+      const rule = store.sessionRules.get(res.output.proposed[0].ruleId);
+      assert.equal(rule.sourceLearningId, l.id);
+    });
+
+    it('will not propose from a provisional learning — recurrence is the bar', async () => {
+      store.learnings.create({ projectId: project.id, content: 'seen once', tier: 'provisional' });
+      const res = await ruleProposal.run({ project });
+      assert.equal(res.status, 'skipped');
+      assert.match(res.output.reason, /no active learnings/);
+    });
+
+    it('never re-proposes a learning the operator already rejected', async () => {
+      // The whole reason a rejection is recorded instead of deleted.
+      store.learnings.create({ projectId: project.id, content: 'recurring', tier: 'active' });
+      const first = await ruleProposal.run({ project });
+      store.sessionRules.setStatus(first.output.proposed[0].ruleId, 'rejected');
+      const second = await ruleProposal.run({ project });
+      assert.equal(second.status, 'skipped');
+      assert.match(second.output.reason, /already have a rule or a decision/);
+    });
+
+    it('is idempotent across repeated wraps', async () => {
+      store.learnings.create({ projectId: project.id, content: 'once only', tier: 'active' });
+      await ruleProposal.run({ project });
+      const again = await ruleProposal.run({ project });
+      assert.equal(again.status, 'skipped');
+      assert.equal(store.sessionRules.list({ projectId: project.id }).length, 1);
+    });
+
+    it('skips rather than blocks when there is nothing to work with', async () => {
+      const res = await ruleProposal.run({ project });
+      assert.equal(res.ok, true, 'a wrap must not fail because rule proposal had nothing to do');
+      assert.equal(res.status, 'skipped');
+    });
+  });
+});

--- a/test/self-improvement-loop.test.js
+++ b/test/self-improvement-loop.test.js
@@ -303,6 +303,39 @@ describe('self-improvement loop (#569)', () => {
       assert.equal(store.learnings.list(project.id).length, 2);
     });
 
+    it('accrues confirmations to the OLDEST matching row, not the newest', async () => {
+      // Without an explicit sort this is silently wrong: `learnings.list`
+      // returns newest-first, so a first-wins map keeps the newest row and
+      // confirmations scatter instead of accumulating on one canonical
+      // learning. Two rows must share a recurrence key for the choice to be
+      // observable at all — nothing else in the suite creates that state.
+      const older = store.learnings.create({
+        projectId: project.id, content: '## 2026-07-01 — Dupe subject\n\nShared body.'
+      });
+      const newer = store.learnings.create({
+        projectId: project.id, content: '## 2026-07-02 — Dupe subject\n\nShared body.'
+      });
+      assert.ok(newer.id > older.id, 'precondition: the second row is the newer one');
+
+      // Force distinct timestamps. Both rows are created in the same second, so
+      // created_at ties and the newest-first query happens to return them in id
+      // order — under which an unsorted map picks the oldest by luck and this
+      // test cannot see the difference. Verified by reverting the sort: without
+      // these two lines it passes either way.
+      store.getDb().prepare('UPDATE learnings SET created_at = ? WHERE id = ?')
+        .run('2026-07-01 00:00:00', older.id);
+      store.getDb().prepare('UPDATE learnings SET created_at = ? WHERE id = ?')
+        .run('2026-07-02 00:00:00', newer.id);
+
+      await mirror('## 2026-07-03 — Dupe subject\n\nShared body.\n', '2026-07-03');
+
+      const rows = store.learnings.list(project.id);
+      const oldRow = rows.find((r) => r.id === older.id);
+      const newRow = rows.find((r) => r.id === newer.id);
+      assert.equal(oldRow.confirmedCount, 1, 'the oldest row must take the confirmation');
+      assert.equal(newRow.confirmedCount, 0, 'the newer duplicate must be left alone');
+    });
+
     it('matches across incidental whitespace and case, which is all normalization claims', async () => {
       await mirror('## 2026-06-01 — Normalize me\n\nSome   body text.\n', '2026-06-01');
       const next = await mirror(

--- a/test/session-rules.test.js
+++ b/test/session-rules.test.js
@@ -530,7 +530,7 @@ describe('sessionRules v19→v20 kind migration (CC-6, #381)', () => {
       // project-scoped: a global (project_id NULL) row would be purged by the
       // v24→v25 tier retirement, which has its own migration test below.
       const ver = db.prepare('SELECT version FROM schema_version ORDER BY version DESC LIMIT 1').get();
-      assert.equal(ver.version, 26);
+      assert.equal(ver.version, 27);
 
       // The pre-existing row backfilled to kind='startup'…
       const rules = store.sessionRules.list();
@@ -589,7 +589,7 @@ describe('sessionRules v22→v23 op CHECK migration (SR-3MW8)', () => {
       const db = store.getDb();
       // Schema advanced to current (v22→v23 op CHECK, then v23→v24 critic_gate).
       const ver = db.prepare('SELECT version FROM schema_version ORDER BY version DESC LIMIT 1').get();
-      assert.equal(ver.version, 26);
+      assert.equal(ver.version, 27);
 
       // The CHECK constraint is now present in the rebuilt table's DDL.
       const ddl = db.prepare(
@@ -721,7 +721,7 @@ describe('sessionRules v23→v24 critic_gate migration (SR-7K2P)', () => {
       const db = store.getDb();
       // Schema advanced to current (the v23→v24 rebuild is the last step).
       const ver = db.prepare('SELECT version FROM schema_version ORDER BY version DESC LIMIT 1').get();
-      assert.equal(ver.version, 26);
+      assert.equal(ver.version, 27);
 
       // The critic_gate CHECK is now present in the rebuilt table's DDL.
       const ddl = db.prepare(
@@ -816,7 +816,7 @@ describe('sessionRules v24→v25 tier-retirement purge', () => {
 
       const db = store.getDb();
       const ver = db.prepare('SELECT version FROM schema_version ORDER BY version DESC LIMIT 1').get();
-      assert.equal(ver.version, 26);
+      assert.equal(ver.version, 27);
 
       // Only the project-scoped startup rule survives.
       const rows = db.prepare('SELECT id, content FROM session_rules ORDER BY id').all();

--- a/test/sessions-webui.test.js
+++ b/test/sessions-webui.test.js
@@ -75,10 +75,10 @@ describe('Web UI session lifecycle', () => {
   // ── Schema v7: default_mode column ──
 
   describe('schema v7: default_mode on openclaw_connections', () => {
-    it('should have schema version 24', () => {
+    it('should have the current schema version', () => {
       const db = store.getDb();
       const row = db.prepare('SELECT version FROM schema_version ORDER BY version DESC LIMIT 1').get();
-      assert.equal(row.version, 26);
+      assert.equal(row.version, 27);
     });
 
     it('should have default_mode column in openclaw_connections', () => {

--- a/test/sessions.test.js
+++ b/test/sessions.test.js
@@ -1769,7 +1769,7 @@ describe('sessions', () => {
       // priming-roll/pr-check) so the routing assertion
       // doesn't accidentally trip on a missing tmux session.
       const wrapPipelineMod = require('../lib/wrap-pipeline');
-      const realKinds = ['lint', 'test', 'ai-content', 'learnings-db-write', 'priming-roll', 'pr-check', 'pr-merge', 'commit', 'features-toc', 'project-map', 'index-describe'];
+      const realKinds = ['lint', 'test', 'ai-content', 'learnings-db-write', 'rule-proposal', 'priming-roll', 'pr-check', 'pr-merge', 'commit', 'features-toc', 'project-map', 'index-describe'];
       const dispatchOrig = {};
       const noopRun = async () => ({ ok: true, status: 'done', output: null, blockers: [] });
       for (const kind of realKinds) {
@@ -1789,8 +1789,8 @@ describe('sessions', () => {
         // `features-toc`; PIDX #426 added `index-describe` after `project-map`;
         // #466 added `learnings-db-write` after `learnings-capture`; #570 added
         // `apply-pr-resolutions` last — prawduct now ships 13 steps.
-        assert.equal(result.pipelineResult.results.length, 13,
-          'prawduct pipeline runs all thirteen steps');
+        assert.equal(result.pipelineResult.results.length, 14,
+          'prawduct pipeline runs all fourteen steps');
         assert.equal(result.wrapCommand, null, 'V2 reports no legacy wrapCommand');
       } finally {
         for (const kind of realKinds) {

--- a/test/skills.test.js
+++ b/test/skills.test.js
@@ -92,7 +92,7 @@ describe('skills', () => {
       // surface order here reflects the template-level edits.
       assert.deepStrictEqual(skills.getWrapSkill('prawduct'), {
         command: null,
-        steps: ['open-pr-check', 'changelog-update', 'version-bump', 'learnings-capture', 'learnings-db-write', 'next-session-prime', 'features-toc', 'project-map', 'index-describe', 'memory-update', 'commit', 'continuity-write', 'apply-pr-resolutions'],
+        steps: ['open-pr-check', 'changelog-update', 'version-bump', 'learnings-capture', 'learnings-db-write', 'rule-proposal', 'next-session-prime', 'features-toc', 'project-map', 'index-describe', 'memory-update', 'commit', 'continuity-write', 'apply-pr-resolutions'],
         captureFields: ['summary', 'nextSteps', 'learnings']
       });
       assert.deepStrictEqual(skills.getWrapSkill('minimal'), {

--- a/test/store-openclaw.test.js
+++ b/test/store-openclaw.test.js
@@ -296,7 +296,7 @@ describe('store.openclawConnections', () => {
         const db = store.getDb();
         // Schema version advanced to current (v14 → v15 bridge_port rebuild → v16 instance_dir → v17 migration_status → v18 session_rules → v19 session_rule_versions → v20 session_rules.kind → v21 sessions.owner → v22 projects.orchestration_profile → v23 session_rule_versions.op CHECK → v24 session_rule_versions.critic_gate).
         const ver = db.prepare('SELECT version FROM schema_version ORDER BY version DESC LIMIT 1').get();
-        assert.equal(ver.version, 26);
+        assert.equal(ver.version, 27);
         // Column constraint actually changed (v15).
         const cols = db.prepare("PRAGMA table_info(openclaw_connections)").all();
         const bridgeCol = cols.find((c) => c.name === 'bridge_port');

--- a/test/store-portleases.test.js
+++ b/test/store-portleases.test.js
@@ -170,9 +170,9 @@ describe('store.portLeases', () => {
     assert.ok(row, 'port_leases table should exist');
   });
 
-  it('schema version is 24', () => {
+  it('schema version matches CURRENT_SCHEMA_VERSION', () => {
     const db = store.getDb();
     const row = db.prepare('SELECT version FROM schema_version ORDER BY version DESC LIMIT 1').get();
-    assert.equal(row.version, 26);
+    assert.equal(row.version, 27);
   });
 });

--- a/test/store-session-mode.test.js
+++ b/test/store-session-mode.test.js
@@ -87,10 +87,10 @@ describe('schema v6: session_mode column', () => {
     assert.equal(sessions[0].sessionMode, 'tmux');
   });
 
-  it('should handle schema version 24', () => {
+  it('should handle the current schema version', () => {
     const db = store.getDb();
     const row = db.prepare('SELECT version FROM schema_version ORDER BY version DESC LIMIT 1').get();
-    assert.equal(row.version, 26);
+    assert.equal(row.version, 27);
   });
 
   it('should have session_mode column in sessions table', () => {

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -77,7 +77,7 @@ describe('store', () => {
 
       const db = store.getDb();
       const row = db.prepare('SELECT version FROM schema_version ORDER BY version DESC LIMIT 1').get();
-      assert.equal(row.version, 26);
+      assert.equal(row.version, 27);
     });
 
     it('should copy bundled engine profiles', () => {
@@ -2144,7 +2144,7 @@ describe('sessions v20→v21 owner migration (AUTH-3, #1)', () => {
       store.init();
 
       const db = store.getDb();
-      assert.equal(db.prepare('SELECT version FROM schema_version ORDER BY version DESC LIMIT 1').get().version, 26);
+      assert.equal(db.prepare('SELECT version FROM schema_version ORDER BY version DESC LIMIT 1').get().version, 27);
 
       // The pre-AUTH-3 row gained the column with a NULL value (unauthenticated == null).
       const old = store.sessions.get(1);

--- a/test/wrap-changelog-transaction.test.js
+++ b/test/wrap-changelog-transaction.test.js
@@ -88,6 +88,16 @@ describe('wrap CHANGELOG transaction — step order is load-bearing', () => {
       'learnings-db-write', 'next-session-prime', 'features-toc', 'project-map',
       'index-describe', 'memory-update', 'commit', 'continuity-write',
       'apply-pr-resolutions'
+    ],
+    // 7: `rule-proposal` added after `learnings-db-write` (#569). Position is
+    // not cosmetic — the proposal step reads the learnings that step has just
+    // confirmed and promoted, so running it earlier would propose from the
+    // previous wrap's state and miss this session's recurrences entirely.
+    7: [
+      'open-pr-check', 'changelog-update', 'version-bump', 'learnings-capture',
+      'learnings-db-write', 'rule-proposal', 'next-session-prime', 'features-toc',
+      'project-map', 'index-describe', 'memory-update', 'commit', 'continuity-write',
+      'apply-pr-resolutions'
     ]
   };
 

--- a/test/wrap-drawer.test.js
+++ b/test/wrap-drawer.test.js
@@ -252,10 +252,27 @@ describe('wrap-drawer helpers — KIND_DESCRIPTIONS (per-step help)', () => {
   const H = loadHelpers();
   // The canonical wrap-step kinds (mirrors test/wrap-pipeline.test.js realKinds).
   const CANONICAL_KINDS = [
-    'lint', 'test', 'ai-content', 'learnings-db-write', 'priming-roll',
+    'lint', 'test', 'ai-content', 'learnings-db-write', 'rule-proposal', 'priming-roll',
     'pr-check', 'commit', 'version-bump', 'features-toc',
     'project-map', 'index-describe', 'continuity-write'
   ];
+
+  it('surfaces the proposal count, so a wrap that proposed rules does not look like one that did not', () => {
+    const row = H.buildStepRow({
+      stepId: 'rule-proposal', kind: 'rule-proposal', status: 'done',
+      output: { count: 2, proposed: [{}, {}] }, blockers: []
+    });
+    assert.match(row.detail, /2 rules proposed/);
+    assert.match(row.detail, /awaiting your review/);
+  });
+
+  it('renders no proposal detail when nothing was proposed', () => {
+    const row = H.buildStepRow({
+      stepId: 'rule-proposal', kind: 'rule-proposal', status: 'done',
+      output: { count: 0, proposed: [] }, blockers: []
+    });
+    assert.equal(row.detail, null);
+  });
 
   it('has a non-empty help description for every canonical wrap-step kind (drift guard)', () => {
     for (const k of CANONICAL_KINDS) {

--- a/test/wrap-drawer.test.js
+++ b/test/wrap-drawer.test.js
@@ -253,7 +253,7 @@ describe('wrap-drawer helpers — KIND_DESCRIPTIONS (per-step help)', () => {
   // The canonical wrap-step kinds (mirrors test/wrap-pipeline.test.js realKinds).
   const CANONICAL_KINDS = [
     'lint', 'test', 'ai-content', 'learnings-db-write', 'rule-proposal', 'priming-roll',
-    'pr-check', 'commit', 'version-bump', 'features-toc',
+    'pr-check', 'pr-merge', 'commit', 'version-bump', 'features-toc',
     'project-map', 'index-describe', 'continuity-write'
   ];
 
@@ -264,6 +264,22 @@ describe('wrap-drawer helpers — KIND_DESCRIPTIONS (per-step help)', () => {
     });
     assert.match(row.detail, /2 rules proposed/);
     assert.match(row.detail, /awaiting your review/);
+  });
+
+  it('says "1 rule" not "1 rules"', () => {
+    const row = H.buildStepRow({
+      stepId: 'rule-proposal', kind: 'rule-proposal', status: 'done',
+      output: { count: 1, proposed: [{}] }, blockers: []
+    });
+    assert.match(row.detail, /1 rule proposed/);
+  });
+
+  it('renders no proposal detail when the count is absent entirely', () => {
+    const row = H.buildStepRow({
+      stepId: 'rule-proposal', kind: 'rule-proposal', status: 'done',
+      output: {}, blockers: []
+    });
+    assert.equal(row.detail, null);
   });
 
   it('renders no proposal detail when nothing was proposed', () => {

--- a/test/wrap-pipeline.test.js
+++ b/test/wrap-pipeline.test.js
@@ -76,7 +76,7 @@ describe('wrap-pipeline (#139 Chunk 3)', () => {
       // dispatch entry to the canonical no-op result for this test only.
       // The real-handler behavior is covered by per-handler describes
       // below.
-      const realKinds = ['lint', 'test', 'ai-content', 'learnings-db-write', 'priming-roll', 'pr-check', 'pr-merge', 'commit', 'version-bump', 'features-toc', 'project-map', 'index-describe', 'continuity-write'];
+      const realKinds = ['lint', 'test', 'ai-content', 'learnings-db-write', 'rule-proposal', 'priming-roll', 'pr-check', 'pr-merge', 'commit', 'version-bump', 'features-toc', 'project-map', 'index-describe', 'continuity-write'];
       const originals = {};
       const noopRun = async () => ({ ok: true, status: 'done', output: null, blockers: [] });
       for (const kind of realKinds) {
@@ -97,7 +97,7 @@ describe('wrap-pipeline (#139 Chunk 3)', () => {
         // after `features-toc`; PIDX #426 added `index-describe` after
         // `project-map`; #466 added `learnings-db-write` after
         // `learnings-capture` — prawduct now ships 12 pipeline steps.
-        assert.equal(result.results.length, 13, 'prawduct has thirteen pipeline steps');
+        assert.equal(result.results.length, 14, 'prawduct has fourteen pipeline steps');
         for (const stepResult of result.results) {
           assert.equal(stepResult.status, 'done');
           assert.deepStrictEqual(stepResult.blockers, []);
@@ -113,7 +113,7 @@ describe('wrap-pipeline (#139 Chunk 3)', () => {
       const result = await wrapPipeline.runWrapPipeline('pipeline-test');
       assert.deepStrictEqual(
         result.results.map((r) => r.stepId),
-        ['open-pr-check', 'changelog-update', 'version-bump', 'learnings-capture', 'learnings-db-write', 'next-session-prime', 'features-toc', 'project-map', 'index-describe', 'memory-update', 'commit', 'continuity-write', 'apply-pr-resolutions']
+        ['open-pr-check', 'changelog-update', 'version-bump', 'learnings-capture', 'learnings-db-write', 'rule-proposal', 'next-session-prime', 'features-toc', 'project-map', 'index-describe', 'memory-update', 'commit', 'continuity-write', 'apply-pr-resolutions']
       );
     });
 
@@ -121,7 +121,7 @@ describe('wrap-pipeline (#139 Chunk 3)', () => {
       const result = await wrapPipeline.runWrapPipeline('pipeline-test');
       const kinds = result.results.map((r) => r.kind);
       assert.deepStrictEqual(kinds,
-        ['pr-check', 'ai-content', 'version-bump', 'ai-content', 'learnings-db-write', 'priming-roll', 'features-toc', 'project-map', 'index-describe', 'ai-content', 'commit', 'continuity-write', 'pr-merge']);
+        ['pr-check', 'ai-content', 'version-bump', 'ai-content', 'learnings-db-write', 'rule-proposal', 'priming-roll', 'features-toc', 'project-map', 'index-describe', 'ai-content', 'commit', 'continuity-write', 'pr-merge']);
     });
 
     it('runner is transactionally inert — every stub receives an empty staged scratch and no step writes to it', async () => {
@@ -134,7 +134,7 @@ describe('wrap-pipeline (#139 Chunk 3)', () => {
       // Patch every kind the pipeline actually uses (incl. `continuity-write`, CC-1, and
       // `project-map`, PIDX slice 3) so the inertness check captures all ten
       // steps rather than letting a real handler run mid-test.
-      const wrapKinds = ['pr-check', 'pr-merge', 'lint', 'test', 'ai-content', 'learnings-db-write', 'priming-roll', 'version-bump', 'features-toc', 'project-map', 'index-describe', 'commit', 'continuity-write'];
+      const wrapKinds = ['pr-check', 'pr-merge', 'lint', 'test', 'ai-content', 'learnings-db-write', 'rule-proposal', 'priming-roll', 'version-bump', 'features-toc', 'project-map', 'index-describe', 'commit', 'continuity-write'];
       const originals = {};
       for (const kind of wrapKinds) {
         originals[kind] = wrapPipeline.STEP_DISPATCH[kind];
@@ -148,7 +148,7 @@ describe('wrap-pipeline (#139 Chunk 3)', () => {
 
       try {
         await wrapPipeline.runWrapPipeline('pipeline-test');
-        assert.equal(capturedStaged.length, 13, 'every prawduct step receives a context');
+        assert.equal(capturedStaged.length, 14, 'every prawduct step receives a context');
         // All captured references must be the SAME object (single-transaction
         // shared scratch) AND must remain {} (no step wrote to it).
         for (let i = 0; i < capturedStaged.length; i++) {
@@ -167,7 +167,7 @@ describe('wrap-pipeline (#139 Chunk 3)', () => {
     // #583 — `options.onStepStart` progress hook feeds the wrap-run
     // registry so `GET /wrap/status` can report where a running wrap is.
     it('#583 — invokes onStepStart before each dispatched step, in template order', async () => {
-      const wrapKinds = ['pr-check', 'pr-merge', 'lint', 'test', 'ai-content', 'learnings-db-write', 'priming-roll', 'version-bump', 'features-toc', 'project-map', 'index-describe', 'commit', 'continuity-write'];
+      const wrapKinds = ['pr-check', 'pr-merge', 'lint', 'test', 'ai-content', 'learnings-db-write', 'rule-proposal', 'priming-roll', 'version-bump', 'features-toc', 'project-map', 'index-describe', 'commit', 'continuity-write'];
       const originals = {};
       const dispatched = [];
       for (const kind of wrapKinds) {
@@ -184,7 +184,7 @@ describe('wrap-pipeline (#139 Chunk 3)', () => {
         await wrapPipeline.runWrapPipeline('pipeline-test', {
           onStepStart: (stepId, kind) => started.push({ stepId, kind })
         });
-        assert.equal(started.length, 13, 'hook fires once per step');
+        assert.equal(started.length, 14, 'hook fires once per step');
         assert.deepStrictEqual(started.map((s) => s.stepId), dispatched,
           'hook order matches dispatch order');
         assert.equal(started[0].kind, 'pr-check', 'hook receives the step kind');
@@ -200,7 +200,7 @@ describe('wrap-pipeline (#139 Chunk 3)', () => {
     });
 
     it('#583 — onStepStart does not fire for pending steps after a halt, and a throwing hook never alters the outcome', async () => {
-      const wrapKinds = ['pr-check', 'pr-merge', 'lint', 'test', 'ai-content', 'learnings-db-write', 'priming-roll', 'version-bump', 'features-toc', 'project-map', 'index-describe', 'commit', 'continuity-write'];
+      const wrapKinds = ['pr-check', 'pr-merge', 'lint', 'test', 'ai-content', 'learnings-db-write', 'rule-proposal', 'priming-roll', 'version-bump', 'features-toc', 'project-map', 'index-describe', 'commit', 'continuity-write'];
       const originals = {};
       for (const kind of wrapKinds) {
         originals[kind] = wrapPipeline.STEP_DISPATCH[kind];


### PR DESCRIPTION
Chunk 05a of the Wrap v2 / methodology-sunset plan. Closes the engine half of #569.

## What was broken

Both halves of #569's loop were drawn but not connected:

- Every learning a wrap captured was written `tier:'provisional'`, and **nothing in the codebase ever advanced one**. `getActive()` feeds the `## Active Learnings` block injected at session start — so that block was empty on every project, permanently.
- **Nothing turned a learning into a rule.** `promoteFromLearning` had exactly one caller: an HTTP route no UI ever invoked.

## What discovery changed

The advancer looked nearly free — `learnings-db-write` already dedups, `confirm()` already auto-promotes. Both turned out to be traps:

1. **The dedup compares full content *including* the entry's own `## YYYY-MM-DD` heading**, so it is a same-day *retry* guard that can never see a recurrence across sessions. A date-independent normalized key was the actual missing piece.
2. **`confirm()` promotes at 2 *confirmations* — three sightings.** For exactly-matching normalized text that essentially never happens, so deferring to it would have shipped a loop that technically works and practically doesn't. The step owns a two-sighting bar; `confirm()`'s general contract is untouched.

## The state model

`session_rules.status` — `proposed | active | rejected` (v26→v27, CHECK-constrained), **orthogonal to `enabled`**. `enabled` means "the operator switched this off"; storing proposals there would make a *rejected* rule indistinguishable from an unreviewed one, and the wrap would re-propose declined rules forever. Rejection is a recorded state for exactly that reason.

Only `active` is ever injected — launch prime, Project Master, and the wrap's own prompts.

## The safety property, and its honest ceiling

AI authorship cannot produce a governing rule on its own say-so, enforced at **both** doors into `active` (`create` and `setStatus`) because a gate on one entrance is not a gate. `createdBy` can't decide it alone — it records *authorship*, not *authority*; a rule promoted from a learning is genuinely AI-authored even when an operator pressed the button.

**The Critic caught me handing that away at the HTTP boundary.** The promote route asserted operator authority simply because it had been reached, and the status route trusted a caller-supplied `changedBy`. This API is on localhost and this project instructs in-session agents to call it — so an agent could `curl` a learning straight to a governing rule while every store-level test stayed green. Authority now comes from the operator-password gate (`checkDeletePassword`), the same gate as deleting a project.

That gate permits everyone when no delete password is configured. The docs and CHANGELOG now say so plainly rather than claiming an unconditional human gate — the false assurance was the real defect.

## Critic

`cumulative` → 2 blocking, 15 warning → fixed → `verify-resolutions` → 0 blocking, 5 warning → fixed → `verify-resolutions` → **0 blocking**. Also fixed: `findConflictCandidates` (missed in my status-reader audit — I swept injection sites and stopped), the recurrence map keeping the newest row while its comment claimed oldest, proposals rendering as live rules in the Project Rules modal, and a missing drawer detail that made a wrap which proposed rules look like one that proposed none.

## Test plan

- `node --test 'test/*.test.js'` → **4714 pass, 0 fail, 1 skipped**
- New: `test/self-improvement-loop.test.js` (28), `test/api-self-improvement.test.js` (15)
- Migration verified against a **real pre-v27 database**, including one carrying an **orphaned foreign key** — the rebuild disables FK enforcement per SQLite's documented procedure so a pre-existing orphan survives the upgrade instead of aborting it
- Every gate falsified by reverting it. That caught one test that was *not* load-bearing: the oldest-first sort test passed with the sort removed, because both rows shared a second-resolution `created_at`. Timestamps are now pinned and it fails correctly.

## Deferred to 05b (not lost)

- The one-click approve / edit / reject UI. Approve/reject is API-only here.
- `session_rule_versions` has no `status` column, so a decision is recorded as free-text `change_reason` — documented in the JSDoc rather than glossed.