### PR TITLE
Make the first-run install path fail honestly

### DIFF
--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -26,6 +26,43 @@ Tag-line conventions (ART-4K9M, ratified 2026-07-17):
 -->
 
 
+## 2026-07-20: First-run install honesty (#614, #615, #616, #617)
+
+<!-- prawduct: type=bugfix | scope=install-first-run | status=shipped -->
+
+**Why:** the tc-cleanroom acceptance gate reproduces these on every run, and they share one
+shape — the code handled a failure correctly and then described it wrongly. That is the
+worst kind of first-run defect: the remediation text sends a new operator somewhere the
+problem isn't, and two of these sent them in a loop.
+
+**What:** `install.sh` gained a platform guard so a Linux user gets the refusal the README
+already documented instead of a Linuxbrew bootstrap and unusable launchd steps (#614). Its
+Homebrew bootstrap now captures the installer, rejects an empty payload, and executes it as
+separate steps — `bash -c "$(curl …)"` turned a failed download into an empty script that
+exits 0, so the guard never fired and the script blamed PATH for a Homebrew that was never
+installed (#615). The startup banner takes its scheme from the constructed server via a new
+`serverProtocol()` rather than from config intent, and marks `httpsFallback: true` when the
+two diverge — on a fresh install HTTPS is enabled before any certificate exists, so the
+server falls back to HTTP and then announced `https://` two lines later (#616).
+
+**Notable:** #617 was misdiagnosed as filed. The README's 3102 is correct for the documented
+path (the generated plist sets `TANGLECLAW_PORT=3102`); the gate saw 3101 only because
+install.sh had already refused on Linux, so the server was started by hand on the code
+default. Fixing it as asked would have sent every real macOS installer to a dead port, so
+the distinction is documented instead. Reviewing that paragraph surfaced a genuine docs bug
+it would otherwise have compounded: five places documented ttyd on 3101 when it binds 3100
+in direct mode and a Unix socket under caddy — leaving 3101 meaning two different services
+in one README.
+
+**Tests:** the install.sh tests execute the script rather than grepping it, because these
+defects were behavioral and a source-shape assertion matches the broken version just as
+happily. Each is interlocked — it asserts from the source that the fix is present and
+precedes any shell-out, and only then runs the script. That interlock is load-bearing, not
+ceremony: without it a regressed guard escapes the stubbed PATH through
+`ensure_homebrew`'s absolute `/opt/homebrew` probe and reaches the developer's real
+Homebrew, which is exactly what happened while validating these tests.
+
+
 ## 2026-07-20: Chunk 06b — methodology-layer deletion (#538 second half)
 
 <!-- prawduct: type=refactor | chunks=06b | scope=wrap-v2 | status=shipped -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`install.sh` refuses to run on Linux instead of half-installing (#614).** The script
+  manages launchd services and bootstraps Homebrew, but never checked the platform: a Linux
+  user got a Linuxbrew bootstrap followed by launchd steps that cannot work. It now exits
+  with the same message the README's Prerequisites already carried, before writing or
+  downloading anything.
+- **A failed Homebrew download is reported as a failed download (#615).** `bash -c "$(curl …)"`
+  turns a network failure into an empty script that exits 0, so the guard never fired and the
+  script blamed PATH for a Homebrew that was never installed — advice that loops forever, since
+  re-running reproduces it. The installer is now captured, checked for emptiness, then executed,
+  and each failure mode says what actually happened.
+- **The startup banner reports the protocol the server actually speaks (#616).** On a fresh
+  install the shipped default enables HTTPS before any certificate exists, so the server falls
+  back to plain HTTP — and then logged `listening on https://*:3101 … https=true` two lines
+  after logging the fallback. The scheme now comes from the constructed server
+  (`serverProtocol()`) rather than config intent, and the line carries `httpsFallback: true`
+  when the two diverge.
+- **README notes that running `node server.js` by hand uses a different port than installing
+  (#617).** The Quick Start's `http://localhost:3102` is correct for the documented path — the
+  generated plist sets `TANGLECLAW_PORT=3102` — but a fresh clone started by hand listens on
+  the code default 3101, which is what the acceptance gate hit after `install.sh` refused to
+  run. The port itself is unchanged; the ambiguity was the defect.
+
 ### Changed
 
 - **The wrap pipeline is now code-owned — every project runs the same step list,

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Global config lives at `~/.tangleclaw/config.json` (auto-created on first run).
 
 Key settings:
 - `serverPort` — landing page server port (code default: 3101, launchd override: 3102)
-- `ttydPort` — ttyd terminal port (code default: 3100, launchd override: 3101)
+- `ttydPort` — ttyd terminal port (3100; in `caddy` ingress mode ttyd binds a Unix socket instead of a TCP port)
 - `projectsDir` — root directory for managed projects
 - `defaultEngine` — default engine for new projects
 - `deletePassword` — optional password for destructive operations
@@ -270,13 +270,13 @@ launchd (com.tangleclaw.server)
   └─ node server.js
      ├─ Landing page HTTP(S) server (:3102)
      ├─ API endpoints (/api/*)
-     ├─ Reverse proxy /terminal/* → ttyd (:3101)
+     ├─ Reverse proxy /terminal/* → ttyd (:3100)
      ├─ Reverse proxy /openclaw/* → SSH tunnel → OpenClaw gateway
      ├─ WebSocket upgrade (ttyd + OpenClaw)
      └─ Session wrapper + OpenClaw viewer HTML serving
 
 launchd (com.tangleclaw.ttyd)
-  └─ ttyd --port 3101 tmux attach (PTY-leak watchdog supervised)
+  └─ ttyd --port 3100 tmux attach (PTY-leak watchdog supervised)
      └─ WebSocket terminal access
 
 tmux sessions (spawned on demand)

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ The install script:
 3. Installs and loads the services
 4. Runs a health check
 
-Access the landing page at **http://localhost:3102**. On first launch, a setup wizard walks you through configuration — including choosing your **projects directory**. This is a single folder where all your managed projects live (e.g., `~/Projects`). TangleClaw scans this directory, detects existing repos and engines, and lets you attach them as managed projects.
+Access the landing page at **http://localhost:3102**. (That is the port the installed launchd service uses — the plist sets `TANGLECLAW_PORT=3102`. Running `node server.js` by hand instead skips launchd and listens on the code default, **3101**.) On first launch, a setup wizard walks you through configuration — including choosing your **projects directory**. This is a single folder where all your managed projects live (e.g., `~/Projects`). TangleClaw scans this directory, detects existing repos and engines, and lets you attach them as managed projects.
 
 ### Prerequisites
 

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -19,6 +19,18 @@ red() { printf '\033[0;31m%s\033[0m\n' "$1"; }
 green() { printf '\033[0;32m%s\033[0m\n' "$1"; }
 yellow() { printf '\033[0;33m%s\033[0m\n' "$1"; }
 
+# ── Platform guard ──
+# Everything below assumes macOS: the services are launchd agents and the
+# dependency bootstrap is Homebrew. Without this check a Linux user gets a
+# Linuxbrew bootstrap followed by launchd steps that cannot work — a partial
+# install instead of the honest refusal the README already documents. Fail
+# here, before anything is written or downloaded.
+if [ "$(uname -s)" != "Darwin" ]; then
+  red "ERROR: TangleClaw requires macOS — it manages its services with launchd."
+  red "       Linux support is not yet available (see README → Prerequisites)."
+  exit 1
+fi
+
 # ── Dependency bootstrap (single-command install) ──
 # Make `install.sh` self-sufficient: every runtime dependency is auto-installed
 # via Homebrew, and Homebrew itself is bootstrapped if absent. The privileged,
@@ -32,8 +44,21 @@ ensure_homebrew() {
   if command -v brew &>/dev/null; then BREW="$(command -v brew)"; return 0; fi
   yellow "  Homebrew not found — installing it (needed to auto-install dependencies)."
   yellow "  The Homebrew installer may prompt you for your password."
-  NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" \
-    || { red "ERROR: Homebrew install failed. Install it from https://brew.sh and re-run."; exit 1; }
+  # Download and execute as two steps, deliberately. Inlining the command
+  # substitution into `bash -c "$(curl …)"` makes a failed download
+  # indistinguishable from a successful one: curl writes nothing, `bash -c ""`
+  # exits 0, the `||` guard never fires, and the script proceeds to blame PATH
+  # for a Homebrew that was never installed — advice that sends the user in a
+  # loop, since re-running reproduces it. Each failure mode gets its own message.
+  local brew_installer
+  brew_installer="$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" \
+    || { red "ERROR: could not download the Homebrew installer (check your network connection)."; \
+         red "       Install Homebrew manually from https://brew.sh and re-run."; exit 1; }
+  [ -n "$brew_installer" ] \
+    || { red "ERROR: the downloaded Homebrew installer was empty — refusing to run it."; \
+         red "       Install Homebrew manually from https://brew.sh and re-run."; exit 1; }
+  NONINTERACTIVE=1 /bin/bash -c "$brew_installer" \
+    || { red "ERROR: the Homebrew installer failed. Install it from https://brew.sh and re-run."; exit 1; }
   # Prime brew into this shell's PATH (Apple Silicon → /opt/homebrew, Intel → /usr/local).
   if [ -x /opt/homebrew/bin/brew ]; then eval "$(/opt/homebrew/bin/brew shellenv)";
   elif [ -x /usr/local/bin/brew ]; then eval "$(/usr/local/bin/brew shellenv)"; fi

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -19,7 +19,7 @@ Auto-created on first run with defaults. Editable directly or via `PATCH /api/co
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `serverPort` | number | `3101` | Landing page HTTP server port. The install script sets `TANGLECLAW_PORT=3102` via launchd, so the effective default after installation is **3102**. |
-| `ttydPort` | number | `3100` | ttyd terminal emulator port. The install script configures ttyd on port **3101** via launchd. |
+| `ttydPort` | number | `3100` | ttyd terminal emulator port. `install.sh` installs the direct-mode bind (`--port 3100`); in `caddy` ingress mode `ingress-cutover.js` swaps it for a Unix socket so ttyd is reachable only through the proxy. |
 | `defaultEngine` | string | `"claude"` | Default engine for new projects |
 | `projectsDir` | string | `"~/Documents/Projects"` | Root directory for managed projects |
 | `deletePassword` | string\|null | `null` | Password for destructive operations (hashed via scrypt when saved) |

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -22,7 +22,7 @@ cd TangleClaw
 The install script verifies prerequisites, generates launchd plists, loads the services, and runs a health check. On success, you'll see:
 
 - **Landing page**: http://localhost:3102
-- **Terminal (ttyd)**: http://localhost:3101
+- **Terminal (ttyd)**: http://localhost:3100
 
 Both services auto-restart on crash via launchd KeepAlive.
 
@@ -352,7 +352,7 @@ launchctl list | grep ttyd
 launchctl list | grep ttyd
 
 # Test ttyd directly
-curl -s http://localhost:3101
+curl -s http://localhost:3100
 ```
 
 ### Session Won't Launch

--- a/server.js
+++ b/server.js
@@ -4449,10 +4449,6 @@ route('POST', '/api/audit/retention/run', (_req, res, _params, body) => {
 // ── Server Creation ──
 
 /**
- * Create and configure the HTTP server (does not start listening).
- * @returns {http.Server}
- */
-/**
  * Report the protocol a constructed server actually speaks.
  *
  * The distinction this exists to preserve: config `httpsEnabled` is *intent*,

--- a/server.js
+++ b/server.js
@@ -4453,6 +4453,24 @@ route('POST', '/api/audit/retention/run', (_req, res, _params, body) => {
  * @returns {http.Server}
  */
 /**
+ * Report the protocol a constructed server actually speaks.
+ *
+ * The distinction this exists to preserve: config `httpsEnabled` is *intent*,
+ * and `createServer` falls back to plain HTTP whenever HTTPS is asked for
+ * without usable cert/key. That is the ordinary fresh-install state, since the
+ * shipped default enables HTTPS before any certificate exists — so a startup
+ * banner derived from config announced `https://` for a plain-HTTP socket and
+ * sent new operators to debug certificates that were never in play. Ask the
+ * server, not the config.
+ *
+ * @param {http.Server|https.Server} server - The constructed server
+ * @returns {'https'|'http'} The scheme the server actually serves
+ */
+function serverProtocol(server) {
+  return server instanceof https.Server ? 'https' : 'http';
+}
+
+/**
  * Create and configure the HTTP/HTTPS server (does not start listening).
  * @param {object} [options]
  * @param {boolean} [options.httpsEnabled] - Use HTTPS
@@ -4645,7 +4663,9 @@ if (require.main === module) {
     }
   }, 5 * 60 * 1000);
 
-  const protocol = effectiveHttps ? 'https' : 'http';
+  // Describe the socket that exists, not the one the config asked for.
+  const protocol = serverProtocol(server);
+  const servingHttps = protocol === 'https';
   const bindHost = caddyMode ? '127.0.0.1' : null;
   const bindLabel = caddyMode ? '127.0.0.1' : '*';
 
@@ -4662,7 +4682,11 @@ if (require.main === module) {
     log.info(`TangleClaw v${_getVersion()} listening on ${protocol}://${bindLabel}:${port}${caddyMode ? ' (behind Caddy)' : ''}`, {
       node: process.version,
       pid: process.pid,
-      https: effectiveHttps,
+      https: servingHttps,
+      // Surfaced only when intent and reality diverge, so the listen line
+      // points back at the fallback WARN logged during construction rather
+      // than leaving the operator to notice the mismatch themselves.
+      ...(effectiveHttps && !servingHttps ? { httpsFallback: true } : {}),
       ingressMode: config.ingressMode || 'direct'
     });
     // Start ttyd zombie-child watcher (#94). macOS-only; no-op elsewhere.
@@ -4722,4 +4746,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { createServer, handleRequest, handleUpgrade, route, matchRoute, jsonResponse, errorResponse, parseBody, parseQuery, reqUrl, MAX_BODY_SIZE, _setRestartScheduler, _openclawProxyHeaders, _openclawWsRequestLines };
+module.exports = { createServer, serverProtocol, handleRequest, handleUpgrade, route, matchRoute, jsonResponse, errorResponse, parseBody, parseQuery, reqUrl, MAX_BODY_SIZE, _setRestartScheduler, _openclawProxyHeaders, _openclawWsRequestLines };

--- a/test/install-sh.test.js
+++ b/test/install-sh.test.js
@@ -161,6 +161,130 @@ describe('deploy/install.sh', () => {
     });
   });
 
+  // These two run the real script rather than grepping it, because both defects
+  // were failures of BEHAVIOR that a source-shape assertion would have happily
+  // matched: the script "handled" a failed download and "supported" Linux right
+  // up until you ran it.
+  //
+  // Executing an installer in a unit test needs a hard safety story, and a
+  // stubbed PATH is NOT sufficient on its own: `ensure_homebrew` probes
+  // /opt/homebrew/bin/brew and /usr/local/bin/brew by ABSOLUTE path, so on a
+  // developer's Mac a regressed guard escapes the sandbox and reaches the real
+  // Homebrew (observed while validating these tests — the unguarded script
+  // reached `brew` and began auto-updating it). So each test is interlocked:
+  // it first asserts, from the source, that the fix under test is present and
+  // positioned before anything that could shell out. If that assertion fails
+  // the test fails THERE and never executes the script. Execution therefore
+  // only ever happens against a script already known to refuse early.
+  describe('first-run failure honesty (executed, not grepped)', () => {
+    const { execFileSync } = require('node:child_process');
+    const os = require('node:os');
+
+    /**
+     * Build a sandbox: a stub bin dir on an otherwise-empty PATH, plus a
+     * throwaway HOME. `dirname` is symlinked in because install.sh resolves its
+     * own location before doing anything else.
+     * @param {Record<string, string>} stubs - stub name → script body
+     * @returns {{ bin: string, home: string }}
+     */
+    function sandbox(stubs) {
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-install-sh-'));
+      const bin = path.join(root, 'bin');
+      const home = path.join(root, 'home');
+      fs.mkdirSync(bin);
+      fs.mkdirSync(home);
+      for (const real of ['dirname']) {
+        const found = ['/usr/bin', '/bin'].map((d) => path.join(d, real)).find((p) => fs.existsSync(p));
+        if (found) fs.symlinkSync(found, path.join(bin, real));
+      }
+      for (const [name, body] of Object.entries(stubs)) {
+        const p = path.join(bin, name);
+        fs.writeFileSync(p, `#!/bin/sh\n${body}\n`);
+        fs.chmodSync(p, 0o755);
+      }
+      return { bin, home };
+    }
+
+    /**
+     * Run install.sh in a sandbox, returning its combined output and exit code.
+     * @param {{ bin: string, home: string }} box
+     * @returns {{ code: number, output: string }}
+     */
+    function runInstall(box) {
+      try {
+        // Spawn the interpreter by absolute path: the sandbox PATH deliberately
+        // has no bash, and resolving it through that PATH would fail to spawn
+        // (exit status null) rather than run the script under test.
+        const output = execFileSync('/bin/bash', [SCRIPT_PATH], {
+          env: { PATH: box.bin, HOME: box.home },
+          encoding: 'utf8',
+          stdio: ['ignore', 'pipe', 'pipe'],
+          timeout: 30000
+        });
+        return { code: 0, output };
+      } catch (err) {
+        return { code: err.status, output: `${err.stdout || ''}${err.stderr || ''}` };
+      }
+    }
+
+    it('refuses to run on a non-Darwin platform instead of bootstrapping Homebrew (#614)', () => {
+      // Without the guard the script plows past the platform check into a
+      // Linuxbrew bootstrap and on toward launchd steps that cannot work,
+      // handing a Linux user a partial install instead of the honest refusal
+      // the README already documents.
+
+      // Safety interlock (see the describe comment): the guard must exist and
+      // precede every shell-out, or we do not run the script at all.
+      const guardAt = script.search(/if \[ "\$\(uname -s\)" != "Darwin" \]/);
+      assert.notEqual(guardAt, -1, 'the platform guard must exist');
+      const firstShellOut = Math.min(
+        ...[/\bcurl\b/, /ensure_homebrew\b/, /\bbrew\b/]
+          .map((re) => script.search(re))
+          .filter((i) => i !== -1)
+      );
+      assert.ok(guardAt < firstShellOut,
+        'the platform guard must come before anything that shells out, or a regression would run the real Homebrew');
+
+      const box = sandbox({
+        uname: 'echo Linux',
+        curl: 'echo "STUB CURL SHOULD NOT RUN" >&2; exit 99'
+      });
+      const { code, output } = runInstall(box);
+
+      assert.equal(code, 1, 'must exit non-zero on a non-macOS platform');
+      assert.match(output, /requires macOS/i, 'must say plainly that macOS is required');
+      assert.doesNotMatch(output, /Homebrew|brew\.sh/i,
+        'must refuse BEFORE any Homebrew bootstrap — the refusal is the whole point');
+      assert.doesNotMatch(output, /STUB CURL SHOULD NOT RUN/,
+        'must not reach any network call');
+    });
+
+    it('reports a failed installer download as a download failure, not a PATH problem (#615)', () => {
+      // A failed `curl` inside `bash -c "$(curl …)"` yields an empty script,
+      // `bash -c ""` exits 0, and the guard never fires — so the script used to
+      // blame PATH for a Homebrew that was never installed. That advice loops
+      // forever: re-running reproduces it exactly.
+
+      // Safety interlock (see the describe comment): without the two-step
+      // download the script falls through to the real Homebrew probe, so refuse
+      // to execute unless the capture-then-run shape is present.
+      assert.match(script, /brew_installer="\$\(curl/,
+        'the installer must be captured before it is executed, or a regression would reach the real Homebrew');
+
+      const box = sandbox({
+        uname: 'echo Darwin',
+        curl: 'exit 6' // curl(6) — could not resolve host; writes nothing
+      });
+      const { code, output } = runInstall(box);
+
+      assert.equal(code, 1, 'must fail when the installer cannot be downloaded');
+      assert.match(output, /could not download the Homebrew installer/i,
+        'must name the real failure: the download');
+      assert.doesNotMatch(output, /not on PATH/i,
+        'must NOT blame PATH — Homebrew was never installed, and that advice sends the user in a circle');
+    });
+  });
+
   describe('server plist stderr breadcrumb (#324)', () => {
     const plist = fs.readFileSync(
       path.join(__dirname, '..', 'deploy', 'com.tangleclaw.server.plist'),

--- a/test/install-sh.test.js
+++ b/test/install-sh.test.js
@@ -283,6 +283,27 @@ describe('deploy/install.sh', () => {
       assert.doesNotMatch(output, /not on PATH/i,
         'must NOT blame PATH — Homebrew was never installed, and that advice sends the user in a circle');
     });
+
+    it('refuses to execute an empty installer payload (#615)', () => {
+      // The subtler half of the same defect: curl exits 0 on a 200 response
+      // with an empty body (a captive portal, a proxy error page stripped to
+      // nothing), so the download guard passes and we would again run
+      // `bash -c ""` — succeeding at nothing and then blaming PATH. Success
+      // plus an empty payload must still be refused.
+      assert.match(script, /\[ -n "\$brew_installer" \]/,
+        'the empty-payload guard must exist before this test runs the script');
+
+      const box = sandbox({
+        uname: 'echo Darwin',
+        curl: 'exit 0' // succeeds, writes nothing
+      });
+      const { code, output } = runInstall(box);
+
+      assert.equal(code, 1, 'an empty installer payload must fail');
+      assert.match(output, /empty/i, 'must say the payload was empty');
+      assert.doesNotMatch(output, /not on PATH/i,
+        'must not fall through to the PATH diagnosis');
+    });
   });
 
   describe('server plist stderr breadcrumb (#324)', () => {

--- a/test/install-sh.test.js
+++ b/test/install-sh.test.js
@@ -304,6 +304,24 @@ describe('deploy/install.sh', () => {
       assert.doesNotMatch(output, /not on PATH/i,
         'must not fall through to the PATH diagnosis');
     });
+
+    it('reports a failing installer as an installer failure (#615)', () => {
+      // The third branch: the download succeeded and the payload is non-empty,
+      // but running it fails. Distinguishing this from the two above is the
+      // whole point of splitting the steps — all three used to collapse into
+      // the same wrong PATH diagnosis.
+      const box = sandbox({
+        uname: 'echo Darwin',
+        curl: 'echo "exit 1" ' // a valid, non-empty script that fails when run
+      });
+      const { code, output } = runInstall(box);
+
+      assert.equal(code, 1, 'a failing installer must fail the script');
+      assert.match(output, /Homebrew installer failed/i,
+        'must name the installer as what failed');
+      assert.doesNotMatch(output, /could not download/i,
+        'must not report a download problem — the download succeeded');
+    });
   });
 
   describe('server plist stderr breadcrumb (#324)', () => {

--- a/test/install-sh.test.js
+++ b/test/install-sh.test.js
@@ -161,10 +161,10 @@ describe('deploy/install.sh', () => {
     });
   });
 
-  // These two run the real script rather than grepping it, because both defects
-  // were failures of BEHAVIOR that a source-shape assertion would have happily
-  // matched: the script "handled" a failed download and "supported" Linux right
-  // up until you ran it.
+  // These tests run the real script rather than grepping it, because the
+  // defects were failures of BEHAVIOR that a source-shape assertion would have
+  // happily matched: the script "handled" a failed download and "supported"
+  // Linux right up until you ran it.
   //
   // Executing an installer in a unit test needs a hard safety story, and a
   // stubbed PATH is NOT sufficient on its own: `ensure_homebrew` probes
@@ -310,6 +310,14 @@ describe('deploy/install.sh', () => {
       // but running it fails. Distinguishing this from the two above is the
       // whole point of splitting the steps — all three used to collapse into
       // the same wrong PATH diagnosis.
+
+      // Safety interlock (see the describe comment): containment for THIS path
+      // rests on the execution guard exiting non-zero. Regressed to a
+      // non-exiting form, `||` suppresses `set -e`, control falls through to
+      // the absolute-path brew probe and on to a real `brew install node`.
+      assert.match(script, /\/bin\/bash -c "\$brew_installer" \\\n\s*\|\| \{[^}]*exit 1/,
+        'the installer execution must exit non-zero on failure, or a regression would reach the real Homebrew');
+
       const box = sandbox({
         uname: 'echo Darwin',
         curl: 'echo "exit 1" ' // a valid, non-empty script that fails when run

--- a/test/server-listen-protocol.test.js
+++ b/test/server-listen-protocol.test.js
@@ -1,0 +1,97 @@
+'use strict';
+
+// The startup banner must describe the socket that exists, not the config that
+// asked for it (#616). On a fresh install the shipped default is
+// `httpsEnabled: true` with no certificates, so `createServer` falls back to
+// plain HTTP — and the banner, derived from config, announced
+// `listening on https://*:3101 … https=true` two lines after logging the
+// fallback itself. The first URL a new operator trusts pointed at a scheme the
+// server does not speak, sending them to debug certificates never in play.
+//
+// These tests pin the predicate the banner reads. They are deliberately about
+// the FALLBACK paths: that is where intent and reality diverge, and the only
+// place the old derivation was wrong.
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const https = require('node:https');
+const os = require('node:os');
+const path = require('node:path');
+const { setLevel } = require('../lib/logger');
+
+setLevel('error'); // the fallback paths log WARNs by design
+
+const { createServer, serverProtocol } = require('../server');
+
+describe('startup protocol reporting (#616)', () => {
+  describe('serverProtocol reads the constructed server, not config intent', () => {
+    it('reports http for a plain HTTP server', () => {
+      assert.equal(serverProtocol(http.createServer()), 'http');
+    });
+
+    it('reports https for an HTTPS server', () => {
+      // Control: without this, every other assertion here would also pass for a
+      // predicate hard-wired to return 'http'. No certificate material is
+      // needed — the class of the constructed object is what the banner reads,
+      // and binding this to a real keypair would tie the suite to whatever
+      // certs happen to exist on the machine.
+      assert.equal(serverProtocol(https.createServer()), 'https');
+    });
+  });
+
+  describe('the fresh-install path: HTTPS requested, no certificates', () => {
+    it('falls back to a plain HTTP server', () => {
+      const server = createServer({ httpsEnabled: true, certPath: null, keyPath: null });
+      assert.ok(!(server instanceof https.Server),
+        'no cert/key means the socket cannot serve TLS');
+    });
+
+    it('reports http — NOT the https the config asked for', () => {
+      // This is the exact regression: config says https, reality is http, and
+      // the banner must side with reality.
+      const server = createServer({ httpsEnabled: true, certPath: null, keyPath: null });
+      assert.equal(serverProtocol(server), 'http',
+        'the banner must report the effective protocol after the fallback');
+    });
+  });
+
+  describe('HTTPS requested with unusable certificate paths', () => {
+    it('falls back and reports http', () => {
+      const missing = path.join(os.tmpdir(), 'tc-does-not-exist-cert.pem');
+      const server = createServer({ httpsEnabled: true, certPath: missing, keyPath: missing });
+      assert.equal(serverProtocol(server), 'http',
+        'an unreadable cert falls back to HTTP, and the banner must say so');
+    });
+  });
+
+  describe('HTTPS not requested', () => {
+    it('reports http', () => {
+      const server = createServer({ httpsEnabled: false });
+      assert.equal(serverProtocol(server), 'http');
+    });
+  });
+
+  // The behavioral tests above pin the predicate; they cannot see whether the
+  // banner still USES it. The original defect was precisely a correct fallback
+  // paired with a banner that read config instead — so re-deriving the scheme
+  // from `effectiveHttps` at the log site would reintroduce #616 with every
+  // test above still green. The banner lives inside `require.main === module`
+  // and is not reachable from a unit test, so this coupling is pinned at the
+  // source level. It is a structural check standing in for an unreachable
+  // behavioral one, not a preference about how the line is written.
+  describe('the startup banner is wired to the predicate', () => {
+    const fs = require('node:fs');
+    const serverSource = fs.readFileSync(path.join(__dirname, '..', 'server.js'), 'utf8');
+
+    it('derives the listen protocol from serverProtocol(server)', () => {
+      assert.match(serverSource, /const protocol = serverProtocol\(server\)/,
+        'the listen banner must take its scheme from the constructed server');
+    });
+
+    it('does not derive the listen protocol from config intent', () => {
+      assert.doesNotMatch(serverSource, /const protocol = effectiveHttps/,
+        'deriving the banner from config intent is the #616 regression');
+    });
+  });
+});

--- a/test/server-listen-protocol.test.js
+++ b/test/server-listen-protocol.test.js
@@ -93,5 +93,16 @@ describe('startup protocol reporting (#616)', () => {
       assert.doesNotMatch(serverSource, /const protocol = effectiveHttps/,
         'deriving the banner from config intent is the #616 regression');
     });
+
+    it('flags the divergence when HTTPS was requested but is not being served', () => {
+      // Reporting `http` is honest but silent about WHY, and the fallback WARN
+      // it points back at scrolls away in a busy startup. The marker is what
+      // links the two lines for an operator reading the log after the fact —
+      // which is the normal case here, since the operator is rarely at the
+      // machine. Structural for the same reason as the pins above: the banner
+      // is inside `require.main === module`.
+      assert.match(serverSource, /effectiveHttps && !servingHttps \? \{ httpsFallback: true \}/,
+        'the banner must mark the intent-vs-reality divergence');
+    });
   });
 });


### PR DESCRIPTION
## What

Fixes the four install/first-run defects the tc-cleanroom acceptance gate reproduces on every run. Three share one shape: **the code handled a failure correctly and then described it wrongly** — and two of those descriptions sent the user in a loop.

- **#614** — `install.sh` had no platform guard. A Linux user got a Linuxbrew bootstrap and launchd steps that cannot work, instead of the refusal the README's Prerequisites already documented. It now exits before writing or downloading anything.
- **#615** — `ensure_homebrew` ran `bash -c "$(curl …)"`. A failed download yields an empty script, `bash -c ""` exits 0, the `||` guard never fires, and the next check blamed **PATH** for a Homebrew that was never installed. Re-running reproduces it exactly, forever. Download and execution are now separate steps, with the three failure modes (download failed / empty payload / installer failed) each saying what actually happened.
- **#616** — the startup banner derived its scheme from config intent, while `createServer` falls back to plain HTTP without usable certs. That is the *ordinary fresh-install state* (the shipped default enables HTTPS before any certificate exists), so the banner announced `listening on https://*:3101 … https=true` two lines after logging the fallback. The scheme now comes from the constructed server via `serverProtocol()`, and the line carries `httpsFallback: true` when intent and reality diverge.
- **#617** — **misdiagnosed as filed.** The README's 3102 is correct for the documented path: `install.sh` generates a plist setting `TANGLECLAW_PORT=3102`. The gate saw 3101 only because `install.sh` had already refused on Linux, so the server was started by hand on the code default. Changing the README to 3101 as the issue asked would have sent every real macOS installer to a dead port. The distinction is documented instead.

Reviewing that paragraph surfaced a genuine docs bug it would otherwise have compounded: five places documented **ttyd on 3101**, when ttyd binds **3100** in direct mode and a Unix socket under caddy. Left alone, the README would have used 3101 for two different services — the exact ambiguity #617 was filed against. Corrected across README, user-guide, and configuration-reference.

## Why the tests execute the script

Both install.sh defects were behavioral, and a source-shape assertion matches the broken version just as happily as the fixed one — so these tests run the real script under a stubbed PATH and a throwaway HOME.

That needs a hard safety story, and a stubbed PATH is **not** containment: `ensure_homebrew` probes `/opt/homebrew/bin/brew` by absolute path. While validating these tests, the unguarded script escaped the sandbox, reached the developer's real Homebrew, and began auto-updating it. So each executed test is **interlocked** — it first asserts from source that the fix under test is present and precedes any shell-out, and only then runs the script. Execution therefore only ever happens against a script already known to refuse early.

## Test plan

- `node --test 'test/*.test.js'` — 4502 tests, **0 failures**, 1 skipped.
- Machine-backed evidence recorded at the head tree (`prawduct-hook test-evidence`, 0 failed).
- Live check of #616: `createServer({httpsEnabled: true, certPath: null, keyPath: null})` now reports `http` / `https=false`, matching the fallback WARN.
- Critic: `cumulative` (0 blocking, 7 warnings) → fixes → two `verify-resolutions` passes, ending 0 blocking.

## Deliberately not in scope

**#654** — the same config-intent-vs-reality shape survives in two *port* derivations (`server.js:1105` post-HTTPS-restart `redirectUrl`, `scripts/ingress-cutover.js:235`) and two more *protocol* ones (`install.sh`'s health check; `/api/health` + `/api/config` reporting `httpsEnabled` intent). The `redirectUrl` one is operator-facing — on a standard install it redirects to a dead port after the HTTPS setup flow. Filed rather than folded in: it needs its own decision about where the single derivation lives, and the cleanest answer is probably to have the running server report its own effective port and protocol so every consumer asks instead of deriving.

Fixes #614
Fixes #615
Fixes #616
Fixes #617