### PR TITLE
Give wrap rule proposals an operator review surface (#569)

### DIFF
--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -26,6 +26,41 @@ Tag-line conventions (ART-4K9M, ratified 2026-07-17):
 -->
 
 
+## 2026-07-20: Chunk 05b — the operator review surface for wrap-proposed rules (#569)
+
+<!-- prawduct: type=feat | chunks=05b | scope=wrap-v2 -->
+
+**Why:** 05a made the loop safe and auditable but API-only — a proposal could only be
+approved or rejected by hand-crafting a `curl`, and the operator is almost always remote,
+on a phone. The review surface is what makes the human gate usable rather than
+theoretical.
+
+**What:** the wrap drawer renders the `rule-proposal` step's output as a decision widget
+following the established descriptor→renderer pattern (`ruleProposalWidget` in
+`public/wrap-drawer.js`; `renderRuleProposalWidget` / `resolveRuleProposal` in
+`public/session.js`): per proposal, editable text + Approve / Reject. Approve saves any
+edit BEFORE flipping status (never activate text the operator didn't see), replays the
+wrap modal's cached password against the `PUT /api/session-rules/:id/status` gate, and a
+403 reveals an inline password input instead of failing opaquely. Reject is ungated and
+recorded. Decisions are per-rule API writes, not pipeline retries — no double-commit
+path. The step now also reports the provisional-learnings backlog on every exit path
+(`lib/wrap-steps/rule-proposal.js` counts `tier:'provisional'`; the drawer's detail line
+and skip reasons carry "N provisional learnings building recurrence" — #569 proposal 3).
+Pending proposals also surface in the Settings modal's Project Rules list with an amber
+`Proposed` badge and an inert enabled-toggle (`fetchProjectRules` now fetches unfiltered
+and drops only rejections client-side). `public/sw.js` CACHE_NAME bumped (ui.js/style.css
+are precached).
+
+**Tests:** `test/wrap-rule-proposal-widget.test.js` (new — source-level pins on the
+widget: edit-save ordering, 403 recovery, no-retry, a11y, 44px targets);
+`test/wrap-drawer.test.js` (+8: `ruleProposalWidget` edge cases, backlog detail);
+`test/self-improvement-loop.test.js` (+4: backlog counts on every step exit path);
+`test/project-rules-modal.test.js` (+4: badge, unfiltered fetch, inert toggle). Full
+suite 4743 pass / 0 fail / 1 skipped.
+
+**Operator verification:** queued as VRF-569-proposal-review (visual, iPhone). Closes
+#569 with 05a.
+
 ## 2026-07-20: Chunk 05a — the self-improvement loop stops being a loop on paper (#569)
 
 <!-- prawduct: type=feat | chunks=05a | scope=wrap-v2 | status=shipped -->

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -48,15 +48,21 @@ path. The step now also reports the provisional-learnings backlog on every exit 
 and skip reasons carry "N provisional learnings building recurrence" — #569 proposal 3).
 Pending proposals also surface in the Settings modal's Project Rules list with an amber
 `Proposed` badge and an inert enabled-toggle (`fetchProjectRules` now fetches unfiltered
-and drops only rejections client-side). `public/sw.js` CACHE_NAME bumped (ui.js/style.css
+and drops only rejections client-side). Per the cumulative Critic's two warnings (one
+root), the modal is the **durable** decision surface: the drawer renders only the wrap
+that just ran, so proposed rows carry their own Approve / Reject buttons IN PLACE of
+Delete (`resolveProjectRuleProposal`) — deleting a proposed row would erase the recorded
+decision and re-arm re-proposal; approve is the same gated status route, with a hidden
+password field revealed on 403. `public/sw.js` CACHE_NAME bumped (ui.js/style.css
 are precached).
 
 **Tests:** `test/wrap-rule-proposal-widget.test.js` (new — source-level pins on the
 widget: edit-save ordering, 403 recovery, no-retry, a11y, 44px targets);
 `test/wrap-drawer.test.js` (+8: `ruleProposalWidget` edge cases, backlog detail);
 `test/self-improvement-loop.test.js` (+4: backlog counts on every step exit path);
-`test/project-rules-modal.test.js` (+4: badge, unfiltered fetch, inert toggle). Full
-suite 4743 pass / 0 fail / 1 skipped.
+`test/project-rules-modal.test.js` (+6: badge, unfiltered fetch, inert toggle,
+Approve/Reject-instead-of-Delete, status-route wiring with 403 password reveal). Full
+suite 4745 pass / 0 fail / 1 skipped.
 
 **Operator verification:** queued as VRF-569-proposal-review (visual, iPhone). Closes
 #569 with 05a.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,10 @@ All notable changes to TangleClaw are documented in this file.
   the drawer re-uses the password you already typed); reject is recorded so the same
   learning is never re-proposed. The step's row also reports the provisional-learnings
   backlog ("N provisional learnings building recurrence"), so the loop's queue is visible
-  instead of silent, and pending proposals appear in the Settings modal's Project Rules
-  list with a `Proposed` badge until you decide.
+  instead of silent. And because the drawer only shows the wrap that just ran, pending
+  proposals also appear in the Settings modal's Project Rules list with a `Proposed`
+  badge and their own Approve / Reject buttons — closed the drawer, changed your mind
+  later, either way the decision is always one tap away.
 
 ## [4.28.0] - 2026-07-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **You can now approve, edit, or reject the wrap's rule proposals from the wrap drawer
+  (#569).** The self-improvement loop shipped safe-but-API-only: the wrap proposed rules
+  from recurring learnings, but acting on a proposal meant hand-crafting a `curl`. Now a
+  wrap that proposed rules renders each one in the drawer with its text editable in place
+  and one-tap Approve / Reject — approve saves your edit first, then makes the rule
+  govern future sessions (behind the same operator password gate as the wrap itself, and
+  the drawer re-uses the password you already typed); reject is recorded so the same
+  learning is never re-proposed. The step's row also reports the provisional-learnings
+  backlog ("N provisional learnings building recurrence"), so the loop's queue is visible
+  instead of silent, and pending proposals appear in the Settings modal's Project Rules
+  list with a `Proposed` badge until you decide.
+
 ## [4.28.0] - 2026-07-19
 
 ### Added

--- a/docs/session-rules-self-improvement.md
+++ b/docs/session-rules-self-improvement.md
@@ -97,6 +97,17 @@ was empty on every project and rules never evolved.
    proposal is never re-proposed, which is why rejection is a recorded state rather than a
    delete.
 
+   The review surface is the **wrap drawer**: when the `rule-proposal` step proposed
+   anything, its results render as a decision widget — one row per proposal with editable
+   text plus Approve / Reject. Approve saves any edit *first*, then flips the status
+   (password-gated, replaying the password the wrap modal already collected; a 403 reveals
+   an inline password input). Reject needs no password. The step's row also reports the
+   provisional-learnings backlog ("N provisional learnings building recurrence") so a
+   young loop is distinguishable from a dead one. Between wraps, pending proposals stay
+   visible in the Settings modal's Project Rules list with a `Proposed` badge and an inert
+   enabled-toggle; rejected rules don't render there (the record lives in the DB and the
+   rule's version history, not the working list).
+
 **The gate, stated once:** AI authorship cannot produce a governing rule on its own say-so.
 `createdBy` records *authorship*, not *authority* — a rule promoted from a learning is
 genuinely AI-authored, yet an operator pressing Promote must produce a live rule. Authority

--- a/docs/session-rules-self-improvement.md
+++ b/docs/session-rules-self-improvement.md
@@ -103,10 +103,16 @@ was empty on every project and rules never evolved.
    (password-gated, replaying the password the wrap modal already collected; a 403 reveals
    an inline password input). Reject needs no password. The step's row also reports the
    provisional-learnings backlog ("N provisional learnings building recurrence") so a
-   young loop is distinguishable from a dead one. Between wraps, pending proposals stay
-   visible in the Settings modal's Project Rules list with a `Proposed` badge and an inert
-   enabled-toggle; rejected rules don't render there (the record lives in the DB and the
-   rule's version history, not the working list).
+   young loop is distinguishable from a dead one.
+
+   The drawer widget renders only the wrap that just ran, so the **Project Rules list**
+   (Settings modal) is the *durable* decision surface: pending proposals appear there with
+   a `Proposed` badge, an inert enabled-toggle, and their own Approve / Reject buttons —
+   deliberately in place of Delete, because deleting a proposed row would erase the
+   recorded decision and re-arm re-proposal at the next wrap. Approve there is gated by
+   the same operator password (revealed inline on 403). Rejected rules don't render in
+   the list (the record lives in the DB and the rule's version history, not the working
+   list).
 
 **The gate, stated once:** AI authorship cannot produce a governing rule on its own say-so.
 `createdBy` records *authorship*, not *authority* — a rule promoted from a learning is

--- a/lib/wrap-steps/rule-proposal.js
+++ b/lib/wrap-steps/rule-proposal.js
@@ -59,6 +59,23 @@ async function run(context) {
   const project = context && context.project;
   if (!project || !project.id) return _skipped('no project id — cannot propose rules');
 
+  // The provisional backlog — learnings captured but not yet recurring enough
+  // to advance. Proposals only ever come from ACTIVE learnings, so without
+  // this count a healthy-but-young loop is indistinguishable from a dead one:
+  // "nothing to propose" reads the same whether zero learnings exist or ten
+  // are one recurrence away. Counted up front so every exit path can carry it.
+  let provisionalCount = 0;
+  try {
+    provisionalCount = store.learnings.list(project.id, { tier: 'provisional' }).length;
+  } catch (err) {
+    log.warn('provisional-learnings count unavailable — continuing without it', {
+      project: project.name, error: err.message
+    });
+  }
+  const backlogNote = provisionalCount > 0
+    ? ` (${provisionalCount} provisional learning${provisionalCount === 1 ? '' : 's'} building recurrence)`
+    : '';
+
   let learnings;
   try {
     learnings = store.learnings.getActive(project.id);
@@ -66,7 +83,7 @@ async function run(context) {
     return _skipped(`learnings.getActive failed: ${err.message}`);
   }
   if (!learnings || learnings.length === 0) {
-    return _skipped('no active learnings — nothing recurring enough to propose');
+    return _skipped(`no active learnings — nothing recurring enough to propose${backlogNote}`);
   }
 
   // Every learning that has ALREADY produced a rule is off the table, whatever
@@ -86,7 +103,7 @@ async function run(context) {
 
   const candidates = learnings.filter((l) => !alreadyProposed.has(l.id));
   if (candidates.length === 0) {
-    return _skipped(`all ${learnings.length} active learning(s) already have a rule or a decision`);
+    return _skipped(`all ${learnings.length} active learning(s) already have a rule or a decision${backlogNote}`);
   }
 
   const proposed = [];
@@ -125,7 +142,12 @@ async function run(context) {
   return {
     ok: true,
     status: 'done',
-    output: { proposed, count: proposed.length, detail },
+    output: {
+      proposed,
+      count: proposed.length,
+      detail,
+      backlog: { provisional: provisionalCount }
+    },
     blockers: []
   };
 }

--- a/public/session.css
+++ b/public/session.css
@@ -2174,6 +2174,65 @@ body {
   opacity: 0.6;
   cursor: default;
 }
+/* #569 rule-proposal review widget — one row per proposed rule with
+   editable text + Approve/Reject. Touch-first: 44px action targets. */
+.wrap-proposal-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.wrap-proposal-row {
+  padding: 8px;
+  background: var(--card-bg);
+  border-left: 3px solid #fb923c;
+  border-radius: 4px;
+}
+.wrap-proposal-row--decided {
+  opacity: 0.75;
+  border-left-color: var(--elevated-bg);
+}
+.wrap-proposal-row--decided .wrap-proposal-actions {
+  display: none;
+}
+.wrap-proposal-text {
+  width: 100%;
+  min-height: 64px;
+  resize: vertical;
+  font-family: inherit;
+  font-size: 0.9rem;
+  padding: 6px 8px;
+  background: var(--elevated-bg);
+  border: 1px solid var(--elevated-bg);
+  border-radius: 4px;
+  color: var(--text-primary);
+}
+.wrap-proposal-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+}
+.wrap-proposal-actions .btn {
+  min-height: 44px;
+  min-width: 88px;
+}
+.wrap-proposal-note {
+  margin: 6px 0 0;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+.wrap-proposal-password {
+  margin-top: 10px;
+}
+.wrap-proposal-password-input {
+  width: 100%;
+  min-height: 44px;
+  padding: 8px;
+  background: var(--card-bg);
+  border: 1px solid var(--elevated-bg);
+  border-radius: 4px;
+  color: var(--text-primary);
+  font-size: 0.9rem;
+}
 /* Per-step help glyph — tap/click to reveal inline "what this step does"
    text (works on touch; native title= is a desktop hover bonus). */
 .wrap-step-help {

--- a/public/session.js
+++ b/public/session.js
@@ -3314,6 +3314,17 @@ function renderWrapDrawer(pipelineResult) {
         widgetRendered = true;
       }
     }
+    if (row.kind === 'rule-proposal') {
+      // #569: the wrap proposed rules from recurring learnings. Like the
+      // plan-picker this widget performs per-rule API writes (approve/reject),
+      // not a pipeline retry — so it does NOT set `warningOnly`: the step is
+      // done, the decisions are independent of the wrap, and Done just closes.
+      const rpWidget = H.ruleProposalWidget(row, raw.output);
+      if (rpWidget) {
+        decisionEl.appendChild(renderRuleProposalWidget(rpWidget));
+        widgetRendered = true;
+      }
+    }
   }
   decisionEl.classList.toggle('hidden', !widgetRendered);
 
@@ -3678,6 +3689,174 @@ async function setActivePlan(sel, btn, noteEl) {
   }
   noteEl.textContent = `Active plan set to ${filename} ✓ — the next wrap will roll its pointer. Click Done to close.`;
   btn.textContent = 'Saved';
+}
+
+/**
+ * Build the rule-proposal review widget (#569) — one row per proposed rule
+ * with editable text and Approve / Reject buttons. Each decision is an
+ * independent API write (no pipeline retry, no double-commit risk): approve
+ * saves any text edit first, then flips the rule to `active`; reject flips it
+ * to `rejected`, which is recorded so the same learning is never re-proposed.
+ *
+ * Approval is a protected operation server-side (the same operator gate as
+ * the wrap itself), so the widget replays the wrap modal's cached password
+ * and only surfaces a password input if the server actually refuses (403) —
+ * e.g. after a page reload dropped the cache.
+ *
+ * @param {object} widget - From `ruleProposalWidget` ({kind, proposals}).
+ * @returns {HTMLDivElement}
+ */
+function renderRuleProposalWidget(widget) {
+  const wrap = document.createElement('div');
+  wrap.className = 'wrap-decision wrap-decision--proposals';
+  wrap.dataset.kind = 'rule-proposal';
+
+  const groupLabelId = 'wrapRuleProposalGroupLabel';
+  const label = document.createElement('div');
+  label.className = 'wrap-decision-label';
+  label.id = groupLabelId;
+  const n = widget.proposals.length;
+  label.textContent = `The wrap proposed ${n} rule${n === 1 ? '' : 's'} from recurring learnings:`;
+  wrap.appendChild(label);
+
+  const why = document.createElement('p');
+  why.className = 'wrap-decision-help';
+  why.textContent = 'Why: a learning that kept recurring across sessions is a candidate rule for future sessions. Nothing governs anything until you approve it — edit the text first if it needs sharpening. Rejections are remembered, so a rejected rule won’t be proposed again.';
+  wrap.appendChild(why);
+
+  // Hidden until the server refuses an approval (403) — normally the wrap
+  // modal's cached password covers it and this never appears. Created before
+  // the rows because each row's buttons capture it.
+  const pwGroup = document.createElement('div');
+  pwGroup.className = 'wrap-proposal-password hidden';
+  const pwLabel = document.createElement('label');
+  pwLabel.className = 'wrap-decision-label';
+  pwLabel.htmlFor = 'wrapProposalPassword';
+  pwLabel.textContent = 'Approving a rule needs the delete password:';
+  const pwInput = document.createElement('input');
+  pwInput.type = 'password';
+  pwInput.id = 'wrapProposalPassword';
+  pwInput.className = 'wrap-proposal-password-input';
+  pwInput.autocomplete = 'current-password';
+  pwGroup.appendChild(pwLabel);
+  pwGroup.appendChild(pwInput);
+
+  const list = document.createElement('div');
+  list.className = 'wrap-proposal-list';
+  list.setAttribute('role', 'group');
+  list.setAttribute('aria-labelledby', groupLabelId);
+  for (const p of widget.proposals) {
+    const row = document.createElement('div');
+    row.className = 'wrap-proposal-row';
+    row.dataset.ruleId = String(p.ruleId);
+
+    const ta = document.createElement('textarea');
+    ta.className = 'wrap-proposal-text';
+    ta.value = p.content;
+    ta.rows = 3;
+    ta.spellcheck = false;
+    ta.setAttribute('aria-label', `Proposed rule ${p.ruleId} — edit before approving if needed`);
+    row.appendChild(ta);
+
+    const actions = document.createElement('div');
+    actions.className = 'wrap-proposal-actions';
+    const approveBtn = document.createElement('button');
+    approveBtn.type = 'button';
+    approveBtn.className = 'btn btn-small btn-primary wrap-proposal-approve';
+    approveBtn.textContent = 'Approve';
+    approveBtn.title = 'Make this a governing rule for future sessions (saves your edits first).';
+    const rejectBtn = document.createElement('button');
+    rejectBtn.type = 'button';
+    rejectBtn.className = 'btn btn-small wrap-proposal-reject';
+    rejectBtn.textContent = 'Reject';
+    rejectBtn.title = 'Decline — recorded so this learning is not proposed again.';
+    actions.appendChild(approveBtn);
+    actions.appendChild(rejectBtn);
+    row.appendChild(actions);
+
+    const note = document.createElement('p');
+    note.className = 'wrap-proposal-note';
+    note.setAttribute('role', 'status');
+    row.appendChild(note);
+
+    approveBtn.addEventListener('click', () =>
+      resolveRuleProposal(p, 'active', { row, ta, approveBtn, rejectBtn, note, passwordGroup: pwGroup, passwordInput: pwInput }));
+    rejectBtn.addEventListener('click', () =>
+      resolveRuleProposal(p, 'rejected', { row, ta, approveBtn, rejectBtn, note, passwordGroup: pwGroup, passwordInput: pwInput }));
+    list.appendChild(row);
+  }
+  wrap.appendChild(list);
+  wrap.appendChild(pwGroup);
+
+  return wrap;
+}
+
+/**
+ * Resolve one proposed rule — approve into a governing rule or reject (#569).
+ * Approve saves a text edit first (PUT content), then flips status; the two
+ * writes are sequential so an edit can never be approved un-saved. Reflects
+ * the outcome inline and disables the row once decided; on a 403 (password
+ * gate) reveals the widget's password input instead of failing opaquely.
+ *
+ * @param {{ruleId: number, content: string}} proposal - The proposal as rendered.
+ * @param {'active'|'rejected'} decision - The operator's answer.
+ * @param {object} els - Row elements: {row, ta, approveBtn, rejectBtn, note, passwordGroup, passwordInput}.
+ */
+async function resolveRuleProposal(proposal, decision, els) {
+  const { ta, approveBtn, rejectBtn, note, passwordGroup, passwordInput } = els;
+  approveBtn.disabled = true;
+  rejectBtn.disabled = true;
+  ta.disabled = true;
+
+  const finishEnabled = () => {
+    approveBtn.disabled = false;
+    rejectBtn.disabled = false;
+    ta.disabled = false;
+  };
+
+  if (decision === 'active') {
+    const edited = ta.value.trim();
+    if (!edited) {
+      note.textContent = 'Rule text can’t be empty — edit it or Reject instead.';
+      finishEnabled();
+      return;
+    }
+    if (edited !== proposal.content.trim()) {
+      const saved = await apiMutate(`/api/session-rules/${proposal.ruleId}`, 'PUT', { content: edited });
+      if (!saved) {
+        note.textContent = `Couldn’t save your edit: ${api.lastError || 'unknown error'}. Nothing was approved.`;
+        finishEnabled();
+        return;
+      }
+      proposal.content = edited;
+    }
+    const body = { status: 'active' };
+    const pw = (passwordInput && passwordInput.value) || currentWrapPassword;
+    if (pw) body.password = pw;
+    const data = await apiMutate(`/api/session-rules/${proposal.ruleId}/status`, 'PUT', body);
+    if (!data) {
+      if (api.lastErrorCode === 'FORBIDDEN' && passwordGroup) {
+        passwordGroup.classList.remove('hidden');
+        note.textContent = 'The server needs the delete password to approve — enter it below and tap Approve again.';
+        if (passwordInput) passwordInput.focus();
+      } else {
+        note.textContent = `Approve failed: ${api.lastError || 'unknown error'}.`;
+      }
+      finishEnabled();
+      return;
+    }
+    note.textContent = 'Approved ✓ — this rule now governs future sessions.';
+  } else {
+    const data = await apiMutate(`/api/session-rules/${proposal.ruleId}/status`, 'PUT', { status: 'rejected' });
+    if (!data) {
+      note.textContent = `Reject failed: ${api.lastError || 'unknown error'}.`;
+      finishEnabled();
+      return;
+    }
+    note.textContent = 'Rejected — recorded, so this won’t be proposed again.';
+  }
+  // Decided: the row stays visible as a record but takes no further input.
+  els.row.classList.add('wrap-proposal-row--decided');
 }
 
 /**

--- a/public/style.css
+++ b/public/style.css
@@ -1039,6 +1039,14 @@ body {
   color: var(--engine-codex);
   vertical-align: middle;
 }
+/* #569: a wrap-proposed rule awaiting operator review — visible but not live. */
+.session-rule-badge--proposed {
+  background: rgba(251, 146, 60, 0.18);
+  color: #fb923c;
+}
+.session-rule-item--proposed {
+  border-left: 3px solid rgba(251, 146, 60, 0.6);
+}
 /* ── Project Rules section in Settings modal (CC-6, #381) ── */
 .project-rules-section {
   margin-top: 16px;

--- a/public/style.css
+++ b/public/style.css
@@ -1047,6 +1047,15 @@ body {
 .session-rule-item--proposed {
   border-left: 3px solid rgba(251, 146, 60, 0.6);
 }
+.session-rule-decide {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+  align-items: center;
+}
+.session-rule-decide .btn {
+  min-height: 44px;
+}
 /* ── Project Rules section in Settings modal (CC-6, #381) ── */
 .project-rules-section {
   margin-top: 16px;

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 // even after they hit Cmd+Shift+R. The network-first carve-out below
 // is the structural fix; this bump is the one-time unblock for
 // existing installs.
-const CACHE_NAME = 'tangleclaw-v3-54';
+const CACHE_NAME = 'tangleclaw-v3-55';
 const STATIC_ASSETS = [
   '/',
   '/style.css',

--- a/public/ui.js
+++ b/public/ui.js
@@ -1033,16 +1033,31 @@ function renderProjectRulesSection(project) {
 }
 
 /**
+ * Fetch one kind's rules for a project, ready to render: active rules plus
+ * pending proposals (#569 — a proposed rule is visible with a "Proposed"
+ * badge so the queue isn't silent), minus rejections (a rejected row is the
+ * record of a decision, not a rule — rendering it forever would read as
+ * clutter, and its whole point is that the wrap won't re-raise it).
+ * @param {number} projectId - DB project id
+ * @param {string} kind - Rule kind
+ * @returns {Promise<object[]>}
+ */
+async function fetchProjectRules(projectId, kind) {
+  const data = await api(`/api/session-rules?projectId=${encodeURIComponent(projectId)}&kind=${kind}`);
+  return (data ? data.rules || [] : []).filter((r) => r.status !== 'rejected');
+}
+
+/**
  * Fetch this project's rules for each kind and render its list.
  * @param {number} projectId - DB project id
  */
 async function loadProjectRules(projectId) {
   projectRulesTargetId = projectId;
   for (const { kind } of PROJECT_RULE_KINDS) {
-    const data = await api(`/api/session-rules?projectId=${encodeURIComponent(projectId)}&kind=${kind}&status=active`);
+    const rules = await fetchProjectRules(projectId, kind);
     // The modal may have been closed/reopened on another project while awaiting.
     if (projectRulesTargetId !== projectId) return;
-    renderProjectRulesList(kind, data ? data.rules || [] : []);
+    renderProjectRulesList(kind, rules);
   }
 }
 
@@ -1058,15 +1073,25 @@ function renderProjectRulesList(kind, rules) {
     list.innerHTML = '<p class="session-rules-empty">No rules yet.</p>';
     return;
   }
-  list.innerHTML = rules.map((rule) => `
-    <div class="session-rule-item${rule.enabled ? '' : ' session-rule-disabled'}" data-rule-id="${rule.id}">
+  list.innerHTML = rules.map((rule) => {
+    // #569: a proposed rule is in the review queue — it governs nothing yet,
+    // so its enabled-toggle is inert and disabled (checking it would read as
+    // "this is live"). The decision itself belongs to the wrap drawer's
+    // review widget (or the status API), not this list.
+    const isProposed = rule.status === 'proposed';
+    const badges = [
+      rule.createdBy === 'ai' ? '<span class="session-rule-badge" title="AI-authored">AI</span> ' : '',
+      isProposed ? '<span class="session-rule-badge session-rule-badge--proposed" title="Proposed by the wrap from a recurring learning — not governing sessions yet. Approve or reject it in the wrap drawer after a wrap.">Proposed</span> ' : ''
+    ].join('');
+    return `
+    <div class="session-rule-item${rule.enabled ? '' : ' session-rule-disabled'}${isProposed ? ' session-rule-item--proposed' : ''}" data-rule-id="${rule.id}">
       <label class="session-rule-toggle">
-        <input type="checkbox" data-action="toggle-rule" data-rule-id="${rule.id}" ${rule.enabled ? 'checked' : ''}>
+        <input type="checkbox" data-action="toggle-rule" data-rule-id="${rule.id}" ${rule.enabled && !isProposed ? 'checked' : ''} ${isProposed ? 'disabled' : ''}>
       </label>
-      <span class="session-rule-content">${rule.createdBy === 'ai' ? '<span class="session-rule-badge" title="AI-authored">AI</span> ' : ''}${esc(rule.content)}</span>
+      <span class="session-rule-content">${badges}${esc(rule.content)}</span>
       <button class="btn btn-small btn-danger session-rule-delete" data-action="delete-rule" data-rule-id="${rule.id}" aria-label="Delete rule">&times;</button>
-    </div>
-  `).join('');
+    </div>`;
+  }).join('');
 }
 
 /**
@@ -1084,8 +1109,7 @@ async function addProjectRule(kind) {
   if (data) {
     if (input) input.value = '';
     _setProjectRulesStatus('Added', true);
-    const list = await api(`/api/session-rules?projectId=${encodeURIComponent(projectRulesTargetId)}&kind=${kind}&status=active`);
-    renderProjectRulesList(kind, list ? list.rules || [] : []);
+    renderProjectRulesList(kind, await fetchProjectRules(projectRulesTargetId, kind));
   } else {
     _setProjectRulesStatus('Add failed', false);
   }
@@ -1100,8 +1124,7 @@ async function addProjectRule(kind) {
 async function toggleProjectRule(id, enabled, kind) {
   const data = await apiMutate(`/api/session-rules/${id}`, 'PUT', { enabled });
   if (!data) { _setProjectRulesStatus('Update failed', false); return; }
-  const list = await api(`/api/session-rules?projectId=${encodeURIComponent(projectRulesTargetId)}&kind=${kind}&status=active`);
-  renderProjectRulesList(kind, list ? list.rules || [] : []);
+  renderProjectRulesList(kind, await fetchProjectRules(projectRulesTargetId, kind));
 }
 
 /**
@@ -1113,8 +1136,7 @@ async function deleteProjectRule(id, kind) {
   const data = await apiMutate(`/api/session-rules/${id}`, 'DELETE', {});
   if (!data) { _setProjectRulesStatus('Delete failed', false); return; }
   _setProjectRulesStatus('Deleted', true);
-  const list = await api(`/api/session-rules?projectId=${encodeURIComponent(projectRulesTargetId)}&kind=${kind}&status=active`);
-  renderProjectRulesList(kind, list ? list.rules || [] : []);
+  renderProjectRulesList(kind, await fetchProjectRules(projectRulesTargetId, kind));
 }
 
 /**

--- a/public/ui.js
+++ b/public/ui.js
@@ -1028,6 +1028,10 @@ function renderProjectRulesSection(project) {
         <div class="wrap-section-grid">${sectionChecks}</div>
       </div>
       <div class="project-rules-grid">${ruleBlocks}</div>
+      <div id="projRulesPwGroup" class="form-group hidden">
+        <label class="form-label" for="projRulesPw">Delete password (required to approve a proposed rule)</label>
+        <input type="password" class="form-input" id="projRulesPw" autocomplete="current-password">
+      </div>
       <div id="projectRulesStatus" class="rules-status hidden" role="status"></div>
     </div>`;
 }
@@ -1076,20 +1080,29 @@ function renderProjectRulesList(kind, rules) {
   list.innerHTML = rules.map((rule) => {
     // #569: a proposed rule is in the review queue — it governs nothing yet,
     // so its enabled-toggle is inert and disabled (checking it would read as
-    // "this is live"). The decision itself belongs to the wrap drawer's
-    // review widget (or the status API), not this list.
+    // "this is live"). The decision affordances here are Approve/Reject, NOT
+    // Delete: the drawer widget only renders the wrap that just ran, so this
+    // list is the durable decision surface — and deleting a proposed row
+    // would erase the recorded decision and re-arm re-proposal at the next
+    // wrap (the exact zombie the recorded `rejected` state exists to prevent).
     const isProposed = rule.status === 'proposed';
     const badges = [
       rule.createdBy === 'ai' ? '<span class="session-rule-badge" title="AI-authored">AI</span> ' : '',
-      isProposed ? '<span class="session-rule-badge session-rule-badge--proposed" title="Proposed by the wrap from a recurring learning — not governing sessions yet. Approve or reject it in the wrap drawer after a wrap.">Proposed</span> ' : ''
+      isProposed ? '<span class="session-rule-badge session-rule-badge--proposed" title="Proposed by the wrap from a recurring learning — not governing sessions yet. Approve or reject it here, or in the wrap drawer right after the wrap that proposed it.">Proposed</span> ' : ''
     ].join('');
+    const actions = isProposed
+      ? `<span class="session-rule-decide">
+           <button class="btn btn-small btn-primary" data-action="approve-rule" data-rule-id="${rule.id}">Approve</button>
+           <button class="btn btn-small" data-action="reject-rule" data-rule-id="${rule.id}">Reject</button>
+         </span>`
+      : `<button class="btn btn-small btn-danger session-rule-delete" data-action="delete-rule" data-rule-id="${rule.id}" aria-label="Delete rule">&times;</button>`;
     return `
     <div class="session-rule-item${rule.enabled ? '' : ' session-rule-disabled'}${isProposed ? ' session-rule-item--proposed' : ''}" data-rule-id="${rule.id}">
       <label class="session-rule-toggle">
         <input type="checkbox" data-action="toggle-rule" data-rule-id="${rule.id}" ${rule.enabled && !isProposed ? 'checked' : ''} ${isProposed ? 'disabled' : ''}>
       </label>
       <span class="session-rule-content">${badges}${esc(rule.content)}</span>
-      <button class="btn btn-small btn-danger session-rule-delete" data-action="delete-rule" data-rule-id="${rule.id}" aria-label="Delete rule">&times;</button>
+      ${actions}
     </div>`;
   }).join('');
 }
@@ -1140,6 +1153,41 @@ async function deleteProjectRule(id, kind) {
 }
 
 /**
+ * Resolve a proposed rule from the Project Rules list (#569): approve it into
+ * a governing rule or reject it. This is the durable decision surface — the
+ * wrap drawer's widget only renders the wrap that just ran, so a proposal
+ * whose drawer was dismissed is decided here. Approve is password-gated
+ * server-side; the hidden password field is revealed on a 403 rather than
+ * asked for up-front (with no delete password configured it never appears).
+ * A rejected rule leaves the list on re-render — the record lives on in the
+ * DB, which is what stops the wrap re-proposing the same learning.
+ * @param {number} id - Rule id
+ * @param {'active'|'rejected'} status - The operator's decision
+ * @param {string} kind - Rule kind (for the targeted re-render)
+ */
+async function resolveProjectRuleProposal(id, status, kind) {
+  const body = { status };
+  const pwInput = document.getElementById('projRulesPw');
+  if (status === 'active' && pwInput && pwInput.value) body.password = pwInput.value;
+  const data = await apiMutate(`/api/session-rules/${id}/status`, 'PUT', body);
+  if (!data) {
+    const pwGroup = document.getElementById('projRulesPwGroup');
+    if (api.lastErrorCode === 'FORBIDDEN' && pwGroup) {
+      pwGroup.classList.remove('hidden');
+      _setProjectRulesStatus('Approving needs the delete password — enter it above and tap Approve again', false);
+      if (pwInput) pwInput.focus();
+    } else {
+      _setProjectRulesStatus(`${status === 'active' ? 'Approve' : 'Reject'} failed`, false);
+    }
+    return;
+  }
+  _setProjectRulesStatus(status === 'active'
+    ? 'Approved — this rule now governs future sessions'
+    : 'Rejected — recorded, so it won’t be proposed again', true);
+  renderProjectRulesList(kind, await fetchProjectRules(projectRulesTargetId, kind));
+}
+
+/**
  * Delegated handler for clicks/changes inside the Project Rules section.
  * Attached once to #settingsBody (stable element; innerHTML is swapped per open).
  * @param {Event} e
@@ -1156,6 +1204,10 @@ function handleProjectRulesEvent(e) {
     toggleProjectRule(Number(target.getAttribute('data-rule-id')), target.checked, kind);
   } else if (action === 'delete-rule' && e.type === 'click') {
     deleteProjectRule(Number(target.getAttribute('data-rule-id')), kind);
+  } else if (action === 'approve-rule' && e.type === 'click') {
+    resolveProjectRuleProposal(Number(target.getAttribute('data-rule-id')), 'active', kind);
+  } else if (action === 'reject-rule' && e.type === 'click') {
+    resolveProjectRuleProposal(Number(target.getAttribute('data-rule-id')), 'rejected', kind);
   }
 }
 

--- a/public/wrap-drawer.js
+++ b/public/wrap-drawer.js
@@ -21,6 +21,7 @@
     'ai-content': 'AI content',
     'priming-roll': 'Roll priming pointer',
     'version-bump': 'Version bump',
+    'rule-proposal': 'Propose rules',
     'commit': 'Commit'
   };
 
@@ -232,7 +233,17 @@
         // silent-loop problem #569 was filed about.
         const n = output.count;
         if (typeof n !== 'number' || n <= 0) return null;
-        return `${n} rule${n === 1 ? '' : 's'} proposed — awaiting your review`;
+        let text = `${n} rule${n === 1 ? '' : 's'} proposed — awaiting your review`;
+        // The provisional backlog rides along so the loop's queue is visible
+        // even in sessions that DID propose — "2 proposed, 3 more building
+        // recurrence" is the loop's whole state in one line (#569 proposal 3).
+        const prov = output.backlog && typeof output.backlog.provisional === 'number'
+          ? output.backlog.provisional
+          : 0;
+        if (prov > 0) {
+          text += ` · ${prov} provisional learning${prov === 1 ? '' : 's'} building recurrence`;
+        }
+        return text;
       }
       default:
         return null;
@@ -493,6 +504,36 @@
   }
 
   /**
+   * Descriptor for the rule-proposal review widget (#569): when the wrap
+   * proposed rules from recurring learnings, surface each proposal so the
+   * operator can approve, edit-then-approve, or reject it inline. Like the
+   * plan-picker this is a config write (PUT per rule), not a retry option —
+   * so it carries no `optionsKey` and never gates the pipeline: the step is
+   * done, the proposals simply await a decision. Returns `null` unless the
+   * step is a completed rule-proposal carrying ≥1 well-formed proposal
+   * (a `ruleId` to address and `content` to show).
+   *
+   * @param {object} stepRow - View-model from `buildStepRow`.
+   * @param {object} rawOutput - Raw `step.output` from the runner.
+   * @returns {{kind: 'rule-proposal', proposals: Array<{ruleId: number, learningId: number|null, content: string}>}|null}
+   */
+  function ruleProposalWidget(stepRow, rawOutput) {
+    if (!stepRow || stepRow.kind !== 'rule-proposal') return null;
+    if (stepRow.status !== 'done') return null;
+    if (!rawOutput || typeof rawOutput !== 'object') return null;
+    const proposed = Array.isArray(rawOutput.proposed) ? rawOutput.proposed : [];
+    const proposals = proposed
+      .filter((p) => p && typeof p.ruleId === 'number' && typeof p.content === 'string' && p.content.trim())
+      .map((p) => ({
+        ruleId: p.ruleId,
+        learningId: typeof p.learningId === 'number' ? p.learningId : null,
+        content: p.content
+      }));
+    if (proposals.length === 0) return null;
+    return { kind: 'rule-proposal', proposals };
+  }
+
+  /**
    * Read the drawer's decision-widget DOM and assemble an `options`
    * object suitable for the retry POST body. Pure aside from the DOM
    * reads, which take a document-like accessor so tests can stub.
@@ -657,6 +698,7 @@
     decisionWidgetForBlockedStep,
     prCheckResolutionWidget,
     planPickerWidget,
+    ruleProposalWidget,
     collectOptionsFromAccessors,
     accumulateAiContentSkips,
     buildReportText,

--- a/server.js
+++ b/server.js
@@ -1176,10 +1176,9 @@ route('GET', '/api/session-rules', (req, res) => {
   if (query.projectId !== undefined) options.projectId = Number(query.projectId);
   // CC-6 (#381): filter the per-project modal's rule boxes by kind.
   if (query.kind !== undefined) options.kind = query.kind;
-  // #569: review state. Unfiltered by default so a future review surface can
-  // list proposals; the Project Rules modal asks for `active` only, because it
-  // renders every row it receives as an enabled, governing rule and would
-  // otherwise show proposals and rejections as live.
+  // #569: review state. Unfiltered by default; the Project Rules modal fetches
+  // unfiltered and renders proposals with a "Proposed" badge (rejections it
+  // drops client-side — a rejected row is a decision record, not a rule).
   if (query.status !== undefined) options.status = query.status;
   const rules = store.sessionRules.list(options);
   jsonResponse(res, 200, { rules });

--- a/test/project-rules-modal.test.js
+++ b/test/project-rules-modal.test.js
@@ -131,6 +131,32 @@ describe('Project Rules modal (CC-6, #381)', () => {
       assert.match(ui, /\$\{isProposed \? 'disabled' : ''\}/);
     });
 
+    it('a proposed row offers Approve/Reject INSTEAD of Delete — deleting would erase the decision record', () => {
+      // The rule-proposal step's re-proposal guard is the rule row itself
+      // (sourceLearningId): delete the row and the same learning comes back
+      // next wrap. So Delete must not be the modal's dismissal gesture.
+      assert.match(ui, /const actions = isProposed\s*\?/);
+      assert.match(ui, /data-action="approve-rule"/);
+      assert.match(ui, /data-action="reject-rule"/);
+      // Delete renders only on the non-proposed arm of the ternary.
+      const renderFn = ui.slice(ui.indexOf('function renderProjectRulesList'), ui.indexOf('async function addProjectRule'));
+      const ternary = renderFn.slice(renderFn.indexOf('const actions = isProposed'));
+      const approveArm = ternary.slice(0, ternary.indexOf(':'));
+      assert.ok(!/delete-rule/.test(approveArm), 'the proposed arm must not render a delete button');
+    });
+
+    it('approve/reject wire to the status route, with 403 revealing the password field', () => {
+      assert.match(ui, /async function resolveProjectRuleProposal\(id, status, kind\)/);
+      assert.match(ui, /apiMutate\(`\/api\/session-rules\/\$\{id\}\/status`, 'PUT', body\)/);
+      assert.match(ui, /lastErrorCode === 'FORBIDDEN'/);
+      assert.match(ui, /projRulesPwGroup/);
+      // The password group starts hidden — it only appears when the server refuses.
+      assert.match(ui, /id="projRulesPwGroup" class="form-group hidden"/);
+      // Both decisions are delegated through the section's event handler.
+      assert.match(ui, /action === 'approve-rule'/);
+      assert.match(ui, /action === 'reject-rule'/);
+    });
+
     it('style.css styles the proposed badge and row accent', () => {
       assert.match(css, /\.session-rule-badge--proposed\s*\{/);
       assert.match(css, /\.session-rule-item--proposed\s*\{/);

--- a/test/project-rules-modal.test.js
+++ b/test/project-rules-modal.test.js
@@ -100,4 +100,40 @@ describe('Project Rules modal (CC-6, #381)', () => {
       assert.match(css, /\.project-rules-block\s*\{/);
     });
   });
+
+  describe('#569 — proposal visibility in the rules list', () => {
+    it('fetches unfiltered and drops only rejections client-side', () => {
+      // Proposals must reach the list (they get a badge); rejections must not
+      // (a rejected row is a decision record, not a rule).
+      assert.match(ui, /async function fetchProjectRules\(projectId, kind\)/);
+      assert.match(ui, /\.filter\(\(r\) => r\.status !== 'rejected'\)/);
+      // The project-rules fetch must not re-narrow to active-only, which would
+      // silently hide the proposal queue again. (The Master rules fetches stay
+      // active-only on purpose — the wrap never proposes master rules.)
+      const helperStart = ui.indexOf('async function fetchProjectRules');
+      const helperEnd = ui.indexOf('async function loadProjectRules');
+      assert.ok(helperStart !== -1 && helperEnd > helperStart);
+      assert.doesNotMatch(ui.slice(helperStart, helperEnd), /status=/);
+      // And no per-kind re-fetch elsewhere in the modal bypasses the helper.
+      assert.doesNotMatch(ui, /projectId=\$\{encodeURIComponent\(projectRulesTargetId\)\}&kind=\$\{kind\}&status=/);
+    });
+
+    it('renders a Proposed badge on proposed rules, alongside the AI badge', () => {
+      assert.match(ui, /session-rule-badge--proposed/);
+      assert.match(ui, /rule\.status === 'proposed'/);
+      // The AI-authorship badge must survive — status and authorship are
+      // different facts and both render.
+      assert.match(ui, /AI-authored/);
+    });
+
+    it('a proposed rule’s enabled-toggle is inert — it governs nothing yet', () => {
+      assert.match(ui, /rule\.enabled && !isProposed \? 'checked' : ''/);
+      assert.match(ui, /\$\{isProposed \? 'disabled' : ''\}/);
+    });
+
+    it('style.css styles the proposed badge and row accent', () => {
+      assert.match(css, /\.session-rule-badge--proposed\s*\{/);
+      assert.match(css, /\.session-rule-item--proposed\s*\{/);
+    });
+  });
 });

--- a/test/self-improvement-loop.test.js
+++ b/test/self-improvement-loop.test.js
@@ -417,4 +417,44 @@ describe('self-improvement loop (#569)', () => {
       assert.equal(res.status, 'skipped');
     });
   });
+
+  describe('the provisional backlog is visible, not silent (#569 proposal 3)', () => {
+    // Proposals only come from ACTIVE learnings, so without the backlog count a
+    // young-but-healthy loop ("3 learnings one recurrence away") reads exactly
+    // like a dead one ("no learnings at all"). Each exit path must carry it.
+
+    it('a skip for no active learnings names how many provisional ones are building recurrence', async () => {
+      store.learnings.create({ projectId: project.id, content: 'seen once', tier: 'provisional' });
+      store.learnings.create({ projectId: project.id, content: 'also once', tier: 'provisional' });
+      const res = await ruleProposal.run({ project });
+      assert.equal(res.status, 'skipped');
+      assert.match(res.output.reason, /2 provisional learnings building recurrence/);
+    });
+
+    it('a skip with a genuinely empty backlog does not claim one', async () => {
+      const res = await ruleProposal.run({ project });
+      assert.equal(res.status, 'skipped');
+      assert.doesNotMatch(res.output.reason, /provisional/);
+    });
+
+    it('an all-decided skip still reports the backlog', async () => {
+      store.learnings.create({ projectId: project.id, content: 'recurring', tier: 'active' });
+      store.learnings.create({ projectId: project.id, content: 'young', tier: 'provisional' });
+      await ruleProposal.run({ project });
+      const again = await ruleProposal.run({ project });
+      assert.equal(again.status, 'skipped');
+      assert.match(again.output.reason, /already have a rule or a decision/);
+      assert.match(again.output.reason, /1 provisional learning building recurrence/);
+    });
+
+    it('a done result carries the count as structured output for the drawer', async () => {
+      store.learnings.create({ projectId: project.id, content: 'recurring', tier: 'active' });
+      store.learnings.create({ projectId: project.id, content: 'young A', tier: 'provisional' });
+      store.learnings.create({ projectId: project.id, content: 'young B', tier: 'provisional' });
+      store.learnings.create({ projectId: project.id, content: 'young C', tier: 'provisional' });
+      const res = await ruleProposal.run({ project });
+      assert.equal(res.status, 'done');
+      assert.deepEqual(res.output.backlog, { provisional: 3 });
+    });
+  });
 });

--- a/test/wrap-drawer.test.js
+++ b/test/wrap-drawer.test.js
@@ -290,6 +290,28 @@ describe('wrap-drawer helpers — KIND_DESCRIPTIONS (per-step help)', () => {
     assert.equal(row.detail, null);
   });
 
+  it('appends the provisional backlog so the queue is visible (#569 proposal 3)', () => {
+    const row = H.buildStepRow({
+      stepId: 'rule-proposal', kind: 'rule-proposal', status: 'done',
+      output: { count: 2, proposed: [{}, {}], backlog: { provisional: 3 } }, blockers: []
+    });
+    assert.match(row.detail, /2 rules proposed/);
+    assert.match(row.detail, /3 provisional learnings building recurrence/);
+  });
+
+  it('claims no backlog when it is empty or absent', () => {
+    const withZero = H.buildStepRow({
+      stepId: 'rule-proposal', kind: 'rule-proposal', status: 'done',
+      output: { count: 1, proposed: [{}], backlog: { provisional: 0 } }, blockers: []
+    });
+    assert.doesNotMatch(withZero.detail, /provisional/);
+    const without = H.buildStepRow({
+      stepId: 'rule-proposal', kind: 'rule-proposal', status: 'done',
+      output: { count: 1, proposed: [{}] }, blockers: []
+    });
+    assert.doesNotMatch(without.detail, /provisional/);
+  });
+
   it('has a non-empty help description for every canonical wrap-step kind (drift guard)', () => {
     for (const k of CANONICAL_KINDS) {
       const d = H.KIND_DESCRIPTIONS[k];
@@ -607,6 +629,68 @@ describe('wrap-drawer helpers — planPickerWidget (#428)', () => {
   it('returns null on missing/invalid rawOutput', () => {
     assert.equal(H.planPickerWidget({ kind: 'priming-roll', status: 'blocked' }, null), null);
     assert.equal(H.planPickerWidget(null, { candidates: ['x.md'] }), null);
+  });
+});
+
+describe('wrap-drawer helpers — ruleProposalWidget (#569)', () => {
+  const H = loadHelpers();
+
+  it('returns the proposals for a completed rule-proposal step', () => {
+    const w = H.ruleProposalWidget(
+      { kind: 'rule-proposal', status: 'done' },
+      { proposed: [
+        { ruleId: 7, learningId: 3, content: 'always pin timestamps in tests', status: 'proposed' },
+        { ruleId: 8, learningId: 4, content: 'restart the server after code changes', status: 'proposed' }
+      ] }
+    );
+    assert.equal(w.kind, 'rule-proposal');
+    // JSON round-trip: the helpers load in a vm sandbox, so their objects have
+    // cross-realm prototypes deepEqual would reject on identity alone.
+    assert.deepEqual(JSON.parse(JSON.stringify(w.proposals)), [
+      { ruleId: 7, learningId: 3, content: 'always pin timestamps in tests' },
+      { ruleId: 8, learningId: 4, content: 'restart the server after code changes' }
+    ]);
+  });
+
+  it('drops malformed entries — no ruleId or blank content means nothing to address', () => {
+    const w = H.ruleProposalWidget(
+      { kind: 'rule-proposal', status: 'done' },
+      { proposed: [
+        { ruleId: 7, learningId: 3, content: 'keep me' },
+        { learningId: 9, content: 'no ruleId' },
+        { ruleId: 10, content: '   ' },
+        null
+      ] }
+    );
+    assert.equal(w.proposals.length, 1);
+    assert.equal(w.proposals[0].ruleId, 7);
+  });
+
+  it('tolerates a missing learningId (null, still renderable)', () => {
+    const w = H.ruleProposalWidget(
+      { kind: 'rule-proposal', status: 'done' },
+      { proposed: [{ ruleId: 7, content: 'orphan provenance' }] }
+    );
+    assert.equal(w.proposals[0].learningId, null);
+  });
+
+  it('returns null for a skipped rule-proposal step — nothing to review', () => {
+    const w = H.ruleProposalWidget(
+      { kind: 'rule-proposal', status: 'skipped' },
+      { proposed: [{ ruleId: 7, content: 'x' }] }
+    );
+    assert.equal(w, null);
+  });
+
+  it('returns null when every entry is malformed or the list is empty', () => {
+    assert.equal(H.ruleProposalWidget({ kind: 'rule-proposal', status: 'done' }, { proposed: [] }), null);
+    assert.equal(H.ruleProposalWidget({ kind: 'rule-proposal', status: 'done' }, { proposed: [{ content: 'no id' }] }), null);
+  });
+
+  it('returns null for other kinds and invalid inputs', () => {
+    assert.equal(H.ruleProposalWidget({ kind: 'pr-check', status: 'done' }, { proposed: [{ ruleId: 1, content: 'x' }] }), null);
+    assert.equal(H.ruleProposalWidget({ kind: 'rule-proposal', status: 'done' }, null), null);
+    assert.equal(H.ruleProposalWidget(null, { proposed: [{ ruleId: 1, content: 'x' }] }), null);
   });
 });
 

--- a/test/wrap-rule-proposal-widget.test.js
+++ b/test/wrap-rule-proposal-widget.test.js
@@ -1,0 +1,153 @@
+'use strict';
+
+/*
+ * #569 — the rule-proposal review widget in the wrap drawer.
+ *
+ * The wrap proposes rules from recurring learnings; this widget is where the
+ * operator answers. The load-bearing properties pinned here:
+ *
+ *   1. The drawer actually renders it — a proposal the operator never sees is
+ *      the silent loop #569 was filed about, one layer up.
+ *   2. Decisions are API writes, not pipeline retries — approving a rule must
+ *      never re-run the wrap (double commit).
+ *   3. An edit is saved BEFORE approval flips status — approving un-saved text
+ *      would activate a rule the operator never saw.
+ *   4. Approval replays the wrap's cached operator password, and a 403 surfaces
+ *      the password input instead of failing opaquely.
+ *
+ * session.js render functions are browser DOM code (not require()-able), so —
+ * per the test/wrap-drawer-select-a11y.test.js convention — these are
+ * source-level pins over the function bodies.
+ */
+
+const { describe, it, before } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+/**
+ * Slice out a top-level function body by brace-matching from its declaration.
+ * @param {string} src full source text
+ * @param {string} decl the function declaration to find
+ * @returns {string} the function body including its braces
+ */
+function functionBody(src, decl) {
+  const start = src.indexOf(decl);
+  assert.ok(start !== -1, `${decl} must exist`);
+  const bodyStart = src.indexOf('{', start);
+  let depth = 0;
+  for (let i = bodyStart; i < src.length; i++) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}') {
+      depth--;
+      if (depth === 0) return src.slice(bodyStart, i + 1);
+    }
+  }
+  assert.fail(`${decl} body must close`);
+}
+
+describe('#569 rule-proposal review widget (wrap drawer)', () => {
+  let session, sessionCss;
+
+  before(() => {
+    const pub = path.resolve(__dirname, '..', 'public');
+    session = fs.readFileSync(path.join(pub, 'session.js'), 'utf8');
+    sessionCss = fs.readFileSync(path.join(pub, 'session.css'), 'utf8');
+  });
+
+  describe('the drawer renders the widget', () => {
+    it('renderWrapDrawer wires ruleProposalWidget into the decision area', () => {
+      const body = functionBody(session, 'function renderWrapDrawer(');
+      assert.ok(/H\.ruleProposalWidget\(row, raw\.output\)/.test(body),
+        'renderWrapDrawer must derive the widget from the step row');
+      assert.ok(/renderRuleProposalWidget\(/.test(body),
+        'renderWrapDrawer must render the derived widget');
+    });
+
+    it('proposal decisions are not a pipeline retry — the branch must not set warningOnly', () => {
+      const body = functionBody(session, 'function renderWrapDrawer(');
+      const branch = body.slice(body.indexOf("row.kind === 'rule-proposal'"));
+      const branchEnd = branch.indexOf("decisionEl.classList.toggle");
+      assert.ok(!/warningOnly = true/.test(branch.slice(0, branchEnd)),
+        'rule-proposal must not enable the Retry path — a retry re-runs the wrap and double-commits');
+    });
+  });
+
+  describe('the widget itself', () => {
+    it('renders an editable textarea plus Approve and Reject per proposal', () => {
+      const body = functionBody(session, 'function renderRuleProposalWidget(');
+      assert.ok(/ta\.value = p\.content/.test(body), 'proposal text must be editable, prefilled');
+      assert.ok(/wrap-proposal-approve/.test(body), 'approve button must render');
+      assert.ok(/wrap-proposal-reject/.test(body), 'reject button must render');
+    });
+
+    it('is a labelled group with per-proposal accessible names (a11y)', () => {
+      const body = functionBody(session, 'function renderRuleProposalWidget(');
+      assert.ok(/list\.setAttribute\('role',\s*'group'\)/.test(body));
+      assert.ok(/list\.setAttribute\('aria-labelledby',\s*groupLabelId\)/.test(body));
+      assert.ok(/ta\.setAttribute\('aria-label'/.test(body),
+        'each textarea needs its own accessible name');
+    });
+
+    it('carries a hidden password input for the 403 recovery path', () => {
+      const body = functionBody(session, 'function renderRuleProposalWidget(');
+      assert.ok(/wrap-proposal-password hidden/.test(body),
+        'password group must start hidden — it only appears when the server refuses');
+    });
+  });
+
+  describe('resolving a proposal', () => {
+    it('approve saves a text edit BEFORE flipping status', () => {
+      const body = functionBody(session, 'async function resolveRuleProposal(');
+      const contentPut = body.indexOf("'PUT', { content: edited }");
+      const statusPut = body.indexOf('/status`');
+      assert.ok(contentPut !== -1, 'approve must PUT the edited content');
+      assert.ok(statusPut !== -1, 'approve must PUT the status');
+      assert.ok(contentPut < statusPut,
+        'the edit must be saved before approval — approving un-saved text activates a rule the operator never saw');
+    });
+
+    it('a failed edit-save aborts the approval', () => {
+      const body = functionBody(session, 'async function resolveRuleProposal(');
+      const failBranch = body.slice(body.indexOf('Couldn’t save your edit'));
+      assert.ok(/Nothing was approved/.test(failBranch.slice(0, 200)),
+        'the operator must be told the approval did not proceed');
+      assert.ok(/return;/.test(failBranch.slice(0, 300)),
+        'the approve flow must stop when the edit could not be saved');
+    });
+
+    it('approve replays the cached wrap password, preferring a freshly typed one', () => {
+      const body = functionBody(session, 'async function resolveRuleProposal(');
+      assert.ok(/passwordInput && passwordInput\.value\) \|\| currentWrapPassword/.test(body));
+    });
+
+    it('a 403 reveals the password input instead of failing opaquely', () => {
+      const body = functionBody(session, 'async function resolveRuleProposal(');
+      assert.ok(/lastErrorCode === 'FORBIDDEN'/.test(body));
+      assert.ok(/passwordGroup\.classList\.remove\('hidden'\)/.test(body));
+    });
+
+    it('reject needs no password and is recorded, not deleted', () => {
+      const body = functionBody(session, 'async function resolveRuleProposal(');
+      const rejectCall = body.match(/\{ status: 'rejected' \}/);
+      assert.ok(rejectCall, 'reject must PUT status rejected — the record is what prevents re-proposal');
+    });
+
+    it('an empty edited rule cannot be approved', () => {
+      const body = functionBody(session, 'async function resolveRuleProposal(');
+      assert.ok(/Rule text can’t be empty/.test(body));
+    });
+  });
+
+  describe('session.css', () => {
+    it('styles the widget with 44px touch targets (mobile-first)', () => {
+      assert.match(sessionCss, /\.wrap-proposal-row\s*\{/);
+      assert.match(sessionCss, /\.wrap-proposal-actions \.btn\s*\{[^}]*min-height:\s*44px/);
+      assert.match(sessionCss, /\.wrap-proposal-password-input\s*\{[^}]*min-height:\s*44px/);
+    });
+
+    it('a decided row hides its actions — the decision is one-shot in this render', () => {
+      assert.match(sessionCss, /\.wrap-proposal-row--decided \.wrap-proposal-actions\s*\{\s*display:\s*none/);
+    });
+  });
+});


### PR DESCRIPTION
## What

Chunk 05b of the wrap-v2 build plan — the operator review surface for the self-improvement loop.

- **Wrap drawer**: the `rule-proposal` step's output renders as a decision widget (descriptor→renderer triad, plan-picker cousin): each proposed rule shows with editable text plus one-tap Approve / Reject. Approve saves any edit *before* flipping status, replays the wrap modal's cached operator password, and a 403 reveals an inline password input. Decisions are per-rule API writes, never a pipeline retry — no double-commit path.
- **Backlog visibility (#569 proposal 3)**: the step reports the provisional-learnings backlog on every exit path ("N provisional learnings building recurrence"), so a young loop is distinguishable from a dead one.
- **Project Rules list is the durable decision surface**: the drawer renders only the wrap that just ran, so pending proposals appear in the Settings modal with a `Proposed` badge, an inert enabled-toggle, and their own Approve / Reject buttons — deliberately in place of Delete, which would erase the recorded decision and re-arm re-proposal.
- `sw.js` CACHE_NAME bump (ui.js/style.css are precached).

## Why

05a made the loop safe and auditable but API-only — acting on a proposal meant hand-crafting a curl, and the operator is almost always remote on a phone. Closes #569 (with 05a's engine).

## Test plan

- New `test/wrap-rule-proposal-widget.test.js` (source-level pins: edit-save ordering, 403 recovery, no-retry, a11y, 44px targets)
- +8 `test/wrap-drawer.test.js` (`ruleProposalWidget` edge cases, backlog detail), +4 `test/self-improvement-loop.test.js` (backlog counts on every exit path), +6 `test/project-rules-modal.test.js` (badge, unfiltered fetch, inert toggle, Approve/Reject-instead-of-Delete, status wiring)
- Full suite: 4745 pass / 0 fail / 1 skipped

## Review

- Cumulative Critic (3 reviewers): 1 blocking / 2 warning / 4 note → all blocking+warnings fixed, verify-resolutions 0/0/0; notes recorded on the backlog (SR-8V4T, SR-2W7F; SR-6D3W, TST-6L2P updated)
- Independent PR reviewer: 0 blocking / 1 warning (change-log lag — amended in `1ac24ed`)
- Operator verification queued: `VRF-569-proposal-review` (visual, iPhone)

Fixes #569