### PR TITLE
Enforce port-lease ownership instead of trusting clients

### DIFF
--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -26,6 +26,45 @@ Tag-line conventions (ART-4K9M, ratified 2026-07-17):
 -->
 
 
+## 2026-07-20: Port leases enforce ownership (#613)
+
+<!-- prawduct: type=bugfix | scope=porthub-ownership | status=shipped -->
+
+**Why:** PortHub's whole purpose is conflict prevention, and the guarantee rested on every
+client choosing to check first. That is not a guarantee, and it failed live: a session leased
+a port a running project already owned, the owner's row was overwritten with a `201`, and
+recovering it meant pulling the old row out of a Time Machine snapshot. The injected guide
+said "never overwrite another project's lease" while the API cheerfully did exactly that.
+
+**What:** `store.portLeases.lease()` checks ownership before the upsert — enforcement sits in
+the store, not the route, so no caller can bypass it, including in-process ones. A
+cross-project claim on a LIVE lease throws `PORT_CONFLICT` (409 with the owner in the body);
+`force: true` takes it over and logs the displaced lease to the server log and the activity
+feed. Same-project re-lease is a renewal, and an expired lease blocks nobody.
+
+**Two things the boundary investigation changed about the design.** PortHub's bootstrap
+re-registers the infra ports on every boot under a project name derived from the CHECKOUT
+DIRECTORY name — so a clone or worktree named anything else would 409 against its own
+previous lease and fail to start. Bootstrap therefore passes `force`, which is correct on its
+own terms: the server is binding those ports regardless, so a refusal would make the registry
+lie rather than prevent anything. Separately, `lib/tunnel.js` already implemented this exact
+ownership guard in userland — evidence the rule was real and merely unenforceable where it
+mattered.
+
+**Liveness is defined as the exact inverse of `expireStale`'s predicate**, and compared inside
+SQLite rather than JS: `expires_at` is stored as UTC in `YYYY-MM-DD HH:MM:SS` form with no
+zone suffix, so `new Date()` would read it as local time and shift liveness by the machine's
+UTC offset everywhere outside UTC.
+
+**Tests:** the existing `upsert updates existing lease` asserted the defect was correct
+behavior. It is inverted rather than deleted — the renewal half of that upsert is real and
+still needs a contract; only the cross-project half was wrong. Live-verified against the real
+route on an isolated store: claim → 409 with owner → self-renew 201 → forced takeover 201 →
+takeover logged.
+
+**Filed, not absorbed:** #656 — `release` and `heartbeat` take no `project` at all, so any
+caller can delete or renew another project's lease. Release is arguably the wider hole, and
+fixing it is a breaking signature change that deserves its own decision.
 ## 2026-07-20: First-run install honesty (#614, #615, #616, #617)
 
 <!-- prawduct: type=bugfix | scope=install-first-run | status=shipped -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,23 @@ All notable changes to TangleClaw are documented in this file.
   the parser tolerates absent headings, so this is inert. The `methodology` project
   field no longer influences the wrap; the field, chooser, templates, and registry
   are removed in the second half of #538.
