### PR TITLE
Converge the Feature Index and cap what it costs the prime (#568)

### DIFF
--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -26,6 +26,37 @@ Tag-line conventions (ART-4K9M, ratified 2026-07-17):
 -->
 
 
+## 2026-07-20: Feature Index converges + prime cap (#568)
+
+<!-- prawduct: type=bugfix | scope=feature-index-convergence | status=shipped | chunks=A,B -->
+
+**Why:** the Feature Index had no path from auto-stubbed to indexed. `features-toc`
+appended `## TODO (auto-stubbed <date>)` blocks of `- **TBD** — …` entries; `index-describe`
+could fill their `<!-- describe -->` markers but was forbidden (the #426 curation invariant)
+from NAMING them or MOVING them into a real category. So curated sections stayed empty forever,
+TODO piles grew one block per wrap, and `sessions.js` inlined the entire mostly-"TBD" file into
+every session prime — paying prime budget for noise (TiLT: 13.5 KB, 106 entries all "TBD").
+
+**What:** two coordinated fixes. **(A)** a graduate mode in `index-describe.js` — for the Feature
+Index it names each TODO-block entry, describes it, and files it under the best-fit existing
+category, deleting emptied blocks. The curation invariant is re-scoped from "touch only
+`<!-- describe -->` lines" to "touch only entries inside a TODO block"; it triggers on ANY
+TODO-block entry (so pre-existing installs converge), honors the same one-wrap-lag staged-write
+gate as describe mode, and reports an honest `Feature Index: graduated N` commit line counted by
+ARRIVALS under a category (conservation — a dropped entry can't read as success; a mismatch is
+logged). Project Map keeps its fill-only describe contract. **(B)** a capped prime — new
+dependency-free `lib/feature-index-prime.js` inlines only curated categories and replaces the
+auto-stubbed backlog with a one-line count; it is also the single source of truth for the
+auto-stub block parse (both `sessions.js` and `index-describe` scan through it), staying
+`require`-free to sit off the `projects → sessions` cycle. `lib/wrap-steps/commit.js` renders the
+new graduated audit line.
+
+**Critic:** cumulative 0 blocking / 4 warning / 3 note → all code warnings fixed (shared scanner
+dedup, conservation-based honest count, test evidence, real-format parser pin); verify-resolutions
+clean. Full suite 4639/4640 (1 pre-existing skip). Closes #568 (and clears the last of #571's
+four children).
+
+
 ## 2026-07-20: AI-content wrap step survives operator interaction mid-wrap (#672)
 
 <!-- prawduct: type=bugfix | scope=wrap-672 | status=shipped -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,19 +24,24 @@ All notable changes to TangleClaw are documented in this file.
   converge too; it honors the same one-wrap-lag staged-write gate as describe mode
   (a pending `features-toc` append defers graduation to the next wrap to avoid the
   commit-flush clobber); and the commit body reports an honest
-  `Feature Index: graduated N entr(y/ies)` line. The Project Map keeps its
-  fill-only describe contract unchanged. **(2) a capped prime** — new pure
-  `lib/feature-index-prime.js:summarizeFeatureIndexForPrime` inlines only the curated
-  categories and replaces the auto-stubbed backlog with a one-line count (`_(N
-  auto-stubbed entries awaiting graduation in M backlog block(s) — omitted here …)_`),
-  so the prime cost tracks converged content, not the raw pile. Kept dependency-free
-  to stay off the `projects → sessions` require cycle. **Tests.** New
-  `_countTodoEntries` unit tests; graduate-mode handler tests (graduation + honest
-  count, any-TODO-entry trigger, no-TODO-block skip, staged-write defer, curated
-  content preserved); `feature-index-prime` unit tests; and prime-cap integration
-  tests (backlog capped to a count, TBD stubs absent from the prime, singular/plural).
-  `lib/wrap-steps/index-describe.js`, `lib/wrap-steps/commit.js`, `lib/sessions.js`,
-  `lib/feature-index-prime.js`.
+  `Feature Index: graduated N entr(y/ies)` line — counted by **arrivals under a real
+  category** (conservation), so an entry the AI drops instead of filing can't read as
+  success (a mismatch is logged, not billed). The Project Map keeps its fill-only
+  describe contract unchanged. **(2) a capped prime** — new dependency-free
+  `lib/feature-index-prime.js` inlines only the curated categories and replaces the
+  auto-stubbed backlog with a one-line count (`_(N auto-stubbed entries awaiting
+  graduation in M backlog block(s) — omitted here …)_`), so the prime cost tracks
+  converged content, not the raw pile. It is also the single source of truth for the
+  auto-stub block parse — both `sessions.js` and `index-describe` scan through it
+  rather than each re-implementing the format (which is a contract with the
+  `features-toc` producer) — and stays `require`-free to sit off the
+  `projects → sessions` cycle. **Tests.** `feature-index-prime` unit tests incl. a
+  pin against real `features-toc._appendTodoSection` output; graduate-mode handler
+  tests (graduation + honest count, any-TODO-entry trigger, no-TODO-block skip,
+  staged-write defer, dropped-entry-not-billed, curated content preserved); and
+  prime-cap integration tests (backlog capped to a count, TBD stubs absent from the
+  prime, singular/plural). `lib/wrap-steps/index-describe.js`,
+  `lib/wrap-steps/commit.js`, `lib/sessions.js`, `lib/feature-index-prime.js`.
 
 - **An AI-content wrap step no longer times out when the operator interacts with
   the session mid-wrap (#672).** `changelog-update` / `learnings-capture` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,38 @@ All notable changes to TangleClaw are documented in this file.
 
 ### Fixed
 
+- **The Feature Index now converges instead of piling up "TBD" stubs, and the
+  session prime stops paying for the pile (#568).** `features-toc` appended
+  `## TODO (auto-stubbed <date>)` blocks of `- **TBD** — … ` entries, and
+  `index-describe` could fill their `<!-- describe -->` markers but was forbidden
+  (the #426 curation invariant) from **naming** them or **moving** them into a real
+  category — so the curated sections stayed empty forever, the TODO blocks grew one
+  per wrap, and `sessions.js` inlined the entire file (mostly literal "TBD") into
+  every prime. Two coordinated fixes: **(1) a graduation mode in `index-describe`**
+  — for the Feature Index it now names each TODO-block entry, describes it, and
+  files it under the best-fit existing category, deleting the block once empty. The
+  curation invariant is re-scoped from "touch only `<!-- describe -->` lines" to
+  "touch only entries **inside** a `## TODO (auto-stubbed …)` block", so curated
+  entries under real categories stay untouchable while the one restructure the design
+  needs is allowed. It triggers on **any** TODO-block entry (not only ones still
+  carrying a marker), so pre-existing installs with described-but-un-graduated stubs
+  converge too; it honors the same one-wrap-lag staged-write gate as describe mode
+  (a pending `features-toc` append defers graduation to the next wrap to avoid the
+  commit-flush clobber); and the commit body reports an honest
+  `Feature Index: graduated N entr(y/ies)` line. The Project Map keeps its
+  fill-only describe contract unchanged. **(2) a capped prime** — new pure
+  `lib/feature-index-prime.js:summarizeFeatureIndexForPrime` inlines only the curated
+  categories and replaces the auto-stubbed backlog with a one-line count (`_(N
+  auto-stubbed entries awaiting graduation in M backlog block(s) — omitted here …)_`),
+  so the prime cost tracks converged content, not the raw pile. Kept dependency-free
+  to stay off the `projects → sessions` require cycle. **Tests.** New
+  `_countTodoEntries` unit tests; graduate-mode handler tests (graduation + honest
+  count, any-TODO-entry trigger, no-TODO-block skip, staged-write defer, curated
+  content preserved); `feature-index-prime` unit tests; and prime-cap integration
+  tests (backlog capped to a count, TBD stubs absent from the prime, singular/plural).
+  `lib/wrap-steps/index-describe.js`, `lib/wrap-steps/commit.js`, `lib/sessions.js`,
+  `lib/feature-index-prime.js`.
+
 - **An AI-content wrap step no longer times out when the operator interacts with
   the session mid-wrap (#672).** `changelog-update` / `learnings-capture` /
   `memory-update` detected the AI's completion via `detectIdle` — ≥10s of unchanged

--- a/lib/feature-index-prime.js
+++ b/lib/feature-index-prime.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /**
- * Feature Index prime summarizer (#568).
+ * Feature Index scan + prime summarizer (#568).
  *
  * The session prime used to inline the **entire** `FEATURES.md` under its
  * `## Feature Index` heading. Because the index could never converge — auto
@@ -9,15 +9,18 @@
  * per wrap and never graduated into a real category — every session paid the
  * whole file's prime budget for a list where most entries were literally "TBD".
  *
- * This summarizer caps that cost: the prime inlines only the CURATED content
- * (the real category sections) and replaces the auto-stubbed backlog with a
- * one-line count. As the graduate step (`lib/wrap-steps/index-describe.js`)
- * moves entries out of TODO blocks and into categories, the inlined content
- * grows with real value while the backlog shrinks to a number — the prime cost
- * tracks converged content, not the raw pile.
+ * This module is the single, dependency-free source of truth for parsing that
+ * structure. It serves two consumers:
+ *   - `lib/sessions.js` caps the prime: inline only the CURATED categories and
+ *     replace the auto-stubbed backlog with a one-line count.
+ *   - `lib/wrap-steps/index-describe.js` (graduate mode) uses the same scan to
+ *     count backlog entries (its trigger) and curated entries (its honest
+ *     graduated count), rather than re-implementing the block parse.
  *
- * Kept dependency-free (no `require`) and pure so it can live off the
- * `projects → sessions` require cycle and be unit-tested in isolation.
+ * The auto-stub format is a contract shared with the producer
+ * (`lib/wrap-steps/features-toc.js`); keeping one parser means the format lives
+ * in one place per role. Kept `require`-free so it stays off the
+ * `projects → sessions` cycle and is trivially unit-testable.
  *
  * @module lib/feature-index-prime
  */
@@ -26,6 +29,45 @@
 // block runs from its heading until the next `## ` heading or EOF.
 const TODO_HEADING_RE = /^##\s+TODO\s+\(auto-stubbed\b/i;
 const H2_HEADING_RE = /^##\s/;
+// A top-level list entry (not an indented sub-bullet).
+const LIST_ENTRY_RE = /^-\s+/;
+
+/**
+ * Single-pass scan of a `FEATURES.md`. Classifies every line as inside a
+ * `## TODO (auto-stubbed …)` block or not, and counts the top-level list
+ * entries on each side.
+ *
+ * @param {string} content
+ * @returns {{keptLines:string[], backlogEntries:number, backlogBlocks:number, curatedEntries:number}}
+ *   `keptLines` — every line NOT inside a TODO block (the TODO headings and
+ *   their bodies dropped); `backlogEntries` — top-level entries inside TODO
+ *   blocks; `backlogBlocks` — number of TODO blocks; `curatedEntries` —
+ *   top-level entries outside any TODO block (i.e. under real categories).
+ */
+function _scan(content) {
+  const out = { keptLines: [], backlogEntries: 0, backlogBlocks: 0, curatedEntries: 0 };
+  if (!content || typeof content !== 'string') return out;
+  let inTodo = false;
+  for (const line of content.split('\n')) {
+    if (TODO_HEADING_RE.test(line)) {
+      inTodo = true;
+      out.backlogBlocks += 1;
+      continue; // drop the TODO heading itself
+    }
+    if (H2_HEADING_RE.test(line)) {
+      inTodo = false; // a real category heading ends the backlog block
+      out.keptLines.push(line);
+      continue;
+    }
+    if (inTodo) {
+      if (LIST_ENTRY_RE.test(line)) out.backlogEntries += 1;
+      continue; // drop everything inside the TODO block
+    }
+    if (LIST_ENTRY_RE.test(line)) out.curatedEntries += 1;
+    out.keptLines.push(line);
+  }
+  return out;
+}
 
 /**
  * Summarize a `FEATURES.md` for the session prime: strip the auto-stubbed
@@ -38,34 +80,35 @@ const H2_HEADING_RE = /^##\s/;
  *   entries that were inside TODO blocks; `backlogBlocks` — count of TODO blocks.
  */
 function summarizeFeatureIndexForPrime(content) {
-  if (!content || typeof content !== 'string') {
-    return { curated: '', backlogEntries: 0, backlogBlocks: 0 };
-  }
-  const kept = [];
-  let inTodo = false;
-  let backlogEntries = 0;
-  let backlogBlocks = 0;
-  for (const line of content.split('\n')) {
-    if (TODO_HEADING_RE.test(line)) {
-      inTodo = true;
-      backlogBlocks += 1;
-      continue; // drop the TODO heading itself
-    }
-    if (H2_HEADING_RE.test(line)) {
-      inTodo = false; // a real category heading ends the backlog block
-      kept.push(line);
-      continue;
-    }
-    if (inTodo) {
-      if (/^-\s+/.test(line)) backlogEntries += 1;
-      continue; // drop everything inside the TODO block
-    }
-    kept.push(line);
-  }
+  const { keptLines, backlogEntries, backlogBlocks } = _scan(content);
   // Collapse 3+ consecutive newlines (left by a removed mid-file block) to a
   // single blank line, and trim leading/trailing whitespace.
-  const curated = kept.join('\n').replace(/\n{3,}/g, '\n\n').trim();
+  const curated = keptLines.join('\n').replace(/\n{3,}/g, '\n\n').trim();
   return { curated, backlogEntries, backlogBlocks };
 }
 
-module.exports = { summarizeFeatureIndexForPrime };
+/**
+ * Count the top-level entries currently inside `## TODO (auto-stubbed …)`
+ * blocks. Counts an entry whether or not it still carries a `<!-- describe -->`
+ * marker — a described-but-un-graduated `**TBD**` entry still awaits graduation.
+ *
+ * @param {string} content
+ * @returns {number}
+ */
+function countTodoEntries(content) {
+  return _scan(content).backlogEntries;
+}
+
+/**
+ * Count the top-level entries that sit OUTSIDE any TODO block — i.e. under a
+ * real category heading. Used as the conservation baseline for graduate mode:
+ * a correctly filed entry increments this count, a dropped entry does not.
+ *
+ * @param {string} content
+ * @returns {number}
+ */
+function countCuratedEntries(content) {
+  return _scan(content).curatedEntries;
+}
+
+module.exports = { summarizeFeatureIndexForPrime, countTodoEntries, countCuratedEntries };

--- a/lib/feature-index-prime.js
+++ b/lib/feature-index-prime.js
@@ -1,0 +1,71 @@
+'use strict';
+
+/**
+ * Feature Index prime summarizer (#568).
+ *
+ * The session prime used to inline the **entire** `FEATURES.md` under its
+ * `## Feature Index` heading. Because the index could never converge — auto
+ * `## TODO (auto-stubbed …)` blocks of `- **TBD** — …` entries piled up one
+ * per wrap and never graduated into a real category — every session paid the
+ * whole file's prime budget for a list where most entries were literally "TBD".
+ *
+ * This summarizer caps that cost: the prime inlines only the CURATED content
+ * (the real category sections) and replaces the auto-stubbed backlog with a
+ * one-line count. As the graduate step (`lib/wrap-steps/index-describe.js`)
+ * moves entries out of TODO blocks and into categories, the inlined content
+ * grows with real value while the backlog shrinks to a number — the prime cost
+ * tracks converged content, not the raw pile.
+ *
+ * Kept dependency-free (no `require`) and pure so it can live off the
+ * `projects → sessions` require cycle and be unit-tested in isolation.
+ *
+ * @module lib/feature-index-prime
+ */
+
+// A `## TODO (auto-stubbed <date>)` heading and any level-2 heading. A TODO
+// block runs from its heading until the next `## ` heading or EOF.
+const TODO_HEADING_RE = /^##\s+TODO\s+\(auto-stubbed\b/i;
+const H2_HEADING_RE = /^##\s/;
+
+/**
+ * Summarize a `FEATURES.md` for the session prime: strip the auto-stubbed
+ * backlog and report its size, leaving the curated categories intact.
+ *
+ * @param {string} content - Raw `FEATURES.md` contents (may be empty).
+ * @returns {{curated:string, backlogEntries:number, backlogBlocks:number}}
+ *   `curated` — the file with every `## TODO (auto-stubbed …)` block removed and
+ *   runs of blank lines collapsed; `backlogEntries` — count of top-level list
+ *   entries that were inside TODO blocks; `backlogBlocks` — count of TODO blocks.
+ */
+function summarizeFeatureIndexForPrime(content) {
+  if (!content || typeof content !== 'string') {
+    return { curated: '', backlogEntries: 0, backlogBlocks: 0 };
+  }
+  const kept = [];
+  let inTodo = false;
+  let backlogEntries = 0;
+  let backlogBlocks = 0;
+  for (const line of content.split('\n')) {
+    if (TODO_HEADING_RE.test(line)) {
+      inTodo = true;
+      backlogBlocks += 1;
+      continue; // drop the TODO heading itself
+    }
+    if (H2_HEADING_RE.test(line)) {
+      inTodo = false; // a real category heading ends the backlog block
+      kept.push(line);
+      continue;
+    }
+    if (inTodo) {
+      if (/^-\s+/.test(line)) backlogEntries += 1;
+      continue; // drop everything inside the TODO block
+    }
+    kept.push(line);
+  }
+  // Collapse 3+ consecutive newlines (left by a removed mid-file block) to a
+  // single blank line, and trim leading/trailing whitespace.
+  const curated = kept.join('\n').replace(/\n{3,}/g, '\n\n').trim();
+  return { curated, backlogEntries, backlogBlocks };
+}
+
+module.exports = { summarizeFeatureIndexForPrime };

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -21,6 +21,7 @@ const orchestration = require('./orchestration');
 const medusa = require('./medusa');
 const sessionOwnership = require('./session-ownership');
 const { unsafeReason } = require('./ssh-target-safety');
+const { summarizeFeatureIndexForPrime } = require('./feature-index-prime');
 const { createLogger } = require('./logger');
 
 const log = createLogger('sessions');
@@ -772,11 +773,14 @@ function generatePrimePrompt(project, engineProfile, options = {}) {
     }
   }
 
-  // Feature Index injection (#207, chunk 2). Symmetric gate (ADR 0001):
+  // Feature Index injection (#207; capped #568). Symmetric gate (ADR 0001):
   // all three of {project toggle, project silentPrime, engine capability}
   // must be true. Asymmetric gates leak orphan state — feedback_symmetric_capability_gates.
   // FEATURES.md lives at the project root and is git-tracked; the
   // template-stub is seeded by `_seedFeatureIndexFile` on toggle-on (chunk 1).
+  // Only the CURATED categories are inlined; the auto-stubbed TODO backlog is
+  // replaced by a one-line count so the prime cost tracks converged content,
+  // not the raw pile that graduated entries drain into the categories above.
   if (projConfig.featureIndexEnabled === true
       && projConfig.silentPrime === true
       && engineProfile
@@ -785,10 +789,19 @@ function generatePrimePrompt(project, engineProfile, options = {}) {
     try {
       const featuresPath = path.join(project.path, 'FEATURES.md');
       const contents = fs.readFileSync(featuresPath, 'utf8');
-      const trimmed = contents.trim();
-      if (trimmed.length > 0) {
+      const { curated, backlogEntries, backlogBlocks } = summarizeFeatureIndexForPrime(contents);
+      if (curated.length > 0 || backlogEntries > 0) {
         sections.push('## Feature Index');
-        sections.push(trimmed);
+        if (curated.length > 0) {
+          sections.push(curated);
+        }
+        if (backlogEntries > 0) {
+          sections.push(
+            `_(${backlogEntries} auto-stubbed entr${backlogEntries === 1 ? 'y' : 'ies'} awaiting graduation`
+            + ` in ${backlogBlocks} backlog block${backlogBlocks === 1 ? '' : 's'} — omitted here;`
+            + ' they are named and filed into the categories above on wrap.)_'
+          );
+        }
         sections.push('');
       }
     } catch {

--- a/lib/wrap-steps/commit.js
+++ b/lib/wrap-steps/commit.js
@@ -165,9 +165,11 @@ function _buildSubject(branch) {
  *   - `{featuresToc:true, created, addedCount, addedFiles}` (features-toc, #207/#425)
  *       → "Feature Index: created [(N stub(s) appended)]" when `created`
  *         (self-heal, #425), else "Feature Index: N stub(s) appended (files…)"
- *   - `{indexDescribe:true, describedCount}` (index-describe, #426)
- *       → "Index: described N stub(s)" when N > 0 (the AI filled that many
- *         empty `<!-- describe -->` stubs across the enabled index file(s))
+ *   - `{indexDescribe:true, describedCount, graduatedCount}` (index-describe, #426/#568)
+ *       → "Feature Index: graduated N entr(y/ies)" when graduatedCount > 0 (the
+ *         AI named + filed that many TODO-block entries into real categories),
+ *         and/or "Index: described N stub(s)" when describedCount > 0 (empty
+ *         `<!-- describe -->` stubs filled). Both, one, or neither may render.
  *   - `{oldVersion, newVersion, bumpLevel}` (version-bump)
  *       → "Bumped <old> → <new> (<level>)". Deduped — version-bump
  *         stages TWO entries (version-json + changelog) carrying the
@@ -282,8 +284,12 @@ function _buildBodyLines(staged) {
     // filled empty `<!-- describe -->` stubs in the enabled index file(s)
     // directly (the edits land via the commit's `git add -A`, not a staged
     // flush); this just surfaces the audit line with the actually-filled count.
-    if (entry.indexDescribe === true && typeof entry.describedCount === 'number') {
-      if (entry.describedCount > 0) {
+    if (entry.indexDescribe === true
+        && (typeof entry.describedCount === 'number' || typeof entry.graduatedCount === 'number')) {
+      if (typeof entry.graduatedCount === 'number' && entry.graduatedCount > 0) {
+        lines.push(`- Feature Index: graduated ${entry.graduatedCount} entr${entry.graduatedCount === 1 ? 'y' : 'ies'}`);
+      }
+      if (typeof entry.describedCount === 'number' && entry.describedCount > 0) {
         lines.push(`- Index: described ${entry.describedCount} stub(s)`);
       }
       continue;

--- a/lib/wrap-steps/index-describe.js
+++ b/lib/wrap-steps/index-describe.js
@@ -78,13 +78,14 @@ const STEP_ID = 'index-describe';
 // Feature Index auto-stubs: "- **TBD** — touched in this session: `p`. <!-- describe -->").
 const STUB_MARKER = '<!-- describe -->';
 
-// A `## TODO (auto-stubbed <date>)` heading — the auto-stubbed backlog block
-// `features-toc` appends. Its entries are unfinished (`- **TBD** — … `path`.`)
-// and never leave the block on their own; the graduate mode below names them
-// and files them into a real category. The block runs until the next `## `
-// heading or EOF.
-const TODO_HEADING_RE = /^##\s+TODO\s+\(auto-stubbed\b/i;
-const H2_HEADING_RE = /^##\s/;
+// The `## TODO (auto-stubbed …)` block parse is shared with the prime
+// summarizer (one dependency-free source of truth for the auto-stub format,
+// which is a contract with the `features-toc` producer). `feature-index-prime`
+// has no requires, so importing it here introduces no cycle.
+const {
+  countTodoEntries: _countTodoEntries,
+  countCuratedEntries: _countCuratedEntries
+} = require('../feature-index-prime');
 
 /**
  * Count the empty `<!-- describe -->` stubs in a string. Substring count — a
@@ -96,35 +97,6 @@ const H2_HEADING_RE = /^##\s/;
 function _countStubs(content) {
   if (!content || typeof content !== 'string') return 0;
   return content.split(STUB_MARKER).length - 1;
-}
-
-/**
- * Count the top-level list entries that currently sit inside a
- * `## TODO (auto-stubbed …)` block. Unlike `_countStubs`, this counts an entry
- * whether or not it still carries a `<!-- describe -->` marker — a
- * described-but-un-graduated `**TBD**` entry (the pre-existing-install case)
- * still needs graduating. Sub-bullets (indented) and non-list lines don't
- * count; a real category heading ends the block.
- *
- * @param {string} content
- * @returns {number}
- */
-function _countTodoEntries(content) {
-  if (!content || typeof content !== 'string') return 0;
-  let inTodo = false;
-  let count = 0;
-  for (const line of content.split('\n')) {
-    if (TODO_HEADING_RE.test(line)) {
-      inTodo = true;
-      continue;
-    }
-    if (H2_HEADING_RE.test(line)) {
-      inTodo = false;
-      continue;
-    }
-    if (inTodo && /^-\s+/.test(line)) count++;
-  }
-  return count;
 }
 
 /**
@@ -202,7 +174,12 @@ async function run(context) {
       if (entriesBefore === 0) {
         continue; // nothing to graduate
       }
-      targets.push({ ...c, filePath, entriesBefore, stubsBefore: 0 });
+      // curatedBefore = entries already under real categories. The honest
+      // graduated count is how many NEW curated entries appear (arrivals), not
+      // how many left the backlog — a dropped entry leaves the backlog without
+      // arriving anywhere.
+      const curatedBefore = _countCuratedEntries(content);
+      targets.push({ ...c, filePath, entriesBefore, curatedBefore, stubsBefore: 0 });
     } else {
       const stubsBefore = _countStubs(content);
       if (stubsBefore === 0) {
@@ -258,8 +235,20 @@ async function run(context) {
       continue; // can't measure — count nothing for this file
     }
     if (t.mode === 'graduate') {
+      // Honest count = entries that ARRIVED under a real category (curated
+      // growth), clamped ≥0. This can't be inflated by an entry the AI dropped
+      // instead of filing. If more entries left the backlog than arrived in
+      // categories, the difference vanished — surface it rather than bill it as
+      // graduated (the commit audit line must not read data loss as success).
       const entriesAfter = _countTodoEntries(after);
-      graduatedCount += Math.max(0, t.entriesBefore - entriesAfter);
+      const leftBacklog = Math.max(0, t.entriesBefore - entriesAfter);
+      const arrived = Math.max(0, _countCuratedEntries(after) - t.curatedBefore);
+      graduatedCount += arrived;
+      if (leftBacklog > arrived) {
+        log.warn('index-describe: TODO entries left the backlog without landing in a category', {
+          project: project.name, file: t.filename, leftBacklog, arrived, dropped: leftBacklog - arrived
+        });
+      }
     } else {
       const stubsAfter = _countStubs(after);
       describedCount += Math.max(0, t.stubsBefore - stubsAfter);

--- a/lib/wrap-steps/index-describe.js
+++ b/lib/wrap-steps/index-describe.js
@@ -1,22 +1,36 @@
 'use strict';
 
 /**
- * `index-describe` wrap step (#426) — the value-delivery half of the PIDX
- * auto-orientation indexes. The Feature Index (`FEATURES.md`, #207) and the
- * Project Map (`PROJECT-MAP.md`, #360) both seed *empty* description stubs
- * (`<!-- describe -->`) that a human otherwise fills by hand, leaving the value
- * latent. This step asks the live session's AI to fill **only the empty stubs**
- * with a brief one-line note based on each directory's / feature's actual
- * contents — turning the indexes from skeletons into useful orientation.
+ * `index-describe` wrap step (#426, #568) — the value-delivery half of the PIDX
+ * auto-orientation indexes. It runs the live session's AI over the enabled
+ * index file(s) at wrap, in one of two modes per file:
+ *
+ *   - **describe** (Project Map, `PROJECT-MAP.md`, #360): fill each empty
+ *     `<!-- describe -->` stub with a brief one-line note based on the
+ *     directory's actual contents — fill-only, never restructure.
+ *   - **graduate** (Feature Index, `FEATURES.md`, #207 / #568): the Feature
+ *     Index can otherwise never converge. `features-toc` appends
+ *     `## TODO (auto-stubbed …)` blocks of `- **TBD** — … ` entries that the
+ *     old fill-only contract could describe but never NAME or MOVE, so curated
+ *     categories stayed empty forever and the TODO piles grew without bound.
+ *     Graduate mode names each TODO-block entry, describes it, and files it
+ *     under the best-fit real category, deleting emptied blocks — the missing
+ *     step that lets the index converge. The curation invariant is re-scoped
+ *     from "touch only `<!-- describe -->` lines" to "touch only entries inside
+ *     a TODO block": a graduate step must restructure, but curated entries
+ *     under real categories stay untouchable.
  *
  * **Contract (never blocks — it is an enhancement, not a gate):**
  *
  *   - Skip when there is no active session (nothing to drive the AI).
  *   - Skip when neither index toggle is on (`projectMapEnabled` /
  *     `featureIndexEnabled`).
- *   - For each enabled index file, include it as a describe target ONLY when:
+ *   - For each enabled index file, include it as a target ONLY when:
  *       1. the file exists on disk, AND
- *       2. it has ≥1 empty `<!-- describe -->` stub, AND
+ *       2. it has work to do for its mode — a describe file with ≥1 empty
+ *          `<!-- describe -->` stub, or a graduate file with ≥1 entry inside a
+ *          `## TODO (auto-stubbed …)` block (whether or not that entry still
+ *          carries a `<!-- describe -->` marker), AND
  *       3. it has **no pending staged write this wrap** — `features-toc` and
  *          `project-map` *stage* their writes (`staged['features-toc:append']`
  *          / `staged['project-map:refresh']`) for `commit.js:_flushStagedWrites`
@@ -27,18 +41,19 @@
  *          content. Skipping such files defers their brand-new stubs to the
  *          NEXT wrap (when the file is settled on disk with no pending write) —
  *          a self-converging one-wrap lag. See `index-auto-describe.md`.
- *   - Skip when no target files qualify (no enabled file has describable,
- *     non-pending empty stubs).
- *   - Otherwise: build a prompt naming the target file(s) + the
- *     fill-only-empty-stubs contract and delegate send→poll→capture to
- *     `ai-content.run` (reuse, not reimplement — no captureFields, the AI edits
- *     the files directly memory-update-style; `commit`'s `git add -A` picks the
- *     edits up). After the AI turn, re-scan each target and report
- *     `describedCount = Σ(emptyBefore − emptyAfter)` (clamped ≥0, the honest
- *     count of stubs actually filled), staged under `staged['index-describe']`
- *     as `{indexDescribe:true, describedCount}` so `commit.js:_buildBodyLines`
- *     renders `- Index: described N stub(s)`. Any ai-content non-success
- *     (timeout / declined / webui-skip / send failure) → graceful `skipped`.
+ *   - Skip when no target files qualify (no enabled file has stubs to describe
+ *     or entries to graduate, non-pending).
+ *   - Otherwise: build a mode-branched prompt naming the target file(s) and
+ *     delegate send→poll→capture to `ai-content.run` (reuse, not reimplement —
+ *     no captureFields, the AI edits the files directly memory-update-style;
+ *     `commit`'s `git add -A` picks the edits up). After the AI turn, re-scan
+ *     each target and report `describedCount = Σ(stubsBefore − stubsAfter)` and
+ *     `graduatedCount = Σ(todoEntriesBefore − todoEntriesAfter)` (each clamped
+ *     ≥0, the honest count of what actually happened), staged under
+ *     `staged['index-describe']` as `{indexDescribe:true, describedCount,
+ *     graduatedCount}` so `commit.js:_buildBodyLines` renders the audit lines.
+ *     Any ai-content non-success (timeout / declined / webui-skip / send
+ *     failure) → graceful `skipped`.
  *
  * **Why lazy-require `../projects`.** Same wrap-pipeline require cycle the
  * project-map handler documents (`projects → sessions → wrap-pipeline →
@@ -63,6 +78,14 @@ const STEP_ID = 'index-describe';
 // Feature Index auto-stubs: "- **TBD** — touched in this session: `p`. <!-- describe -->").
 const STUB_MARKER = '<!-- describe -->';
 
+// A `## TODO (auto-stubbed <date>)` heading — the auto-stubbed backlog block
+// `features-toc` appends. Its entries are unfinished (`- **TBD** — … `path`.`)
+// and never leave the block on their own; the graduate mode below names them
+// and files them into a real category. The block runs until the next `## `
+// heading or EOF.
+const TODO_HEADING_RE = /^##\s+TODO\s+\(auto-stubbed\b/i;
+const H2_HEADING_RE = /^##\s/;
+
 /**
  * Count the empty `<!-- describe -->` stubs in a string. Substring count — a
  * line can only carry one marker, so occurrences == describable stubs.
@@ -73,6 +96,35 @@ const STUB_MARKER = '<!-- describe -->';
 function _countStubs(content) {
   if (!content || typeof content !== 'string') return 0;
   return content.split(STUB_MARKER).length - 1;
+}
+
+/**
+ * Count the top-level list entries that currently sit inside a
+ * `## TODO (auto-stubbed …)` block. Unlike `_countStubs`, this counts an entry
+ * whether or not it still carries a `<!-- describe -->` marker — a
+ * described-but-un-graduated `**TBD**` entry (the pre-existing-install case)
+ * still needs graduating. Sub-bullets (indented) and non-list lines don't
+ * count; a real category heading ends the block.
+ *
+ * @param {string} content
+ * @returns {number}
+ */
+function _countTodoEntries(content) {
+  if (!content || typeof content !== 'string') return 0;
+  let inTodo = false;
+  let count = 0;
+  for (const line of content.split('\n')) {
+    if (TODO_HEADING_RE.test(line)) {
+      inTodo = true;
+      continue;
+    }
+    if (H2_HEADING_RE.test(line)) {
+      inTodo = false;
+      continue;
+    }
+    if (inTodo && /^-\s+/.test(line)) count++;
+  }
+  return count;
 }
 
 /**
@@ -109,19 +161,24 @@ async function run(context) {
 
   // Candidate index files, each gated by its own toggle. The Feature Index
   // filename comes from `projects` so the constant has a single source.
+  // Each candidate carries a `mode`: the Feature Index is `graduate` (name +
+  // describe TODO-block stubs and file them into a real category — #568), the
+  // Project Map is `describe` (fill empty `<!-- describe -->` stubs in place —
+  // #426). The mode picks the trigger, the prompt contract, and the count.
   const candidates = [];
   if (projConfig.featureIndexEnabled === true) {
-    candidates.push({ filename: projects.FEATURE_INDEX_FILENAME, stagedKey: 'features-toc:append', label: 'Feature Index' });
+    candidates.push({ filename: projects.FEATURE_INDEX_FILENAME, stagedKey: 'features-toc:append', label: 'Feature Index', mode: 'graduate' });
   }
   if (projConfig.projectMapEnabled === true) {
-    candidates.push({ filename: projects.PROJECT_MAP_FILENAME, stagedKey: 'project-map:refresh', label: 'Project Map' });
+    candidates.push({ filename: projects.PROJECT_MAP_FILENAME, stagedKey: 'project-map:refresh', label: 'Project Map', mode: 'describe' });
   }
   if (candidates.length === 0) {
     return _skipped('neither featureIndexEnabled nor projectMapEnabled is true');
   }
 
-  // Resolve describe targets: on-disk, has empty stubs, and NO pending staged
-  // write this wrap (else the commit-step flush would clobber the AI's edits).
+  // Resolve targets: on-disk, has work to do (mode-specific trigger), and NO
+  // pending staged write this wrap (else the commit-step flush would clobber
+  // the AI's edits — the same one-wrap-lag gate for both modes).
   const targets = [];
   for (const c of candidates) {
     if (staged && staged[c.stagedKey]) {
@@ -137,15 +194,26 @@ async function run(context) {
     } catch {
       continue; // unreadable — skip this file, never block
     }
-    const stubsBefore = _countStubs(content);
-    if (stubsBefore === 0) {
-      continue; // nothing empty to describe
+    if (c.mode === 'graduate') {
+      // Trigger on ANY entry inside a TODO block — not only entries that still
+      // carry a `<!-- describe -->` marker — so a described-but-un-graduated
+      // `**TBD**` entry (pre-existing installs) still gets finished.
+      const entriesBefore = _countTodoEntries(content);
+      if (entriesBefore === 0) {
+        continue; // nothing to graduate
+      }
+      targets.push({ ...c, filePath, entriesBefore, stubsBefore: 0 });
+    } else {
+      const stubsBefore = _countStubs(content);
+      if (stubsBefore === 0) {
+        continue; // nothing empty to describe
+      }
+      targets.push({ ...c, filePath, stubsBefore, entriesBefore: 0 });
     }
-    targets.push({ ...c, filePath, stubsBefore });
   }
 
   if (targets.length === 0) {
-    return _skipped('no enabled index file has describable empty stubs (or all have pending staged writes)');
+    return _skipped('no enabled index file has stubs to describe or entries to graduate (or all have pending staged writes)');
   }
 
   const prompt = _buildPrompt(targets);
@@ -176,9 +244,12 @@ async function run(context) {
     return _skipped(`describe not applied: ${reason}`);
   }
 
-  // Re-scan each target to count stubs actually filled. The AI edited the
-  // files on disk during its turn; an honest count beats reporting the target.
+  // Re-scan each target to count what the AI actually did. It edited the files
+  // on disk during its turn; an honest count beats reporting the target. Count
+  // by mode: describe files by stubs filled, graduate files by TODO entries
+  // that left the backlog.
   let describedCount = 0;
+  let graduatedCount = 0;
   for (const t of targets) {
     let after;
     try {
@@ -186,19 +257,25 @@ async function run(context) {
     } catch {
       continue; // can't measure — count nothing for this file
     }
-    const stubsAfter = _countStubs(after);
-    describedCount += Math.max(0, t.stubsBefore - stubsAfter);
+    if (t.mode === 'graduate') {
+      const entriesAfter = _countTodoEntries(after);
+      graduatedCount += Math.max(0, t.entriesBefore - entriesAfter);
+    } else {
+      const stubsAfter = _countStubs(after);
+      describedCount += Math.max(0, t.stubsBefore - stubsAfter);
+    }
   }
 
-  // Replace ai-content's generic capture marker with the describe-count shape
-  // so the commit body renders "- Index: described N stub(s)" (not the generic
+  // Replace ai-content's generic capture marker with the describe/graduate-count
+  // shape so the commit body renders honest audit lines (not the generic
   // "AI content (index-describe): captured" line).
-  staged[STEP_ID] = { indexDescribe: true, describedCount, stepId: STEP_ID };
+  staged[STEP_ID] = { indexDescribe: true, describedCount, graduatedCount, stepId: STEP_ID };
 
   log.info('index-describe applied', {
     project: project.name,
     targets: targets.map((t) => t.filename),
-    describedCount
+    describedCount,
+    graduatedCount
   });
 
   return {
@@ -206,44 +283,86 @@ async function run(context) {
     status: 'done',
     output: {
       describedCount,
+      graduatedCount,
       files: targets.map((t) => t.filename),
-      detail: `described ${describedCount} stub(s) across ${targets.length} index file(s)`
+      detail: `graduated ${graduatedCount} entr${graduatedCount === 1 ? 'y' : 'ies'}, described ${describedCount} stub(s) across ${targets.length} index file(s)`
     },
     blockers: []
   };
 }
 
 /**
- * Build the describe prompt naming the target index file(s) and the
- * fill-only-empty-stubs contract. The instructions bound the AI to empty
- * `<!-- describe -->` stubs and forbid touching curated entries or
- * adding/removing entries (curation-preserving — the same invariant the
- * index refreshers honor).
+ * Build the AI prompt for the target index file(s). Two contracts, keyed on
+ * each target's `mode`:
  *
- * @param {Array<{filename:string, label:string, stubsBefore:number}>} targets
+ *   - `describe` (Project Map): fill empty `<!-- describe -->` stubs in place;
+ *     the invariant forbids touching any entry that already has a description,
+ *     and forbids restructuring (the #426 curation-preserving contract).
+ *   - `graduate` (Feature Index, #568): name the `**TBD**` entries inside a
+ *     `## TODO (auto-stubbed …)` block, describe them, and MOVE them under the
+ *     best-fit real category, deleting the block once empty. The invariant is
+ *     re-scoped to "only touch entries inside a TODO block" — a graduate step
+ *     must restructure, so the fill-only invariant is too tight, but curated
+ *     entries under real categories stay untouchable.
+ *
+ * @param {Array<{filename:string, label:string, mode?:string, stubsBefore?:number, entriesBefore?:number}>} targets
  * @returns {string}
  */
 function _buildPrompt(targets) {
-  const fileList = targets
-    .map((t) => `- \`${t.filename}\` (${t.label}, ${t.stubsBefore} empty stub${t.stubsBefore === 1 ? '' : 's'})`)
-    .join('\n');
-  return [
-    'You are at the end of a development session. The project keeps AI-orientation index file(s) whose description stubs are currently empty. Fill them in so future sessions can find things faster.',
+  const describeTargets = targets.filter((t) => t.mode !== 'graduate');
+  const graduateTargets = targets.filter((t) => t.mode === 'graduate');
+  const parts = [
+    'You are at the end of a development session. The project keeps AI-orientation index file(s) that need finishing so future sessions can find things faster.',
+    ''
+  ];
+
+  if (describeTargets.length > 0) {
+    const fileList = describeTargets
+      .map((t) => `- \`${t.filename}\` (${t.label}, ${t.stubsBefore} empty stub${t.stubsBefore === 1 ? '' : 's'})`)
+      .join('\n');
+    parts.push(
+      'FILL empty description stubs (do not restructure these files):',
+      fileList,
+      '',
+      `For EACH empty \`${STUB_MARKER}\` stub in the file(s) above:`,
+      `- Replace the literal \`${STUB_MARKER}\` marker with a brief one-line description of what that directory or feature contains, based on its ACTUAL contents (read the directory / files if unsure).`,
+      '- Keep it to a single concise line. No trailing newline changes to the rest of the file.',
+      '',
+      'STRICT rules (fill-only files):',
+      `- Only touch lines that still contain the literal \`${STUB_MARKER}\` marker. Never overwrite an entry that already has a description (preserve curation).`,
+      '- Do NOT add, remove, reorder, or restructure entries. Only fill empty stubs in place.',
+      ''
+    );
+  }
+
+  if (graduateTargets.length > 0) {
+    const fileList = graduateTargets
+      .map((t) => `- \`${t.filename}\` (${t.label}, ${t.entriesBefore} entr${t.entriesBefore === 1 ? 'y' : 'ies'} awaiting graduation)`)
+      .join('\n');
+    parts.push(
+      'CURATE the auto-stubbed backlog (graduate TODO entries into their real home):',
+      fileList,
+      '',
+      'Each file above has one or more `## TODO (auto-stubbed <date>)` blocks whose entries were auto-added when a session touched new files. Finish the job for EACH entry inside a `## TODO (auto-stubbed …)` block:',
+      '- Give it a real short **Name** in place of `**TBD**`, inferred from what the file actually is (read the file if unsure).',
+      '- Write a brief one-line description (keep an existing good description; replace any leftover `<!-- describe -->` marker).',
+      '- Keep the exact backtick path token unchanged (e.g. `lib/foo.js`) — it is the stable anchor.',
+      '- MOVE the finished entry out of the TODO block and under the single best-fit EXISTING category heading. Match the category to the entry; do not invent new categories.',
+      '- When a `## TODO (auto-stubbed …)` block has no entries left, DELETE the now-empty heading and its surrounding blank lines.',
+      '',
+      'STRICT rules (curated files):',
+      '- Only ever touch entries currently inside a `## TODO (auto-stubbed …)` block, and the TODO headings themselves. NEVER modify, reorder, or delete an entry already under a real category heading, and never touch the file\'s top comment. That existing curation is authoritative.',
+      '- Do not drop any entry: every TODO entry must end up under a category. If you truly cannot tell what a file is, give it a best-effort name and file it under the closest category — never delete it.',
+      ''
+    );
+  }
+
+  parts.push(
+    'Edit the file(s) directly with your file tools. The wrap commit picks the changes up automatically.',
     '',
-    'Target file(s):',
-    fileList,
-    '',
-    `For EACH empty \`${STUB_MARKER}\` stub in those file(s):`,
-    `- Replace the literal \`${STUB_MARKER}\` marker with a brief one-line description of what that directory or feature contains, based on its ACTUAL contents (read the directory / files if unsure).`,
-    '- Keep it to a single concise line — a few words to a short sentence. No trailing newline changes to the rest of the file.',
-    '',
-    'STRICT rules:',
-    `- Only touch lines that still contain the literal \`${STUB_MARKER}\` marker. Never overwrite an entry that already has a human- or AI-written description (preserve curation).`,
-    '- Do NOT add new entries, remove entries, reorder, or restructure the file. Only fill empty stubs in place.',
-    '- Edit the file(s) directly with your file tools. The wrap commit picks the changes up automatically.',
-    '',
-    'When done, reply with a single `## Result` heading followed by a one-line summary (e.g. "Described N stubs in PROJECT-MAP.md"). If there was nothing fillable, say so — do not fabricate descriptions.'
-  ].join('\n');
+    'When done, reply with a single `## Result` heading followed by a one-line summary (e.g. "Graduated N entries, described M stubs"). If there was nothing to do, say so — do not fabricate.'
+  );
+  return parts.join('\n');
 }
 
 /**
@@ -269,6 +388,7 @@ module.exports = {
   run,
   _buildPrompt,
   _countStubs,
+  _countTodoEntries,
   _skipped,
   _internal,
   STEP_ID,

--- a/test/feature-index-prime.test.js
+++ b/test/feature-index-prime.test.js
@@ -7,7 +7,12 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
 
-const { summarizeFeatureIndexForPrime } = require('../lib/feature-index-prime');
+const {
+  summarizeFeatureIndexForPrime,
+  countTodoEntries,
+  countCuratedEntries
+} = require('../lib/feature-index-prime');
+const featuresToc = require('../lib/wrap-steps/features-toc');
 
 const TODO = '## TODO (auto-stubbed 2026-07-02)';
 
@@ -71,6 +76,29 @@ describe('summarizeFeatureIndexForPrime (#568)', () => {
     const content = `# Feature Index\n\n${TODO}\n\n- **TBD** — \`a.js\`.\n- **TBD** — \`b.js\`.\n`;
     const { curated, backlogEntries, backlogBlocks } = summarizeFeatureIndexForPrime(content);
     assert.equal(curated, '# Feature Index');
+    assert.equal(backlogEntries, 2);
+    assert.equal(backlogBlocks, 1);
+  });
+
+  it('counts curated entries outside any TODO block', () => {
+    const content = `# Feature Index\n\n## UI / Web\n\n- **A** — \`a.js\`\n- **B** — \`b.js\`\n\n${TODO}\n\n- **TBD** — \`c.js\`.\n`;
+    assert.equal(countCuratedEntries(content), 2);
+    assert.equal(countTodoEntries(content), 1);
+  });
+
+  it('parses the ACTUAL features-toc stub format (not just hand-written fixtures)', () => {
+    // Pin the parser against the producer's real output so the shared auto-stub
+    // contract can't drift silently (#568 / R-6).
+    const seeded = featuresToc._appendTodoSection(
+      '# Feature Index\n\n## Server / API\n\n- **Existing** — desc. `lib/e.js`\n',
+      ['lib/new-a.js', 'lib/new-b.js'],
+      '2026-07-20'
+    );
+    assert.equal(countTodoEntries(seeded), 2, 'both auto-stubbed entries are counted as backlog');
+    assert.equal(countCuratedEntries(seeded), 1, 'the pre-existing curated entry is not counted as backlog');
+    const { curated, backlogEntries, backlogBlocks } = summarizeFeatureIndexForPrime(seeded);
+    assert.match(curated, /\*\*Existing\*\*/);
+    assert.doesNotMatch(curated, /new-a\.js/, 'auto-stubbed paths are stripped from the prime');
     assert.equal(backlogEntries, 2);
     assert.equal(backlogBlocks, 1);
   });

--- a/test/feature-index-prime.test.js
+++ b/test/feature-index-prime.test.js
@@ -1,0 +1,77 @@
+'use strict';
+
+// Tests for the Feature Index prime summarizer (#568) — the pure function that
+// caps what `FEATURES.md` contributes to the session prime: curated categories
+// inline, the auto-stubbed TODO backlog reduced to a count.
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { summarizeFeatureIndexForPrime } = require('../lib/feature-index-prime');
+
+const TODO = '## TODO (auto-stubbed 2026-07-02)';
+
+describe('summarizeFeatureIndexForPrime (#568)', () => {
+  it('is null/non-string safe', () => {
+    for (const v of [null, undefined, 42, {}]) {
+      assert.deepEqual(summarizeFeatureIndexForPrime(v), { curated: '', backlogEntries: 0, backlogBlocks: 0 });
+    }
+  });
+
+  it('returns curated content unchanged when there is no TODO backlog', () => {
+    const content = '# Feature Index\n\n## UI / Web\n\n- **Pill** — a pill. `lib/pill.js`\n';
+    const { curated, backlogEntries, backlogBlocks } = summarizeFeatureIndexForPrime(content);
+    assert.match(curated, /## UI \/ Web/);
+    assert.match(curated, /\*\*Pill\*\*/);
+    assert.equal(backlogEntries, 0);
+    assert.equal(backlogBlocks, 0);
+  });
+
+  it('strips the TODO block and counts its entries', () => {
+    const content = `# Feature Index\n\n## Server / API\n\n- **Real** — desc. \`r.js\`\n\n${TODO}\n\n`
+      + '- **TBD** — touched in this session: `lib/a.js`. <!-- describe -->\n'
+      + '- **TBD** — touched in this session: `lib/b.js`. <!-- describe -->\n';
+    const { curated, backlogEntries, backlogBlocks } = summarizeFeatureIndexForPrime(content);
+    // Curated keeps the real category + entry...
+    assert.match(curated, /## Server \/ API/);
+    assert.match(curated, /\*\*Real\*\*/);
+    // ...and drops the TODO heading + its TBD entries entirely.
+    assert.doesNotMatch(curated, /TODO \(auto-stubbed/);
+    assert.doesNotMatch(curated, /\*\*TBD\*\*/);
+    assert.doesNotMatch(curated, /lib\/a\.js/);
+    assert.equal(backlogEntries, 2);
+    assert.equal(backlogBlocks, 1);
+  });
+
+  it('counts across multiple TODO blocks and stops each at the next real heading', () => {
+    const content = `# Feature Index\n\n${TODO}\n\n- **TBD** — \`a.js\`.\n\n`
+      + '## CLI / Tooling\n\n- **After** — a real one. `b.js`\n\n'
+      + '## TODO (auto-stubbed 2026-07-03)\n\n- **TBD** — `c.js`.\n- **TBD** — `d.js`.\n';
+    const { curated, backlogEntries, backlogBlocks } = summarizeFeatureIndexForPrime(content);
+    assert.match(curated, /## CLI \/ Tooling/);
+    assert.match(curated, /\*\*After\*\*/);
+    assert.doesNotMatch(curated, /\*\*TBD\*\*/);
+    assert.equal(backlogEntries, 3);
+    assert.equal(backlogBlocks, 2);
+  });
+
+  it('collapses the blank-line gap a removed mid-file block leaves', () => {
+    const content = `# Feature Index\n\n## UI / Web\n\n- **X** — \`x.js\`\n\n${TODO}\n\n- **TBD** — \`y.js\`.\n\n## Server / API\n\n- **Z** — \`z.js\`\n`;
+    const { curated } = summarizeFeatureIndexForPrime(content);
+    assert.doesNotMatch(curated, /\n{3,}/, 'no 3+ consecutive newlines after removing the block');
+    assert.match(curated, /## UI \/ Web/);
+    assert.match(curated, /## Server \/ API/);
+  });
+
+  it('a whitespace/empty file yields empty curated and a zero backlog', () => {
+    assert.deepEqual(summarizeFeatureIndexForPrime('   \n\n\t \n'), { curated: '', backlogEntries: 0, backlogBlocks: 0 });
+  });
+
+  it('an all-backlog file yields curated with only the header and a nonzero count', () => {
+    const content = `# Feature Index\n\n${TODO}\n\n- **TBD** — \`a.js\`.\n- **TBD** — \`b.js\`.\n`;
+    const { curated, backlogEntries, backlogBlocks } = summarizeFeatureIndexForPrime(content);
+    assert.equal(curated, '# Feature Index');
+    assert.equal(backlogEntries, 2);
+    assert.equal(backlogBlocks, 1);
+  });
+});

--- a/test/sessions.test.js
+++ b/test/sessions.test.js
@@ -629,6 +629,45 @@ describe('sessions', () => {
         assert.ok(prompt.includes('lib/pill.js:42'), 'prime should contain the file pointer');
       });
 
+      it('inlines only curated categories and caps the TODO backlog to a count (#568)', () => {
+        store.projectConfig.save(fiProjectPath, {
+          engine: 'claude',
+          silentPrime: true,
+          featureIndexEnabled: true
+        });
+        fs.writeFileSync(featuresPath,
+          '# Feature Index\n\n## Server / API\n\n- **Handler** — serves X. `lib/h.js`\n\n'
+          + '## TODO (auto-stubbed 2026-07-02)\n\n'
+          + '- **TBD** — touched in this session: `lib/a.js`. <!-- describe -->\n'
+          + '- **TBD** — touched in this session: `lib/b.js`. <!-- describe -->\n');
+
+        const engine = store.engines.get('claude');
+        const prompt = sessions.generatePrimePrompt(fiProject, engine);
+
+        assert.ok(prompt.includes('## Feature Index'), 'section header present');
+        assert.ok(prompt.includes('**Handler**'), 'curated category entry inlined');
+        // The auto-stubbed backlog is NOT inlined — only counted.
+        assert.equal(prompt.includes('**TBD**'), false, 'TBD stubs must not reach the prime');
+        assert.equal(prompt.includes('lib/a.js'), false, 'backlog paths must not reach the prime');
+        assert.ok(prompt.includes('2 auto-stubbed entries awaiting graduation in 1 backlog block'),
+          'backlog is summarized as a count line');
+      });
+
+      it('singularizes the backlog count line for a single entry/block (#568)', () => {
+        store.projectConfig.save(fiProjectPath, {
+          engine: 'claude',
+          silentPrime: true,
+          featureIndexEnabled: true
+        });
+        fs.writeFileSync(featuresPath,
+          '# Feature Index\n\n## TODO (auto-stubbed 2026-07-02)\n\n- **TBD** — `lib/a.js`. <!-- describe -->\n');
+
+        const engine = store.engines.get('claude');
+        const prompt = sessions.generatePrimePrompt(fiProject, engine);
+        assert.ok(prompt.includes('1 auto-stubbed entry awaiting graduation in 1 backlog block'),
+          'singular entry + singular block');
+      });
+
       it('is skipped when featureIndexEnabled is false (even with silentPrime + capability)', () => {
         store.projectConfig.save(fiProjectPath, {
           engine: 'claude',

--- a/test/wrap-step-index-describe.test.js
+++ b/test/wrap-step-index-describe.test.js
@@ -48,19 +48,86 @@ describe('wrap-step index-describe (#426)', () => {
   });
 
   describe('_buildPrompt (contract)', () => {
-    it('names the target files and pins the fill-only-empty-stubs rules', () => {
+    it('describe-mode: names the file and pins the fill-only-empty-stubs rules', () => {
       const prompt = indexDescribe._buildPrompt([
-        { filename: 'PROJECT-MAP.md', label: 'Project Map', stubsBefore: 2 },
-        { filename: 'FEATURES.md', label: 'Feature Index', stubsBefore: 1 }
+        { filename: 'PROJECT-MAP.md', label: 'Project Map', mode: 'describe', stubsBefore: 2 }
       ]);
       assert.match(prompt, /PROJECT-MAP\.md/);
-      assert.match(prompt, /FEATURES\.md/);
       assert.match(prompt, /2 empty stubs/);
-      assert.match(prompt, /1 empty stub\b/);
       assert.match(prompt, /<!-- describe -->/);
       assert.match(prompt, /preserve curation/i);
-      assert.match(prompt, /Do NOT add new entries/);
+      assert.match(prompt, /Do NOT add, remove, reorder, or restructure/);
       assert.match(prompt, /## Result/);
+      // No graduate section when there are no graduate targets.
+      assert.doesNotMatch(prompt, /graduate the auto-stubbed backlog/i);
+    });
+
+    it('a missing mode defaults to describe (fill-only), never graduate', () => {
+      const prompt = indexDescribe._buildPrompt([
+        { filename: 'PROJECT-MAP.md', label: 'Project Map', stubsBefore: 1 }
+      ]);
+      assert.match(prompt, /1 empty stub\b/);
+      assert.match(prompt, /Only fill empty stubs in place/);
+      assert.doesNotMatch(prompt, /CURATE the auto-stubbed backlog/);
+    });
+
+    it('graduate-mode: names the file and pins the TODO-block-only curation rules', () => {
+      const prompt = indexDescribe._buildPrompt([
+        { filename: 'FEATURES.md', label: 'Feature Index', mode: 'graduate', entriesBefore: 3 }
+      ]);
+      assert.match(prompt, /FEATURES\.md/);
+      assert.match(prompt, /3 entries awaiting graduation/);
+      assert.match(prompt, /## TODO \(auto-stubbed/);
+      assert.match(prompt, /best-fit EXISTING category/);
+      assert.match(prompt, /Only ever touch entries currently inside a/);
+      assert.match(prompt, /NEVER modify, reorder, or delete an entry already under a real category/);
+      assert.match(prompt, /never delete it/);
+      assert.match(prompt, /## Result/);
+      // No describe/fill section when there are no describe targets.
+      assert.doesNotMatch(prompt, /FILL empty description stubs/);
+    });
+
+    it('both modes: emits both sections when a describe and a graduate target are present', () => {
+      const prompt = indexDescribe._buildPrompt([
+        { filename: 'PROJECT-MAP.md', label: 'Project Map', mode: 'describe', stubsBefore: 1 },
+        { filename: 'FEATURES.md', label: 'Feature Index', mode: 'graduate', entriesBefore: 2 }
+      ]);
+      assert.match(prompt, /FILL empty description stubs/);
+      assert.match(prompt, /CURATE the auto-stubbed backlog/);
+      assert.match(prompt, /PROJECT-MAP\.md/);
+      assert.match(prompt, /FEATURES\.md/);
+    });
+  });
+
+  describe('_countTodoEntries (pure)', () => {
+    const H = '## TODO (auto-stubbed 2026-07-02)';
+    it('counts list entries inside a TODO block', () => {
+      const c = `# Feature Index\n\n${H}\n\n- **TBD** — \`a.js\`. <!-- describe -->\n- **TBD** — \`b.js\`. <!-- describe -->\n`;
+      assert.equal(indexDescribe._countTodoEntries(c), 2);
+    });
+    it('counts a described-but-un-graduated entry (no marker left)', () => {
+      const c = `# Feature Index\n\n${H}\n\n- **TBD** — the a feature. \`a.js\`\n`;
+      assert.equal(indexDescribe._countTodoEntries(c), 1);
+    });
+    it('does not count entries under a real category heading', () => {
+      const c = `# Feature Index\n\n## Server / API\n\n- **Real** — desc. \`r.js\`\n\n${H}\n\n- **TBD** — \`a.js\`. <!-- describe -->\n`;
+      assert.equal(indexDescribe._countTodoEntries(c), 1);
+    });
+    it('a real heading ends the TODO block', () => {
+      const c = `${H}\n\n- **TBD** — \`a.js\`.\n\n## CLI / Tooling\n\n- **After** — \`b.js\`\n`;
+      assert.equal(indexDescribe._countTodoEntries(c), 1);
+    });
+    it('handles multiple TODO blocks', () => {
+      const c = `${H}\n\n- **TBD** — \`a.js\`.\n\n## TODO (auto-stubbed 2026-07-03)\n\n- **TBD** — \`b.js\`.\n- **TBD** — \`c.js\`.\n`;
+      assert.equal(indexDescribe._countTodoEntries(c), 3);
+    });
+    it('does not count indented sub-bullets', () => {
+      const c = `${H}\n\n- **TBD** — \`a.js\`.\n  - a nested note\n`;
+      assert.equal(indexDescribe._countTodoEntries(c), 1);
+    });
+    it('is null/non-string safe and 0 when no TODO block', () => {
+      assert.equal(indexDescribe._countTodoEntries(null), 0);
+      assert.equal(indexDescribe._countTodoEntries('# Feature Index\n\n## UI / Web\n\n- x\n'), 0);
     });
   });
 
@@ -132,7 +199,7 @@ describe('wrap-step index-describe (#426)', () => {
         '# Project Map\n\n## Structure\n\n- `lib/` — already described.\n');
       const result = await indexDescribe.run({ project: createdProject, session: SESSION, staged: {} });
       assert.equal(result.status, 'skipped');
-      assert.match(result.output.reason, /describable empty stubs/);
+      assert.match(result.output.reason, /stubs to describe or entries to graduate/);
     });
 
     it('skips a file that has a pending staged write this wrap (clobber-avoidance)', async () => {
@@ -187,30 +254,29 @@ describe('wrap-step index-describe (#426)', () => {
     it('describes empty stubs and reports the honest filled count from a post-scan', async () => {
       const mapPath = path.join(projectPath, 'PROJECT-MAP.md');
       const featPath = path.join(projectPath, 'FEATURES.md');
+      // Project Map (describe mode) has the stubs; keep FEATURES out of this case
+      // so the count is unambiguously the describe path.
       fs.writeFileSync(mapPath,
         '# Project Map\n\n## Structure\n\n- `lib/` — <!-- describe -->\n- `test/` — <!-- describe -->\n');
-      fs.writeFileSync(featPath,
-        '# Feature Index\n\n- **TBD** — `lib/x.js`. <!-- describe -->\n');
+      if (fs.existsSync(featPath)) fs.unlinkSync(featPath);
 
       const orig = aiContent.run;
-      // Simulate the AI editing the files on disk: fill ALL stubs in the map,
-      // and the one in FEATURES.md.
-      aiContent.run = async (ctx) => {
+      // Simulate the AI editing the files on disk: fill ALL stubs in the map.
+      aiContent.run = async () => {
         fs.writeFileSync(mapPath,
           '# Project Map\n\n## Structure\n\n- `lib/` — core library.\n- `test/` — the test suite.\n');
-        fs.writeFileSync(featPath,
-          '# Feature Index\n\n- **TBD** — `lib/x.js`. the x feature.\n');
-        return { ok: true, status: 'done', output: { capturedText: '## Result\nDescribed 3 stubs.' }, blockers: [] };
+        return { ok: true, status: 'done', output: { capturedText: '## Result\nDescribed 2 stubs.' }, blockers: [] };
       };
       try {
         const staged = {};
         const result = await indexDescribe.run({ project: createdProject, session: SESSION, staged });
         assert.equal(result.ok, true);
         assert.equal(result.status, 'done');
-        assert.equal(result.output.describedCount, 3, '2 in the map + 1 in FEATURES.md');
+        assert.equal(result.output.describedCount, 2, 'both map stubs filled');
+        assert.equal(result.output.graduatedCount, 0, 'no graduate target this case');
         // Staged shape drives the commit body line — NOT ai-content's generic marker.
         assert.deepEqual(staged['index-describe'], {
-          indexDescribe: true, describedCount: 3, stepId: 'index-describe'
+          indexDescribe: true, describedCount: 2, graduatedCount: 0, stepId: 'index-describe'
         });
       } finally {
         aiContent.run = orig;
@@ -264,19 +330,184 @@ describe('wrap-step index-describe (#426)', () => {
     });
   });
 
-  describe('commit-step body-line emission (#426)', () => {
+  describe('handler — graduate mode (Feature Index convergence, #568)', () => {
+    let tmpDir;
+    let projectPath;
+    let createdProject;
+
+    before(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-index-graduate-'));
+      store._setBasePath(path.join(tmpDir, 'tangleclaw'));
+      store.init();
+      const projectsDir = path.join(tmpDir, 'projects');
+      fs.mkdirSync(projectsDir, { recursive: true });
+      const cfg = store.config.load();
+      cfg.projectsDir = projectsDir;
+      store.config.save(cfg);
+      projectPath = path.join(projectsDir, 'idx-grad');
+      fs.mkdirSync(projectPath, { recursive: true });
+      createdProject = store.projects.create({ name: 'idx-grad', path: projectPath, engine: 'claude' });
+      // Feature Index on, Project Map off — isolate the graduate path.
+      store.projectConfig.save(projectPath, {
+        engine: 'claude', methodology: 'minimal', featureIndexEnabled: true, projectMapEnabled: false
+      });
+    });
+
+    after(() => {
+      store.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    const featPath = () => path.join(projectPath, 'FEATURES.md');
+
+    it('graduates TODO-block entries into a category and reports the honest count', async () => {
+      fs.writeFileSync(featPath(),
+        '# Feature Index\n\n## Server / API\n\n## TODO (auto-stubbed 2026-07-02)\n\n'
+        + '- **TBD** — touched in this session: `lib/a.js`. <!-- describe -->\n'
+        + '- **TBD** — touched in this session: `lib/b.js`. <!-- describe -->\n');
+
+      const orig = aiContent.run;
+      // Simulate the AI graduating both entries under the category and deleting
+      // the now-empty TODO block.
+      aiContent.run = async () => {
+        fs.writeFileSync(featPath(),
+          '# Feature Index\n\n## Server / API\n\n'
+          + '- **A handler** — does A. `lib/a.js`\n'
+          + '- **B handler** — does B. `lib/b.js`\n');
+        return { ok: true, status: 'done', output: {}, blockers: [] };
+      };
+      try {
+        const staged = {};
+        const result = await indexDescribe.run({ project: createdProject, session: SESSION, staged });
+        assert.equal(result.status, 'done');
+        assert.equal(result.output.graduatedCount, 2, 'both TODO entries left the backlog');
+        assert.equal(result.output.describedCount, 0, 'no describe-mode target');
+        assert.deepEqual(staged['index-describe'], {
+          indexDescribe: true, describedCount: 0, graduatedCount: 2, stepId: 'index-describe'
+        });
+      } finally {
+        aiContent.run = orig;
+      }
+    });
+
+    it('triggers on a described-but-un-graduated TODO entry (no marker left)', async () => {
+      // The pre-existing-install case: entry has a description but still says
+      // **TBD** and sits in a TODO block, with no `<!-- describe -->` marker.
+      fs.writeFileSync(featPath(),
+        '# Feature Index\n\n## CLI / Tooling\n\n## TODO (auto-stubbed 2026-07-01)\n\n'
+        + '- **TBD** — already has a description. `lib/c.js`\n');
+
+      const orig = aiContent.run;
+      let called = false;
+      aiContent.run = async () => {
+        called = true;
+        fs.writeFileSync(featPath(),
+          '# Feature Index\n\n## CLI / Tooling\n\n- **C tool** — already has a description. `lib/c.js`\n');
+        return { ok: true, status: 'done', output: {}, blockers: [] };
+      };
+      try {
+        const result = await indexDescribe.run({ project: createdProject, session: SESSION, staged: {} });
+        assert.equal(called, true, 'must drive the AI even with no <!-- describe --> marker');
+        assert.equal(result.output.graduatedCount, 1);
+      } finally {
+        aiContent.run = orig;
+      }
+    });
+
+    it('skips when FEATURES.md has no TODO block (nothing to graduate)', async () => {
+      fs.writeFileSync(featPath(),
+        '# Feature Index\n\n## Server / API\n\n- **Real** — desc. `lib/r.js`\n');
+      const orig = aiContent.run;
+      let called = false;
+      aiContent.run = async () => { called = true; return { ok: true, status: 'done', output: {}, blockers: [] }; };
+      try {
+        const result = await indexDescribe.run({ project: createdProject, session: SESSION, staged: {} });
+        assert.equal(result.status, 'skipped');
+        assert.equal(called, false, 'a fully-graduated index needs no AI turn');
+      } finally {
+        aiContent.run = orig;
+      }
+    });
+
+    it('defers FEATURES.md when features-toc staged an append this wrap (clobber-avoidance)', async () => {
+      fs.writeFileSync(featPath(),
+        '# Feature Index\n\n## TODO (auto-stubbed 2026-07-02)\n\n- **TBD** — `lib/a.js`. <!-- describe -->\n');
+      const orig = aiContent.run;
+      let called = false;
+      aiContent.run = async () => { called = true; return { ok: true, status: 'done', output: {}, blockers: [] }; };
+      try {
+        const staged = { 'features-toc:append': { featuresToc: true, addedCount: 1 } };
+        const result = await indexDescribe.run({ project: createdProject, session: SESSION, staged });
+        assert.equal(result.status, 'skipped');
+        assert.equal(called, false, 'must not graduate a file with a pending staged append');
+      } finally {
+        aiContent.run = orig;
+      }
+    });
+
+    it('curation invariant: does not report entries the AI left under a real category', async () => {
+      // The AI (misbehaving) touches nothing — a curated entry must never be
+      // counted as graduated, and the pre-existing curated entry is preserved.
+      fs.writeFileSync(featPath(),
+        '# Feature Index\n\n## UI / Web\n\n- **Kept** — a curated entry. `public/x.js`\n\n'
+        + '## TODO (auto-stubbed 2026-07-02)\n\n- **TBD** — `lib/a.js`. <!-- describe -->\n');
+      const orig = aiContent.run;
+      aiContent.run = async () => ({ ok: true, status: 'done', output: {}, blockers: [] }); // no edit
+      try {
+        const result = await indexDescribe.run({ project: createdProject, session: SESSION, staged: {} });
+        assert.equal(result.output.graduatedCount, 0, 'nothing moved → nothing graduated');
+        // The curated entry is untouched on disk.
+        const after = fs.readFileSync(featPath(), 'utf8');
+        assert.match(after, /- \*\*Kept\*\* — a curated entry\. `public\/x\.js`/);
+      } finally {
+        aiContent.run = orig;
+      }
+    });
+  });
+
+  describe('commit-step body-line emission (#426/#568)', () => {
     it('emits "- Index: described N stub(s)" when describedCount > 0', () => {
       const lines = commitStep._buildBodyLines({
-        'index-describe': { indexDescribe: true, describedCount: 4, stepId: 'index-describe' }
+        'index-describe': { indexDescribe: true, describedCount: 4, graduatedCount: 0, stepId: 'index-describe' }
       });
       assert.ok(lines.includes('- Index: described 4 stub(s)'));
     });
 
-    it('emits nothing when describedCount is 0 (AI filled nothing)', () => {
+    it('emits "- Feature Index: graduated N entries" when graduatedCount > 0', () => {
       const lines = commitStep._buildBodyLines({
-        'index-describe': { indexDescribe: true, describedCount: 0, stepId: 'index-describe' }
+        'index-describe': { indexDescribe: true, describedCount: 0, graduatedCount: 3, stepId: 'index-describe' }
       });
+      assert.ok(lines.includes('- Feature Index: graduated 3 entries'));
       assert.equal(lines.find((l) => l.startsWith('- Index:')), undefined);
+    });
+
+    it('singularizes a single graduated entry', () => {
+      const lines = commitStep._buildBodyLines({
+        'index-describe': { indexDescribe: true, describedCount: 0, graduatedCount: 1, stepId: 'index-describe' }
+      });
+      assert.ok(lines.includes('- Feature Index: graduated 1 entry'));
+    });
+
+    it('emits both lines when the AI both graduated and described', () => {
+      const lines = commitStep._buildBodyLines({
+        'index-describe': { indexDescribe: true, describedCount: 2, graduatedCount: 5, stepId: 'index-describe' }
+      });
+      assert.ok(lines.includes('- Feature Index: graduated 5 entries'));
+      assert.ok(lines.includes('- Index: described 2 stub(s)'));
+    });
+
+    it('emits nothing when both counts are 0', () => {
+      const lines = commitStep._buildBodyLines({
+        'index-describe': { indexDescribe: true, describedCount: 0, graduatedCount: 0, stepId: 'index-describe' }
+      });
+      assert.equal(lines.find((l) => l.startsWith('- Index:') || l.startsWith('- Feature Index:')), undefined);
+    });
+
+    it('still renders the legacy shape (describedCount only, no graduatedCount)', () => {
+      const lines = commitStep._buildBodyLines({
+        'index-describe': { indexDescribe: true, describedCount: 4, stepId: 'index-describe' }
+      });
+      assert.ok(lines.includes('- Index: described 4 stub(s)'));
     });
   });
 });

--- a/test/wrap-step-index-describe.test.js
+++ b/test/wrap-step-index-describe.test.js
@@ -445,6 +445,27 @@ describe('wrap-step index-describe (#426)', () => {
       }
     });
 
+    it('honest count: an entry the AI drops (not filed) is NOT billed as graduated', async () => {
+      // Conservation guard (#568): graduatedCount counts arrivals under a real
+      // category, so an entry that merely leaves the TODO block (deleted, not
+      // filed) must not read as success.
+      fs.writeFileSync(featPath(),
+        '# Feature Index\n\n## Server / API\n\n## TODO (auto-stubbed 2026-07-02)\n\n'
+        + '- **TBD** — `lib/a.js`. <!-- describe -->\n- **TBD** — `lib/b.js`. <!-- describe -->\n');
+      const orig = aiContent.run;
+      // Misbehaving AI: deletes the TODO block entirely, files nothing.
+      aiContent.run = async () => {
+        fs.writeFileSync(featPath(), '# Feature Index\n\n## Server / API\n');
+        return { ok: true, status: 'done', output: {}, blockers: [] };
+      };
+      try {
+        const result = await indexDescribe.run({ project: createdProject, session: SESSION, staged: {} });
+        assert.equal(result.output.graduatedCount, 0, 'two entries vanished but zero arrived → graduated 0');
+      } finally {
+        aiContent.run = orig;
+      }
+    });
+
     it('curation invariant: does not report entries the AI left under a real category', async () => {
       // The AI (misbehaving) touches nothing — a curated entry must never be
       // counted as graduated, and the pre-existing curated entry is preserved.


### PR DESCRIPTION
## What

Fixes #568 — the Feature Index could never converge. `features-toc` appended `## TODO (auto-stubbed <date>)` blocks of `- **TBD** — …` entries; `index-describe` could fill their `<!-- describe -->` markers but was forbidden (the #426 curation invariant) from **naming** them or **moving** them into a real category. So curated sections stayed empty forever, the TODO piles grew one block per wrap, and `sessions.js` inlined the entire mostly-"TBD" file into every session prime (TiLT: 13.5 KB, 106 entries all "TBD").

Two coordinated fixes (operator ratified "Full fix" scope):

- **(A) Graduation** — `index-describe` gains a graduate mode for the Feature Index: it names each TODO-block entry, describes it, and files it under the best-fit existing category, deleting emptied blocks. The curation invariant is re-scoped from "touch only `<!-- describe -->` lines" to **"touch only entries inside a TODO block"**, so curated entries under real categories stay untouchable while the one restructure the design needs is allowed. It triggers on **any** TODO-block entry (so pre-existing installs with described-but-un-graduated stubs converge too), honors the same one-wrap-lag staged-write gate as describe mode (a pending `features-toc` append defers graduation to the next wrap to avoid the commit-flush clobber), and reports an honest `Feature Index: graduated N` commit line — counted by **arrivals under a real category** (conservation), so an entry the AI drops instead of filing can't read as success. The Project Map keeps its fill-only describe contract unchanged.
- **(B) Capped prime** — new dependency-free `lib/feature-index-prime.js` inlines only the curated categories and replaces the auto-stubbed backlog with a one-line count, so the prime cost tracks converged content, not the raw pile. It is also the single source of truth for the auto-stub block parse (both `sessions.js` and `index-describe` scan through it, rather than each re-implementing the format that is a contract with the `features-toc` producer), and stays `require`-free to sit off the `projects → sessions` cycle.

## Why

Every session with `featureIndexEnabled` paid prime budget for a list where most entries were literally "TBD" — worse than not having the feature. The index is supposed to converge; it structurally couldn't, because no step existed to name/graduate stubs. This closes the last of #571's four children (#569/#570/#540 already closed).

## Test plan

- `test/feature-index-prime.test.js` — summarizer + `countTodoEntries`/`countCuratedEntries` units, incl. a pin against real `features-toc._appendTodoSection` output.
- `test/wrap-step-index-describe.test.js` — graduate-mode handler tests: graduation + honest count, any-TODO-entry trigger, no-TODO-block skip, staged-write defer, **dropped-entry-not-billed**, curated content preserved; both-mode prompt; commit body lines.
- `test/sessions.test.js` — prime-cap integration: backlog capped to a count, TBD stubs absent from the prime, singular/plural.
- Full suite **4639 pass / 1 pre-existing skip / 0 fail**.

## Governance

- Critic cumulative: 0 blocking, 4 warning, 3 note → all four code warnings fixed (shared-scanner dedup, conservation honest count, test evidence, real-format parser pin); `verify-resolutions` clean.
- Independent PR review: 0 blocking / 0 warning / 0 note.
- R-4 (supersession note in `.prawduct/artifacts/index-auto-describe.md`) done on disk; `.prawduct/artifacts/` is gitignored here, so it's outside the reviewable tree.

Closes #568.