### PR TITLE
Judge changelog coverage per session, not per commit (#665)

### DIFF
--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -26,6 +26,38 @@ Tag-line conventions (ART-4K9M, ratified 2026-07-17):
 -->
 
 
+## 2026-07-21: Session-level changelog coverage — stop the wrap false-blocking disciplined sessions (#665)
+
+<!-- prawduct: type=bugfix | scope=session-level-changelog-coverage | status=shipped -->
+
+**Why:** the wrap's `changelog-update` coverage predicate required EVERY non-merge,
+non-wrap commit in the session range to touch `CHANGELOG.md` in its own diff. That is
+stricter than the rule it enforces ("the changelog was maintained for this session's
+work") and it blocked exactly the sessions that complied a common way. Hit live this
+session: the launch-mode-guard work logged its entry in the code commit but a separate
+commit touched only `.prawduct/change-log.md` (a changelog, just not `CHANGELOG.md`, and
+no user-visible code) — "1 of 2 commits never touched it" blocked the wrap. Same failure
+class as #665's reported PV-AI backfill (all feature PRs logged in one backfill commit).
+
+**What:** `lib/wrap-steps/changelog-coverage.js` `evaluate()` now returns `covered` when
+ANY judged commit in the range touched a declared path or coverage glob, instead of
+requiring all of them to. The uncommitted-edit route and the merge/wrap-commit exclusions
+are unchanged; the gate blocks only when NO commit maintained the changelog, and then
+names every judged commit in the remediation. Module header, `@returns`, and the affected
+tests updated to the session-level contract (per-commit "separates covered from unlogged"
+cases became "covered via a sibling that maintained the changelog"); new tests pin the
+backfill-in-one-commit and doc-only-bookkeeping-commit scenarios and the all-unlogged block.
+
+**Decision (operator-ratified):** #665 left the direction open (per-commit-exempt vs
+session-level vs status-quo). Chose session-level: for TC the per-commit atomicity guarantee
+is never cashed in (PRs squash-merge to main), and entry COMPLETENESS is driven by the
+`changelog-update` step, not this backstop. Trade-off accepted: an incomplete entry can now
+pass the gate — the entry-writing step is responsible for preventing that.
+
+**Honest confidence:** high — full suite 0 failed (coverage suite 51/51); the fix is a
+pure predicate change with the mutation-check fallback untouched. Closes #665.
+
+
 ## 2026-07-21: Close launch-mode guard write-path holes (#622, #682 trigger)
 
 <!-- prawduct: type=bugfix | scope=launch-mode-guard-622 | status=shipped -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to TangleClaw are documented in this file.
 
 ### Fixed
 
+- **The wrap's `changelog-update` gate now judges changelog coverage per session,
+  not per commit, so a disciplined session no longer false-blocks the wrap
+  (#665).** The coverage predicate required *every* non-merge, non-wrap commit in
+  the session range to touch `CHANGELOG.md` in its own diff. That is stricter than
+  the rule it enforces — "the changelog was maintained for this session's work" —
+  and it blocked exactly the sessions that complied a common way: a session that
+  logs all its work in one entry, backfills several commits' entries in a single
+  commit, or lands a doc-only/bookkeeping commit (e.g. one touching only
+  `.prawduct/change-log.md`) beside its logged code. `lib/wrap-steps/changelog-coverage.js`
+  now returns `covered` when **any** judged commit in the range touched a declared
+  path or coverage glob (the uncommitted-edit and merge/wrap-exclusion routes are
+  unchanged); it blocks only when *no* commit maintained the changelog, and then
+  names every judged commit. The per-commit guarantee bought little here — the
+  `changelog-update` step is what drives a *complete* entry; this predicate only
+  confirms the changelog was maintained at all. Trade-off: an incomplete entry can
+  now pass the gate, which the entry-writing step is responsible for preventing.
+
 - **An engine switch can no longer strand a launch mode the new engine can't
   honor, and the eyes-open bypass-hidden guard no longer has a hole a stranded
   mode slips through (#622; closes #682's trigger).** `updateProject` changed a

--- a/lib/wrap-steps/changelog-coverage.js
+++ b/lib/wrap-steps/changelog-coverage.js
@@ -12,10 +12,15 @@
  * sessions that complied (GH #645). This module answers the question the gate
  * actually wants: was the changelog MAINTAINED for the work this session shipped?
  *
- * **The predicate.** Every non-merge, non-wrap commit in the session range must
- * have touched the changelog in its own diff. Per-commit rather than
- * once-per-session, because the rule being verified is per-change; a single edit
- * vouching for a ten-commit session is the weaker claim.
+ * **The predicate.** The session range is covered if ANY non-merge, non-wrap
+ * commit in it touched the changelog — the obligation is "the changelog was
+ * maintained for this session's work", not "every commit logged itself in its own
+ * diff". A session that writes one entry for several commits, backfills its log in
+ * a single commit, or lands a doc-only / bookkeeping commit beside its logged work
+ * all satisfy it. Per-commit was tried first and was stricter than the rule it
+ * enforced: it false-blocked exactly those disciplined sessions (GH #665). The
+ * completeness of the entry is driven by the wrap's changelog-update step; this
+ * predicate confirms the changelog was maintained, not that each change self-logged.
  *
  * **A commit satisfies by touching any declared path OR any coverage glob.** The
  * declared paths (the step's `verifyChanged`) are matched exactly, so a lookalike
@@ -128,9 +133,10 @@ const VERDICTS = Object.freeze({
  *   omitting them, or passing a non-array, leaves exact-match behavior unchanged.
  *   Grammar in {@link _globToRegExp}.
  * @returns {{verdict:string, uncovered:Array<{sha:string, subject:string}>, checkedCount:number, range:(string|null), reason:(string|null)}}
- *   `verdict` is one of `covered` | `uncovered` | `unavailable`. `uncovered` lists
- *   the commits that touched neither a declared path nor a coverage glob (empty
- *   otherwise). `checkedCount` is how many commits the verdict was computed over.
+ *   `verdict` is one of `covered` | `uncovered` | `unavailable`. `uncovered` is
+ *   empty when covered; on an `uncovered` verdict it lists every judged commit,
+ *   since none maintained the changelog. `checkedCount` is how many commits the
+ *   verdict was computed over.
  *   `reason` explains an `unavailable` verdict and is null otherwise.
  */
 function evaluate(projectPath, paths, coveragePaths) {
@@ -218,20 +224,29 @@ function evaluate(projectPath, paths, coveragePaths) {
     return _unavailable('the session range contains no commits this predicate can judge', range);
   }
 
-  const uncovered = checkable
-    .filter((c) => !c.files.some(isCovered))
-    .map(({ sha, subject }) => ({ sha, subject }));
   const checkedCount = checkable.length;
 
-  if (uncovered.length === 0) {
+  // Session-level coverage: the obligation is "the changelog was maintained for
+  // this session's work", and it is met if ANY judged commit in the range touched
+  // a declared path or coverage glob — the entry need not ride the same commit as
+  // each change. A session commonly logs all its work in one entry, backfills
+  // several commits in a single commit, or lands a doc-only/bookkeeping commit
+  // beside its logged work; the former per-commit rule false-blocked all three
+  // even though the changelog was fully maintained. Per-commit bought little here:
+  // the wrap's changelog-update step is what drives a COMPLETE entry; this
+  // predicate only confirms the changelog was maintained at all.
+  if (checkable.some((c) => c.files.some(isCovered))) {
     log.info('changelog coverage satisfied', { range, checkedCount });
     return { verdict: VERDICTS.COVERED, uncovered: [], checkedCount, range, reason: null };
   }
 
-  log.warn('changelog coverage incomplete', {
+  // No judged commit touched the changelog and no uncommitted edit maintains it —
+  // it was not maintained this session. Name every judged commit so the
+  // remediation points at the work that shipped with no entry anywhere.
+  const uncovered = checkable.map(({ sha, subject }) => ({ sha, subject }));
+  log.warn('changelog coverage incomplete — no commit maintained the changelog', {
     range,
     checkedCount,
-    uncoveredCount: uncovered.length,
     coveragePaths: globSources
   });
   return { verdict: VERDICTS.UNCOVERED, uncovered, checkedCount, range, reason: null };

--- a/test/wrap-changelog-coverage.test.js
+++ b/test/wrap-changelog-coverage.test.js
@@ -223,17 +223,53 @@ describe('changelog-coverage — evaluate()', () => {
     assert.equal(out.checkedCount, 1);
   });
 
-  it('UNCOVERED when a commit shipped without touching a declared path, and names it', () => {
+  it('COVERED when one commit maintained the changelog and another shipped no entry (session-level)', () => {
+    // The changelog need not ride every commit — one entry covering the session's
+    // work satisfies the obligation, so a sibling code commit without its own
+    // entry no longer blocks (#665).
     scenario([
       { sha: 'aaa1111', subject: 'Fix a thing (#657)', files: ['CHANGELOG.md'] },
-      { sha: 'bbb2222', subject: 'Unlogged work (#999)', files: ['lib/b.js'] }
+      { sha: 'bbb2222', subject: 'More work, logged in aaa1111 (#999)', files: ['lib/b.js'] }
+    ]);
+    const out = cov.evaluate('/p', PATHS);
+    assert.equal(out.verdict, cov.VERDICTS.COVERED);
+    assert.deepEqual(out.uncovered, []);
+    assert.equal(out.checkedCount, 2, 'checkedCount is the denominator regardless of verdict');
+  });
+
+  it('COVERED when a later backfill commit logs work earlier commits shipped unlogged (#665)', () => {
+    scenario([
+      { sha: 'aaa1111', subject: 'feat: a (#70)', files: ['lib/a.js'] },
+      { sha: 'bbb2222', subject: 'fix: b (#71)', files: ['lib/b.js'] },
+      { sha: 'ccc3333', subject: 'docs: backfill CHANGELOG for the session', files: ['CHANGELOG.md'] }
+    ]);
+    const out = cov.evaluate('/p', PATHS);
+    assert.equal(out.verdict, cov.VERDICTS.COVERED);
+    assert.equal(out.checkedCount, 3);
+  });
+
+  it('COVERED when a doc-only bookkeeping commit ships no entry beside a logged code commit', () => {
+    // The launch-mode-guard session: code + CHANGELOG.md in one commit, a separate
+    // commit touching only the other changelog. The bookkeeping commit carries no
+    // CHANGELOG.md obligation, and the session's changelog was maintained.
+    scenario([
+      { sha: 'aaa1111', subject: 'Close guard holes (#622)', files: ['lib/projects.js', 'CHANGELOG.md'] },
+      { sha: 'bbb2222', subject: 'Change-log: guard holes (#622)', files: ['.prawduct/change-log.md'] }
+    ]);
+    const out = cov.evaluate('/p', PATHS);
+    assert.equal(out.verdict, cov.VERDICTS.COVERED);
+  });
+
+  it('UNCOVERED only when NO commit in the range maintained the changelog, naming them all', () => {
+    scenario([
+      { sha: 'aaa1111', subject: 'Unlogged work (#998)', files: ['lib/a.js'] },
+      { sha: 'bbb2222', subject: 'More unlogged work (#999)', files: ['lib/b.js'] }
     ]);
     const out = cov.evaluate('/p', PATHS);
     assert.equal(out.verdict, cov.VERDICTS.UNCOVERED);
-    assert.equal(out.uncovered.length, 1);
-    assert.equal(out.uncovered[0].sha, 'bbb2222');
-    assert.equal(out.uncovered[0].subject, 'Unlogged work (#999)');
-    assert.equal(out.checkedCount, 2, 'checkedCount is the denominator, not the failure count');
+    assert.equal(out.checkedCount, 2);
+    assert.deepEqual(out.uncovered.map((c) => c.sha), ['aaa1111', 'bbb2222'],
+      'every judged commit is named when none maintained the changelog');
   });
 
   it('matches a declared path exactly — a lookalike elsewhere in the tree does not count', () => {
@@ -411,17 +447,17 @@ describe('changelog-coverage — coverage globs (nested changelogs)', () => {
     assert.equal(cov.evaluate('/p', PATHS, ['packages/*/CHANGELOG.md']).verdict, cov.VERDICTS.UNCOVERED);
   });
 
-  it('separates covered-by-glob commits from genuinely-unlogged ones', () => {
-    // The full RentalClaw shape: skill commits log to the nested file (covered),
-    // a chore/docs commit logs nowhere (uncovered and named).
+  it('COVERED via a glob-matched commit even when a sibling commit logs nowhere (session-level)', () => {
+    // The full RentalClaw shape: a skill commit logs to the nested file (covered
+    // by the glob), a chore/docs commit logs nowhere. Session-level coverage: the
+    // changelog was maintained for the session, so the sibling does not block.
     scenario([
       { sha: 'aaa1111', subject: 'airbnb-gateway v0.1.0', files: ['skills/airbnb-gateway/CHANGELOG.md'] },
       { sha: 'ccc3333', subject: 'Remove vendored hook remnants', files: ['tools/lib/core.py'] }
     ]);
     const out = cov.evaluate('/p', PATHS, ['skills/*/CHANGELOG.md']);
-    assert.equal(out.verdict, cov.VERDICTS.UNCOVERED);
-    assert.equal(out.uncovered.length, 1);
-    assert.equal(out.uncovered[0].sha, 'ccc3333');
+    assert.equal(out.verdict, cov.VERDICTS.COVERED);
+    assert.deepEqual(out.uncovered, []);
     assert.equal(out.checkedCount, 2);
   });
 


### PR DESCRIPTION
## What

The wrap's `changelog-update` coverage predicate (`lib/wrap-steps/changelog-coverage.js`) required **every** non-merge, non-wrap commit in the session range to touch `CHANGELOG.md` in its own diff. That's stricter than the rule it enforces — *"the changelog was maintained for this session's work"* — and it false-blocked disciplined sessions that log a common way.

`evaluate()` now returns `covered` when **any** judged commit in the range touched a declared path or coverage glob. The uncommitted-edit route and the merge/wrap-commit exclusions are unchanged; it blocks only when *no* commit maintained the changelog, and then names every judged commit.

## Why

Hit live this session: the launch-mode-guard work (PR #683) logged its `CHANGELOG.md` entry in the code commit, but a separate commit touched only `.prawduct/change-log.md` (a changelog, just not `CHANGELOG.md`, and no user-visible code) — so the wrap blocked with *"1 of 2 commits never touched it."* Same failure class as #665's reported PV-AI backfill (all feature PRs logged in one backfill commit).

**Decision (operator-ratified):** #665 left the direction open. Chose session-level over the narrower per-commit-exempt option because for TC the per-commit atomicity guarantee is never cashed in (PRs squash-merge to `main`), and entry *completeness* is driven by the `changelog-update` step, not this backstop. **Trade-off accepted:** an incomplete entry can now pass the gate — the entry-writing step is responsible for preventing that.

## Test plan

- `test/wrap-changelog-coverage.test.js`: two per-commit cases updated to the session-level contract; three new tests pin the unblock scenarios (one-entry-for-many-commits, single-commit backfill, doc-only bookkeeping sibling) plus the all-unlogged block. Coverage suite 51/51.
- Full suite: 0 failed (evidence recorded).
- Critic: clean (0/0/0). PR reviewer: 0 blocking / 0 warning / 0 note.
- Module header + `@returns` updated in lockstep with the logic.

Closes #665.