### PR TITLE
Close launch-mode guard write-path holes (#622, #682 trigger)

### DIFF
--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -26,6 +26,39 @@ Tag-line conventions (ART-4K9M, ratified 2026-07-17):
 -->
 
 
+## 2026-07-21: Close launch-mode guard write-path holes (#622, #682 trigger)
+
+<!-- prawduct: type=bugfix | scope=launch-mode-guard-622 | status=shipped -->
+
+**Why:** `updateProject` changed a project's engine but never re-validated the stored
+`defaultLaunchMode`, so a claude project set to `bypassPermissions`, switched to codex
+(which defines no such mode), kept `bypassPermissions` on disk — a posture the engine
+can't run, and the exact stale configuration that preceded #682's project launch dying
+before its prime could paste. Compounding it, the eyes-open bypass-hidden guard fired only
+when the mode resolved to a `launchModes` entry carrying a `warning`; a stranded
+(unresolvable) mode left `modeConfig` falsy and the guard was skipped, so a
+`{showLaunchModePicker: false}` PATCH could persist a hidden picker over that stale mode.
+
+**What:** a new `reconcileLaunchMode(mode, engineProfile)` helper returns the mode the
+engine will actually keep — a mode it can't honor reconciles to `default` (the
+universally-valid, warning-free interactive mode). The engine-change block applies it to
+reset a stranded stored mode on switch (logged); the guard judges the *reconciled* effective
+mode, so it still blocks a genuine warning-mode + hidden picker without `confirmBypassHidden`
+yet no longer false-blocks a switch whose reconciliation makes it safe. This makes #682's
+`bypassPermissions`-on-codex configuration unreachable through the API.
+
+**Evidence note:** #622 hypothesised the *create* path persisted the dangerous combination,
+but a repo-wide grep proved the only server-side writers of these two fields are
+`DEFAULT_PROJECT_CONFIG` (safe defaults) and the guarded PATCH — `create`/`attach` deep-copy
+the safe defaults and write neither field. The fix builds on that code evidence, not the
+issue's unreproduced writer claim, and a write-path regression test pins the invariant.
+
+**Honest confidence:** high for the API-reachability fix — 5 regression tests (reset-stranded,
+preserve-honored, switch-and-hide-safe, create-safe, still-blocks-bypass+hidden); full suite
+0 failed; Critic clean (0/0/0). #682's launch-death *mechanism* (why codex exits pre-prime)
+needs a live reproduction and remains an open scoped follow-up — descoped, not dropped.
+
+
 ## 2026-07-21: Self-identifying wrap ai-content prompt headers (#627)
 
 <!-- prawduct: type=bugfix | scope=wrap-627-prompt-headers | status=shipped -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **An engine switch can no longer strand a launch mode the new engine can't
+  honor, and the eyes-open bypass-hidden guard no longer has a hole a stranded
+  mode slips through (#622; closes #682's trigger).** `updateProject` changed a
+  project's engine but never re-validated the stored `defaultLaunchMode`, so a
+  claude project set to `bypassPermissions`, switched to codex (which defines no
+  such mode), kept `bypassPermissions` on disk — a posture the engine can't run.
+  Compounding it, the eyes-open guard only fired when the mode resolved to a
+  `launchModes` entry carrying a `warning`; a stranded (unresolvable) mode left
+  `modeConfig` falsy and the guard was skipped, so a `{showLaunchModePicker:
+  false}` PATCH could persist a hidden picker over that stale mode. An engine
+  switch now reconciles a mode the new engine can't honor down to `default` (the
+  universally-valid, warning-free interactive mode — never a dangerous posture),
+  logged; and the guard judges the *reconciled* effective mode via a shared
+  `reconcileLaunchMode` helper, so it still blocks a genuine warning-mode +
+  hidden picker without `confirmBypassHidden` yet doesn't false-block a
+  switch-to-safe. This makes #682's `bypassPermissions`-on-codex configuration
+  unreachable through the API — the config that preceded that project's launch
+  dying before its prime could paste. `create`/`attach` were confirmed to write
+  only the safe `DEFAULT_PROJECT_CONFIG` defaults (not the dangerous combination
+  #622 hypothesised the create path persisted — a writer never reproducible in
+  the current code), and a write-path regression test now pins that invariant.
+  #682's launch-death *mechanism* itself (why codex exits pre-prime) needs a live
+  reproduction and remains open as a scoped follow-up.
+
 ## [4.31.2] - 2026-07-21
 
 ### Fixed

