### PR TITLE
Stamp a squash-safe lastWrapSha so the session range stops ballooning (#664)

### DIFF
--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -26,6 +26,24 @@ Tag-line conventions (ART-4K9M, ratified 2026-07-17):
 -->
 
 
+## 2026-07-20: Squash-safe lastWrapSha stops the session range ballooning (#664)
+
+<!-- prawduct: type=bugfix | scope=wrap-664 | status=shipped -->
+
+**Why:** the commit step stamped `lastWrapSha` to the wrap BRANCH commit
+(`git rev-parse HEAD`), but the wrap PR squash-merges onto the trunk, which replaces that
+commit with a new one and orphans the stamped SHA. The next session's `<lastWrapSha>..HEAD`
+then widened to the last shared ancestor — PV-AI-Guidebook resolved a 22-commit, 11-day range
+spanning two prior wraps, blocking the wrap on 18 already-released commits.
+
+**What:** stamp the wrap commit's PARENT (the pre-wrap tip, which squash-merge stacks onto so
+it stays an ancestor of the trunk) instead of the wrap commit itself
+(`lib/wrap-steps/commit.js`); and require `lastWrapSha` to be an ANCESTOR of HEAD before using
+`<sha>..HEAD` — an orphaned or stale stamp (including any written before this fix) falls back
+to the trunk range rather than ballooning (`lib/wrap-steps/_git-range.js`, new
+`isAncestorOfHead`). Fixes the shared session range for both `changelog-coverage` and
+`features-toc`. `commitSha` (the UI/result handle) is unchanged — it is still the wrap commit.
+
 ## 2026-07-20: Copy report reflects the resolved release banner (#667)
 
 <!-- prawduct: type=bugfix | scope=wrap-667 | status=shipped -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to TangleClaw are documented in this file.
 
 ### Fixed
 
