### PR TITLE
Skip the wrap's priming-roll on a plan-less project instead of blocking it (#676)

### DIFF
--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -26,6 +26,23 @@ Tag-line conventions (ART-4K9M, ratified 2026-07-17):
 -->
 
 
+## 2026-07-21: Wrap priming-roll skips a plan-less project instead of blocking (#676)
+
+<!-- prawduct: type=bugfix | scope=priming-roll-missing-plans-skip | status=shipped -->
+
+**Why:** `next-session-prime` (`lib/wrap-steps/priming-roll.js`) handled "no plans" two
+inconsistent ways. An EMPTY `.tangleclaw/plans/` dir skipped gracefully (#302 — "Blocking
+that state failed every clean wrap"), but a MISSING plans dir returned an error → rendered a
+red BLOCKED step under the green "Wrap committed" banner on every project that doesn't keep TC
+build plans (observed on a WheresMy wrap). The #302 fix stopped at the empty-dir case.
+
+**What:** the missing-dir path now returns the same `{ok:false, skip:true, reason}` shape as
+the empty-dir path, so `run()` reports `skipped`, not `blocked`. The reason still names both
+plan homes. Boundary preserved: an explicit-but-unresolvable `step.planPath` still errors.
+Regression tests updated/added (missing-dir skip, explicit-planPath still blocks, #428
+no-candidates on skip). Full suite 4640/4641 (1 pre-existing skip). Closes #676.
+
+
 ## 2026-07-20: Feature Index converges + prime cap (#568)
 
 <!-- prawduct: type=bugfix | scope=feature-index-convergence | status=shipped | chunks=A,B -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ All notable changes to TangleClaw are documented in this file.
 
 ### Fixed
 
+- **The wrap's priming-roll step skips a plan-less project instead of blocking it
+  (#676).** `next-session-prime` (`lib/wrap-steps/priming-roll.js`) handled "no
+  plans" two inconsistent ways: an **empty** `.tangleclaw/plans/` dir skipped
+  gracefully (`#302` — *"Blocking that state failed every clean wrap"*), but a
+  **missing** plans dir returned an error → rendered a red **BLOCKED** step under
+  the green "Wrap committed" banner on every project that simply doesn't keep TC
+  build plans (seen on a WheresMy wrap). A plan-less project is at least as benign
+  as one with an empty dir, so the missing-dir case now returns the same
+  `skip:true` outcome ("no plans directory … nothing to roll") and reports
+  `skipped`, not `blocked`. The boundary is preserved: an explicit but unresolvable
+  `step.planPath` still errors — a configured-but-broken pointer is a real mistake
+  worth surfacing. Regression tests: missing-dir skips + names both plan homes in
+  the reason, the explicit-planPath error still blocks, and the `#428` no-candidates
+  contract holds on the skip path. `lib/wrap-steps/priming-roll.js`.
+
 - **The Feature Index now converges instead of piling up "TBD" stubs, and the
   session prime stops paying for the pile (#568).** `features-toc` appended
   `## TODO (auto-stubbed <date>)` blocks of `- **TBD** — … ` entries, and

--- a/lib/wrap-steps/priming-roll.js
+++ b/lib/wrap-steps/priming-roll.js
@@ -450,6 +450,10 @@ function _readGovernedPlan(projectPath) {
  *      same meaning as zero-in-progress, the well-behaved all-archived
  *      end state (#302). The `.md` filter is non-recursive, so an
  *      `archive/` subdir of shipped plans does not count.
+ *   7. no plans directory at all → skip ("this project doesn't keep TC build
+ *      plans"): a plan-less project is at least as benign as an empty plans
+ *      dir, so it skips rather than blocks (#676). Only an explicit
+ *      `step.planPath` that fails to resolve (step 1) errors.
  *
  * @param {string} projectPath
  * @param {object} step - Step spec
@@ -561,9 +565,17 @@ function _resolvePlanPath(projectPath, step) {
 
   const resolved = _resolvePlansDir(projectPath);
   if (!resolved) {
+    // No plans directory at all — a project that simply doesn't keep TC build
+    // plans. This is at least as benign as an empty plans dir (which skips
+    // below, #302), so skip cleanly rather than block: there is nothing to
+    // roll. Blocking it rendered a red BLOCKED under a green "Wrap committed"
+    // banner on every plan-less project's wrap (#676). An explicit-but-
+    // unresolvable `step.planPath` is handled above and still errors — this
+    // path is only reached when no pointer of any kind was configured.
     return {
       ok: false,
-      error: `No plans directory at ${DEFAULT_PLANS_DIR} or ${LEGACY_PLANS_DIR} (and no step.planPath configured)`
+      skip: true,
+      reason: `No plans directory at ${DEFAULT_PLANS_DIR} or ${LEGACY_PLANS_DIR} — this project doesn't keep TC build plans; nothing to roll`
     };
   }
   const plansDir = resolved.dir;

--- a/test/wrap-step-priming-roll.test.js
+++ b/test/wrap-step-priming-roll.test.js
@@ -346,11 +346,27 @@ describe('wrap-step priming-roll — handler (#139 Chunk 6)', () => {
     assert.match(result.blockers[0], /requires context\.project\.path/);
   });
 
-  it('blocks when no .claude/plans directory exists and no step.planPath', async () => {
+  it('skips (not blocks) when no plans directory exists and no step.planPath (#676)', async () => {
+    // A project that simply doesn't keep TC build plans is at least as benign
+    // as one with an empty plans dir (which already skips, #302). Blocking it
+    // rendered a red BLOCKED under a green "Wrap committed" banner on every
+    // plan-less project's wrap. Must skip cleanly.
     const result = await primingRoll.run(buildContext({ id: 'next-session-prime' }));
+    assert.equal(result.ok, true, 'a plan-less project must not block the wrap');
+    assert.equal(result.status, 'skipped');
+    assert.match(result.output.reason, /No plans directory/);
+    assert.match(result.output.reason, /nothing to roll/i);
+    assert.deepEqual(result.blockers, []);
+  });
+
+  it('still BLOCKS when an explicit step.planPath cannot be resolved (#676 boundary)', async () => {
+    // The skip above is only for the no-pointer-configured case. An operator
+    // who explicitly pointed at a plan that does not exist gets a real error —
+    // a configured-but-broken pointer is a mistake worth surfacing.
+    const result = await primingRoll.run(buildContext({ id: 'next-session-prime', planPath: 'plans/does-not-exist.md' }));
     assert.equal(result.ok, false);
     assert.equal(result.status, 'blocked');
-    assert.match(result.blockers[0], /No plans directory/);
+    assert.match(result.blockers[0], /planPath does not exist/i);
   });
 
   it('skips (not blocks) when .claude/plans is empty (#302)', async () => {
@@ -399,14 +415,14 @@ describe('wrap-step priming-roll — handler (#139 Chunk 6)', () => {
     assert.deepStrictEqual(result.output.candidates.slice().sort(), ['one.md', 'two.md']);
   });
 
-  it('does NOT emit output.candidates for a single-plan/skip block (#428)', async () => {
-    // The candidates array is specific to the multi-in-progress case. A
-    // chunk-less single plan skips (no block, no candidates); the
-    // no-plans-dir case blocks WITHOUT candidates.
+  it('does NOT emit output.candidates outside the multi-in-progress case (#428)', async () => {
+    // The candidates array is specific to the multi-in-progress block. The
+    // no-plans-dir case now skips (#676) and, like any non-multi outcome,
+    // carries no candidates array.
     const skip = await primingRoll.run(buildContext({ id: 'next-session-prime' }));
-    assert.equal(skip.status, 'blocked'); // no .claude/plans dir → blocked
+    assert.equal(skip.status, 'skipped'); // no plans dir → skip (#676)
     assert.equal(skip.output.candidates, undefined,
-      'a non-multi-plan block must not carry a candidates array');
+      'a non-multi-plan outcome must not carry a candidates array');
   });
 
   it('auto-picks the single in-progress plan when others are complete (#226)', async () => {
@@ -1293,15 +1309,17 @@ describe('wrap-step priming-roll — engine-agnostic path resolution (#612 widen
     assert.equal(primingRoll._resolvePlansDir(projectPath).relative, '.claude/plans');
   });
 
-  it('names BOTH locations when no plans directory is found', async () => {
+  it('names BOTH locations in the skip reason when no plans directory is found (#676)', async () => {
     const result = await primingRoll.run({
       project: { path: projectPath },
       step: { id: 'next-session-prime' },
       staged: {}
     });
-    // An error naming only one home sends the operator to the wrong place.
-    assert.match(result.blockers.join(' '), /\.tangleclaw\/plans/);
-    assert.match(result.blockers.join(' '), /\.claude\/plans/);
+    // The no-plans-dir case skips (#676), not blocks; the reason still names
+    // both homes so a reader who DID expect a plan knows where it should live.
+    assert.equal(result.status, 'skipped');
+    assert.match(result.output.reason, /\.tangleclaw\/plans/);
+    assert.match(result.output.reason, /\.claude\/plans/);
   });
 
   it('resolves a bare activePlan filename against the LEGACY dir when that is where plans live', () => {


### PR DESCRIPTION
## What

Fixes #676. The wrap's `next-session-prime` (`lib/wrap-steps/priming-roll.js`) handled "no plans" two inconsistent ways:

- an **empty** `.tangleclaw/plans/` dir → `skip:true` → graceful **SKIP** (#302 — *"Blocking that state failed every clean wrap"*)
- a **missing** plans dir → `error` → **BLOCKED**

So any project that simply doesn't keep TC build plans got a red BLOCKED step under the green "Wrap committed" banner (observed on a WheresMy wrap). A plan-less project is at least as benign as one with an empty dir, so the missing-dir case now returns the same `skip:true` outcome and reports `skipped`, not `blocked`.

## Why

A false BLOCKED on a benign, expected state trains operators to distrust the wrap and muddies the drawer (a green "committed" banner over a red step). The #302 fix stopped at the empty-dir case and never covered missing-dir.

## Boundary preserved

An explicit but unresolvable `step.planPath` still errors and blocks — a configured-but-broken pointer is a real mistake worth surfacing. Covered by a dedicated regression test.

## Test plan

- `test/wrap-step-priming-roll.test.js`: missing-dir now skips + names both plan homes in the reason; explicit-`planPath`-unresolvable still blocks; the #428 no-candidates contract holds on the skip path.
- Full suite **4640 pass / 1 pre-existing skip / 0 fail**.

## Governance

- Critic cumulative: 0 blocking / 0 warning / 0 note.
- Independent PR review: 0 / 0 / 0.

Closes #676.