### PR TITLE
Ratify the full wrap pipeline as the default for new projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,16 @@ All notable changes to TangleClaw are documented in this file.
   seed sweep keys on the dropped column and has no birth-time equivalent). Known-open
   install defects #614–#617 reproduced and excluded as not-new. Result recorded in
   `.prawduct/artifacts/wrap-v2-build-plan.md`.
+- **Ratified the full wrap pipeline as the default for new projects (#652).** A project
+  created or attached after the methodology cutover carries no `wrapStepOverrides` and
+  runs every shipped step — a deliberate reversal of the old default, where a new project
+  was born `minimal` and had to be opted into the rest. Documented in
+  `docs/configuration-reference.md` (including the consequence: on a project with no
+  `CHANGELOG.md` or `.tangleclaw/memories/`, the verifying steps stop the wrap for an
+  operator-confirmed skip until they're disabled), and pinned by a test so reintroducing
+  birth-time commit-only seeding fails rather than silently re-flipping the default. The
+  20 projects migrated at the cutover keep their seeded maps as ordinary per-project
+  config.
 
 ### Removed
 

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -80,7 +80,7 @@ Stored in `<project>/.tangleclaw/project.json`. Created when a project is added 
 | `projectMapEnabled` | boolean | `false` | Maintain `PROJECT-MAP.md` during wrap |
 | `wrapAutoPrEnabled` | boolean | `true` | After an auto-branched wrap commit, push and open a PR back to the original branch |
 | `wrapSections` | array\|null | `null` | Which continuity wrap-summary sections render. `null` = all of them |
-| `wrapStepOverrides` | object | `{}` | Per-step wrap overrides, keyed by step id — see [Wrap step overrides](#wrap-step-overrides) below |
+| `wrapStepOverrides` | object | `{}` | Per-step wrap overrides, keyed by step id. `{}` means no overrides, so the project runs the **full** shipped pipeline — see [Wrap step overrides](#wrap-step-overrides) below |
 | `medusaEnabled` | boolean | `false` | Auto-start this project's sessions on the Medusa switchboard |
 | `medusaWake` | boolean | `false` | Wake an idle session on inbound switchboard messages |
 | `defaultLaunchMode` | string | `"default"` | Engine launch-mode key this project launches in by default |
@@ -124,11 +124,27 @@ one shared pipeline that every project runs):
 The pipeline's step list ships in code and cannot be edited per project; overrides in
 `project.json` — a file only the project owns — are the per-project configuration surface.
 
+**The default is the full pipeline.** A project created or attached with no overrides runs
+every step in the shipped list — including the steps that block on an unsatisfied
+verification (`open-pr-check`, `changelog-update`, `learnings-capture`, `memory-update`). A
+project that should wrap more lightly says so here, per step; there is no lighter starting
+template to pick at creation time. This is a deliberate reversal of the pre-#652 default,
+where a new project began life running a commit-only wrap and had to be opted *into* the
+rest.
+
+The practical consequence worth knowing before you attach a repo: on a project with no
+`CHANGELOG.md` and no `.tangleclaw/memories/`, the steps that verify those files changed
+will stop the wrap and ask you to confirm the skip. That is the verification working as
+designed — a no-op is an operator's explicit decision, not something the wrap reports as
+done — but on a project that will never keep a changelog, disable those steps here once
+rather than ratifying the same skip every session.
+
 Projects whose wrap was commit-only before the pipeline became code-owned were migrated
 automatically: TangleClaw seeded overrides disabling every step except `commit`, plus a
 `wrapOverridesSeeded: true` marker. The marker makes the seeding one-shot — clear
 the overrides map (leave the marker) to opt the project into the full pipeline; it will
-not be re-seeded.
+not be re-seeded. That migration covered the projects that existed at the cutover only;
+it is not a default for new ones.
 
 | Field | Type | Effect |
 |-------|------|--------|

--- a/test/wrap-default-pipeline.test.js
+++ b/test/wrap-default-pipeline.test.js
@@ -274,6 +274,35 @@ describe('v27→v28 methodology drop — terminal wrap-config seed', () => {
     store.close();
   });
 
+  it('does NOT seed a project born after the cutover — the full pipeline is the ratified default (#652)', () => {
+    // The seed sweep is scoped to the migrating population and deliberately has
+    // no birth-time equivalent: it keys on a column that no longer exists.
+    // A project created after the cutover therefore starts with an empty
+    // override map and runs every shipped step. That is a REVERSAL of the
+    // pre-cutover default (a new project used to be born `minimal`, i.e.
+    // commit-only), ratified by the operator on 2026-07-20 after the
+    // tc-cleanroom Phase B exit gate surfaced the inversion.
+    //
+    // This pins the decision so reintroducing birth-time commit-only seeding
+    // fails here rather than silently re-flipping the default.
+    const base = makeV27Store([]);
+    migrate(base);
+
+    const newborn = makeProjectDir('born-after-cutover');
+    const config = store.projectConfig.load(newborn);
+
+    assert.deepStrictEqual(config.wrapStepOverrides, {},
+      'a project born after the cutover carries no overrides');
+    assert.ok(!config.wrapOverridesSeeded,
+      'the one-shot migration marker belongs to migrated projects only');
+    assert.deepStrictEqual(
+      defaultPipeline.effectiveStepIds(config.wrapStepOverrides),
+      defaultPipeline.steps().map((s) => s.id),
+      'a newborn project runs the FULL shipped pipeline, not a commit-only wrap'
+    );
+    store.close();
+  });
+
   it('refuses to leave an unreadable project.json half-migrated', () => {
     // A corrupt config reads as "not yet seeded" through the defaults-returning
     // loader; the migration must raw-read so it never overwrites a file it


### PR DESCRIPTION
## What

Records and pins the operator's ratification of the wrap default that the tc-cleanroom Phase B exit gate surfaced as #652.

- `docs/configuration-reference.md` — states that `wrapStepOverrides: {}` means the **full** shipped pipeline, that this is a deliberate reversal of the pre-cutover default, and what it costs in practice (on a project with no `CHANGELOG.md` or `.tangleclaw/memories/`, the verifying steps stop the wrap for an operator-confirmed skip until they're disabled). Also scopes the migration paragraph to the migrating population so it can't be read as a default for new projects.
- `test/wrap-default-pipeline.test.js` — pins the decision: a project born after the cutover carries no overrides, no `wrapOverridesSeeded` marker, and resolves to every shipped step.

Docs + test only. No production code changes.

## Why

The gate found that a project created *after* the methodology cutover gets the full 14-step wrap (four of them blockers), where the same project created a day earlier would have been `minimal` → commit-only. Chunk 06a's behavior-preserving guarantee covers every project that existed at the cutover, because the v27→v28 seed sweep enumerates `WHERE methodology = 'minimal'` before dropping the column — it has no birth-time equivalent and can't have one, since it keys on a column that no longer exists.

The operator ratified the new default rather than restoring commit-only. The risk in a ratified-by-conversation default is that it stays a conversation: the next person to read the seed sweep sees commit-only being carefully preserved and reasonably concludes that's what new projects should get too. So the decision goes in the reference doc, and the test makes reintroducing birth-time seeding fail rather than silently re-flip the default.

Existing projects are untouched — the 20 migrated at the cutover keep their seeded maps, now just ordinary per-project config on the Settings → Wrap steps surface.

## Test plan

- `node --test 'test/*.test.js'` — 4490 pass, 0 fail, 1 skipped.
- New test verified to run (the v27→v28 suite goes 9 → 10 subtests).

Closes #652