+- **The wrap stamps a squash-safe `lastWrapSha`, so a session's coverage range no
+  longer balloons across prior sessions (#664).** The commit step stamped
+  `lastWrapSha` to the wrap *branch* commit (`git rev-parse HEAD`), but the wrap PR
+  squash-merges onto the trunk — replacing that commit with a new one and orphaning
+  the stamped SHA. The next session's `<lastWrapSha>..HEAD` then widened back to the
+  last shared ancestor: PV-AI-Guidebook resolved a 22-commit, 11-day range spanning
+  two prior wraps, re-judging already-released work. The stamp is now the wrap
+  commit's **parent** (the pre-wrap tip, which squash-merge stacks onto and so stays
+  an ancestor of the trunk), and `resolveSessionRange` additionally requires the
+  recorded SHA to be an **ancestor of HEAD** — an orphaned or stale stamp (including
+  those written before this fix) falls back to the trunk range instead of
+  ballooning. Fixes the shared range for both `changelog-coverage` and
+  `features-toc`. `lib/wrap-steps/commit.js`, `lib/wrap-steps/_git-range.js`.
+
 - **The wrap drawer's Copy report reflects the resolved release banner, not a
   frozen "release pending" (#667).** `buildReportText` re-derived the report
   header from the pipeline result captured at wrap time, so a report copied after

--- a/lib/wrap-steps/_git-range.js
+++ b/lib/wrap-steps/_git-range.js
@@ -53,7 +53,16 @@ const BASE_BRANCH_CANDIDATES = ['main', 'master'];
  */
 function resolveSessionRange(cwd, lastWrapSha, options = {}) {
   const { dots = 'three', exec = execSync } = options;
-  if (lastWrapSha && SHA_RE.test(lastWrapSha) && isResolvableCommit(cwd, lastWrapSha, exec)) {
+  // The recorded SHA must be an ANCESTOR of HEAD, not merely resolvable. A wrap
+  // stamps its base and the wrap squash-merges onto the trunk; an older stamp made
+  // before #664 recorded the wrap BRANCH commit, which squash-merge orphans. An
+  // orphaned SHA still resolves (the object exists) but is not on HEAD's history,
+  // so `<sha>..HEAD` widens to the last shared ancestor — many sessions of
+  // already-released work. Falling back to the trunk range keeps a stale or
+  // orphaned stamp from ballooning the session (#664).
+  if (lastWrapSha && SHA_RE.test(lastWrapSha)
+    && isResolvableCommit(cwd, lastWrapSha, exec)
+    && isAncestorOfHead(cwd, lastWrapSha, exec)) {
     return { range: `${lastWrapSha}..HEAD`, kind: 'session', baseBranch: null };
   }
   const baseBranch = resolveBaseBranch(cwd, exec);
@@ -92,6 +101,32 @@ function isResolvableCommit(cwd, ref, exec = execSync) {
 }
 
 /**
+ * Whether `ref` is an ancestor of HEAD — i.e. on the current history, so a
+ * `<ref>..HEAD` range means "commits since ref" rather than a walk back to the
+ * last shared ancestor. Guards against a `lastWrapSha` orphaned by squash-merge.
+ *
+ * @param {string} cwd - Absolute path to run git in.
+ * @param {string} ref - A git ref or SHA already known to resolve.
+ * @param {Function} [exec=execSync] - `execSync` replacement, for tests.
+ * @returns {boolean}
+ */
+function isAncestorOfHead(cwd, ref, exec = execSync) {
+  try {
+    exec(`git merge-base --is-ancestor ${ref} HEAD`, {
+      cwd,
+      timeout: GIT_EXEC_TIMEOUT_MS,
+      stdio: ['ignore', 'pipe', 'ignore']
+    });
+    return true;
+  } catch {
+    // Exit 1 = resolves but is not an ancestor (the orphaned-stamp case). Any
+    // other non-zero (bad repo, missing git) lands here too, and the caller's
+    // move is the same either way: fall back to the trunk range.
+    return false;
+  }
+}
+
+/**
  * Resolve the trunk branch to measure divergence from. Returns null when no
  * candidate resolves as a verifiable ref.
  *
@@ -118,6 +153,7 @@ function resolveBaseBranch(cwd, exec = execSync) {
 module.exports = {
   resolveSessionRange,
   isResolvableCommit,
+  isAncestorOfHead,
   resolveBaseBranch,
   SHA_RE,
   GIT_EXEC_TIMEOUT_MS

--- a/lib/wrap-steps/commit.js
+++ b/lib/wrap-steps/commit.js
@@ -502,8 +502,9 @@ async function _autoPrCloseLoop({ cwd, branch, originalBranch, staged }) {
  *
  * @param {string} projectPath
  * @param {string} sha - The base the next session measures its range from — the
- *   wrap commit's PARENT, chosen because it survives the squash-merge that lands
- *   the wrap on a protected branch (see the call site, #664).
+ *   wrap commit's PARENT (or the wrap commit itself when it is a parentless root
+ *   commit), chosen because the parent survives the squash-merge that lands the
+ *   wrap on a protected branch (see the call site, #664).
  * @returns {boolean} True iff the stamp was persisted
  */
 function _stampLastWrapSha(projectPath, sha) {
@@ -741,6 +742,14 @@ async function run(context) {
   const parentRes = await _internal.exec('git', ['rev-parse', '--verify', '--quiet', 'HEAD~1'], { cwd });
   if (parentRes.exitCode === 0) {
     baseSha = parentRes.stdout.trim() || null;
+  } else {
+    // Almost always a root commit (a repo whose first-ever commit is a wrap) — the
+    // fallback below stamps the wrap commit itself. Logged, not silent, so the rare
+    // non-root failure (a broken git that also failed the step-7 HEAD capture) is
+    // visible when someone asks why the range base looks wrong.
+    log.info('git rev-parse HEAD~1 found no parent; stamping the wrap commit as the range base', {
+      project: project.name, exitCode: parentRes.exitCode
+    });
   }
   // A wrap commit with no parent (a repo whose first-ever commit is a wrap) has no
   // pre-wrap base — fall back to the wrap commit's own SHA rather than skip the

--- a/lib/wrap-steps/commit.js
+++ b/lib/wrap-steps/commit.js
@@ -501,7 +501,9 @@ async function _autoPrCloseLoop({ cwd, branch, originalBranch, staged }) {
  * needs a file lock or moved into the store DB.
  *
  * @param {string} projectPath
- * @param {string} sha
+ * @param {string} sha - The base the next session measures its range from — the
+ *   wrap commit's PARENT, chosen because it survives the squash-merge that lands
+ *   the wrap on a protected branch (see the call site, #664).
  * @returns {boolean} True iff the stamp was persisted
  */
 function _stampLastWrapSha(projectPath, sha) {
@@ -725,10 +727,28 @@ async function run(context) {
     });
   }
 
-  // 8. Stamp lastWrapSha. Non-fatal — see _stampLastWrapSha doc.
+  // 8. Stamp lastWrapSha — the base the NEXT session measures its range from.
+  //    Record the wrap commit's PARENT, not the wrap commit itself: this wrap
+  //    lands on a protected branch by squash-merge, which replaces the wrap
+  //    commit with a brand-new commit and orphans the one made here. Stamping the
+  //    orphaned SHA leaves the next session with a `lastWrapSha` that is not an
+  //    ancestor of HEAD, so `<lastWrapSha>..HEAD` balloons back to the last shared
+  //    ancestor — many sessions of already-released work (#664). The parent is the
+  //    pre-wrap tip; squash-merge stacks the new commit on top of it, so the parent
+  //    stays an ancestor and `parent..HEAD` is exactly the next session's work
+  //    (the squashed wrap commit falls in range but is excluded by subject).
+  let baseSha = null;
+  const parentRes = await _internal.exec('git', ['rev-parse', '--verify', '--quiet', 'HEAD~1'], { cwd });
+  if (parentRes.exitCode === 0) {
+    baseSha = parentRes.stdout.trim() || null;
+  }
+  // A wrap commit with no parent (a repo whose first-ever commit is a wrap) has no
+  // pre-wrap base — fall back to the wrap commit's own SHA rather than skip the
+  // stamp, so the next session still has a boundary to measure from.
+  const stampSha = baseSha || commitSha;
   let stamped = false;
-  if (commitSha) {
-    stamped = _stampLastWrapSha(project.path, commitSha);
+  if (stampSha) {
+    stamped = _stampLastWrapSha(project.path, stampSha);
   }
 
   // 9. #467 — close the loop on an auto-branched commit. Without this,

--- a/test/wrap-git-range.test.js
+++ b/test/wrap-git-range.test.js
@@ -65,6 +65,35 @@ describe('_git-range — session range resolution', () => {
     const out = gitRange.resolveSessionRange('/p', 'deadbee', { dots: 'two', exec: fakeExec(/deadbee/) });
     assert.equal(out.range, 'main..HEAD');
   });
+
+  it('falls back to the trunk range when the SHA resolves but is NOT an ancestor of HEAD (#664)', () => {
+    // A lastWrapSha orphaned by squash-merge still resolves as an object but is off
+    // HEAD's history, so `<sha>..HEAD` would balloon to the last shared ancestor —
+    // whole prior sessions of already-released work. rev-parse succeeds; only the
+    // ancestry probe (`merge-base --is-ancestor`) fails.
+    const out = gitRange.resolveSessionRange('/p', 'c1f94ac', {
+      dots: 'two',
+      exec: fakeExec(/is-ancestor/)
+    });
+    assert.equal(out.range, 'main..HEAD');
+    assert.equal(out.kind, 'branch', 'an orphaned stamp must not read as a session range');
+  });
+
+  it('takes the session range when the SHA resolves AND is an ancestor', () => {
+    const out = gitRange.resolveSessionRange('/p', 'c1f94ac', { exec: fakeExec() });
+    assert.equal(out.range, 'c1f94ac..HEAD');
+    assert.equal(out.kind, 'session');
+  });
+});
+
+describe('_git-range — isAncestorOfHead (#664)', () => {
+  it('true when git merge-base --is-ancestor exits zero', () => {
+    assert.equal(gitRange.isAncestorOfHead('/p', 'c1f94ac', fakeExec()), true);
+  });
+
+  it('false when it exits non-zero — the orphaned or off-history ref', () => {
+    assert.equal(gitRange.isAncestorOfHead('/p', 'c1f94ac', fakeExec(/is-ancestor/)), false);
+  });
 });
 
 describe('_git-range — SHA shape', () => {

--- a/test/wrap-pipeline.test.js
+++ b/test/wrap-pipeline.test.js
@@ -2245,6 +2245,25 @@ describe('wrap-step commit — handler against real git repo (#139 Chunk 9)', ()
       'stamping the wrap commit is the #664 bug — squash-merge orphans it, ballooning the next range');
   });
 
+  it('falls back to the wrap commit itself when it is a parentless root commit (#664)', async () => {
+    const storeMod = require('../lib/store');
+    // A repo whose very first commit is the wrap commit — HEAD~1 does not resolve,
+    // so there is no pre-wrap base and the stamp falls back to the wrap commit.
+    const rootRepo = fs.mkdtempSync(path.join(tmpDir, 'rootrepo-'));
+    execSync('git init --quiet', { cwd: rootRepo });
+    execSync('git config user.email t@example.com && git config user.name Test',
+      { cwd: rootRepo, shell: '/bin/sh' });
+    fs.writeFileSync(path.join(rootRepo, 'first.txt'), 'hi\n');
+    const ctx = buildContext({}, { name: 'rootrepo', path: rootRepo, id: 2 });
+    const result = await commitStep.run(ctx);
+    assert.equal(result.ok, true);
+    assert.ok(result.output.commitSha);
+    assert.equal(result.output.stamped, true, 'a root-commit wrap still stamps a base');
+    const cfg = storeMod.projectConfig.load(rootRepo);
+    assert.equal(cfg.lastWrapSha, result.output.commitSha,
+      'with no parent, the stamp falls back to the wrap commit itself');
+  });
+
   it('returns blocked when git commit exits non-zero (pre-commit hook rejection)', async () => {
     // Install a pre-commit hook that rejects everything.
     const hookDir = path.join(projectPath, '.git/hooks');

--- a/test/wrap-pipeline.test.js
+++ b/test/wrap-pipeline.test.js
@@ -2225,7 +2225,7 @@ describe('wrap-step commit — handler against real git repo (#139 Chunk 9)', ()
       'AI-written MEMORY.md must be included in the wrap commit');
   });
 
-  it('stamps lastWrapSha on projConfig after a successful commit', async () => {
+  it('stamps lastWrapSha with the wrap commit\'s PARENT, so it survives squash-merge (#664)', async () => {
     // projectConfig.load/save are file-based on the project's own
     // `.tangleclaw/project.json` — no store DB init needed.
     const storeMod = require('../lib/store');
@@ -2233,12 +2233,16 @@ describe('wrap-step commit — handler against real git repo (#139 Chunk 9)', ()
     const ctx = buildContext({});
     const result = await commitStep.run(ctx);
     assert.equal(result.ok, true);
-    assert.ok(result.output.commitSha);
+    assert.ok(result.output.commitSha, 'commitSha (for the UI) is still the wrap commit');
     assert.equal(result.output.stamped, true);
 
+    const parentSha = execSync('git rev-parse HEAD~1', { cwd: projectPath }).toString().trim();
     const cfg = storeMod.projectConfig.load(projectPath);
-    assert.equal(cfg.lastWrapSha, result.output.commitSha,
-      'projConfig.lastWrapSha must equal the commit SHA');
+    assert.equal(cfg.lastWrapSha, parentSha,
+      'lastWrapSha must be the wrap commit PARENT (the pre-wrap tip that survives a '
+      + 'squash-merge as an ancestor), not the wrap commit itself');
+    assert.notEqual(cfg.lastWrapSha, result.output.commitSha,
+      'stamping the wrap commit is the #664 bug — squash-merge orphans it, ballooning the next range');
   });
 
   it('returns blocked when git commit exits non-zero (pre-commit hook rejection)', async () => {
@@ -2365,13 +2369,13 @@ describe('wrap-step commit — handler against real git repo (#139 Chunk 9)', ()
     // surfaces commitSha:null + stamped:false on this path.
     fs.writeFileSync(path.join(projectPath, 'rev-parse-test.txt'), 'x\n');
 
-    // Replace exec so the LAST call (rev-parse HEAD) returns non-zero
-    // while the prior three (status, add, commit) hit the real git.
+    // Fail BOTH post-commit SHA captures — `rev-parse HEAD` (the wrap commit, for
+    // the UI) and `rev-parse ... HEAD~1` (its parent, the stamp base, #664) — while
+    // the prior calls (status, add, commit) hit real git. In reality a broken git
+    // fails both, and the contract under test is "no capturable SHA → no stamp".
     const realExec = commitStep._internal.exec;
-    let callIdx = 0;
     commitStep._internal.exec = async (file, args, opts) => {
-      callIdx++;
-      if (file === 'git' && args[0] === 'rev-parse' && args[1] === 'HEAD') {
+      if (file === 'git' && args[0] === 'rev-parse' && (args.includes('HEAD') || args.includes('HEAD~1'))) {
         return { exitCode: 1, stdout: '', stderr: 'fake rev-parse failure' };
       }
       return realExec(file, args, opts);

--- a/test/wrap-step-features-toc.test.js
+++ b/test/wrap-step-features-toc.test.js
@@ -728,6 +728,7 @@ describe('wrap-step features-toc (#207 Chunk 3)', () => {
       let sawSessionDiff = false;
       featuresToc._internal.execSync = (cmd) => {
         if (cmd.includes(`${SHA}^{commit}`)) return Buffer.from(''); // SHA resolves
+        if (cmd.includes('merge-base --is-ancestor')) return Buffer.from(''); // SHA is on HEAD's history (#664)
         // The OLD (branch) range is empty — this is the wrap-on-main bug condition.
         if (cmd.includes('main...HEAD')) return Buffer.from('');
         // The NEW (session) range captures everything merged since the last wrap.


### PR DESCRIPTION
Fixes #664.

## What

The wrap now records a `lastWrapSha` that survives squash-merge, so the next session's coverage range is exactly that session's work instead of ballooning back across prior sessions.

## Why

The commit step stamped `lastWrapSha` to the wrap **branch** commit (`git rev-parse HEAD`). But the wrap PR squash-merges onto the trunk, which replaces that commit with a brand-new one and **orphans** the stamped SHA. The next session's `<lastWrapSha>..HEAD` then widened to the last shared ancestor — PV-AI-Guidebook resolved a **22-commit, 11-day range spanning two prior wraps**, blocking its wrap on 18 already-released commits. It corrupts the shared range for both `changelog-coverage` and `features-toc`.

## How

- **`lib/wrap-steps/commit.js`** — stamp the wrap commit's **parent** (the pre-wrap tip). Squash-merge stacks the new trunk commit on top of that parent, so it stays an ancestor of the trunk and `parent..HEAD` is exactly the next session's work (the squashed wrap commit falls in range but is excluded by `WRAP_SUBJECT_RE`). `commitSha` (the UI/result handle) is unchanged — still the wrap commit. A parentless root commit falls back to the wrap commit itself.
- **`lib/wrap-steps/_git-range.js`** — `resolveSessionRange` now requires `lastWrapSha` to be an **ancestor of HEAD** (new `isAncestorOfHead`), not merely resolvable. An orphaned or stale stamp — including any written before this fix — falls back to the trunk range instead of ballooning. This heals already-corrupted stores (PV-AI) and backstops the parent-stamp fix.

The two halves are complementary: the parent-stamp fixes new wraps; the ancestor guard heals existing bad data and defends forever.

## Test plan

- Full suite green: **4602 passing, 0 failing** (JUnit-backed).
- New coverage: stamp is the parent not the wrap commit; parentless root-commit fallback; `resolveSessionRange` falls back to trunk when the SHA resolves but isn't an ancestor; `isAncestorOfHead` true/false. Updated the rev-parse-failure test to fail both HEAD and HEAD~1 (the realistic broken-git case) and the `#465` features-toc mock to answer the new `merge-base --is-ancestor` probe.

## Review

- Critic cumulative: 0 blocking, 1 warning (untested root-commit fallback) + 5 notes → warning + actionable notes fixed in `62b0182`; `verify-resolutions` clean.
- Independent PR reviewer: **0 blocking, 0 warning, 0 notes**.

## Follow-up

- The session→trunk range **downgrade is unlogged** (Critic note 3) — an operator debugging "why didn't coverage engage?" gets no signal. Worth adding observability to the shared resolver; filing separately to keep this fix focused.