### PR TITLE
Copy report reflects the resolved release banner, not "release pending" (#667)

### DIFF
--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -26,6 +26,21 @@ Tag-line conventions (ART-4K9M, ratified 2026-07-17):
 -->
 
 
+## 2026-07-20: Copy report reflects the resolved release banner (#667)
+
+<!-- prawduct: type=bugfix | scope=wrap-667 | status=shipped -->
+
+**Why:** the wrap drawer's Copy report built its header from `summarizePipelineStatus` over
+the pipeline result captured at wrap time, so a report copied after the PR merged still read
+"release pending" while the on-screen banner (repainted by the #638 release resolution) read
+"Wrap shipped — PR merged". The operator had to share both the screenshot and the copied text
+to convey the full outcome.
+
+**What:** record the banner at its single paint choke point (`paintWrapStatus` in
+`public/session.js`) and pass it to `buildReportText` (`public/wrap-drawer.js`), which heads
+the report with it when present and falls back to the pipeline verdict otherwise. The report
+header now always matches the on-screen banner, including "Recheck release" repaints.
+
 ## 2026-07-20: Coverage gate credits nested/sub-package changelogs (#663)
 
 <!-- prawduct: type=bugfix | scope=wrap-663 | status=shipped -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The wrap drawer's Copy report reflects the resolved release banner, not a
+  frozen "release pending" (#667).** `buildReportText` re-derived the report
+  header from the pipeline result captured at wrap time, so a report copied after
+  the PR merged still read `Wrap committed — release pending PR merge` while the
+  on-screen banner said `Wrap shipped — PR merged`. The operator had to share both
+  the screenshot and the copied text. The drawer now records the banner at its
+  single paint choke point (`paintWrapStatus`) and heads the report with it, so
+  the copied report always matches what's on screen — including manual "Recheck
+  release" repaints. Falls back to the pipeline verdict when the banner was never
+  repainted. `public/session.js`, `public/wrap-drawer.js`.
+
 ### Added
 
 - **`coveragePaths` wrap-step override — the changelog-coverage gate credits a

--- a/public/session.js
+++ b/public/session.js
@@ -3029,6 +3029,17 @@ let wrapBumpLevel = '';
 let currentWrapBaseStatus = null;
 
 /**
+ * The status banner currently PAINTED in the drawer — the pipeline's own verdict
+ * until the #638 release resolution (or a "Recheck release") repaints it to the
+ * merged/pending/blocked outcome. Held so the copied report reflects what the
+ * operator is looking at: without it, `buildReportText` re-derives the header from
+ * the frozen pipeline result and reports "release pending" even after the PR merged
+ * on screen, forcing the operator to share both the screenshot and the text.
+ * @type {{label: string, tone: string, detail: string|null}|null}
+ */
+let currentWrapDisplayedStatus = null;
+
+/**
  * Open the wrap drawer with a rendered pipeline result and wire its
  * action buttons for the current state (retry / done / close).
  *
@@ -3064,6 +3075,7 @@ function closeWrapDrawer() {
   currentWrapPassword = '';
   currentWrapPipelineResult = null;
   currentWrapBaseStatus = null;
+  currentWrapDisplayedStatus = null;
   sessionState.wrapDrawerOpen = false;
 }
 
@@ -3075,7 +3087,11 @@ function closeWrapDrawer() {
  */
 async function copyWrapReport() {
   if (!currentWrapPipelineResult || !window.tcWrapDrawerHelpers) return;
-  const text = window.tcWrapDrawerHelpers.buildReportText(currentWrapPipelineResult);
+  // Pass the currently-painted banner so the report header reflects the resolved
+  // release outcome (PR merged / pending / blocked), not the frozen pipeline verdict.
+  const text = window.tcWrapDrawerHelpers.buildReportText(
+    currentWrapPipelineResult, currentWrapDisplayedStatus
+  );
   const toast = document.getElementById('toast');
   const flash = (msg, cls) => {
     if (!toast) return;
@@ -3105,6 +3121,10 @@ async function copyWrapReport() {
  *   pipeline warning could be lost behind a green release.
  */
 function paintWrapStatus(status, prForRecheck, baseStatus) {
+  // The single choke point for the banner, so the copied report always matches
+  // the banner on screen regardless of which path painted it (initial verdict,
+  // the #638 release resolution, or a manual "Recheck release").
+  currentWrapDisplayedStatus = status;
   const statusEl = document.getElementById('wrapDrawerStatus');
   statusEl.className = `wrap-drawer-status wrap-drawer-status--${status.tone}`;
   statusEl.innerHTML = '';

--- a/public/session.js
+++ b/public/session.js
@@ -3121,9 +3121,11 @@ async function copyWrapReport() {
  *   pipeline warning could be lost behind a green release.
  */
 function paintWrapStatus(status, prForRecheck, baseStatus) {
-  // The single choke point for the banner, so the copied report always matches
-  // the banner on screen regardless of which path painted it (initial verdict,
-  // the #638 release resolution, or a manual "Recheck release").
+  // Mirror the painted banner so the copied report matches what's on screen. This
+  // is the primary paint path (initial verdict, the #638 release resolution, a
+  // manual "Recheck release"); the error and notice paths below paint the same
+  // element directly and update this mirror themselves, so the report never lags
+  // any state the banner can show.
   currentWrapDisplayedStatus = status;
   const statusEl = document.getElementById('wrapDrawerStatus');
   statusEl.className = `wrap-drawer-status wrap-drawer-status--${status.tone}`;
@@ -3859,6 +3861,10 @@ async function resolveRuleProposal(proposal, decision, els) {
  * @param {string} message - Human-readable error message.
  */
 function renderWrapDrawerError(message) {
+  // A retry can fail with the pipeline result still set, so Copy report is live in
+  // this state — mirror the "Retry failed" banner so the report doesn't carry the
+  // pre-failure header (the same divergence the release-resolution mirror closes).
+  currentWrapDisplayedStatus = { label: 'Retry failed', tone: 'error', detail: message };
   const statusEl = document.getElementById('wrapDrawerStatus');
   statusEl.className = 'wrap-drawer-status wrap-drawer-status--error';
   statusEl.innerHTML = '';
@@ -4141,6 +4147,9 @@ function openWrapDrawerNotice(label, detail) {
   renderWrapDrawerError(detail);
   const statusEl = document.getElementById('wrapDrawerStatus');
   if (statusEl.firstChild) statusEl.firstChild.textContent = label;
+  // renderWrapDrawerError mirrored a "Retry failed" label; this notice overrode it,
+  // so keep the report mirror in step with the displayed label.
+  currentWrapDisplayedStatus = { label, tone: 'error', detail };
   document.getElementById('wrapDrawerBackdrop').classList.add('open');
   document.getElementById('wrapDrawer').classList.add('open');
 }

--- a/public/wrap-drawer.js
+++ b/public/wrap-drawer.js
@@ -615,10 +615,18 @@
    * copied text is the same source of truth as the on-screen report (#268).
    *
    * @param {object} pipelineResult - Runner return (`POST /wrap` body).
+   * @param {{label: string, detail: (string|null)}} [displayedStatus] - The banner
+   *   currently shown in the drawer. When present it heads the report instead of
+   *   the pipeline's own verdict, so a report copied after the release resolves
+   *   reads "Wrap shipped — PR merged" rather than the frozen "release pending".
+   *   Omitted (or malformed) falls back to the pipeline verdict, preserving the
+   *   report for a wrap whose banner was never repainted.
    * @returns {string} Multi-line report. Never throws on a malformed shape.
    */
-  function buildReportText(pipelineResult) {
-    const status = summarizePipelineStatus(pipelineResult);
+  function buildReportText(pipelineResult, displayedStatus) {
+    const status = (displayedStatus && typeof displayedStatus.label === 'string')
+      ? displayedStatus
+      : summarizePipelineStatus(pipelineResult);
     const lines = [`Session Wrap — ${status.label}`];
     if (status.detail) lines.push(status.detail);
 

--- a/test/wrap-drawer.test.js
+++ b/test/wrap-drawer.test.js
@@ -836,6 +836,30 @@ describe('wrap-drawer helpers — buildReportText (#268)', () => {
     // No results array → header only, no step blocks.
     assert.equal(H.buildReportText({ commitSha: 'abc123def456' }).split('\n\n').length, 1);
   });
+
+  it('heads the report with the displayed banner when given, not the frozen pipeline verdict', () => {
+    // The pipeline result says "release pending"; the drawer has since resolved the
+    // PR to merged and repainted the banner. The copied report must match the screen.
+    const pipelineResult = {
+      commitSha: 'f8d107c4f96c0000',
+      results: [{ stepId: 'commit', kind: 'commit', status: 'done', output: {}, blockers: [] }]
+    };
+    const displayed = { label: 'Wrap shipped — PR merged', tone: 'success', detail: 'the release landed on the base branch' };
+    const text = H.buildReportText(pipelineResult, displayed);
+    assert.match(text, /Session Wrap — Wrap shipped — PR merged/);
+    assert.match(text, /the release landed on the base branch/);
+    assert.doesNotMatch(text, /release pending/);
+    // Step blocks still render — only the header is overridden.
+    assert.match(text, /\[Done\] Commit — commit/);
+  });
+
+  it('falls back to the pipeline verdict when the displayed banner is absent or malformed', () => {
+    const pipelineResult = { commitSha: 'abc123def456', results: [] };
+    const fromPipeline = H.buildReportText(pipelineResult);
+    // A malformed override (no string label) must not head the report.
+    assert.equal(H.buildReportText(pipelineResult, { tone: 'success' }), fromPipeline);
+    assert.equal(H.buildReportText(pipelineResult, null), fromPipeline);
+  });
 });
 
 describe('wrap-drawer helpers — shouldStartEndedCountdown (#268)', () => {


### PR DESCRIPTION
Fixes #667.

## What

The wrap drawer's **Copy report** now heads its text with the banner currently shown in the drawer, so a report copied after the PR merges reads `Wrap shipped — PR merged / the release landed on the base branch` instead of the frozen `Wrap committed — release pending PR merge`.

## Why

`buildReportText` re-derived the header from `summarizePipelineStatus(pipelineResult)` — the pipeline's verdict at wrap time. But the on-screen banner is repainted later by the #638 release resolution (`GET /wrap/pr-status` → `composeReleaseBanner`). The report never saw that, so the copied text and the visible banner disagreed, forcing the operator to share both a screenshot and the copied report.

## How

- Mirror the banner at its paint sites into `currentWrapDisplayedStatus` (`public/session.js`), reset in `closeWrapDrawer`.
- `buildReportText(pipelineResult, displayedStatus)` heads the report with the mirror when present (`typeof label === 'string'` guard), else falls back to the pipeline verdict — preserving the report for a wrap whose banner was never repainted.
- All three paint paths keep the mirror in step: `paintWrapStatus` (normal + release-resolution + Recheck), `renderWrapDrawerError` (retry-failed, which is copyable), and `openWrapDrawerNotice`.

## Test plan

- Full suite green: **4598 passing, 0 failing**.
- New `buildReportText` tests: the displayed banner heads the report (and `release pending` is absent); a malformed/absent override falls back to the pipeline verdict.

## Review

- Critic cumulative: 0 blocking, 0 warning, 2 notes → the actionable note (comment overclaimed "single choke point") fixed in `d74a536`; `verify-resolutions` clean.
- Independent PR reviewer: **0 blocking, 0 warning, 0 notes**.