--- a/lib/projects.js
+++ b/lib/projects.js
@@ -1711,6 +1711,27 @@ function _syncLiveMedusaListener(project, enabled) {
 }
 
 /**
+ * The launch mode an engine will actually keep: a mode the engine cannot honor
+ * (absent from its `launchModes`, or present-but-disabled) reconciles to
+ * `'default'` — the universally-valid, warning-free interactive mode every
+ * engine defines. Used both to persist a reconciled mode after an engine switch
+ * and to judge the eyes-open guard against the value that will really be stored,
+ * so a stranded mode can neither slip a hidden picker past the guard nor
+ * false-block a switch that reconciliation makes harmless.
+ * @param {string} mode - The requested/stored `defaultLaunchMode`.
+ * @param {object|null} engineProfile - The engine whose modes gate validity.
+ * @returns {string} `mode` if the engine honors it, else `'default'`.
+ */
+function reconcileLaunchMode(mode, engineProfile) {
+  if (typeof mode !== 'string' || mode === 'default') return 'default';
+  const modes = engineProfile && engineProfile.launchModes;
+  const honored = modes
+    && Object.prototype.hasOwnProperty.call(modes, mode)
+    && modes[mode].disabled !== true;
+  return honored ? mode : 'default';
+}
+
+/**
  * Update project configuration (engine, tags, rules).
  * @param {string} name - Project name
  * @param {object} updates - Fields to update
@@ -1864,14 +1885,21 @@ function updateProject(name, updates) {
   // combination never blocks unrelated updates; it was confirmed when set).
   if (updates.defaultLaunchMode !== undefined || updates.showLaunchModePicker !== undefined) {
     const projConfig = store.projectConfig.load(project.path);
-    const effectiveMode = updates.defaultLaunchMode !== undefined
-      ? updates.defaultLaunchMode
-      : (typeof projConfig.defaultLaunchMode === 'string' && projConfig.defaultLaunchMode.trim() ? projConfig.defaultLaunchMode : 'default');
     const effectiveShow = updates.showLaunchModePicker !== undefined
       ? updates.showLaunchModePicker
       : projConfig.showLaunchModePicker !== false;
     const guardEngineId = updates.engine || projConfig.engine || project.engineId;
     const guardProfile = guardEngineId ? store.engines.get(guardEngineId) : null;
+    // Judge the mode the engine will actually keep. An explicit update already
+    // passed the membership check above, so it reconciles to itself; a stored
+    // mode the (possibly newly switched) engine can't honor reconciles to
+    // 'default' — matching what the engine-change block persists — so the guard
+    // neither lets a stranded mode carry a hidden picker through nor blocks a
+    // switch-to-safe that reconciliation renders harmless.
+    const requestedMode = updates.defaultLaunchMode !== undefined
+      ? updates.defaultLaunchMode
+      : (typeof projConfig.defaultLaunchMode === 'string' && projConfig.defaultLaunchMode.trim() ? projConfig.defaultLaunchMode : 'default');
+    const effectiveMode = reconcileLaunchMode(requestedMode, guardProfile);
     const modeConfig = guardProfile && guardProfile.launchModes && guardProfile.launchModes[effectiveMode];
     if (effectiveShow === false && modeConfig && modeConfig.warning && updates.confirmBypassHidden !== true) {
       return { project: null, errors: [`hiding the launch-mode picker with default mode "${effectiveMode}" removes its warning from the launch flow — resend with confirmBypassHidden: true to confirm`] };
@@ -1958,6 +1986,19 @@ function updateProject(name, updates) {
     // Regenerate engine config
     const projConfig = store.projectConfig.load(project.path);
     projConfig.engine = updates.engine;
+    // Reconcile a stored defaultLaunchMode the new engine can't honor (e.g.
+    // claude's bypassPermissions on a codex project). Left stranded, the launch
+    // path later resolves a mode the engine never defined; reset it to the
+    // universally-valid interactive default instead. 'default' carries no launch
+    // warning, so this can never leave an unconfirmed bypass-hidden posture.
+    const reconciled = reconcileLaunchMode(projConfig.defaultLaunchMode, engineProfile);
+    if (reconciled !== projConfig.defaultLaunchMode) {
+      log.info('Reset stranded defaultLaunchMode on engine switch', {
+        project: project.name, engine: updates.engine,
+        from: projConfig.defaultLaunchMode, to: reconciled
+      });
+      projConfig.defaultLaunchMode = reconciled;
+    }
     store.projectConfig.save(project.path, projConfig);
 
     // #240 drift-aware write — surfaces a warning when the on-disk

--- a/test/launch-mode-settings.test.js
+++ b/test/launch-mode-settings.test.js
@@ -169,6 +169,77 @@ describe('launch-mode settings', () => {
     });
   });
 
+  describe('engine-switch reconciliation (#682 trigger, #622)', () => {
+    it('resets a stored mode the new engine cannot honor to default', () => {
+      mkProject('lm-switch');
+      // Claude honors bypassPermissions; codex does not.
+      const set = projects.updateProject('lm-switch', {
+        defaultLaunchMode: 'bypassPermissions',
+        showLaunchModePicker: false,
+        confirmBypassHidden: true
+      });
+      assert.deepEqual(set.errors, []);
+      assert.equal(set.project.defaultLaunchMode, 'bypassPermissions');
+
+      const switched = projects.updateProject('lm-switch', { engine: 'codex' });
+      assert.deepEqual(switched.errors.filter(e => /defaultLaunchMode|launch mode/i.test(e)), []);
+      // The stranded mode is reconciled to the universally-valid default.
+      const cfg = store.projectConfig.load(switched.project.path);
+      assert.equal(cfg.defaultLaunchMode, 'default');
+      assert.equal(switched.project.defaultLaunchMode, 'default');
+    });
+
+    it('preserves a stored mode the new engine still honors', () => {
+      mkProject('lm-switch-keep');
+      // 'default' is valid for every engine — a switch must not disturb it.
+      const switched = projects.updateProject('lm-switch-keep', { engine: 'codex' });
+      assert.deepEqual(switched.errors, []);
+      assert.equal(store.projectConfig.load(switched.project.path).defaultLaunchMode, 'default');
+    });
+
+    it('allows switching engine AND hiding the picker together when reconciliation makes it safe', () => {
+      mkProject('lm-switch-hide');
+      projects.updateProject('lm-switch-hide', {
+        defaultLaunchMode: 'bypassPermissions',
+        showLaunchModePicker: false,
+        confirmBypassHidden: true
+      });
+      // Switching to codex reconciles bypassPermissions -> default, so the
+      // hidden picker no longer sits over a warning mode: the guard must not
+      // block this switch-to-safe, and no re-confirm should be demanded.
+      const result = projects.updateProject('lm-switch-hide', {
+        engine: 'codex',
+        showLaunchModePicker: false
+      });
+      assert.deepEqual(result.errors.filter(e => /confirmBypassHidden/.test(e)), []);
+      const cfg = store.projectConfig.load(result.project.path);
+      assert.equal(cfg.defaultLaunchMode, 'default');
+      assert.equal(cfg.showLaunchModePicker, false);
+    });
+  });
+
+  describe('write-path invariant — no path persists an unconfirmed dangerous posture', () => {
+    it('create writes the safe defaults, never a hidden bypass posture', () => {
+      const name = 'lm-create-safe';
+      const projPath = path.join(projectsDir, name);
+      fs.mkdirSync(projPath, { recursive: true });
+      store.projects.create({ name, path: projPath, engine: 'claude' });
+      const cfg = store.projectConfig.load(projPath);
+      assert.equal(cfg.defaultLaunchMode, 'default');
+      assert.notEqual(cfg.showLaunchModePicker, false);
+    });
+
+    it('the guard still blocks claude bypass + hidden without confirm after hardening', () => {
+      mkProject('lm-still-guarded');
+      const blocked = projects.updateProject('lm-still-guarded', {
+        defaultLaunchMode: 'bypassPermissions',
+        showLaunchModePicker: false
+      });
+      assert.equal(blocked.project, null);
+      assert.match(blocked.errors[0], /confirmBypassHidden/);
+    });
+  });
+
   describe('launch resolution (lib/sessions.js)', () => {
     const tmux = require('../lib/tmux');
     const enginesModule = require('../lib/engines');


### PR DESCRIPTION
## What

Closes two verified holes in `updateProject`'s launch-mode handling, making a dangerous or engine-invalid launch posture unreachable through the API.

- **Engine-switch stranding.** `updateProject` changed a project's engine but never re-validated the stored `defaultLaunchMode`, so a claude project set to `bypassPermissions`, switched to codex (no such mode), kept `bypassPermissions` on disk — a posture the engine can't run. This is the exact stale configuration that preceded #682's launch dying before its prime could paste.
- **Guard hole.** The eyes-open bypass-hidden guard fired only when the mode resolved to a `launchModes` entry carrying a `warning`; a stranded (unresolvable) mode left `modeConfig` falsy and the guard was skipped, so `{showLaunchModePicker: false}` could persist a hidden picker over that stale mode.

A new `reconcileLaunchMode(mode, engineProfile)` helper returns the mode the engine will actually keep (an unhonorable mode reconciles to `default` — universally valid, warning-free). The engine-change block resets a stranded stored mode on switch (logged); the guard judges the **reconciled** effective mode, so it still blocks a genuine warning-mode + hidden picker without `confirmBypassHidden`, yet no longer false-blocks a switch whose reconciliation makes it safe.

## Why

Prevent-by-construction for the launch-mode bug pair: this makes #682's `bypassPermissions`-on-codex configuration unreachable via the API — the config that triggered the launch failure.

**Evidence note:** #622 hypothesised the *create* path persisted the dangerous combination, but a repo-wide grep proved the only server-side writers of these fields are `DEFAULT_PROJECT_CONFIG` (safe defaults) and the guarded PATCH — `create`/`attach` deep-copy the safe defaults and write neither field. The fix builds on that code evidence, not the unreproduced writer claim, and a write-path regression test pins the invariant.

## Test plan

- 5 new regression tests in `test/launch-mode-settings.test.js`: reset-stranded, preserve-honored, switch-and-hide-safe, create-safe, still-blocks-bypass+hidden.
- Full suite: 0 failed (evidence recorded).
- Independent Critic: clean (0 blocking / 0 warning / 0 note).
- PR reviewer: 0 blocking / 0 warning / 1 note (regen-views scope rollup — resolved, local/gitignored).

## Scope

Fixes #622. Closes #682's **trigger** (the reachable bad config). #682's launch-death *mechanism* (why codex exits pre-prime) needs a live reproduction and stays open as a scoped follow-up — descoped, not dropped.