### PR TITLE
Classify wrap release on the check rollup, not the BLOCKED string (#686)

### DIFF
--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -26,6 +26,26 @@ Tag-line conventions (ART-4K9M, ratified 2026-07-17):
 -->
 
 
+## 2026-07-22: Wrap release status — stop crying "BLOCKED, did not ship" while checks run (#686)
+
+<!-- prawduct: type=bugfix | scope=wrap-686 | status=shipped -->
+
+**Why:** GitHub reports `mergeStateStatus: BLOCKED` for ANY unmet branch-protection
+condition, including a required check that is merely still running. The wrap release
+probe (`lib/wrap-pr-status.js` `classify()`) read a bare `BLOCKED` as a definite failure,
+so a wrap PR whose CI was mid-flight showed "Wrap committed — release BLOCKED, did not
+ship" and the Recheck button repeated it — then auto-merge shipped the PR seconds later
+once the check passed. Hit live on wrap PR #685 (2026-07-21): panel said BLOCKED at
+22:54:53; GitHub merged at 22:55:54.
+
+**What:** `classify()` now discriminates on the actual `statusCheckRollup` (new
+`hasFailingCheck()`), not the overloaded `BLOCKED` string — `blocked` only for a
+closed-unmerged PR, a `DIRTY` conflict, or a check with a terminally failing conclusion;
+a QUEUED/IN_PROGRESS check reads `pending`. Preserves the #636 red-check guard via the
+check's own conclusion. Drawer blocked-detail copy split (closed / conflict / failed
+check); api-contracts.md doc parity; the CheckRun fixture shape verified against a real
+`gh pr view 685 --json statusCheckRollup`.
+
 ## 2026-07-21: Session-level changelog coverage — stop the wrap false-blocking disciplined sessions (#665)
 
 <!-- prawduct: type=bugfix | scope=session-level-changelog-coverage | status=shipped -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Wrap release status no longer reports "release BLOCKED, did not ship" (and the
+  Recheck button no longer repeats it) while a wrap PR's required checks are
+  still running. `lib/wrap-pr-status.js` now classifies on the actual
+  `statusCheckRollup` — `blocked` only for a closed-unmerged PR, a `DIRTY`
+  conflict, or a check that terminally **failed**; a check still QUEUED/
+  IN_PROGRESS classifies as `pending`, so an armed auto-merge that ships seconds
+  later reads honestly. Preserves the #636 red-check guard (now via the check's
+  own conclusion, not the overloaded `BLOCKED` merge-state string). (#686)
+
 ## [4.31.3] - 2026-07-21
 
 ### Fixed

--- a/docs/adr/0002-wrap-pipeline-contract.md
+++ b/docs/adr/0002-wrap-pipeline-contract.md
@@ -93,12 +93,29 @@ Two consequences bind on consumers:
    bump stranded on an unmerged branch.
 2. **The true outcome is a read-only, on-demand probe.**
    `GET /api/sessions/:project/wrap/pr-status?url=<prUrl>` runs `gh pr view
-   --json state,mergeStateStatus` and maps to `merged | pending | blocked |
-   unknown` (`lib/wrap-pr-status.js`). `blocked` (`state=CLOSED`, or `OPEN` with
-   `mergeStateStatus ∈ {BLOCKED, DIRTY}`) MUST NOT render as success; `unknown`
-   (no `gh`, probe failure) stays honestly indeterminate rather than claiming
-   either result. The drawer resolves once on render and offers an explicit
-   "Recheck release" button — no polling timer, per the no-timer-driven-UI rule.
+   --json state,mergeStateStatus,statusCheckRollup` and maps to `merged | pending
+   | blocked | unknown` (`lib/wrap-pr-status.js`). `blocked` MUST NOT render as
+   success; `unknown` (no `gh`, probe failure) stays honestly indeterminate
+   rather than claiming either result. The drawer resolves once on render and
+   offers an explicit "Recheck release" button — no polling timer, per the
+   no-timer-driven-UI rule.
+
+   **Extended 2026-07-22 (#686 — `blocked` discriminates on the check rollup,
+   not the `BLOCKED` string):** GitHub reports `mergeStateStatus: BLOCKED` for
+   *any* unmet branch-protection condition — including a required check that is
+   merely still **running** — so reading bare `BLOCKED` as failure mislabeled an
+   armed wrap PR whose CI was mid-flight ("release BLOCKED, did not ship", the
+   Recheck button repeating it) seconds before auto-merge shipped it. `classify`
+   now reserves `blocked` for a genuine dead-end: `state=CLOSED` (closed
+   unmerged), `OPEN`+`DIRTY` (branch conflicts), or an `OPEN` PR with a
+   `statusCheckRollup` entry whose conclusion is terminally failing
+   (`FAILURE`/`ERROR`/`TIMED_OUT`/`CANCELLED`/`ACTION_REQUIRED`/`STARTUP_FAILURE`/
+   `STALE`). Everything else open-and-not-failed — checks pending, `CLEAN`/
+   `UNSTABLE`/`BEHIND`, or a bare `BLOCKED` with no failing check (e.g. a
+   missing required review) — is `pending`. This preserves the #636 red-check
+   guard through the check's own conclusion instead of the ambiguous merge-state
+   string. If required reviews are ever enabled on wrap PRs, a review-only block
+   reads `pending` rather than surfacing as review-needed — revisit then.
 
 ### Back-compat shim (Chunk 2)
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -238,11 +238,11 @@ If a `deletePassword` is configured, you'll need to enter it to wrap.
 **Did it actually ship?** A wrap that commits has not necessarily *released*. When the wrap opens a PR (see protected branches below), the version bump and CHANGELOG promotion only reach `main` once that PR merges — which happens after its checks pass, and never if a required check fails. The drawer says which of these is true:
 
 - **Wrap shipped — PR merged** — the release landed.
-- **Release pending checks** — the PR hasn't merged yet; it lands when its checks pass.
-- **Release BLOCKED, did not ship** — a required check failed, a review is missing, or the branch conflicts. **This is a failure**: the wrap's version bump is stranded on an unmerged branch. Fix the PR, then merge it.
+- **Release pending checks** — the PR hasn't merged yet; it lands when its checks pass. A PR whose required check is still *running* shows this, not "blocked" — armed auto-merge will land it once the check goes green.
+- **Release BLOCKED, did not ship** — a required check actually *failed*, or the branch has merge conflicts. **This is a failure**: the wrap's version bump is stranded on an unmerged branch. Fix the PR, then merge it.
 - **Release not confirmed** — TangleClaw couldn't reach GitHub (no `gh`, not signed in). The outcome is genuinely unknown, not assumed good.
 
-Use **Recheck release** in the drawer to re-query at any time — checks usually take longer than the wrap itself, so "pending" right after a wrap is normal.
+Use **Recheck release** in the drawer to re-query at any time — checks usually take longer than the wrap itself, so "pending" right after a wrap is normal, and Recheck flips it to "shipped" once the check passes and auto-merge lands.
 
 **Steps that were skipped.** If any wrap steps skipped, the drawer shows *"Skipped N of M steps"* with the reason for each, so a wrap that quietly did nothing doesn't look the same as one that did everything.
 

--- a/lib/wrap-pr-status.js
+++ b/lib/wrap-pr-status.js
@@ -117,6 +117,13 @@ function classify(data) {
   const mss = String(data && data.mergeStateStatus || '').toUpperCase();
   if (mss === 'DIRTY') return 'blocked';
   if (hasFailingCheck(data && data.statusCheckRollup)) return 'blocked';
+  // Any remaining OPEN state — checks pending, CLEAN/UNSTABLE/BEHIND, or a bare
+  // BLOCKED with no failing check — is `pending`. Edge case: a PR blocked SOLELY
+  // by a missing required review (no failing check) also reads `pending` here;
+  // correct for this repo (wrap PRs require no review), but if required reviews
+  // are ever enabled, such a PR would sit `pending` rather than surfacing as a
+  // review-needed block — revisit then (an `autoMergeRequest`/review-decision
+  // signal would distinguish it).
   return 'pending';
 }
 

--- a/lib/wrap-pr-status.js
+++ b/lib/wrap-pr-status.js
@@ -25,7 +25,45 @@ const { createLogger } = require('./logger');
 const log = createLogger('wrap-pr-status');
 
 const EXEC_TIMEOUT_MS = 15000;
-const GH_JSON_FIELDS = 'state,mergeStateStatus,url,number';
+const GH_JSON_FIELDS = 'state,mergeStateStatus,url,number,statusCheckRollup';
+
+/**
+ * Terminal `CheckRun.conclusion` / `StatusContext.state` values that mean a
+ * required check genuinely FAILED (not merely still running). A rollup entry in
+ * one of these states is what separates a real block (#636) from a wrap PR that
+ * is only `BLOCKED` because its checks have not finished yet (#686).
+ * @type {Set<string>}
+ */
+const FAILING_CHECK_STATES = new Set([
+  'FAILURE', 'ERROR', 'TIMED_OUT', 'CANCELLED', 'ACTION_REQUIRED', 'STARTUP_FAILURE', 'STALE'
+]);
+
+/**
+ * Whether any entry in a `gh pr view --json statusCheckRollup` array is a
+ * completed, terminally-failing required check. Tolerates both rollup shapes:
+ * a `CheckRun` (uses `status`/`conclusion`) and a legacy `StatusContext` (uses
+ * `state`). A check that is still QUEUED/IN_PROGRESS is NOT failing — it is
+ * pending, and the whole point of #686 is that pending must not read as blocked.
+ *
+ * @param {Array<object>|undefined|null} rollup - The `statusCheckRollup` array
+ * @returns {boolean} True if at least one check has terminally failed
+ */
+function hasFailingCheck(rollup) {
+  if (!Array.isArray(rollup)) return false;
+  return rollup.some((c) => {
+    if (!c || typeof c !== 'object') return false;
+    // CheckRun: only COMPLETED runs carry a meaningful conclusion; an
+    // in-progress run has conclusion null / '' and must not count as failing.
+    const status = String(c.status || '').toUpperCase();
+    const conclusion = String(c.conclusion || '').toUpperCase();
+    if (conclusion && (status === 'COMPLETED' || status === '') && FAILING_CHECK_STATES.has(conclusion)) {
+      return true;
+    }
+    // StatusContext (legacy commit status): the terminal signal is `state`.
+    const state = String(c.state || '').toUpperCase();
+    return FAILING_CHECK_STATES.has(state);
+  });
+}
 
 /**
  * A full GitHub PR URL. `gh pr view` accepts a URL or a bare number; we accept
@@ -47,20 +85,29 @@ function isValidPrRef(ref) {
 }
 
 /**
- * Classify a `gh pr view --json state,mergeStateStatus` payload into the
- * release outcome the drawer renders.
+ * Classify a `gh pr view --json state,mergeStateStatus,statusCheckRollup`
+ * payload into the release outcome the drawer renders.
+ *
+ * `blocked` is reserved for a release that will NOT ship without intervention;
+ * `pending` for one that has not shipped yet but is expected to resolve on its
+ * own (checks running, auto-merge armed). The discriminator is the actual check
+ * rollup, NOT `mergeStateStatus` alone — GitHub reports `mergeStateStatus:
+ * BLOCKED` for ANY unmet branch-protection condition, including required checks
+ * that are merely still running. Reading bare `BLOCKED` as failure was the #686
+ * defect: a wrap PR whose CI was mid-flight read "release BLOCKED, did not
+ * ship", then auto-merged seconds later once the check passed.
  *
  * - `MERGED` → `merged` (the release landed; `main` is at the new version).
  * - `CLOSED` (unmerged) → `blocked` (the PR was closed without shipping).
- * - `OPEN` + `mergeStateStatus ∈ {BLOCKED, DIRTY}` → `blocked` — a required
- *   check failed, a review is required and missing, or the branch conflicts;
- *   auto-merge cannot land it as-is. This is the #636 case.
- * - `OPEN` otherwise (`CLEAN`/`UNSTABLE`/`BEHIND`/`HAS_HOOKS`/`UNKNOWN`) →
- *   `pending` — armed and waiting on checks; outcome not yet known. `pending`
- *   is honestly "not confirmed", which is safe; only `blocked`/`merged` are
- *   definite claims.
+ * - `OPEN` + `DIRTY` → `blocked` (the branch conflicts; a definite failure).
+ * - `OPEN` + a terminally-failed required check in the rollup → `blocked` —
+ *   this is the real #636 red-check case, detected via the check's own
+ *   conclusion rather than the ambiguous `BLOCKED` string.
+ * - `OPEN` otherwise (checks pending, `CLEAN`/`UNSTABLE`/`BEHIND`, or `BLOCKED`
+ *   only because checks have not finished) → `pending` — not shipped yet, no
+ *   failure observed; it lands when its checks pass.
  *
- * @param {{state?: string, mergeStateStatus?: string}} data - Parsed gh JSON
+ * @param {{state?: string, mergeStateStatus?: string, statusCheckRollup?: Array<object>}} data - Parsed gh JSON
  * @returns {'merged'|'blocked'|'pending'} Release outcome
  */
 function classify(data) {
@@ -68,7 +115,8 @@ function classify(data) {
   if (state === 'MERGED') return 'merged';
   if (state === 'CLOSED') return 'blocked';
   const mss = String(data && data.mergeStateStatus || '').toUpperCase();
-  if (mss === 'BLOCKED' || mss === 'DIRTY') return 'blocked';
+  if (mss === 'DIRTY') return 'blocked';
+  if (hasFailingCheck(data && data.statusCheckRollup)) return 'blocked';
   return 'pending';
 }
 
@@ -147,4 +195,4 @@ function defaultExec(file, args, options) {
 
 const _internal = { exec: defaultExec };
 
-module.exports = { resolve, classify, isValidPrRef, _internal, PR_URL_RE };
+module.exports = { resolve, classify, hasFailingCheck, isValidPrRef, _internal, PR_URL_RE };

--- a/public/wrap-drawer.js
+++ b/public/wrap-drawer.js
@@ -342,9 +342,15 @@
       return { label: 'Wrap shipped — PR merged', tone: 'success', detail: 'the release landed on the base branch' };
     }
     if (outcome === 'blocked') {
+      // #686: `blocked` now means a genuine dead-end — closed-unmerged, a
+      // conflict (DIRTY), or a required check that actually FAILED. Checks that
+      // are merely still running classify as `pending`, not here, so this copy
+      // no longer has to hedge "failed or still running".
       const why = status.state === 'CLOSED'
         ? 'PR was closed without merging'
-        : `PR cannot merge (${status.mergeStateStatus || 'blocked'}) — a required check failed or the branch conflicts`;
+        : status.mergeStateStatus === 'DIRTY'
+          ? 'the branch has merge conflicts'
+          : 'a required check failed';
       return { label: 'Wrap committed — release BLOCKED, did not ship', tone: 'error', detail: why };
     }
     if (outcome === 'pending') {

--- a/test/api-wrap-pr-status.test.js
+++ b/test/api-wrap-pr-status.test.js
@@ -89,11 +89,20 @@ describe('api GET /wrap/pr-status (#638)', () => {
     assert.equal(res.body.project, 'prstatus-test');
   });
 
-  it('resolves an OPEN+BLOCKED PR to outcome blocked (the #636 case)', async () => {
-    prStatus._internal.exec = async () => ({ exitCode: 0, stdout: JSON.stringify({ state: 'OPEN', mergeStateStatus: 'BLOCKED' }), stderr: '' });
+  it('resolves an OPEN+BLOCKED PR with a FAILED check to outcome blocked (the #636 case)', async () => {
+    const rollup = [{ status: 'COMPLETED', conclusion: 'FAILURE' }];
+    prStatus._internal.exec = async () => ({ exitCode: 0, stdout: JSON.stringify({ state: 'OPEN', mergeStateStatus: 'BLOCKED', statusCheckRollup: rollup }), stderr: '' });
     const res = await request(server, 'GET', '/api/sessions/prstatus-test/wrap/pr-status?url=7');
     assert.equal(res.status, 200);
     assert.equal(res.body.outcome, 'blocked');
+  });
+
+  it('#686: resolves an OPEN+BLOCKED PR whose check is still RUNNING to outcome pending', async () => {
+    const rollup = [{ status: 'IN_PROGRESS', conclusion: null }];
+    prStatus._internal.exec = async () => ({ exitCode: 0, stdout: JSON.stringify({ state: 'OPEN', mergeStateStatus: 'BLOCKED', statusCheckRollup: rollup }), stderr: '' });
+    const res = await request(server, 'GET', '/api/sessions/prstatus-test/wrap/pr-status?url=7');
+    assert.equal(res.status, 200);
+    assert.equal(res.body.outcome, 'pending');
   });
 
   it('an invalid PR ref resolves to unknown WITHOUT invoking gh', async () => {

--- a/test/wrap-drawer.test.js
+++ b/test/wrap-drawer.test.js
@@ -1029,6 +1029,16 @@ describe('wrap-drawer helpers — #638 wrap-PR reporting', () => {
       const b = H.prOutcomeBanner({ outcome: 'blocked', state: 'CLOSED' });
       assert.match(b.detail, /closed without merging/);
     });
+    it('DIRTY → error with a merge-conflict reason', () => {
+      const b = H.prOutcomeBanner({ outcome: 'blocked', state: 'OPEN', mergeStateStatus: 'DIRTY' });
+      assert.equal(b.tone, 'error');
+      assert.match(b.detail, /merge conflicts/);
+    });
+    it('a failed-check block (OPEN, not DIRTY) → error with a failed-check reason', () => {
+      const b = H.prOutcomeBanner({ outcome: 'blocked', state: 'OPEN', mergeStateStatus: 'BLOCKED' });
+      assert.equal(b.tone, 'error');
+      assert.match(b.detail, /required check failed/);
+    });
     it('pending → provisional', () => {
       assert.equal(H.prOutcomeBanner({ outcome: 'pending' }).tone, 'provisional');
     });

--- a/test/wrap-pr-status.test.js
+++ b/test/wrap-pr-status.test.js
@@ -32,7 +32,14 @@ describe('wrap-pr-status.classify', () => {
 
   // #686 — mergeStateStatus BLOCKED is overloaded: it covers a required check
   // that FAILED and one that is merely still RUNNING. The rollup, not the
-  // BLOCKED string, is the discriminator.
+  // BLOCKED string, is the discriminator. The CheckRun rollup shape below
+  // (`__typename`/`status`/`conclusion`) was verified against a real
+  // `gh pr view 685 --json statusCheckRollup` on this repo (a COMPLETED/SUCCESS
+  // `test` CheckRun), so these fixtures track gh's actual output, not a guess.
+  it('#686: real gh CheckRun shape — COMPLETED/SUCCESS → pending (CLEAN would follow)', () => {
+    const rollup = [{ __typename: 'CheckRun', name: 'test', status: 'COMPLETED', conclusion: 'SUCCESS', workflowName: 'Tests' }];
+    assert.equal(prStatus.classify({ state: 'OPEN', mergeStateStatus: 'BLOCKED', statusCheckRollup: rollup }), 'pending');
+  });
   it('#686: OPEN + BLOCKED with a still-running required check → pending (not blocked)', () => {
     const rollup = [{ __typename: 'CheckRun', name: 'ci', status: 'IN_PROGRESS', conclusion: null }];
     assert.equal(prStatus.classify({ state: 'OPEN', mergeStateStatus: 'BLOCKED', statusCheckRollup: rollup }), 'pending');

--- a/test/wrap-pr-status.test.js
+++ b/test/wrap-pr-status.test.js
@@ -20,9 +20,6 @@ describe('wrap-pr-status.classify', () => {
   it('CLOSED (unmerged) → blocked', () => {
     assert.equal(prStatus.classify({ state: 'CLOSED' }), 'blocked');
   });
-  it('OPEN + BLOCKED merge state → blocked (the #636 red-check case)', () => {
-    assert.equal(prStatus.classify({ state: 'OPEN', mergeStateStatus: 'BLOCKED' }), 'blocked');
-  });
   it('OPEN + DIRTY (conflicts) → blocked', () => {
     assert.equal(prStatus.classify({ state: 'OPEN', mergeStateStatus: 'DIRTY' }), 'blocked');
   });
@@ -32,8 +29,66 @@ describe('wrap-pr-status.classify', () => {
   it('OPEN + UNSTABLE → pending (non-required check failing, not blocking)', () => {
     assert.equal(prStatus.classify({ state: 'OPEN', mergeStateStatus: 'UNSTABLE' }), 'pending');
   });
+
+  // #686 — mergeStateStatus BLOCKED is overloaded: it covers a required check
+  // that FAILED and one that is merely still RUNNING. The rollup, not the
+  // BLOCKED string, is the discriminator.
+  it('#686: OPEN + BLOCKED with a still-running required check → pending (not blocked)', () => {
+    const rollup = [{ __typename: 'CheckRun', name: 'ci', status: 'IN_PROGRESS', conclusion: null }];
+    assert.equal(prStatus.classify({ state: 'OPEN', mergeStateStatus: 'BLOCKED', statusCheckRollup: rollup }), 'pending');
+  });
+  it('#686: OPEN + BLOCKED with a QUEUED required check → pending', () => {
+    const rollup = [{ __typename: 'CheckRun', name: 'ci', status: 'QUEUED', conclusion: null }];
+    assert.equal(prStatus.classify({ state: 'OPEN', mergeStateStatus: 'BLOCKED', statusCheckRollup: rollup }), 'pending');
+  });
+  it('#636 preserved: OPEN + BLOCKED with a FAILED required check → blocked', () => {
+    const rollup = [{ __typename: 'CheckRun', name: 'ci', status: 'COMPLETED', conclusion: 'FAILURE' }];
+    assert.equal(prStatus.classify({ state: 'OPEN', mergeStateStatus: 'BLOCKED', statusCheckRollup: rollup }), 'blocked');
+  });
+  it('OPEN + BLOCKED with a passed check but one running → pending (still settling)', () => {
+    const rollup = [
+      { __typename: 'CheckRun', name: 'lint', status: 'COMPLETED', conclusion: 'SUCCESS' },
+      { __typename: 'CheckRun', name: 'ci', status: 'IN_PROGRESS', conclusion: null }
+    ];
+    assert.equal(prStatus.classify({ state: 'OPEN', mergeStateStatus: 'BLOCKED', statusCheckRollup: rollup }), 'pending');
+  });
+  it('bare OPEN + BLOCKED with no rollup → pending (no observed failure)', () => {
+    assert.equal(prStatus.classify({ state: 'OPEN', mergeStateStatus: 'BLOCKED' }), 'pending');
+  });
+  it('legacy StatusContext FAILURE state → blocked', () => {
+    const rollup = [{ __typename: 'StatusContext', context: 'ci/build', state: 'FAILURE' }];
+    assert.equal(prStatus.classify({ state: 'OPEN', mergeStateStatus: 'BLOCKED', statusCheckRollup: rollup }), 'blocked');
+  });
   it('case-insensitive on state and mergeStateStatus', () => {
-    assert.equal(prStatus.classify({ state: 'open', mergeStateStatus: 'blocked' }), 'blocked');
+    assert.equal(prStatus.classify({ state: 'open', mergeStateStatus: 'dirty' }), 'blocked');
+  });
+});
+
+describe('wrap-pr-status.hasFailingCheck', () => {
+  it('false for a non-array / empty rollup', () => {
+    assert.equal(prStatus.hasFailingCheck(undefined), false);
+    assert.equal(prStatus.hasFailingCheck(null), false);
+    assert.equal(prStatus.hasFailingCheck([]), false);
+  });
+  it('false when every check succeeded or is still running', () => {
+    assert.equal(prStatus.hasFailingCheck([
+      { status: 'COMPLETED', conclusion: 'SUCCESS' },
+      { status: 'COMPLETED', conclusion: 'NEUTRAL' },
+      { status: 'COMPLETED', conclusion: 'SKIPPED' },
+      { status: 'IN_PROGRESS', conclusion: null },
+      { state: 'PENDING' }
+    ]), false);
+  });
+  it('true for each terminal failing conclusion', () => {
+    for (const c of ['FAILURE', 'TIMED_OUT', 'CANCELLED', 'ACTION_REQUIRED', 'STARTUP_FAILURE', 'STALE']) {
+      assert.equal(prStatus.hasFailingCheck([{ status: 'COMPLETED', conclusion: c }]), true, `${c} should count as failing`);
+    }
+  });
+  it('does NOT treat a null conclusion on an in-progress run as failing', () => {
+    assert.equal(prStatus.hasFailingCheck([{ status: 'IN_PROGRESS', conclusion: null }]), false);
+  });
+  it('tolerates junk entries without throwing', () => {
+    assert.equal(prStatus.hasFailingCheck([null, 42, 'x', {}, { status: 'COMPLETED', conclusion: 'FAILURE' }]), true);
   });
 });
 
@@ -65,10 +120,19 @@ describe('wrap-pr-status.resolve', () => {
     assert.equal(out.reason, null);
   });
 
-  it('maps an OPEN+BLOCKED PR to outcome blocked', async () => {
-    prStatus._internal.exec = async () => ({ exitCode: 0, stdout: JSON.stringify({ state: 'OPEN', mergeStateStatus: 'BLOCKED' }), stderr: '' });
+  it('#636: maps an OPEN+BLOCKED PR with a FAILED check to outcome blocked', async () => {
+    const rollup = [{ status: 'COMPLETED', conclusion: 'FAILURE' }];
+    prStatus._internal.exec = async () => ({ exitCode: 0, stdout: JSON.stringify({ state: 'OPEN', mergeStateStatus: 'BLOCKED', statusCheckRollup: rollup }), stderr: '' });
     const out = await prStatus.resolve('/tmp/p', '5');
     assert.equal(out.outcome, 'blocked');
+    assert.equal(out.mergeStateStatus, 'BLOCKED');
+  });
+
+  it('#686: maps an OPEN+BLOCKED PR whose check is still RUNNING to outcome pending', async () => {
+    const rollup = [{ status: 'IN_PROGRESS', conclusion: null }];
+    prStatus._internal.exec = async () => ({ exitCode: 0, stdout: JSON.stringify({ state: 'OPEN', mergeStateStatus: 'BLOCKED', statusCheckRollup: rollup }), stderr: '' });
+    const out = await prStatus.resolve('/tmp/p', '5');
+    assert.equal(out.outcome, 'pending');
     assert.equal(out.mergeStateStatus, 'BLOCKED');
   });
 


### PR DESCRIPTION
## What

The Session Wrap panel reported **"Wrap committed — release BLOCKED, did not ship"** — and the **Recheck release** button kept repeating it — for a wrap PR whose required CI check was **still running**. The PR then auto-merged seconds later once the check passed. The operator was told the release failed when it actually shipped.

Observed live on wrap PR #685 (2026-07-21): panel said BLOCKED at 22:54:53; GitHub merged the PR at 22:55:54 (the `test` check ran 05:55:02→05:55:50 UTC — IN_PROGRESS at report time).

## Why

`lib/wrap-pr-status.js` `classify()` mapped `mergeStateStatus === 'BLOCKED'` straight to `blocked`. But GitHub returns `BLOCKED` for **any** unmet branch-protection condition — including a required check that is merely still **running**, not only one that failed. The Recheck button re-ran the same `classify()`, so it repeated the false verdict as long as the check was mid-flight ("recheck wouldn't fix it"). Introduced by #638, which chose `blocked` for `BLOCKED` to avoid rendering a red check as success — right intent, wrong discriminator.

## How

`classify()` now discriminates on the actual `statusCheckRollup` (new `hasFailingCheck()`), not the overloaded string:
- `blocked` only for: a closed-unmerged PR, an `OPEN`+`DIRTY` conflict, or a rollup entry with a terminally **failing** conclusion (`FAILURE`/`ERROR`/`TIMED_OUT`/`CANCELLED`/`ACTION_REQUIRED`/`STARTUP_FAILURE`/`STALE`).
- Everything else open-and-not-failed — checks QUEUED/IN_PROGRESS, `CLEAN`/`UNSTABLE`/`BEHIND`, or a bare `BLOCKED` with no failing check — is `pending`.

Preserves the #636 red-check guard, now via the check's own conclusion. Drawer blocked-detail copy split three ways (closed / conflict / failed check). Doc parity: `docs/user-guide.md`, `docs/adr/0002-wrap-pipeline-contract.md`, and `.prawduct/artifacts/api-contracts.md`.

## Test plan

- Full suite green: 4675 passed / 0 failed / 1 pre-existing skip (`node --test test/*.test.js`).
- New regression tests in `test/wrap-pr-status.test.js` + `test/api-wrap-pr-status.test.js`: BLOCKED + running check → pending; BLOCKED + failed check → blocked (#636 preserved); `hasFailingCheck` across every terminal conclusion, legacy StatusContext, junk-tolerance; CheckRun fixture shape verified against a real `gh pr view 685 --json statusCheckRollup`.
- `test/wrap-drawer.test.js`: DIRTY-conflict and failed-check banner detail branches.

## Review

- Independent Critic (cumulative → verify-resolutions): **0 blocking**; 5 prior warnings/notes all resolved.
- Independent PR reviewer: **0 blocking**, 2 warnings — both tracked-doc parity gaps, fixed in this branch before opening.

Fixes #686