+- **Eval Audit scores every project against one dimension set.** Custom eval dimensions
+  were declared by methodology templates, so the prawduct-specific tier-3
+  `methodology_compliance` dimension retires with them. Scores are now comparable across
+  projects rather than only within a workflow. (Zero recorded scores were affected.)
+- **The prime prompt's size ceiling is code-owned.** It was a per-template number (2000 or
+  4000 tokens); it is now a single 4000-token constant — deliberately the larger of the
+  two, because the cap truncates the prompt's tail and a cut tail silently drops the
+  directive sections at the end of the prime (#557).
+- **New projects no longer get three extension rules switched on for them.** The prawduct
+  template used to enable `independentCritic`, `docsParity`, and `decisionFramework` at
+  create/attach; those rules render into a generated `CLAUDE.md`, which is skipped
+  wholesale for plugin-governed projects — so the seeding was already near-inert for
+  exactly the projects it targeted. Toggle them per project in Settings.
+- **The project-action endpoint reports why it refused.** `POST
+  /api/projects/:name/actions/:command` now routes on an explicit result code instead of
+  matching on error-message text, so an unavailable action returns 404 with a clear
+  reason rather than depending on the wording of a message.
 
 ### Internal
 
@@ -135,26 +152,6 @@ All notable changes to TangleClaw are documented in this file.
   Project actions are now published as a top-level `actions[]` on the project payload.
   No other repo in the fleet consumes these, so this ships as a normal release rather
   than a major bump — say the word if you'd rather it carry a major.
-
-### Changed
-
-- **Eval Audit scores every project against one dimension set.** Custom eval dimensions
-  were declared by methodology templates, so the prawduct-specific tier-3
-  `methodology_compliance` dimension retires with them. Scores are now comparable across
-  projects rather than only within a workflow. (Zero recorded scores were affected.)
-- **The prime prompt's size ceiling is code-owned.** It was a per-template number (2000 or
-  4000 tokens); it is now a single 4000-token constant — deliberately the larger of the
-  two, because the cap truncates the prompt's tail and a cut tail silently drops the
-  directive sections at the end of the prime (#557).
-- **New projects no longer get three extension rules switched on for them.** The prawduct
-  template used to enable `independentCritic`, `docsParity`, and `decisionFramework` at
-  create/attach; those rules render into a generated `CLAUDE.md`, which is skipped
-  wholesale for plugin-governed projects — so the seeding was already near-inert for
-  exactly the projects it targeted. Toggle them per project in Settings.
-- **The project-action endpoint reports why it refused.** `POST
-  /api/projects/:name/actions/:command` now routes on an explicit result code instead of
-  matching on error-message text, so an unavailable action returns 404 with a clear
-  reason rather than depending on the wording of a message.
 
 ## [4.29.0] - 2026-07-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,9 +42,12 @@ All notable changes to TangleClaw are documented in this file.
   `port.takeover`. Renewing a lease your own project already holds is unchanged, so idempotent
   re-registration on every boot needs no special handling, and an expired lease blocks nobody.
   Enforcement lives in `store.portLeases.lease()` rather than the route, so no caller — including
-  in-process ones — can bypass it. `data/porthub-guide.md` (injected into every managed
-  project's engine config) documents the new failure mode, and its long-standing claim that
-  leases are "permanent by default" is corrected: over HTTP the default is `false`.
+  in-process ones — can bypass it *on the lease path*. It is not yet symmetric: `release` and
+  `heartbeat` accept no `project`, so any caller can still release another project's lease and
+  then claim the freed port (#656). `data/porthub-guide.md` (injected into every managed
+  project's engine config) documents the new failure mode and states that limit plainly, and
+  its long-standing claim that leases are "permanent by default" is corrected: over HTTP the
+  default is `false`.
 
 - **The wrap pipeline is now code-owned — every project runs the same step list,
   configured per project instead of per methodology (#538, first half).** The step

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,22 @@ All notable changes to TangleClaw are documented in this file.
 
 ### Changed
 
+- **`POST /api/ports/lease` refuses to overwrite another project's live lease
+  (#613).** The endpoint upserted unconditionally, so claiming a port another project owned
+  replaced the owner's row and returned `201` — no error, no warning, no record of who held
+  it. The documented contract said "never overwrite another project's lease", but enforcement
+  was client convention, and the convention failed live: a session took a port belonging to a
+  running project, and recovering the previous owner meant digging the row out of a Time
+  Machine snapshot. A cross-project claim on a live lease now returns **409** with
+  `code: "PORT_CONFLICT"` and the current `owner` in the body; `"force": true` still takes the
+  port, logging the displaced lease to both the server log and the activity feed as
+  `port.takeover`. Renewing a lease your own project already holds is unchanged, so idempotent
+  re-registration on every boot needs no special handling, and an expired lease blocks nobody.
+  Enforcement lives in `store.portLeases.lease()` rather than the route, so no caller — including
+  in-process ones — can bypass it. `data/porthub-guide.md` (injected into every managed
+  project's engine config) documents the new failure mode, and its long-standing claim that
+  leases are "permanent by default" is corrected: over HTTP the default is `false`.
+
 - **The wrap pipeline is now code-owned — every project runs the same step list,
   configured per project instead of per methodology (#538, first half).** The step
   sequence used to be data in each methodology template

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,7 +151,9 @@ TangleClaw is the central port registry for every project on this machine — re
 ### Rules
 - **Never hardcode ports** — check and register through TangleClaw first.
 - **Register before binding** to a port (dev server, database, API, etc.).
-- **Check for conflicts** before claiming a port — another project may already own it.
+- **Check for conflicts** before claiming a port — another project may already own it. The
+  registry now enforces this: claiming a port another project holds returns **409**, it does
+  not silently take it.
 - **Release** a port once it's no longer needed (service stopped, teardown, cleanup).
 
 ### Port Ranges Convention
@@ -172,7 +174,9 @@ All calls are JSON. The API base URL is injected **below this guide**; use it as
 # Check what's taken (before picking a port)
 GET /api/ports
 
-# Register a port (permanent by default — survives restarts)
+# Register a port. Pass "permanent": true to survive restarts (the default over
+# HTTP is false — an omitted flag gives you a non-permanent lease).
+# Returns 201 on success, or 409 if another project already holds the port.
 POST /api/ports/lease
 { "port": 3200, "project": "my-project", "service": "dev-server", "permanent": true }
 
@@ -194,7 +198,26 @@ POST /api/ports/heartbeat
 - **Release** when removing a service from a project's config, permanently shutting one down (not just a temporary stop), or when the project no longer needs the port.
 
 ### Conflict Resolution
-If `GET /api/ports` shows a port is taken, pick a different one in the same range — never overwrite another project's lease.
+
+Claiming a port another project holds returns **409** with the current owner:
+
+```json
+{ "error": "Port 3200 on localhost is leased by \"other-project\" (dev-server). …",
+  "code": "PORT_CONFLICT",
+  "owner": { "project": "other-project", "service": "dev-server", "permanent": true } }
+```
+
+**Pick a different port in the same range.** That is the answer in almost every case — the
+owner in the response tells you who has it without a second call.
+
+Re-leasing a port **your own project** already holds is a renewal, not a conflict: it
+succeeds normally, so idempotent re-registration on every boot needs no special handling.
+An **expired** lease does not block anyone.
+
+Taking over a live lease requires `"force": true` in the body. It is deliberately explicit
+and it is logged with the displaced owner, because the displaced project is still running
+against a port the registry no longer says is theirs. Use it only when you know the previous
+owner is gone — otherwise release the port from the owning side first.
 
 **TangleClaw API base URL**: `http://localhost:3102`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,6 +219,13 @@ and it is logged with the displaced owner, because the displaced project is stil
 against a port the registry no longer says is theirs. Use it only when you know the previous
 owner is gone — otherwise release the port from the owning side first.
 
+**Scope of enforcement, precisely.** `lease` is guarded. `release` and `heartbeat` are **not** —
+they take only a port, so they cannot check ownership, and any caller can release or renew any
+lease (tracked as issue #656). So "the registry enforces this" means it will not let you
+*overwrite* someone's lease; it cannot yet stop you *releasing* it and then claiming the freed
+port. Treat release as the destructive call it is: release only ports your own project holds.
+
+
 **TangleClaw API base URL**: `http://localhost:3102`
 
 ## Shared Documents

--- a/data/porthub-guide.md
+++ b/data/porthub-guide.md
@@ -72,3 +72,10 @@ Taking over a live lease requires `"force": true` in the body. It is deliberatel
 and it is logged with the displaced owner, because the displaced project is still running
 against a port the registry no longer says is theirs. Use it only when you know the previous
 owner is gone — otherwise release the port from the owning side first.
+
+**Scope of enforcement, precisely.** `lease` is guarded. `release` and `heartbeat` are **not** —
+they take only a port, so they cannot check ownership, and any caller can release or renew any
+lease (tracked as issue #656). So "the registry enforces this" means it will not let you
+*overwrite* someone's lease; it cannot yet stop you *releasing* it and then claiming the freed
+port. Treat release as the destructive call it is: release only ports your own project holds.
+

--- a/data/porthub-guide.md
+++ b/data/porthub-guide.md
@@ -5,7 +5,9 @@ TangleClaw is the central port registry for every project on this machine — re
 ### Rules
 - **Never hardcode ports** — check and register through TangleClaw first.
 - **Register before binding** to a port (dev server, database, API, etc.).
-- **Check for conflicts** before claiming a port — another project may already own it.
+- **Check for conflicts** before claiming a port — another project may already own it. The
+  registry now enforces this: claiming a port another project holds returns **409**, it does
+  not silently take it.
 - **Release** a port once it's no longer needed (service stopped, teardown, cleanup).
 
 ### Port Ranges Convention
@@ -26,7 +28,9 @@ All calls are JSON. The API base URL is injected **below this guide**; use it as
 # Check what's taken (before picking a port)
 GET /api/ports
 
-# Register a port (permanent by default — survives restarts)
+# Register a port. Pass "permanent": true to survive restarts (the default over
+# HTTP is false — an omitted flag gives you a non-permanent lease).
+# Returns 201 on success, or 409 if another project already holds the port.
 POST /api/ports/lease
 { "port": 3200, "project": "my-project", "service": "dev-server", "permanent": true }
 
@@ -48,4 +52,23 @@ POST /api/ports/heartbeat
 - **Release** when removing a service from a project's config, permanently shutting one down (not just a temporary stop), or when the project no longer needs the port.
 
 ### Conflict Resolution
-If `GET /api/ports` shows a port is taken, pick a different one in the same range — never overwrite another project's lease.
+
+Claiming a port another project holds returns **409** with the current owner:
+
+```json
+{ "error": "Port 3200 on localhost is leased by \"other-project\" (dev-server). …",
+  "code": "PORT_CONFLICT",
+  "owner": { "project": "other-project", "service": "dev-server", "permanent": true } }
+```
+
+**Pick a different port in the same range.** That is the answer in almost every case — the
+owner in the response tells you who has it without a second call.
+
+Re-leasing a port **your own project** already holds is a renewal, not a conflict: it
+succeeds normally, so idempotent re-registration on every boot needs no special handling.
+An **expired** lease does not block anyone.
+
+Taking over a live lease requires `"force": true` in the body. It is deliberately explicit
+and it is logged with the displaced owner, because the displaced project is still running
+against a port the registry no longer says is theirs. Use it only when you know the previous
+owner is gone — otherwise release the port from the owning side first.

--- a/lib/porthub.js
+++ b/lib/porthub.js
@@ -52,7 +52,10 @@ function registerPort(port, projectName, service, options = {}) {
       force: options.force === true
     });
     log.info('Port registered', { host, port, project: projectName, service });
-    return { success: true, error: null };
+    // Same key set on both paths so callers can read `.code`/`.owner` without
+    // first checking `.success` — an absent key and a null one read the same in
+    // a truthiness test but not in a strict one.
+    return { success: true, error: null, code: null, owner: null };
   } catch (err) {
     log.warn('Port registration failed', { host, port, project: projectName, error: err.message });
     // Surface the conflict distinctly: callers that can pick another port need

--- a/lib/porthub.js
+++ b/lib/porthub.js
@@ -43,13 +43,22 @@ function registerPort(port, projectName, service, options = {}) {
       service,
       permanent,
       ttlMs: options.ttlMs || null,
-      description: options.description || null
+      description: options.description || null,
+      force: options.force === true
     });
     log.info('Port registered', { host, port, project: projectName, service });
     return { success: true, error: null };
   } catch (err) {
     log.warn('Port registration failed', { host, port, project: projectName, error: err.message });
-    return { success: false, error: err.message };
+    // Surface the conflict distinctly: callers that can pick another port need
+    // to tell "someone else owns this" apart from a malformed request, and the
+    // owner is what makes the failure actionable rather than just a message.
+    return {
+      success: false,
+      error: err.message,
+      code: err.code || null,
+      owner: err.owner || null
+    };
   }
 }
 
@@ -193,9 +202,18 @@ function bootstrap(config) {
   log.info('PortHub bootstrap starting');
 
   // Register TangleClaw infra ports (use directory name to match registered project)
+  //
+  // `force` is required here, and it is not a convenience. These ports are the
+  // server's own — it is binding them regardless of what the registry says, so
+  // a refusal would make the registry lie rather than prevent anything. It also
+  // keeps startup working when the derived name drifts: `selfName` is the
+  // CHECKOUT DIRECTORY name, so a clone or worktree named anything other than
+  // the original re-registers the same ports under a different owner and would
+  // otherwise 409 against its own previous lease on every boot. The takeover is
+  // logged like any other.
   const selfName = path.basename(path.resolve(__dirname, '..'));
-  registerPort(config.ttydPort, selfName, 'ttyd', { permanent: true });
-  registerPort(config.serverPort, selfName, 'server', { permanent: true });
+  registerPort(config.ttydPort, selfName, 'ttyd', { permanent: true, force: true });
+  registerPort(config.serverPort, selfName, 'server', { permanent: true, force: true });
 
   // Sync from old PortHub daemon on every boot.
   // _migrateFromOldPorthub skips ports already in our database,

--- a/lib/porthub.js
+++ b/lib/porthub.js
@@ -20,7 +20,12 @@ let _expirationTimer = null;
  * @param {boolean} [options.permanent] - Whether the lease is permanent (default true)
  * @param {number} [options.ttlMs] - TTL in milliseconds (for non-permanent leases)
  * @param {string} [options.description] - Description
- * @returns {{ success: boolean, error: string|null }}
+ * @param {boolean} [options.force] - Take over a live lease held by a different
+ *   project. Without it such a claim fails with `code: 'PORT_CONFLICT'`;
+ *   renewing a lease this project already holds never needs it.
+ * @returns {{ success: boolean, error: string|null, code: string|null, owner: object|null }}
+ *   On a conflict, `code` is `'PORT_CONFLICT'` and `owner` is the current lease —
+ *   enough to pick another port without a second call.
  */
 function registerPort(port, projectName, service, options = {}) {
   const host = options.host || 'localhost';

--- a/lib/store.js
+++ b/lib/store.js
@@ -3589,6 +3589,18 @@ const portLeasesApi = {
     const existing = portLeasesApi.get(data.port, host);
     if (existing && existing.project !== data.project && _isLeaseLive(existing)) {
       if (!data.force) {
+        // Log the refusal, not just the takeover. A project failing to claim
+        // its port is the FAR more common outcome and may repeat every boot;
+        // without this the only trace is whatever the caller chooses to
+        // report, which for a raw API client is nothing.
+        log.warn('Refused port lease — another project holds it', {
+          host,
+          port: data.port,
+          owner: existing.project,
+          ownerService: existing.service,
+          requestedBy: data.project,
+          requestedService: data.service
+        });
         const err = new StoreError(
           `Port ${data.port} on ${host} is leased by "${existing.project}" (${existing.service}). ` +
           'Release it first, pick another port, or repeat with force to take it over.',
@@ -5533,11 +5545,6 @@ function _rowToSessionRuleVersion(row) {
   };
 }
 
-/**
- * Convert a SQLite port_leases row to an app-level object.
- * @param {object} row - Raw SQLite row
- * @returns {object}
- */
 /**
  * Is this lease still live, i.e. would the expiry sweep leave it alone?
  *

--- a/lib/store.js
+++ b/lib/store.js
@@ -3560,7 +3560,13 @@ const portLeasesApi = {
    * @param {number} [data.ttlMs]
    * @param {string} [data.description]
    * @param {boolean} [data.autoRenew]
+   * @param {boolean} [data.force] - Take over a live lease held by a different
+   *   project. Without it, such a request throws `PORT_CONFLICT` (the error
+   *   carries the current lease on `.owner`). Re-leasing a port this same
+   *   project already holds is a renewal and never needs it.
    * @returns {object}
+   * @throws {StoreError} `PORT_CONFLICT` when another project holds a live
+   *   lease on the port and `force` was not set
    */
   lease(data) {
     _ensureDb();
@@ -3569,6 +3575,51 @@ const portLeasesApi = {
     }
 
     const host = data.host || 'localhost';
+
+    // Ownership check BEFORE the upsert. PortHub's entire purpose is conflict
+    // prevention, and until now that guarantee rested on every client choosing
+    // to check first — which failed live: a session leased a port that a
+    // running project already owned, the previous owner's row was overwritten
+    // with no error and no record, and recovery meant digging the old row out
+    // of a Time Machine snapshot. Enforcing it here rather than in the route
+    // means no caller can bypass it, including the in-process ones.
+    //
+    // Only a LIVE lease blocks. An expired one is already garbage awaiting the
+    // sweep, so taking its port is not a conflict.
+    const existing = portLeasesApi.get(data.port, host);
+    if (existing && existing.project !== data.project && _isLeaseLive(existing)) {
+      if (!data.force) {
+        const err = new StoreError(
+          `Port ${data.port} on ${host} is leased by "${existing.project}" (${existing.service}). ` +
+          'Release it first, pick another port, or repeat with force to take it over.',
+          'PORT_CONFLICT'
+        );
+        err.owner = existing;
+        throw err;
+      }
+      // A forced takeover is legitimate but must never be quiet — the displaced
+      // owner keeps running against a port the registry no longer says is
+      // theirs, and this log is the only trace of who held it.
+      log.warn('Forced takeover of another project\'s port lease', {
+        host,
+        port: data.port,
+        displacedProject: existing.project,
+        displacedService: existing.service,
+        newProject: data.project,
+        newService: data.service
+      });
+      activityApi.log({
+        eventType: 'port.takeover',
+        detail: {
+          host,
+          port: data.port,
+          displacedProject: existing.project,
+          displacedService: existing.service,
+          project: data.project,
+          service: data.service
+        }
+      });
+    }
     const permanent = data.permanent ? 1 : 0;
     const status = data.permanent ? 'permanent' : 'active';
     const ttlMs = data.ttlMs || null;
@@ -5486,6 +5537,35 @@ function _rowToSessionRuleVersion(row) {
  * Convert a SQLite port_leases row to an app-level object.
  * @param {object} row - Raw SQLite row
  * @returns {object}
+ */
+/**
+ * Is this lease still live, i.e. would the expiry sweep leave it alone?
+ *
+ * Defined as the exact inverse of `expireStale`'s predicate so the two can
+ * never disagree about what "expired" means — a lease the sweep is about to
+ * delete must not be able to block a new claim on its port.
+ *
+ * The comparison runs in SQLite deliberately: `expires_at` is written as UTC in
+ * SQLite's `YYYY-MM-DD HH:MM:SS` form with no zone suffix, so `new Date()`
+ * would parse it as LOCAL time and shift liveness by the machine's UTC offset —
+ * silently treating expired leases as live (or the reverse) everywhere outside
+ * UTC.
+ *
+ * @param {object} lease - A lease as returned by `_rowToLease`
+ * @returns {boolean} True when the lease still holds its port
+ */
+function _isLeaseLive(lease) {
+  if (lease.permanent) return true;
+  if (!lease.expiresAt) return true;
+  if (lease.status !== 'active') return true;
+  const row = _db.prepare("SELECT (? >= datetime('now')) AS live").get(lease.expiresAt);
+  return !!(row && row.live);
+}
+
+/**
+ * Convert a SQLite port_leases row to an app-level lease object.
+ * @param {object} row - Raw SQLite row
+ * @returns {object} App-level lease
  */
 function _rowToLease(row) {
   return {

--- a/lib/tunnel.js
+++ b/lib/tunnel.js
@@ -157,11 +157,14 @@ async function ensureTunnel(projectName, config) {
   if (liveEndToEnd && !config.force) {
     const existingPid = _findSshPid(localPort, host);
     log.info('Tunnel already up (end-to-end round-trip OK)', { project: projectName, localPort, pid: existingPid });
-    // Ensure PortHub knows about this port — skip if another project already holds the lease (avoid conflicts)
-    const existingLease = porthub.getLeases().find(l => l.port === localPort && l.host === 'localhost');
-    if (!existingLease || existingLease.project === projectName) {
-      porthub.registerPort(localPort, projectName, 'openclaw-tunnel', { permanent: false, ttlMs: 86400000 });
-    }
+    // Ensure PortHub knows about this port. The ownership check that used to
+    // live here is now enforced inside the lease itself (#613), so a claim on
+    // another project's port fails rather than needing to be pre-empted — and
+    // the store's rule is the stricter one: this guard treated an EXPIRED
+    // foreign lease as a reason to skip, which left the port bound and
+    // unrecorded. A refusal is logged and does not stop the tunnel, which was
+    // already the behavior when this skipped.
+    porthub.registerPort(localPort, projectName, 'openclaw-tunnel', { permanent: false, ttlMs: 86400000 });
     // Track it in memory if not already tracked (handles server restarts)
     if (!_tunnels.has(projectName) && existingPid) {
       _tunnels.set(projectName, { pid: existingPid, localPort, host, remotePort: port });
@@ -214,11 +217,9 @@ async function ensureTunnel(projectName, config) {
     if (live) {
       const pid = _findSshPid(localPort, host);
       _tunnels.set(projectName, { pid, localPort, host, remotePort: port, forwardTarget: target });
-      // Register tunnel port with PortHub — skip if another project already holds the lease (avoid conflicts)
-      const newLease = porthub.getLeases().find(l => l.port === localPort && l.host === 'localhost');
-      if (!newLease || newLease.project === projectName) {
-        porthub.registerPort(localPort, projectName, 'openclaw-tunnel', { permanent: false, ttlMs: 86400000 });
-      }
+      // Ownership is enforced by the lease itself (#613) — see the equivalent
+      // call on the already-up path above.
+      porthub.registerPort(localPort, projectName, 'openclaw-tunnel', { permanent: false, ttlMs: 86400000 });
       log.info('Tunnel established', { project: projectName, localPort, pid, forwardTarget: target });
       return { ok: true, alreadyUp: false, pid, forwardTarget: target, error: null };
     }

--- a/lib/tunnel.js
+++ b/lib/tunnel.js
@@ -126,6 +126,26 @@ async function httpRoundTrip(localPort, timeoutMs = 4000) {
 }
 
 /**
+ * Record a live tunnel's local port in PortHub.
+ *
+ * Both `ensureTunnel` paths — the already-up branch and the freshly-spawned one
+ * — register identically, so they share this rather than repeating it. The
+ * ownership check that used to sit inline at each call site is gone: it is
+ * enforced inside the lease itself now (#613), and the store's rule is the
+ * stricter one. The old guard skipped registration whenever any other project
+ * appeared in the table, expired or not, which left the port bound and
+ * unrecorded. A refusal is logged by the store and deliberately does not fail
+ * the tunnel — which was already the effect when the guard skipped.
+ *
+ * @param {number} localPort - The forwarded local port
+ * @param {string} projectName - Lease owner
+ * @returns {void}
+ */
+function _registerTunnelPort(localPort, projectName) {
+  porthub.registerPort(localPort, projectName, 'openclaw-tunnel', { permanent: false, ttlMs: 86400000 });
+}
+
+/**
  * Ensure an SSH tunnel is running for a project's OpenClaw connection.
  * If the local port already passes an end-to-end round-trip (a genuinely live
  * tunnel), skips spawning; a bound-but-dead "zombie" (or `force`) is torn down
@@ -157,14 +177,7 @@ async function ensureTunnel(projectName, config) {
   if (liveEndToEnd && !config.force) {
     const existingPid = _findSshPid(localPort, host);
     log.info('Tunnel already up (end-to-end round-trip OK)', { project: projectName, localPort, pid: existingPid });
-    // Ensure PortHub knows about this port. The ownership check that used to
-    // live here is now enforced inside the lease itself (#613), so a claim on
-    // another project's port fails rather than needing to be pre-empted — and
-    // the store's rule is the stricter one: this guard treated an EXPIRED
-    // foreign lease as a reason to skip, which left the port bound and
-    // unrecorded. A refusal is logged and does not stop the tunnel, which was
-    // already the behavior when this skipped.
-    porthub.registerPort(localPort, projectName, 'openclaw-tunnel', { permanent: false, ttlMs: 86400000 });
+    _registerTunnelPort(localPort, projectName);
     // Track it in memory if not already tracked (handles server restarts)
     if (!_tunnels.has(projectName) && existingPid) {
       _tunnels.set(projectName, { pid: existingPid, localPort, host, remotePort: port });
@@ -217,9 +230,7 @@ async function ensureTunnel(projectName, config) {
     if (live) {
       const pid = _findSshPid(localPort, host);
       _tunnels.set(projectName, { pid, localPort, host, remotePort: port, forwardTarget: target });
-      // Ownership is enforced by the lease itself (#613) — see the equivalent
-      // call on the already-up path above.
-      porthub.registerPort(localPort, projectName, 'openclaw-tunnel', { permanent: false, ttlMs: 86400000 });
+      _registerTunnelPort(localPort, projectName);
       log.info('Tunnel established', { project: projectName, localPort, pid, forwardTarget: target });
       return { ok: true, alreadyUp: false, pid, forwardTarget: target, error: null };
     }
@@ -641,6 +652,7 @@ module.exports = {
   listTunnels,
   _tunnels,
   _spawnTunnelOnce,
+  _registerTunnelPort,
   _findSshPid,
   _findSshPidByPort,
   _findSshPidByPortLsof,

--- a/server.js
+++ b/server.js
@@ -1560,10 +1560,21 @@ route('POST', '/api/ports/lease', (_req, res, _params, body) => {
       permanent: body.permanent || false,
       ttlMs: body.ttl || null,
       description: body.description || null,
-      autoRenew: body.autoRenew || false
+      autoRenew: body.autoRenew || false,
+      force: body.force === true
     });
     jsonResponse(res, 201, lease);
   } catch (err) {
+    // A port already owned by another project is a conflict, not a malformed
+    // request — 409 lets a caller retry against a different port, and the owner
+    // in the body is what makes that decision possible without a second call.
+    if (err.code === 'PORT_CONFLICT') {
+      return jsonResponse(res, 409, {
+        error: err.message,
+        code: 'PORT_CONFLICT',
+        owner: err.owner || null
+      });
+    }
     return errorResponse(res, 400, err.message, 'BAD_REQUEST');
   }
 });

--- a/test/api-ports.test.js
+++ b/test/api-ports.test.js
@@ -109,6 +109,53 @@ describe('API /api/ports', () => {
     assert.equal(status, 400);
   });
 
+  // #613 — the API used to upsert unconditionally, so a lease request for a
+  // port another project owned silently replaced the owner with a 201. The
+  // documented contract said "never overwrite another project's lease"; it was
+  // enforced only by client convention, and the convention failed live.
+  it('POST /api/ports/lease returns 409 when another project owns the port', async () => {
+    store.portLeases.lease({ port: 5100, project: 'Owner', service: 'dev-server' });
+
+    const { status, data } = await request(server, 'POST', '/api/ports/lease', {
+      port: 5100,
+      project: 'Intruder',
+      service: 'api'
+    });
+
+    assert.equal(status, 409, 'a taken port is a conflict, not a bad request');
+    assert.equal(data.code, 'PORT_CONFLICT');
+    assert.equal(data.owner.project, 'Owner', 'the response names the owner so the caller can choose another port');
+    assert.equal(data.owner.service, 'dev-server');
+    assert.equal(store.portLeases.get(5100).project, 'Owner', 'the owner keeps the lease');
+  });
+
+  it('POST /api/ports/lease renews the same project\'s own lease with 201', async () => {
+    store.portLeases.lease({ port: 5101, project: 'Renewer', service: 'api' });
+
+    const { status, data } = await request(server, 'POST', '/api/ports/lease', {
+      port: 5101,
+      project: 'Renewer',
+      service: 'api-v2'
+    });
+
+    assert.equal(status, 201, 'renewing your own lease is not a conflict');
+    assert.equal(data.service, 'api-v2');
+  });
+
+  it('POST /api/ports/lease takes the port over when force is set', async () => {
+    store.portLeases.lease({ port: 5102, project: 'Owner', service: 'dev-server' });
+
+    const { status, data } = await request(server, 'POST', '/api/ports/lease', {
+      port: 5102,
+      project: 'Taker',
+      service: 'api',
+      force: true
+    });
+
+    assert.equal(status, 201);
+    assert.equal(data.project, 'Taker');
+  });
+
   it('POST /api/ports/release removes a lease', async () => {
     store.portLeases.lease({ port: 6000, project: 'ToRelease', service: 'temp' });
 

--- a/test/porthub.test.js
+++ b/test/porthub.test.js
@@ -111,6 +111,66 @@ describe('porthub (store-backed)', () => {
       assert.equal(server.project, expectedName);
       assert.equal(server.service, 'server');
     });
+
+    it('reclaims infra ports held under a different project name (#613)', () => {
+      // The startup-safety property behind bootstrap's `force`. The project
+      // name is derived from the CHECKOUT DIRECTORY, so a clone or worktree
+      // named anything other than the original re-registers the same ports
+      // under a different owner — and without `force` that is a cross-project
+      // claim on its own previous lease, which would 409 and leave the server
+      // unable to record the ports it is about to bind anyway.
+      store.portLeases.lease({ port: 3100, project: 'TangleClaw-worktree', service: 'ttyd', permanent: true });
+      store.portLeases.lease({ port: 3101, project: 'TangleClaw-worktree', service: 'server', permanent: true });
+
+      porthub.bootstrap({ ttydPort: 3100, serverPort: 3101 });
+
+      const expectedName = path.basename(path.resolve(__dirname, '..'));
+      assert.equal(store.portLeases.get(3100).project, expectedName,
+        'bootstrap must reclaim its own infra port regardless of the recorded owner');
+      assert.equal(store.portLeases.get(3101).project, expectedName);
+    });
+  });
+
+  // #613 — the store refuses a cross-project claim; these cover the wrapper
+  // every in-process caller actually goes through.
+  describe('registerPort ownership (#613)', () => {
+    it('fails without taking the port when another project owns it', () => {
+      store.portLeases.lease({ port: 4300, project: 'Owner', service: 'dev-server' });
+
+      const result = porthub.registerPort(4300, 'Intruder', 'api');
+
+      assert.equal(result.success, false);
+      assert.equal(store.portLeases.get(4300).project, 'Owner', 'the owner keeps the port');
+    });
+
+    it('reports the conflict distinctly from a malformed request', () => {
+      // A caller that wants to pick another port needs to tell "someone else
+      // owns this" apart from "this request was wrong", and needs to know who.
+      store.portLeases.lease({ port: 4301, project: 'Owner', service: 'dev-server' });
+
+      const result = porthub.registerPort(4301, 'Intruder', 'api');
+
+      assert.equal(result.code, 'PORT_CONFLICT');
+      assert.equal(result.owner.project, 'Owner');
+      assert.equal(result.owner.service, 'dev-server');
+    });
+
+    it('takes the port over when force is passed', () => {
+      store.portLeases.lease({ port: 4302, project: 'Owner', service: 'dev-server' });
+
+      const result = porthub.registerPort(4302, 'Taker', 'api', { force: true });
+
+      assert.equal(result.success, true);
+      assert.equal(store.portLeases.get(4302).project, 'Taker');
+    });
+
+    it('renews a port the same project already holds', () => {
+      porthub.registerPort(4303, 'Same', 'api');
+      const result = porthub.registerPort(4303, 'Same', 'api-v2');
+
+      assert.equal(result.success, true);
+      assert.equal(store.portLeases.get(4303).service, 'api-v2');
+    });
   });
 
   describe('shutdown', () => {

--- a/test/store-portleases.test.js
+++ b/test/store-portleases.test.js
@@ -149,14 +149,98 @@ describe('store.portLeases', () => {
     assert.equal(byStatus[0].port, 2000);
   });
 
-  it('upsert updates existing lease', () => {
-    store.portLeases.lease({ port: 1234, project: 'Old', service: 'svc1' });
-    store.portLeases.lease({ port: 1234, project: 'New', service: 'svc2', permanent: true });
+  // This block replaces a test named 'upsert updates existing lease', which
+  // asserted that leasing a port owned by a DIFFERENT project silently replaced
+  // the owner — it pinned the #613 defect as correct behavior. It is inverted
+  // rather than deleted because the renewal half of that upsert is real and
+  // still needs a contract; only the cross-project half was wrong.
+  describe('ownership (#613)', () => {
+    it('renews a lease the same project already holds', () => {
+      store.portLeases.lease({ port: 1234, project: 'Same', service: 'svc1' });
+      store.portLeases.lease({ port: 1234, project: 'Same', service: 'svc2', permanent: true });
 
-    const lease = store.portLeases.get(1234);
-    assert.equal(lease.project, 'New');
-    assert.equal(lease.service, 'svc2');
-    assert.equal(lease.permanent, true);
+      const lease = store.portLeases.get(1234);
+      assert.equal(lease.project, 'Same');
+      assert.equal(lease.service, 'svc2', 'a renewal still updates the lease fields');
+      assert.equal(lease.permanent, true);
+    });
+
+    it('refuses a live lease held by another project', () => {
+      store.portLeases.lease({ port: 1235, project: 'Owner', service: 'dev-server' });
+
+      assert.throws(
+        () => store.portLeases.lease({ port: 1235, project: 'Intruder', service: 'other' }),
+        (err) => err.code === 'PORT_CONFLICT' && /Owner/.test(err.message),
+        'a cross-project claim must be refused, naming the owner'
+      );
+
+      const lease = store.portLeases.get(1235);
+      assert.equal(lease.project, 'Owner', 'the original owner must survive the refusal');
+      assert.equal(lease.service, 'dev-server');
+    });
+
+    it('carries the current owner on the error so the caller can act on it', () => {
+      store.portLeases.lease({ port: 1236, project: 'Owner', service: 'dev-server' });
+
+      try {
+        store.portLeases.lease({ port: 1236, project: 'Intruder', service: 'other' });
+        assert.fail('expected a PORT_CONFLICT');
+      } catch (err) {
+        assert.equal(err.code, 'PORT_CONFLICT');
+        assert.equal(err.owner.project, 'Owner');
+        assert.equal(err.owner.service, 'dev-server');
+      }
+    });
+
+    it('allows an explicit forced takeover', () => {
+      store.portLeases.lease({ port: 1237, project: 'Owner', service: 'dev-server' });
+      store.portLeases.lease({ port: 1237, project: 'Taker', service: 'other', force: true });
+
+      const lease = store.portLeases.get(1237);
+      assert.equal(lease.project, 'Taker', 'force takes the port over');
+      assert.equal(lease.service, 'other');
+    });
+
+    it('records a forced takeover in the activity log', () => {
+      // The displaced project keeps running against a port the registry no
+      // longer says is theirs; without this entry there is no trace of who held
+      // it, which is what made the live incident so expensive to unwind.
+      store.portLeases.lease({ port: 1238, project: 'Owner', service: 'dev-server' });
+      store.portLeases.lease({ port: 1238, project: 'Taker', service: 'other', force: true });
+
+      const events = store.activity.query({ eventType: 'port.takeover', limit: 50 });
+      const entry = events.find((e) => e.detail && e.detail.port === 1238);
+      assert.ok(entry, 'a forced takeover must be logged');
+      assert.equal(entry.detail.displacedProject, 'Owner');
+      assert.equal(entry.detail.project, 'Taker');
+    });
+
+    it('lets a different project claim a port whose lease has expired', () => {
+      // An expired lease is garbage awaiting the sweep — treating it as live
+      // would strand ports behind projects that are already gone.
+      store.portLeases.lease({ port: 1239, project: 'Gone', service: 'old', ttlMs: -1000 });
+      store.portLeases.lease({ port: 1239, project: 'Fresh', service: 'new' });
+
+      assert.equal(store.portLeases.get(1239).project, 'Fresh');
+    });
+
+    it('still refuses when another project holds a permanent lease', () => {
+      store.portLeases.lease({ port: 1240, project: 'Owner', service: 'db', permanent: true });
+
+      assert.throws(
+        () => store.portLeases.lease({ port: 1240, project: 'Intruder', service: 'other' }),
+        (err) => err.code === 'PORT_CONFLICT',
+        'a permanent lease never expires, so it always blocks'
+      );
+    });
+
+    it('scopes ownership to the host — the same port on another host is free', () => {
+      store.portLeases.lease({ port: 1241, project: 'Owner', service: 'svc' });
+      store.portLeases.lease({ port: 1241, host: 'other-box', project: 'Elsewhere', service: 'svc' });
+
+      assert.equal(store.portLeases.get(1241).project, 'Owner');
+      assert.equal(store.portLeases.get(1241, 'other-box').project, 'Elsewhere');
+    });
   });
 
   it('validates required fields', () => {

--- a/test/tunnel.test.js
+++ b/test/tunnel.test.js
@@ -554,6 +554,22 @@ describe('tunnel', () => {
       }
     });
 
+    // The two ensureTunnel branches register through one helper, so testing it
+    // directly covers the spawn-path call site too — that branch needs a real
+    // `ssh -f -N -L` fork to reach, which this suite deliberately avoids.
+    it('_registerTunnelPort refuses a live foreign lease and claims an expired one', () => {
+      store.portLeases.lease({ port: 19980, project: 'live-owner', service: 'dev-server' });
+      tunnel._registerTunnelPort(19980, 'tunnel-project');
+      assert.equal(store.portLeases.get(19980).project, 'live-owner',
+        'a live foreign lease is left alone');
+
+      store.portLeases.lease({ port: 19981, project: 'expired-owner', service: 'old', ttlMs: -1000 });
+      tunnel._registerTunnelPort(19981, 'tunnel-project');
+      assert.equal(store.portLeases.get(19981).project, 'tunnel-project',
+        'an expired foreign lease does not block registration');
+      assert.equal(store.portLeases.get(19981).service, 'openclaw-tunnel');
+    });
+
     it('killTunnel releases port from PortHub', () => {
       const localPort = 19997;
       // Register the port first (simulating what ensureTunnel does)

--- a/test/tunnel.test.js
+++ b/test/tunnel.test.js
@@ -504,6 +504,56 @@ describe('tunnel', () => {
       }
     });
 
+    // #613 — the ownership check that used to sit in ensureTunnel was deleted
+    // once the store began enforcing it. These pin the two behaviors that
+    // changed, so re-adding the old guard cannot pass silently.
+    it('leaves another project\'s live lease alone and still reports the tunnel up', async () => {
+      const server = httpServer();
+      const port = await listen(server);
+      store.portLeases.lease({ port, project: 'someone-else', service: 'dev-server' });
+
+      try {
+        const result = await tunnel.ensureTunnel('test-contended', {
+          host: '198.51.100.10',
+          port: 18789,
+          localPort: port,
+          sshUser: 'test',
+          sshKeyPath: '~/.ssh/id_rsa'
+        });
+
+        assert.equal(result.ok, true, 'a lease refusal must not fail the tunnel');
+        const lease = store.portLeases.get(port);
+        assert.equal(lease.project, 'someone-else', "the owner's lease must survive");
+        assert.equal(lease.service, 'dev-server');
+      } finally {
+        server.close();
+      }
+    });
+
+    it('claims a port whose foreign lease has expired', async () => {
+      // The old guard skipped registration whenever ANY other project appeared
+      // in the table, expired or not — leaving the port bound and unrecorded.
+      const server = httpServer();
+      const port = await listen(server);
+      store.portLeases.lease({ port, project: 'long-gone', service: 'old', ttlMs: -1000 });
+
+      try {
+        await tunnel.ensureTunnel('test-expired', {
+          host: '198.51.100.10',
+          port: 18789,
+          localPort: port,
+          sshUser: 'test',
+          sshKeyPath: '~/.ssh/id_rsa'
+        });
+
+        const lease = store.portLeases.get(port);
+        assert.equal(lease.project, 'test-expired', 'an expired lease must not block registration');
+        assert.equal(lease.service, 'openclaw-tunnel');
+      } finally {
+        server.close();
+      }
+    });
+
     it('killTunnel releases port from PortHub', () => {
       const localPort = 19997;
       // Register the port first (simulating what ensureTunnel does)


### PR DESCRIPTION
## What

`POST /api/ports/lease` upserted unconditionally. Claiming a port another project owned replaced the owner's row and returned `201` — no error, no warning, no record of who held it. The injected guide told every agent "never overwrite another project's lease", but that was enforced by client convention only, and the convention failed live: a session took a port belonging to a running project, and recovering the displaced lease meant digging the row out of a Time Machine snapshot.

A cross-project claim on a **live** lease now returns **409** with `code: "PORT_CONFLICT"` and the current `owner` in the body. `"force": true` still takes the port, logging the displaced lease to both the server log and the activity feed as `port.takeover`. Renewing a lease your own project already holds is unchanged, and an expired lease blocks nobody.

**Enforcement lives in `store.portLeases.lease()`, not the route** — the defect was precisely that the rule existed only where callers chose to honor it, so putting it anywhere bypassable would repeat it.

## What the boundary investigation changed about the design

Two findings that a naive implementation would have gotten wrong:

1. **PortHub's bootstrap re-registers the infra ports on every boot under a project name derived from the checkout *directory*.** A clone or worktree named anything other than the original would make a cross-project claim against its own previous lease and 409 on startup. Bootstrap therefore passes `force` — which is right on its own terms: the server binds those ports regardless, so a refusal would make the registry lie rather than prevent anything. Pinned by a test.

2. **`lib/tunnel.js` already implemented this exact guard in userland** — good evidence the rule was real and merely unenforceable where it mattered. That guard is now deleted, because the store's version is also *stricter*: tunnel's predicate ignored liveness, so an **expired** foreign lease made it skip registration and leave the port bound but unrecorded.

## Correctness note worth flagging

Liveness is defined as the exact inverse of `expireStale`'s predicate, and compared **inside SQLite**. `expires_at` is stored as UTC in `YYYY-MM-DD HH:MM:SS` form with no zone suffix, so `new Date()` would parse it as local time and shift liveness by the machine's UTC offset everywhere outside UTC.

## About the inverted test

`store-portleases.test.js`'s `upsert updates existing lease` asserted that a cross-project overwrite was *correct behavior* — it pinned the defect. It is inverted rather than deleted: the renewal half of that upsert is real and still needs a contract, only the cross-project half was wrong. Called out here because inverting a test deserves scrutiny, not a quiet diff.

## Not fully symmetric — stated plainly, not papered over

`release` and `heartbeat` accept no `project` at all, so any caller can release or renew any lease. A caller refused here can still release-then-claim and reproduce the original overwrite. That is **#656**, and the guide, CHANGELOG, and API contract all say so rather than implying the registry is airtight. #656 also now records that the OpenClaw routes discard `registerPort`'s result, leaving a TOCTOU gap behind their `checkPort` pre-flight.

## Versioning

Filed under `### Changed` without a `BREAKING:` marker, which keeps this a **minor** bump. It is defensible either way and it's your call: previously-succeeding requests now fail, which is textbook breaking — but the documented contract never permitted the overwrite, and the boundary investigation found **zero** in-repo HTTP callers (internal callers pass `force` where legitimate). Say the word and I'll add the marker to force a major.

## Test plan

- `node --test 'test/*.test.js'` — 4508 tests, **0 failures**, 1 skipped. Machine-backed evidence recorded at the head tree.
- Live-exercised against the real route on an isolated store: claim → **409** with owner → self-renew **201** → forced takeover **201** → takeover logged to the activity feed.
- Critic: `cumulative` (1 blocking, 8 warnings) → three `verify-resolutions` passes → **0 blocking, 0 warning, 0 note**.

Fixes #613