### PR TITLE
Complete an AI-content wrap step on file-settle, not only pane-idle (#672)

### DIFF
--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -26,6 +26,24 @@ Tag-line conventions (ART-4K9M, ratified 2026-07-17):
 -->
 
 
+## 2026-07-20: AI-content wrap step survives operator interaction mid-wrap (#672)
+
+<!-- prawduct: type=bugfix | scope=wrap-672 | status=shipped -->
+
+**Why:** `ai-content` wrap steps detected AI completion via `detectIdle` (>=10s of unchanged
+tmux pane, capped at MAX_WAIT_MS=5min). That keys off the last few pane lines, so an operator
+interacting with the session mid-wrap — and the AI answering — reset the idle timer; the step
+never captured and timed out, halting the wrap with a silent, hung-looking drawer. It halted
+this project's own 4.31.0 wrap (finished manually).
+
+**What:** a second, independent completion signal (`lib/wrap-steps/ai-content.js`). The step
+watches the files it is expected to produce (`_watchedOutputPaths` = verifyChanged + captureFile)
+and completes once one has changed from its pre-prompt content AND held still for STABILITY_MS
+(4s) — the actual work product, immune to pane chatter. Pane-idle stays as the fallback for a
+step that legitimately writes nothing (changelog-update satisfied by coverage). tmux path only;
+the gateway/ClawBridge path already keyed off the bridge's own inputReady. MIN_RESPONSE_CHARS is
+skipped on the file-settle path (file evidence is stronger than pane length).
+
 ## 2026-07-20: Squash-safe lastWrapSha stops the session range ballooning (#664)
 
 <!-- prawduct: type=bugfix | scope=wrap-664 | status=shipped -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **An AI-content wrap step no longer times out when the operator interacts with
+  the session mid-wrap (#672).** `changelog-update` / `learnings-capture` /
+  `memory-update` detected the AI's completion via `detectIdle` — ≥10s of unchanged
+  tmux pane, bounded at `MAX_WAIT_MS` (5 min). Because that keys off the last few
+  pane lines, any unrelated output — the operator asking the session a question
+  mid-wrap, and the AI answering — resets the idle timer, so the step could never
+  capture and timed out, halting the wrap with a silent, hung-looking drawer (it
+  bit this project's own 4.31.0 wrap, which had to be finished by hand). The step
+  now also completes on a **file-settle** signal: it watches the files the step is
+  expected to produce (its `verifyChanged` edits plus any `captureFile`) and treats
+  the step as done once one has changed from its pre-prompt content **and** nothing
+  has changed for `STABILITY_MS` — the actual work product, immune to pane chatter.
+  Pane-idle is retained as the fallback for a step that legitimately writes nothing
+  (e.g. `changelog-update` satisfied by coverage). The tmux path only; the
+  gateway/ClawBridge path already keyed off the bridge's own `inputReady` signal.
+  `lib/wrap-steps/ai-content.js`.
+
 ## [4.31.0] - 2026-07-20
 
 ### Fixed

--- a/lib/wrap-steps/ai-content.js
+++ b/lib/wrap-steps/ai-content.js
@@ -77,6 +77,12 @@ const log = createLogger('wrap-step-ai-content');
 const INITIAL_SETTLE_MS = 3000;
 const POLL_INTERVAL_MS = 2000;
 const MAX_WAIT_MS = 5 * 60 * 1000; // 5 minutes — wraps with long Critic dispatches can run this long; bounded so a stuck AI cannot wedge the wrap drawer forever
+
+// #672 — how long a step's declared output files must sit UNCHANGED before the
+// file-settle signal treats the step as complete. Kept short (a discrete write
+// settles fast) and above one POLL_INTERVAL_MS so a multi-file write (e.g.
+// memory-update writing MEMORY.md then the captureFile) isn't split mid-way.
+const STABILITY_MS = 4000;
 const MIN_RESPONSE_CHARS = 20;
 // ClawBridge PTY-broker terminal states (CC-7 B1): a session in any of these
 // will never become input-ready again, so the gateway poll fast-fails on them
@@ -396,9 +402,25 @@ async function run(context) {
   // deterministically testable (tests stub `now` to fast-forward past
   // MAX_WAIT_MS without a 5-minute wall-clock wait).
   const startedAt = _internal.now();
+
+  // #672 — a second, independent completion signal so a busy pane can't starve
+  // the step into a timeout. `detectIdle` keys off the last 3 pane lines, which
+  // any unrelated output resets — including the operator interacting with the
+  // session mid-wrap, which the idle detector cannot distinguish from the AI
+  // still working. So also watch the files this step is expected to PRODUCE (its
+  // `verifyChanged` edits plus any `captureFile`): once one has changed from its
+  // pre-prompt content AND nothing has changed for STABILITY_MS, the AI has done
+  // its work and settled, regardless of what the pane shows. Baseline is captured
+  // BEFORE the settle sleep so a change during that window still registers.
+  const settleWatch = _watchedOutputPaths(step);
+  const settleBaseline = settleWatch.length > 0 ? _snapshotPaths(project.path, settleWatch) : {};
+  let settleLast = settleBaseline;
+  let settleLastChangeAt = startedAt;
+  let settleEverChanged = false;
+
   await _internal.sleep(INITIAL_SETTLE_MS);
 
-  let idled = false;
+  let completedVia = null; // 'idle' | 'files'
   while (_internal.now() - startedAt < MAX_WAIT_MS) {
     let idleInfo;
     try {
@@ -413,13 +435,31 @@ async function run(context) {
       };
     }
     if (idleInfo && idleInfo.idle) {
-      idled = true;
+      completedVia = 'idle';
       break;
+    }
+    // File-settle check. Re-read the watched paths and compare against the last
+    // observation; any difference restarts the stability window. Completion
+    // requires a change from the PRE-PROMPT baseline (the AI actually produced
+    // output) that has then held still for STABILITY_MS.
+    if (settleWatch.length > 0) {
+      const current = _snapshotPaths(project.path, settleWatch);
+      if (settleWatch.some((p) => current[p] !== settleLast[p])) {
+        settleLast = current;
+        settleLastChangeAt = _internal.now();
+      }
+      if (settleWatch.some((p) => current[p] !== settleBaseline[p])) {
+        settleEverChanged = true;
+      }
+      if (settleEverChanged && _internal.now() - settleLastChangeAt >= STABILITY_MS) {
+        completedVia = 'files';
+        break;
+      }
     }
     await _internal.sleep(POLL_INTERVAL_MS);
   }
 
-  if (!idled) {
+  if (!completedVia) {
     // #328: describe the STEP outcome, not the pipeline's. Whether the wrap
     // halts is the runner's call (driven by `step.blocker`), so the handler
     // must not assert "wrap pipeline blocked" — that was false for the
@@ -515,7 +555,11 @@ async function run(context) {
   // No captureFields → minimal validation: just check the AI said
   // *something*. Below this threshold the AI either no-op'd or
   // detectIdle tripped prematurely on a still-streaming response.
-  if (trimmed.length < MIN_RESPONSE_CHARS) {
+  // Skipped when completion came from the file-settle signal (#672): that path
+  // already has proof the AI produced its work product (a watched file changed
+  // and settled), which is stronger than the pane length, and the pane may hold
+  // unrelated operator chatter rather than the AI's response.
+  if (completedVia !== 'files' && trimmed.length < MIN_RESPONSE_CHARS) {
     return {
       ok: false,
       status: 'blocked',
@@ -794,6 +838,26 @@ function _snapshotPaths(projectPath, paths) {
 }
 
 /**
+ * The project-relative files a step is expected to PRODUCE — the paths the
+ * #672 file-settle completion signal watches. A file-edit step declares
+ * `verifyChanged`; a structured-capture step (e.g. `memory-update`) also writes
+ * a `captureFile`. Both are the step's own work product, so a change to either
+ * that then holds still is evidence the AI finished — independent of pane quiet.
+ * Deduped; a step with neither yields `[]` and falls back to pane-idle only.
+ * @param {object} step - The wrap step spec
+ * @returns {string[]} Project-relative output paths
+ */
+function _watchedOutputPaths(step) {
+  const paths = Array.isArray(step.verifyChanged)
+    ? step.verifyChanged.filter((p) => typeof p === 'string' && p.trim())
+    : [];
+  if (typeof step.captureFile === 'string' && step.captureFile.trim()) {
+    paths.push(step.captureFile);
+  }
+  return [...new Set(paths)];
+}
+
+/**
  * D6 gate — after a file-edit content step, confirm the step actually did its job.
  *
  * The step is satisfied by EITHER route:
@@ -955,4 +1019,4 @@ const _internal = {
   bridgeGetFile: clawbridgeLib.getFile
 };
 
-module.exports = { run, _internal, _interpolatePrompt, _appendWrapRules, _parseFields, _normalizeFieldKey, _runGatewayCapture, _resolveEngineConfigFile, _snapshotPaths, _verifyChangedGate, SUPPORTED_PROMPT_TOKENS };
+module.exports = { run, _internal, _interpolatePrompt, _appendWrapRules, _parseFields, _normalizeFieldKey, _runGatewayCapture, _resolveEngineConfigFile, _snapshotPaths, _watchedOutputPaths, _verifyChangedGate, SUPPORTED_PROMPT_TOKENS, STABILITY_MS };

--- a/lib/wrap-steps/ai-content.js
+++ b/lib/wrap-steps/ai-content.js
@@ -27,21 +27,30 @@
  *
  * **Send → poll → capture.** Prompt goes out via `tmux.sendKeys` with
  * Enter; the handler then sleeps the initial settle window and polls
- * `detectIdle` every `POLL_INTERVAL_MS` (default 2s) until idle is
- * reported. `detectIdle` itself defines "idle" as ≥10s of unchanged
- * pane output (see `lib/sessions.js:detectIdle`). Total wait is
- * capped by `MAX_WAIT_MS` (default 5 min) — exceeded → `ok:false,
- * status:'blocked'`. On idle, full pane scrollback is captured via
- * `tmux.capturePane({full:true})` and parsed.
+ * every `POLL_INTERVAL_MS` (default 2s) for EITHER of two completion
+ * signals, whichever fires first, capped by `MAX_WAIT_MS` (default
+ * 5 min → exceeded is `ok:false, status:'blocked'`):
+ *   1. **pane-idle** — `detectIdle` reports ≥10s of unchanged pane
+ *      output (`lib/sessions.js:detectIdle`).
+ *   2. **file-settle (#672)** — a file the step is expected to produce
+ *      (its `verifyChanged` edits plus any `captureFile`) has changed
+ *      from its pre-prompt content AND then held still for
+ *      `STABILITY_MS`. This keys off the work product, not terminal
+ *      quiet, so an operator interacting with the session mid-wrap
+ *      cannot reset the idle timer and starve the step into a timeout.
+ * On completion, full pane scrollback is captured via
+ * `tmux.capturePane({full:true})` and parsed. (The gateway path uses
+ * the bridge's own `inputReady` signal and is unaffected.)
  *
  * **Validation.** If `step.captureFields[]` is set, each field must
  * appear as a `## Heading` (case-insensitive match) with non-empty
  * content. Missing/empty fields → `ok:false, status:'blocked',
- * blockers:[…]`. If `captureFields` is unset/empty, the handler only
+ * blockers:[…]`. If `captureFields` is unset/empty, the handler
  * asserts the AI produced a non-trivial response (≥20 chars after
- * trimming) — this catches AI no-ops and runaway timeouts that
- * detectIdle accepted prematurely (rare; tmux idle is 10s of zero
- * change).
+ * trimming) — catching AI no-ops and a prematurely-accepted idle —
+ * EXCEPT when completion came from the file-settle signal, where a
+ * changed-and-settled output file is stronger evidence than pane
+ * length (and the pane may hold unrelated operator chatter).
  *
  * **Single-transaction discipline.** This handler does NOT touch the
  * filesystem; it stages its captured text in `context.staged` under

--- a/test/wrap-step-ai-content.test.js
+++ b/test/wrap-step-ai-content.test.js
@@ -974,4 +974,20 @@ describe('wrap-step ai-content — #672 file-settle completion (busy pane cannot
     assert.equal(res.ok, false);
     assert.equal(res.status, 'blocked', 'a still-writing file must not be read as settled');
   });
+
+  it('skips the min-response-chars pane check on the file-settle path (pane may be short chatter)', async () => {
+    // The load-bearing half of the fix: file-settle completion must NOT be
+    // re-blocked by the ≥20-char pane check. The pane here is far under the
+    // threshold — file evidence (a changed, settled learnings.md) carries it.
+    let clock = 0;
+    aic._internal.sendKeys = () => {};
+    aic._internal.sleep = async () => { clock += POLL; };
+    aic._internal.now = () => clock;
+    aic._internal.detectIdle = () => ({ idle: false });
+    aic._internal.capturePane = () => ({ lines: ['ok'] }); // 2 chars, below MIN_RESPONSE_CHARS
+    aic._internal.readForVerify = () => (clock === 0 ? 'old' : 'new entry written');
+
+    const res = await aic.run(ctx(settleStep));
+    assert.equal(res.status, 'done', 'a short pane must not re-block a file-settled step');
+  });
 });

--- a/test/wrap-step-ai-content.test.js
+++ b/test/wrap-step-ai-content.test.js
@@ -906,3 +906,72 @@ describe('wrap-step ai-content — D6 verifyChanged file-edit gate', () => {
     });
   });
 });
+
+describe('wrap-step ai-content — #672 file-settle completion (busy pane cannot starve the step)', () => {
+  let saved;
+  beforeEach(() => { saved = { ...aic._internal }; });
+  afterEach(() => { Object.assign(aic._internal, saved); });
+
+  const POLL = 2000;
+  const settleStep = {
+    id: 'learnings-capture', kind: 'ai-content', prompt: 'go',
+    verifyChanged: ['.tangleclaw/memories/learnings.md']
+  };
+  const ctx = (step) => ({
+    project: { name: 'proj', path: '/tmp/proj' },
+    session: { tmuxSession: 'sess' },
+    step, previousResults: [], staged: {}, options: {}
+  });
+
+  it('_watchedOutputPaths merges verifyChanged and captureFile, deduped', () => {
+    assert.deepEqual(aic._watchedOutputPaths({ verifyChanged: ['a.md'], captureFile: 'b.md' }), ['a.md', 'b.md']);
+    assert.deepEqual(aic._watchedOutputPaths({ verifyChanged: ['a.md', 'a.md'] }), ['a.md']);
+    assert.deepEqual(aic._watchedOutputPaths({ captureFile: 'b.md' }), ['b.md']);
+    assert.deepEqual(aic._watchedOutputPaths({}), []);
+  });
+
+  it('completes when a watched file changes and settles, even though the pane NEVER idles', async () => {
+    // The #672 scenario: the operator interacts with the session mid-wrap, so the
+    // pane never goes idle — but the AI wrote its learnings entry and stopped.
+    let clock = 0;
+    aic._internal.sendKeys = () => {};
+    aic._internal.sleep = async () => { clock += POLL; };
+    aic._internal.now = () => clock;
+    aic._internal.detectIdle = () => ({ idle: false });
+    aic._internal.capturePane = () => ({ lines: ['operator chatter in the pane, unrelated to the wrap answer'] });
+    aic._internal.readForVerify = () => (clock === 0 ? 'old learnings' : 'new learnings entry');
+
+    const res = await aic.run(ctx(settleStep));
+    assert.equal(res.ok, true);
+    assert.equal(res.status, 'done', 'file changed + held still → done despite a never-idle pane');
+  });
+
+  it('does NOT complete via files when no watched file ever changes — falls through to the timeout', async () => {
+    let clock = 0;
+    aic._internal.sendKeys = () => {};
+    aic._internal.sleep = async () => { clock += 6 * 60 * 1000; }; // jump past MAX_WAIT
+    aic._internal.now = () => clock;
+    aic._internal.detectIdle = () => ({ idle: false });
+    aic._internal.readForVerify = () => 'unchanged';
+
+    const res = await aic.run(ctx(settleStep));
+    assert.equal(res.ok, false);
+    assert.equal(res.status, 'blocked');
+    assert.match(res.blockers[0], /no idle detected/);
+  });
+
+  it('does NOT settle while the file keeps changing (AI still writing) — only after it holds', async () => {
+    let clock = 0;
+    aic._internal.sendKeys = () => {};
+    aic._internal.sleep = async () => { clock += 30000; };
+    aic._internal.now = () => clock;
+    aic._internal.detectIdle = () => ({ idle: false });
+    // Content differs every poll (keyed on the ever-advancing clock) → the
+    // stability window never elapses → the step times out instead of settling.
+    aic._internal.readForVerify = () => (clock === 0 ? 'v0' : 'v' + clock);
+
+    const res = await aic.run(ctx(settleStep));
+    assert.equal(res.ok, false);
+    assert.equal(res.status, 'blocked', 'a still-writing file must not be read as settled');
+  });
+});


### PR DESCRIPTION
Fixes #672.

## What

An `ai-content` wrap step (`changelog-update` / `learnings-capture` / `memory-update`) no longer times out when the operator interacts with the session mid-wrap.

## Why

Completion was detected only via `detectIdle` — ≥10s of unchanged tmux pane, capped at `MAX_WAIT_MS` (5 min). That keys off the last few pane lines, so an operator asking the session a question mid-wrap — and the AI answering — resets the idle timer; the step never captures and times out, halting the wrap with a silent, hung-looking drawer. **It halted this project's own 4.31.0 wrap, which had to be finished by hand.**

## How

- Add a second, independent completion signal: watch the files the step is expected to produce (`_watchedOutputPaths` = `verifyChanged` + `captureFile`) and complete once one has changed from its **pre-prompt** content **and** held still for `STABILITY_MS` (4s) — the actual work product, immune to pane chatter.
- Content-based snapshots (via the existing `_snapshotPaths`/`readForVerify` seam), a stability window that restarts on any change so a still-writing file can't settle, and completion latched only after a change from baseline.
- `MIN_RESPONSE_CHARS` is skipped on the file-settle path — a changed, settled output file is stronger evidence than pane length, and the pane may hold unrelated chatter.
- **Pane-idle is retained as the fallback** for a step that legitimately writes nothing (e.g. `changelog-update` satisfied by coverage). tmux path only — the gateway/ClawBridge path already keys off the bridge's own `inputReady`.

## Test plan

- Full suite green: **4608 passing, 0 failing**.
- New tests: `_watchedOutputPaths` merge/dedup; file-settle completion despite a never-idle pane; no-change → timeout; still-writing file → never settles; and the load-bearing `MIN_RESPONSE_CHARS`-skip (a 2-char pane still completes on file evidence).

## Review

- Critic cumulative: 0 blocking, 2 warnings (untested min-chars skip, stale docstring) → both fixed in `2c52433`; `verify-resolutions` clean.
- Independent PR reviewer: **0 blocking, 0 warning, 0 notes**.