### PR TITLE
Self-identify each wrap ai-content prompt so progress reads as progress (#627)

### DIFF
--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -26,6 +26,38 @@ Tag-line conventions (ART-4K9M, ratified 2026-07-17):
 -->
 
 
+## 2026-07-21: Self-identifying wrap ai-content prompt headers (#627)
+
+<!-- prawduct: type=bugfix | scope=wrap-627-prompt-headers | status=shipped -->
+
+**Why:** the wrap sends up to three near-identical instruction prompts into the session,
+and none named itself — the operator could not tell "the pipeline is working through its
+steps" from "the wrap re-fired" (reported twice; a false alarm both times, but a wrap that
+*looks* broken trains the operator to stop pressing it — the #571 failure).
+
+**What:** each dispatched `ai-content` prompt is prefixed with a self-identifying first line —
+`[TangleClaw wrap — step N of M: <id>]` for the fixed content steps,
+`[TangleClaw wrap — <id>]` where a position can't be known. Built in prompt fabrication
+(`_wrapStepHeader`, `lib/wrap-steps/ai-content.js`), applied on both the tmux and
+ClawBridge-gateway send paths, plain text so a markdown-rendering TUI can't restyle the marker
+away (#287 class). The "N of M" denominator counts only the prompts a wrap will actually
+send: a runner pre-pass (`_planAiContentPrompts`, `lib/wrap-pipeline.js`) excludes steps
+disabled by `wrapStepOverrides`, opted out via `skipAiContent`, or (on a webui session)
+un-carriable over the gateway.
+
+**Refinement of the issue's proposal:** #627 assumed `index-describe` was a self-skipping
+fourth `ai-content` step (from the since-deleted `template.json`). It now emits its pane
+prompt by *delegating* to the handler and decides to only at its own pipeline position — after
+the earlier prompts have already gone out under a fixed denominator — so it can't join an
+accurate count and gets the numberless header. That is why a normal wrap reads "of 3", never
+"of 4", matching #627's own acceptance assertion.
+
+**Honest confidence:** high — regression tests pin the header on both send paths (numbered +
+numberless), the numberless fallback, the malformed-progress guard, and the denominator under
+overrides / `skipAiContent` / a webui session. Full suite 4652/4653 (1 pre-existing skip).
+Closes #627. Operator-visible in the pane; the live pane render is verifiable at the next wrap.
+
+
 ## 2026-07-21: De-flake the session-rule-delivery suite (#634)
 
 <!-- prawduct: type=bugfix | scope=session-rule-delivery-flake | status=shipped -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Wrap `ai-content` prompts now identify themselves, so consecutive prompts
+  read as pipeline progress rather than a re-fire (#627).** The wrap sends up to
+  three near-identical instruction prompts into the session, and none named
+  itself — the operator could not tell "the wrap is working through its steps"
+  from "the wrap fired twice" (reported twice; a false alarm both times, but the
+  surface, not the reader, was the problem, and a wrap that *looks* broken trains
+  the operator to stop pressing it). Each dispatched prompt is now prefixed with
+  a single self-identifying line: `[TangleClaw wrap — step N of M: <step-id>]`
+  for the fixed content steps, or a numberless `[TangleClaw wrap — <step-id>]`
+  where a position can't be known. The header is built in prompt fabrication
+  (`_wrapStepHeader` in `lib/wrap-steps/ai-content.js`), applied on both the tmux
+  and ClawBridge-gateway send paths, and is plain text with no markdown — so it
+  renders identically in any engine's terminal and a markdown-rendering TUI can't
+  restyle the marker away (the #287 class). The "N of M" denominator counts only
+  the content prompts a wrap will actually send: a new runner pre-pass
+  (`_planAiContentPrompts` in `lib/wrap-pipeline.js`) excludes steps disabled by
+  `wrapStepOverrides`, opted out via `skipAiContent`, or — on a webui session —
+  steps the gateway can't carry, so the number matches what the operator sees.
+  **Refinement of the issue's literal proposal:** `index-describe` (which the
+  issue assumed was a self-skipping fourth `ai-content` step) now emits its pane
+  prompt by *delegating* to the handler, and only decides to at its own pipeline
+  position — after the earlier prompts have already gone out under a fixed
+  denominator. It therefore can't join an accurate count and gets the numberless
+  header, which is why a normal wrap reads "of 3", never "of 4" — matching the
+  issue's own acceptance assertion. Regression tests pin the header on both send
+  paths (numbered and numberless), the numberless fallback, and the denominator
+  under overrides / `skipAiContent` / a webui session.
+  `lib/wrap-steps/ai-content.js`, `lib/wrap-pipeline.js`,
+  `test/wrap-step-ai-content.test.js`, `test/wrap-pipeline.test.js`.
+
 ## [4.31.1] - 2026-07-21
 
 ### Fixed

--- a/lib/wrap-pipeline.js
+++ b/lib/wrap-pipeline.js
@@ -67,6 +67,57 @@ const SKIPPED_UNKNOWN_KIND = Object.freeze({
 });
 
 /**
+ * The ordered ids of `ai-content`-kind steps whose prompt this wrap will send
+ * to the session — the basis for each content prompt's self-identifying
+ * "step N of M" header (#627).
+ *
+ * A step is counted only when it will actually prompt, so the denominator the
+ * operator sees matches the prompts they see:
+ *   - enabled — a step disabled by `wrapStepOverrides` never runs;
+ *   - `kind === 'ai-content'` with a non-empty resolved prompt (an empty prompt
+ *     is the pipeline author's self-skip marker);
+ *   - not opted out for this run via `options.skipAiContent[id]` (honored only
+ *     when the step declares `allowOverride`, matching the handler's own guard);
+ *   - on a webui/gateway session, only a step carrying both `captureFields` and
+ *     a `captureFile` prompts — the others honestly skip over the bridge, so
+ *     counting them would inflate the total the operator sees.
+ *
+ * `index-describe` is deliberately absent: it emits its pane prompt by
+ * delegating to the ai-content handler, but only when it has describable
+ * targets — a fact decided at its own pipeline position, after the earlier
+ * content prompts have already gone out under a fixed denominator. It cannot
+ * join an accurate count, so it self-identifies with a numberless header
+ * instead (`_wrapStepHeader` in `lib/wrap-steps/ai-content.js`).
+ *
+ * @param {object[]} pipelineSteps - The pipeline's base step specs, in run order
+ * @param {object|null} stepOverrides - The project's `wrapStepOverrides` map
+ * @param {object} options - Run options (reads `skipAiContent`)
+ * @param {object|null} session - Active session (its `sessionMode` picks the path)
+ * @returns {string[]} Ordered ids of the content steps that will prompt
+ */
+function _planAiContentPrompts(pipelineSteps, stepOverrides, options, session) {
+  const isWebui = !!(session && session.sessionMode === 'webui');
+  const skipMap = (options && options.skipAiContent) || {};
+  const ids = [];
+  for (const baseStep of pipelineSteps) {
+    const resolution = wrapStepOverrides.resolveStep(baseStep, stepOverrides);
+    if (!resolution.enabled) continue;
+    const step = resolution.step;
+    if (step.kind !== 'ai-content') continue;
+    if (typeof step.prompt !== 'string' || step.prompt.trim() === '') continue;
+    if (step.allowOverride === true && skipMap[step.id] === true) continue;
+    if (isWebui) {
+      const hasCapture = Array.isArray(step.captureFields)
+        && step.captureFields.length > 0
+        && typeof step.captureFile === 'string' && step.captureFile.trim() !== '';
+      if (!hasCapture) continue;
+    }
+    ids.push(step.id);
+  }
+  return ids;
+}
+
+/**
  * Build a fresh runner context. Each invocation gets its own context so
  * concurrent wraps (a future possibility) cannot share scratch state.
  *
@@ -171,6 +222,11 @@ async function runWrapPipeline(projectName, options = {}) {
     stepOverrides = null;
   }
 
+  // Ordered ids of the content prompts this wrap will send, so each can carry a
+  // self-identifying "step N of M" header (#627). Computed once, before the
+  // loop, because the denominator must be known when the FIRST prompt fires.
+  const aiContentPlan = _planAiContentPrompts(pipelineSteps, stepOverrides, options, session);
+
   for (const baseStep of pipelineSteps) {
     if (blockedAt !== null) {
       runState.results.push({
@@ -227,6 +283,15 @@ async function runWrapPipeline(projectName, options = {}) {
       stepResult = { ...SKIPPED_UNKNOWN_KIND };
     } else {
       const context = _buildStepContext(project, session, step, runState, options);
+      // #627 — a fixed content step carries its position so the handler can
+      // prepend a "step N of M" header. Ordinal follows run order because the
+      // plan was built in run order. Steps absent from the plan (including
+      // `index-describe`, which delegates to the handler) get no progress and
+      // the handler falls back to a numberless self-identifying header.
+      const planIdx = aiContentPlan.indexOf(step.id);
+      if (planIdx >= 0) {
+        context.aiContentProgress = { ordinal: planIdx + 1, total: aiContentPlan.length };
+      }
       try {
         stepResult = await handler.run(context);
       } catch (err) {
@@ -317,5 +382,6 @@ function _failResult(error) {
 
 module.exports = {
   runWrapPipeline,
-  STEP_DISPATCH
+  STEP_DISPATCH,
+  _planAiContentPrompts
 };

--- a/lib/wrap-steps/ai-content.js
+++ b/lib/wrap-steps/ai-content.js
@@ -195,6 +195,38 @@ function _interpolatePrompt(promptTemplate, previousResults, project) {
 }
 
 /**
+ * The self-identifying first line prepended to every ai-content prompt sent to
+ * a session (#627). Three near-identical wrap prompts arriving unlabeled read
+ * as a re-fire rather than pipeline progress — the operator could not tell the
+ * two apart, twice, and the rational response to a wrap that looks broken is to
+ * stop pressing it (the #571 failure). A header naming the step, and its
+ * position where that is knowable, lets two consecutive prompts be read as
+ * distinct steps at a glance.
+ *
+ * Plain text, no markdown: this must render identically in any engine's
+ * terminal, and a `## Heading` would be re-styled by a markdown-rendering TUI
+ * (the #287 class) — so the marker would vanish exactly where it is needed.
+ *
+ * `context.aiContentProgress` (`{ordinal, total}`) is set by the runner only
+ * for the fixed content steps, whose count is known before the first prompt
+ * fires. A prompt sent without it — `index-describe`'s conditional delegation,
+ * or a direct unit-test call — gets a numberless header: it still
+ * self-identifies, but is not forced into a count it cannot accurately join.
+ *
+ * @param {object} step - The step spec (`id` names the step)
+ * @param {object} [context] - Runner context (may carry `aiContentProgress`)
+ * @returns {string} The header line (no trailing newline)
+ */
+function _wrapStepHeader(step, context) {
+  const id = (step && typeof step.id === 'string' && step.id) || 'ai-content';
+  const p = context && context.aiContentProgress;
+  if (p && Number.isInteger(p.ordinal) && Number.isInteger(p.total)) {
+    return `[TangleClaw wrap — step ${p.ordinal} of ${p.total}: ${id}]`;
+  }
+  return `[TangleClaw wrap — ${id}]`;
+}
+
+/**
  * Append the project's enabled `kind='wrap'` session rules to an ai-content
  * prompt. This is what makes the Wrap-rules field REAL: rules authored in the
  * Project rules UI (and the self-improvement loop's promoted learnings) reach
@@ -365,7 +397,10 @@ async function run(context) {
     };
   }
 
-  const prompt = _appendWrapRules(_interpolatePrompt(step.prompt, previousResults || [], project), project);
+  const body = _appendWrapRules(_interpolatePrompt(step.prompt, previousResults || [], project), project);
+  // #627 — prefix a self-identifying header so consecutive pane prompts read as
+  // distinct pipeline steps, not a re-fire. First line the operator sees.
+  const prompt = `${_wrapStepHeader(step, context)}\n\n${body}`;
   const tmuxSession = session.tmuxSession;
 
   // D6 (#571 items 4-5, #638) — fail-closed verification for a content step
@@ -655,7 +690,9 @@ async function _runGatewayCapture(context) {
     };
   }
 
-  const prompt = _appendWrapRules(_interpolatePrompt(step.prompt, previousResults || [], project), project);
+  // #627 — same self-identifying header as the tmux path; the gateway prompt is
+  // one of the same content steps, just delivered over the bridge.
+  const prompt = `${_wrapStepHeader(step, context)}\n\n${_appendWrapRules(_interpolatePrompt(step.prompt, previousResults || [], project), project)}`;
 
   // 1. Send the wrap prompt over the bridge. `clawbridge.send` resolves
   // (never rejects), but guard the try in case a future client throws.
@@ -1028,4 +1065,4 @@ const _internal = {
   bridgeGetFile: clawbridgeLib.getFile
 };
 
-module.exports = { run, _internal, _interpolatePrompt, _appendWrapRules, _parseFields, _normalizeFieldKey, _runGatewayCapture, _resolveEngineConfigFile, _snapshotPaths, _watchedOutputPaths, _verifyChangedGate, SUPPORTED_PROMPT_TOKENS, STABILITY_MS };
+module.exports = { run, _internal, _interpolatePrompt, _appendWrapRules, _wrapStepHeader, _parseFields, _normalizeFieldKey, _runGatewayCapture, _resolveEngineConfigFile, _snapshotPaths, _watchedOutputPaths, _verifyChangedGate, SUPPORTED_PROMPT_TOKENS, STABILITY_MS };

--- a/test/wrap-pipeline.test.js
+++ b/test/wrap-pipeline.test.js
@@ -1122,7 +1122,9 @@ describe('wrap-step ai-content — handler (#139 Chunk 5)', () => {
 
     assert.equal(result.ok, true);
     assert.equal(result.status, 'done');
-    assert.equal(sentText, 'Update MEMORY.md');
+    // #627 — sent prompt carries the self-identifying header (numberless: this
+    // direct run() call sets no aiContentProgress).
+    assert.equal(sentText, '[TangleClaw wrap — memory-update]\n\nUpdate MEMORY.md');
     assert.equal(result.output.parsedFields, null);
     assert.ok(staged['memory-update'], 'must stage captured output for the commit step');
     assert.match(staged['memory-update'].capturedText, /meaningful response/);
@@ -3719,5 +3721,50 @@ describe('wrap-step version-bump — handler (open-queue #3, post-#139)', () => 
       assert.equal(result.ok, true, `scenario must return ok:true; got ${JSON.stringify(result)}`);
       assert.deepStrictEqual(result.blockers, [], `scenario must have empty blockers`);
     }
+  });
+});
+
+// #627 — the "step N of M" denominator counts only the content prompts a wrap
+// will actually send, so the number the operator sees matches the prompts they
+// see. `index-describe` is excluded (it delegates conditionally at its own
+// position, after the denominator is fixed) — so a normal wrap reads "of 3".
+describe('_planAiContentPrompts — the content-prompt denominator (#627)', () => {
+  const baseSteps = () => defaultPipeline.steps();
+
+  it('default pipeline on a tmux session → the three fixed content steps, in order', () => {
+    const plan = wrapPipeline._planAiContentPrompts(baseSteps(), null, {}, { tmuxSession: 'sess' });
+    assert.deepEqual(plan, ['changelog-update', 'learnings-capture', 'memory-update']);
+  });
+
+  it('excludes index-describe — a normal wrap reads "of 3", not "of 4"', () => {
+    const plan = wrapPipeline._planAiContentPrompts(baseSteps(), null, {}, { tmuxSession: 'sess' });
+    assert.ok(!plan.includes('index-describe'), 'index-describe must not be counted');
+    assert.equal(plan.length, 3);
+  });
+
+  it('a content step disabled by wrapStepOverrides drops out of the count', () => {
+    const plan = wrapPipeline._planAiContentPrompts(
+      baseSteps(), { 'learnings-capture': { enabled: false } }, {}, { tmuxSession: 'sess' }
+    );
+    assert.deepEqual(plan, ['changelog-update', 'memory-update']);
+  });
+
+  it('a content step opted out for this run via skipAiContent drops out', () => {
+    const plan = wrapPipeline._planAiContentPrompts(
+      baseSteps(), null, { skipAiContent: { 'changelog-update': true } }, { tmuxSession: 'sess' }
+    );
+    assert.deepEqual(plan, ['learnings-capture', 'memory-update']);
+  });
+
+  it('a webui session counts only steps the gateway can carry (captureFields + captureFile)', () => {
+    const plan = wrapPipeline._planAiContentPrompts(baseSteps(), null, {}, { sessionMode: 'webui' });
+    // changelog-update / learnings-capture have no captureFile → they honestly
+    // skip over the bridge, so only memory-update prompts.
+    assert.deepEqual(plan, ['memory-update']);
+  });
+
+  it('no session behaves like the tmux path (all three)', () => {
+    const plan = wrapPipeline._planAiContentPrompts(baseSteps(), null, {}, null);
+    assert.deepEqual(plan, ['changelog-update', 'learnings-capture', 'memory-update']);
   });
 });

--- a/test/wrap-step-ai-content.test.js
+++ b/test/wrap-step-ai-content.test.js
@@ -137,6 +137,91 @@ describe('wrap-step ai-content — #287 captureFile parsing', () => {
   });
 });
 
+// #627 — every ai-content prompt sent to a session is prefixed with a
+// self-identifying header, so three near-identical wrap prompts read as
+// distinct pipeline steps rather than a re-fire.
+describe('wrap-step ai-content — #627 self-identifying prompt header', () => {
+  describe('_wrapStepHeader', () => {
+    it('numbers a fixed content step from its runner-supplied position', () => {
+      const h = aic._wrapStepHeader(
+        { id: 'learnings-capture' },
+        { aiContentProgress: { ordinal: 2, total: 3 } }
+      );
+      assert.equal(h, '[TangleClaw wrap — step 2 of 3: learnings-capture]');
+    });
+
+    it('falls back to a numberless header when no progress is supplied (index-describe delegation)', () => {
+      assert.equal(aic._wrapStepHeader({ id: 'index-describe' }, {}), '[TangleClaw wrap — index-describe]');
+      assert.equal(aic._wrapStepHeader({ id: 'index-describe' }, undefined), '[TangleClaw wrap — index-describe]');
+    });
+
+    it('is plain text — no markdown heading that a rich TUI would restyle away (#287 class)', () => {
+      const h = aic._wrapStepHeader({ id: 'changelog-update' }, { aiContentProgress: { ordinal: 1, total: 3 } });
+      assert.ok(!h.includes('#'), 'header must not contain a markdown hash');
+    });
+
+    it('ignores a malformed progress object rather than printing NaN', () => {
+      assert.equal(
+        aic._wrapStepHeader({ id: 'x' }, { aiContentProgress: { ordinal: 'a', total: 3 } }),
+        '[TangleClaw wrap — x]'
+      );
+    });
+  });
+
+  describe('run() prepends the header to the sent prompt', () => {
+    let saved;
+    let sentPrompt;
+
+    beforeEach(() => {
+      saved = { ...aic._internal };
+      sentPrompt = null;
+      aic._internal.sendKeys = (_sess, prompt) => { sentPrompt = prompt; };
+      aic._internal.sleep = async () => {};
+      aic._internal.detectIdle = () => ({ idle: true, lastOutputAge: 20000 });
+      // ≥20 chars so the no-captureFields step clears the min-response gate.
+      aic._internal.capturePane = () => ({ lines: ['the AI did the work and replied here'] });
+      // No wrap rules — keep the header at the very front of the string.
+      aic._internal.listWrapRules = () => [];
+    });
+
+    afterEach(() => { Object.assign(aic._internal, saved); });
+
+    it('numbers a fixed content step (step 2 of 3: learnings-capture)', async () => {
+      const ctx = {
+        project: { name: 'proj', path: '/tmp/proj' },
+        session: { tmuxSession: 'sess' },
+        step: { id: 'learnings-capture', kind: 'ai-content', prompt: 'capture the learnings' },
+        previousResults: [],
+        staged: {},
+        aiContentProgress: { ordinal: 2, total: 3 }
+      };
+      const res = await aic.run(ctx);
+      assert.equal(res.status, 'done');
+      assert.ok(
+        sentPrompt.startsWith('[TangleClaw wrap — step 2 of 3: learnings-capture]\n\n'),
+        `sent prompt should open with the numbered header, got: ${JSON.stringify(sentPrompt.slice(0, 60))}`
+      );
+      assert.ok(sentPrompt.includes('capture the learnings'), 'the original prompt body is preserved after the header');
+    });
+
+    it('uses a numberless header when the step carries no progress (index-describe delegation shape)', async () => {
+      const ctx = {
+        project: { name: 'proj', path: '/tmp/proj' },
+        session: { tmuxSession: 'sess' },
+        step: { id: 'index-describe', kind: 'ai-content', prompt: 'describe the stubs' },
+        previousResults: [],
+        staged: {}
+      };
+      const res = await aic.run(ctx);
+      assert.equal(res.status, 'done');
+      assert.ok(
+        sentPrompt.startsWith('[TangleClaw wrap — index-describe]\n\n'),
+        `sent prompt should open with the numberless header, got: ${JSON.stringify(sentPrompt.slice(0, 60))}`
+      );
+    });
+  });
+});
+
 // #328 — content ai-content steps (changelog-update / learnings-capture /
 // memory-update) became blockers; the handler gained a per-step Skip & note
 // override, and the timeout message stopped hardcoding "wrap pipeline blocked".
@@ -325,7 +410,9 @@ describe('wrap-step ai-content — CC-7 B1 gateway capture (webui)', () => {
     // Staged for the commit step, same shape the tmux path produces.
     assert.deepEqual(context.staged['summary-derive'].parsedFields, res.output.parsedFields);
     // Sent the interpolated prompt over the bridge addressed by project name.
-    assert.equal(calls.sent.message, 'wrap please');
+    // #627 — prefixed with the self-identifying header (numberless: a direct
+    // _runGatewayCapture call carries no aiContentProgress).
+    assert.equal(calls.sent.message, '[TangleClaw wrap — summary-derive]\n\nwrap please');
     assert.equal(calls.sent.project, 'proj');
     assert.equal(calls.sent.localPort, 4567);
     // Read consume-once from the SAME captureFile path the tmux path uses.
@@ -555,7 +642,8 @@ describe('wrap-step ai-content — wrap-rules bridge', () => {
       });
 
       assert.equal(res.status, 'done');
-      assert.match(sentPrompt, /^write the block\n\n## Project wrap rules\n/);
+      // #627 — the self-identifying header leads, then the body, then the rules.
+      assert.match(sentPrompt, /^\[TangleClaw wrap — memory-update\]\n\nwrite the block\n\n## Project wrap rules\n/);
       assert.match(sentPrompt, /- Close every open loop/);
     });
 
@@ -611,7 +699,8 @@ describe('wrap-step ai-content — wrap-rules bridge (gateway path + ordering)',
     });
 
     assert.equal(res.status, 'done');
-    assert.match(sentMessage, /^wrap please\n\n## Project wrap rules\n/);
+    // #627 — header leads on the gateway path too, matching the tmux path.
+    assert.match(sentMessage, /^\[TangleClaw wrap — summary-derive\]\n\nwrap please\n\n## Project wrap rules\n/);
     assert.match(sentMessage, /- Close every open loop/);
   });
 


### PR DESCRIPTION
## What

Every wrap `ai-content` prompt now begins with a self-identifying header:
- `[TangleClaw wrap — step N of M: <step-id>]` for the fixed content steps
- `[TangleClaw wrap — <step-id>]` where a position can't be known

Applied on both the tmux and ClawBridge-gateway send paths, in prompt fabrication (`_wrapStepHeader`), plain text so a markdown-rendering TUI can't restyle the marker away (#287 class).

The "N of M" denominator counts only the prompts a wrap will actually send — a runner pre-pass (`_planAiContentPrompts`) excludes steps disabled by `wrapStepOverrides`, opted out via `skipAiContent`, or (on a webui session) un-carriable over the gateway.

## Why

The wrap sends up to three near-identical instruction prompts into the session, none naming itself, so the operator could not tell "the pipeline is working through its steps" from "the wrap re-fired" — reported twice (a false alarm both times), and a wrap that *looks* broken trains the operator to stop pressing it (the #571 failure).

## Design note — refinement of the issue's proposal

#627 assumed `index-describe` was a self-skipping fourth `ai-content` step (from the since-deleted `template.json`). It now emits its pane prompt by *delegating* to the handler and decides to only at its own pipeline position — after the earlier prompts already went out under a fixed denominator — so it can't join an accurate count and gets the numberless header. That is why a normal wrap reads **"of 3", never "of 4"**, matching #627's own acceptance assertion.

## Test plan

- `_wrapStepHeader`: numbered + numberless + malformed-progress guard.
- `_planAiContentPrompts`: default → 3 fixed steps (index-describe excluded); denominator drops under a disabled step / `skipAiContent`; webui → only the gateway-carriable step.
- `run()` / `_runGatewayCapture()`: sent prompt begins with the header on both paths.
- Full suite: 4652/4653 (1 pre-existing skip), evidence recorded.

Independent Critic (final) and PR reviewer both clean (0/0/0).

Closes #627.