### PR TITLE
Heal aged dangling FEATURES.md citations at wrap instead of stranding (#640)

### DIFF
--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -26,6 +26,29 @@ Tag-line conventions (ART-4K9M, ratified 2026-07-17):
 -->
 
 
+## 2026-07-22: Heal aged dangling FEATURES.md citations at wrap instead of stranding (#640)
+
+<!-- prawduct: type=bugfix | scope=wrap-640 | status=shipped -->
+
+**Why:** #637 stopped `features-toc` from *creating* stubs for files deleted in the current
+session, but nothing re-checked citations already in `FEATURES.md` whose target was deleted in
+an EARLIER session. TC's own `DOC-3K7Q` contract test (`test/features-index.test.js`) asserts
+every cited committed path exists on disk, so an aged dangling citation reddened the required
+`test` check on the wrap's own PR while every wrap step still reported `[Done]` — stranding the
+version bump on an unmerged branch (silent symptom, same shape as #637's fresh-stub case).
+
+**What:** `features-toc` now scans the existing index on every run (except a fresh create) and
+heals two ways (operator-ratified Hybrid): a dead **auto-stub** it wrote itself (the
+`- **TBD** …` line under a `## TODO (auto-stubbed …)` section) is **pruned** — self-healing our
+own output, emptied sections + separator removed — while a dead **hand-written / already-described**
+citation is **reported** as a named, non-blocking finding and left untouched, so operator prose
+is never rewritten to make a required check pass. The scan runs independent of drift/range (a
+citation dangles even when the session touched nothing indexable), so a prune with no drift still
+stages a healed write. The reporter accepts any file-extension token or `#symbol` anchor (a
+dangling `data/schema.sql` reds the same check) while excluding URLs and extensionless prose;
+this also fixed a pre-existing URL false-positive. `commit.js` gains a
+`- Feature Index: pruned N dead stub(s)` audit line. Critic cumulative + verify-resolutions clean.
+
 ## 2026-07-22: Wrap release status — stop crying "BLOCKED, did not ship" while checks run (#686)
 
 <!-- prawduct: type=bugfix | scope=wrap-686 | status=shipped -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Wrap no longer silently strands on an aged dangling `FEATURES.md` citation (#640).
+  `features-toc` now heals citations whose target was deleted in an **earlier** session,
+  independent of this session's drift: a dead **auto-stub** it wrote itself (the `- **TBD** …`
+  line under a `## TODO (auto-stubbed …)` section) is **pruned** — self-healing our own output,
+  emptied sections and their separator removed — while a dead **hand-written / already-described**
+  citation is **reported** as a named, non-blocking finding and left untouched, so operator prose
+  is never rewritten to make a required check pass. Previously such a citation reddened the
+  `DOC-3K7Q` contract test on the wrap's own PR while every step still reported `[Done]`, leaving
+  the version bump stranded on an unmerged branch. Commit body gains a
+  `- Feature Index: pruned N dead stub(s)` audit line. (`lib/wrap-steps/features-toc.js`,
+  `lib/wrap-steps/commit.js`)
+
 ## [4.31.4] - 2026-07-22
 
 ### Fixed

--- a/lib/wrap-steps/commit.js
+++ b/lib/wrap-steps/commit.js
@@ -277,6 +277,12 @@ function _buildBodyLines(staged) {
           : '';
         lines.push(`- Feature Index: ${n} stub(s) appended (${filesPreview}${suffix})`);
       }
+      // #640: dead auto-stubs pruned this wrap (self-healed dangling citations).
+      // Independent of the append line above — a wrap can prune with no drift.
+      const pruned = typeof entry.prunedCount === 'number' ? entry.prunedCount : 0;
+      if (pruned > 0) {
+        lines.push(`- Feature Index: pruned ${pruned} dead stub(s)`);
+      }
       continue;
     }
 

--- a/lib/wrap-steps/features-toc.js
+++ b/lib/wrap-steps/features-toc.js
@@ -492,10 +492,19 @@ function _pruneDeadAutoStubs(content, projectPath) {
  * Scan content for backticked citation tokens whose committed-repo path no
  * longer exists on disk — the hand-written / already-described citations #640
  * REPORTS rather than prunes. Mirrors the DOC-3K7Q contract test's token shape
- * (backticked, no glob/placeholder, split on `#`, must contain `/`); in place of
- * that test's TC-specific committed-root allowlist it generically requires an
- * indexable extension or a `#symbol` anchor and drops the vendored/build
- * prefixes, so a stray prose token like `and/or` is not misread as a file.
+ * (backticked, no glob/placeholder, split on `#`, must contain `/`). In place of
+ * that test's TC-specific committed-root allowlist — which the generic wrap step
+ * cannot hardcode — it accepts a token with ANY file extension (not just the
+ * indexable set: a dangling `data/schema.sql` or `docs/x.png` reds the same
+ * required check, so it must be reported too) or a `#symbol` anchor, while
+ * dropping URLs (`://`), the vendored/build prefixes, and extensionless
+ * anchorless tokens so stray prose like `and/or` is not misread as a file.
+ *
+ * Known residual: a dangling **extensionless, anchorless** committed-root path
+ * (e.g. `docs/adr-0001`) reds the contract test but is not reported here — it is
+ * indistinguishable from prose without the committed-root allowlist. Rare as a
+ * citation; the extension/anchor forms cover the common cases.
+ *
  * Returns each dangling token once, in first-seen order.
  *
  * @param {string} content
@@ -511,12 +520,13 @@ function _findDanglingCitations(content, projectPath) {
   while ((m = re.exec(content)) !== null) {
     const token = m[1];
     if (/[*<{]/.test(token)) continue;                 // globs / placeholders — out of contract
+    if (token.includes('://')) continue;               // a URL, not a repo path
     const filePath = token.split('#')[0];
     if (!filePath.includes('/')) continue;             // not a repo path
     if (EXCLUDED_PREFIXES.some((p) => filePath.startsWith(p))) continue;
     const hasSymbol = token.includes('#');
-    const ext = path.extname(filePath).toLowerCase();
-    if (!hasSymbol && !INDEXABLE_EXTENSIONS.has(ext)) continue;
+    const hasExt = path.extname(filePath) !== '';
+    if (!hasSymbol && !hasExt) continue;               // extensionless + anchorless → treat as prose
     if (seen.has(token)) continue;
     if (!_internal.existsSync(path.join(projectPath, filePath))) {
       seen.add(token);

--- a/lib/wrap-steps/features-toc.js
+++ b/lib/wrap-steps/features-toc.js
@@ -77,6 +77,17 @@
  * on disk at write time asks the same question the citation contract
  * asks, so the two cannot disagree.
  *
+ * **Aged dangling citations are healed, not ignored (#640).** The write-path
+ * guard above only stops *new* dangling stubs. A citation whose target was
+ * deleted in an *earlier* session still fails the contract test and strands the
+ * wrap PR silently. On every run (except a fresh create — the seed has none),
+ * the handler heals two ways: a dangling **auto-stub** it wrote itself (the
+ * `- **TBD** …` line under a `## TODO (auto-stubbed …)` section) is PRUNED,
+ * self-healing our own output; a dangling **hand-written** or already-described
+ * citation is REPORTED as a named, non-blocking finding and left untouched,
+ * because rewriting operator prose to make a required check pass is the wrong
+ * default. See {@link _pruneDeadAutoStubs} and {@link _findDanglingCitations}.
+ *
  * **Drift extraction.** Existing index entries are tokenized by a
  * single regex that scans for path tokens with the same extension
  * allowlist. The matcher is intentionally permissive (matches inside
@@ -134,6 +145,14 @@ const EXCLUDED_PREFIXES = [
   '.git/',
   '.tangleclaw/'
 ];
+
+// #640 dangling-citation heal. An auto-stubbed TODO section heading and the
+// literal stub-entry line this step writes (see `_appendTodoSection`), plus a
+// generic markdown-heading matcher used to bound a section. Kept adjacent to the
+// writer so the read (prune) and write (append) formats cannot drift apart.
+const AUTOSTUB_HEADING_RE = /^##\s+TODO\s+\(auto-stubbed\s+\d{4}-\d{2}-\d{2}\)\s*$/;
+const AUTOSTUB_ENTRY_RE = /^- \*\*TBD\*\* — touched in this session: `([^`]+)`/;
+const MD_HEADING_RE = /^#{1,6}\s/;
 
 // Path-like token matcher, shared with the continuity Map so their extension
 // allowlists can't drift (CON-8H3Z — see lib/path-tokens). Anchor is
@@ -199,121 +218,312 @@ async function run(context) {
     created = true;
   }
 
+  // Heal dangling citations left by EARLIER sessions, independent of this
+  // session's drift (#640). A cited path deleted in a prior session fails the
+  // citation contract and strands the wrap PR while every step still reports
+  // success. Prune the dead auto-stubs this step itself wrote (self-healing our
+  // own output); report dead hand-written / already-described citations without
+  // touching operator prose. Skipped on a fresh create — the seed has none.
+  let workingContent = indexContent;
+  let prunedPaths = [];
+  let danglingHandwritten = [];
+  if (!created) {
+    const pruned = _pruneDeadAutoStubs(indexContent, project.path);
+    workingContent = pruned.content;
+    prunedPaths = pruned.prunedPaths;
+    danglingHandwritten = _findDanglingCitations(workingContent, project.path);
+  }
+
+  // Compute this session's drift (new files to stub), tolerant of a missing
+  // range or a diff failure — a prune above may still need flushing even when
+  // there is nothing new to append. The `null` sentinels let `_finalize`
+  // distinguish the skip causes when nothing changed and nothing is reported.
+  let drifted = [];
+  let todoDate = null;
+  let touchedCount = null;
+  let indexableCount = null;
+  let candidateCount = null;
+  let diffError = null;
+
   const sessionRange = _resolveSessionRange(project.path, projConfig.lastWrapSha);
-  if (!sessionRange) {
-    // No diff range to compute drift from. If we were going to self-heal,
-    // still create the bare seed so the toggle's intent is honored; otherwise
-    // skip exactly as before.
-    if (created) return _stageCreate(featuresPath, indexContent, staged, project, log);
-    return _skipped('no session range resolves (no lastWrapSha and no main/master base branch)');
-  }
-
-  let touchedFiles;
-  try {
-    touchedFiles = _diffNameOnly(project.path, sessionRange.range);
-  } catch (err) {
-    if (created) return _stageCreate(featuresPath, indexContent, staged, project, log);
-    return _skipped(`git diff failed: ${err.message}`);
-  }
-
-  const indexable = touchedFiles.filter(_isIndexableCandidate);
-  const candidates = indexable.filter((f) => _stillExists(project.path, f));
-  const indexedSet = _extractIndexedPaths(indexContent);
-  const drifted = candidates.filter((f) => !indexedSet.has(f));
-
-  if (drifted.length === 0) {
-    // No new stubs to append. Create the bare seed if self-healing; otherwise
-    // this is the steady-state "everything already indexed" skip.
-    if (created) return _stageCreate(featuresPath, indexContent, staged, project, log);
-    if (touchedFiles.length === 0) return _skipped(`no files touched in ${sessionRange.range}`);
-    if (candidates.length === 0) {
-      // Distinguish the two empty-candidate causes rather than reporting the
-      // generic filter skip — "every touched file was deleted" is a materially
-      // different session from "nothing touched was indexable".
-      return _skipped(indexable.length > 0
-        ? 'no indexable candidates — every touched file was deleted'
-        : 'no indexable candidates after filtering');
+  if (sessionRange) {
+    let touchedFiles = null;
+    try {
+      touchedFiles = _diffNameOnly(project.path, sessionRange.range);
+    } catch (err) {
+      diffError = err.message;
     }
-    return _skipped('no drift — every touched file already in FEATURES.md');
+    if (touchedFiles) {
+      touchedCount = touchedFiles.length;
+      const indexable = touchedFiles.filter(_isIndexableCandidate);
+      indexableCount = indexable.length;
+      const candidates = indexable.filter((f) => _stillExists(project.path, f));
+      candidateCount = candidates.length;
+      const indexedSet = _extractIndexedPaths(workingContent);
+      drifted = candidates.filter((f) => !indexedSet.has(f));
+    }
   }
 
-  const todoDate = _internal.todayIso();
-  const newContent = _appendTodoSection(indexContent, drifted, todoDate);
+  if (drifted.length > 0) {
+    todoDate = _internal.todayIso();
+    workingContent = _appendTodoSection(workingContent, drifted, todoDate);
+  }
 
-  staged['features-toc:append'] = {
-    primingPath: featuresPath,
-    newContent,
-    changed: true,
-    featuresToc: true,
-    created,
-    addedCount: drifted.length,
-    addedFiles: drifted,
-    todoDate
-  };
-
-  log.info(created ? 'features-toc staged create (self-heal) + stub append' : 'features-toc staged stub append', {
-    project: project.name,
-    range: sessionRange.range,
-    rangeKind: sessionRange.kind,
-    created,
-    addedCount: drifted.length
+  return _finalize({
+    staged, featuresPath, indexContent, workingContent, created, drifted,
+    todoDate, prunedPaths, danglingHandwritten, project, sessionRange,
+    touchedCount, indexableCount, candidateCount, diffError
   });
-
-  return {
-    ok: true,
-    status: 'done',
-    output: {
-      featuresPath,
-      created,
-      addedCount: drifted.length,
-      addedFiles: drifted,
-      todoDate,
-      detail: created
-        ? `${FEATURES_FILENAME} created (${drifted.length} stub(s) appended)`
-        : `${drifted.length} untracked file(s) appended to ${FEATURES_FILENAME}`
-    },
-    blockers: []
-  };
 }
 
 /**
- * Stage a bare-seed create when self-healing produced no drift to append.
- * The `{primingPath, newContent, changed}` trio is duck-typed by
- * `commit.js:_flushStagedWrites`, so the file is created during the
- * commit-step flush. `featuresToc:true` + `created:true` drive the
- * "- Feature Index: created" commit body line.
+ * Build the step result: stage the working content when it changed, surface a
+ * dangling-citation report when there is one, else fall through to the existing
+ * skip taxonomy. Centralized (#640) so the create, prune-only, append, and
+ * report outcomes share one staging + reporting path — and so a prune with no
+ * drift still produces a staged write instead of a silent skip.
  *
- * @param {string} featuresPath - Absolute path to FEATURES.md
- * @param {string} seedContent - The template content to write
- * @param {object} staged - Single-transaction scratch space
- * @param {object} project - Project record (for log context)
- * @param {object} logger - Module logger
+ * @param {object} a - Collected run() state.
  * @returns {{ok:boolean, status:string, output:object, blockers:string[]}}
  */
-function _stageCreate(featuresPath, seedContent, staged, project, logger) {
-  staged['features-toc:append'] = {
-    primingPath: featuresPath,
-    newContent: seedContent,
-    changed: true,
-    featuresToc: true,
-    created: true,
-    addedCount: 0,
-    addedFiles: [],
-    todoDate: null
-  };
-  logger.info('features-toc staged create (self-heal, no drift)', { project: project.name });
-  return {
-    ok: true,
-    status: 'done',
-    output: {
-      featuresPath,
-      created: true,
-      addedCount: 0,
-      addedFiles: [],
-      detail: `${FEATURES_FILENAME} created (seed only — no drift to stub)`
-    },
-    blockers: []
-  };
+function _finalize(a) {
+  const {
+    staged, featuresPath, indexContent, workingContent, created, drifted,
+    todoDate, prunedPaths, danglingHandwritten, project, sessionRange,
+    touchedCount, indexableCount, candidateCount, diffError
+  } = a;
+
+  const contentChanged = created || workingContent !== indexContent;
+  const prunedCount = prunedPaths.length;
+  const reportCount = danglingHandwritten.length;
+
+  if (contentChanged) {
+    staged['features-toc:append'] = {
+      primingPath: featuresPath,
+      newContent: workingContent,
+      changed: true,
+      featuresToc: true,
+      created,
+      addedCount: drifted.length,
+      addedFiles: drifted,
+      prunedCount,
+      prunedFiles: prunedPaths,
+      danglingHandwritten,
+      todoDate
+    };
+    log.info('features-toc staged write', {
+      project: project.name,
+      created,
+      addedCount: drifted.length,
+      prunedCount,
+      reportCount,
+      range: sessionRange ? sessionRange.range : null
+    });
+    return {
+      ok: true,
+      status: 'done',
+      output: {
+        featuresPath,
+        created,
+        addedCount: drifted.length,
+        addedFiles: drifted,
+        prunedCount,
+        prunedFiles: prunedPaths,
+        danglingHandwritten,
+        todoDate,
+        detail: _buildDetail({ created, addedCount: drifted.length, prunedCount, reportCount, danglingHandwritten })
+      },
+      blockers: []
+    };
+  }
+
+  // Nothing changed on disk. A dangling hand-written citation still reds this
+  // wrap's PR (the contract test), so surface it as a visible, non-blocking
+  // finding rather than skipping silently — the whole point of #640.
+  if (reportCount > 0) {
+    log.info('features-toc reporting dangling hand-written citations (no content change)', {
+      project: project.name,
+      reportCount
+    });
+    return {
+      ok: true,
+      status: 'done',
+      output: {
+        featuresPath,
+        created: false,
+        addedCount: 0,
+        addedFiles: [],
+        prunedCount: 0,
+        prunedFiles: [],
+        danglingHandwritten,
+        detail: _buildDetail({ created: false, addedCount: 0, prunedCount: 0, reportCount, danglingHandwritten })
+      },
+      blockers: []
+    };
+  }
+
+  // Existing skip taxonomy — reached only when nothing changed and nothing is
+  // reported. Order and wording preserved from the pre-#640 handler.
+  if (!sessionRange) {
+    return _skipped('no session range resolves (no lastWrapSha and no main/master base branch)');
+  }
+  if (diffError !== null) {
+    return _skipped(`git diff failed: ${diffError}`);
+  }
+  if (touchedCount === 0) {
+    return _skipped(`no files touched in ${sessionRange.range}`);
+  }
+  if (candidateCount === 0) {
+    // Distinguish the two empty-candidate causes rather than reporting the
+    // generic filter skip — "every touched file was deleted" is a materially
+    // different session from "nothing touched was indexable".
+    return _skipped(indexableCount > 0
+      ? 'no indexable candidates — every touched file was deleted'
+      : 'no indexable candidates after filtering');
+  }
+  return _skipped('no drift — every touched file already in FEATURES.md');
+}
+
+/**
+ * Compose the human-facing step detail from the outcome counts. Preserves the
+ * pre-#640 append/create wording (tests pin the "N untracked file" and
+ * "created (…)" phrasings), then adds a prune clause and a dangling-citation
+ * report clause when each applies.
+ *
+ * @param {object} p
+ * @param {boolean} p.created
+ * @param {number} p.addedCount
+ * @param {number} p.prunedCount
+ * @param {number} p.reportCount
+ * @param {string[]} p.danglingHandwritten
+ * @returns {string}
+ */
+function _buildDetail({ created, addedCount, prunedCount, reportCount, danglingHandwritten }) {
+  const parts = [];
+  if (created) {
+    parts.push(addedCount > 0
+      ? `${FEATURES_FILENAME} created (${addedCount} stub(s) appended)`
+      : `${FEATURES_FILENAME} created (seed only — no drift to stub)`);
+  } else if (addedCount > 0) {
+    parts.push(`${addedCount} untracked file(s) appended to ${FEATURES_FILENAME}`);
+  }
+  if (prunedCount > 0) {
+    parts.push(`pruned ${prunedCount} dead auto-stub(s)`);
+  }
+  if (reportCount > 0) {
+    const preview = danglingHandwritten.slice(0, 3).join(', ');
+    const more = danglingHandwritten.length > 3
+      ? `, +${danglingHandwritten.length - 3} more`
+      : '';
+    parts.push(`⚠ ${reportCount} dangling hand-written citation(s) — fix before this wrap's PR can merge: ${preview}${more}`);
+  }
+  // A content-changed result always yields at least one part (create/prune/
+  // append); this guard only backstops an unexpected all-zero call.
+  return parts.length > 0 ? parts.join('; ') : `${FEATURES_FILENAME} unchanged`;
+}
+
+/**
+ * Remove auto-stub entries whose cited path no longer exists on disk, healing
+ * the dangling citations this step itself created in an earlier session (#640).
+ * Only the literal `- **TBD** — touched in this session: \`path\`` format under a
+ * `## TODO (auto-stubbed …)` section is touched — once a stub is described or
+ * graduated into curated prose it is no longer ours to delete and is reported
+ * (not pruned). A TODO section left with no surviving stub AND no other
+ * non-blank content has its heading removed too, along with the blank separator
+ * line that preceded it. Sections still holding a live stub or any operator
+ * prose are preserved verbatim.
+ *
+ * @param {string} content - Current FEATURES.md content.
+ * @param {string} projectPath - Absolute project root, for the on-disk check.
+ * @returns {{content:string, prunedPaths:string[]}}
+ */
+function _pruneDeadAutoStubs(content, projectPath) {
+  if (!content || typeof content !== 'string') return { content, prunedPaths: [] };
+  const lines = content.split('\n');
+  const out = [];
+  const prunedPaths = [];
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    if (!AUTOSTUB_HEADING_RE.test(line)) {
+      out.push(line);
+      i += 1;
+      continue;
+    }
+    // Gather the section body up to the next markdown heading (any level) or EOF.
+    const body = [];
+    let j = i + 1;
+    while (j < lines.length && !MD_HEADING_RE.test(lines[j])) {
+      body.push(lines[j]);
+      j += 1;
+    }
+    const keptBody = [];
+    let survivingStubs = 0;
+    for (const bodyLine of body) {
+      const m = AUTOSTUB_ENTRY_RE.exec(bodyLine);
+      if (m) {
+        const cited = m[1].split('#')[0];
+        if (!_internal.existsSync(path.join(projectPath, cited))) {
+          prunedPaths.push(cited);
+          continue; // drop the dead stub line
+        }
+        survivingStubs += 1;
+      }
+      keptBody.push(bodyLine);
+    }
+    const hasOtherContent = keptBody.some((l) => l.trim() !== '');
+    if (survivingStubs > 0 || hasOtherContent) {
+      out.push(line);
+      out.push(...keptBody);
+    } else if (out.length > 0 && out[out.length - 1] === '') {
+      // Whole section died — also swallow the blank separator before its heading.
+      out.pop();
+    }
+    i = j;
+  }
+  let result = out.join('\n');
+  // A dropped trailing section can strip the file's final newline; restore it so
+  // pruning never churns the trailing-newline byte on its own.
+  if (content.endsWith('\n') && !result.endsWith('\n')) result += '\n';
+  return { content: result, prunedPaths };
+}
+
+/**
+ * Scan content for backticked citation tokens whose committed-repo path no
+ * longer exists on disk — the hand-written / already-described citations #640
+ * REPORTS rather than prunes. Mirrors the DOC-3K7Q contract test's token shape
+ * (backticked, no glob/placeholder, split on `#`, must contain `/`); in place of
+ * that test's TC-specific committed-root allowlist it generically requires an
+ * indexable extension or a `#symbol` anchor and drops the vendored/build
+ * prefixes, so a stray prose token like `and/or` is not misread as a file.
+ * Returns each dangling token once, in first-seen order.
+ *
+ * @param {string} content
+ * @param {string} projectPath - Absolute project root.
+ * @returns {string[]}
+ */
+function _findDanglingCitations(content, projectPath) {
+  const out = [];
+  if (!content || typeof content !== 'string') return out;
+  const seen = new Set();
+  const re = /`([^`\s]+)`/g;
+  let m;
+  while ((m = re.exec(content)) !== null) {
+    const token = m[1];
+    if (/[*<{]/.test(token)) continue;                 // globs / placeholders — out of contract
+    const filePath = token.split('#')[0];
+    if (!filePath.includes('/')) continue;             // not a repo path
+    if (EXCLUDED_PREFIXES.some((p) => filePath.startsWith(p))) continue;
+    const hasSymbol = token.includes('#');
+    const ext = path.extname(filePath).toLowerCase();
+    if (!hasSymbol && !INDEXABLE_EXTENSIONS.has(ext)) continue;
+    if (seen.has(token)) continue;
+    if (!_internal.existsSync(path.join(projectPath, filePath))) {
+      seen.add(token);
+      out.push(token);
+    }
+  }
+  return out;
 }
 
 // A plausible git object name — full or abbreviated hex. Validated before a
@@ -529,7 +739,10 @@ module.exports = {
   _stillExists,
   _extractIndexedPaths,
   _appendTodoSection,
-  _stageCreate,
+  _pruneDeadAutoStubs,
+  _findDanglingCitations,
+  _finalize,
+  _buildDetail,
   _todayIsoLocal,
   _internal,
   FEATURES_FILENAME,

--- a/test/wrap-step-features-toc.test.js
+++ b/test/wrap-step-features-toc.test.js
@@ -6,7 +6,7 @@
 // (base-branch resolution, diff parsing), happy-path stage shape, and
 // the commit body line emitted from `lib/wrap-steps/commit.js`.
 
-const { describe, it, before, after, beforeEach } = require('node:test');
+const { describe, it, before, after, beforeEach, afterEach } = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
@@ -983,6 +983,303 @@ describe('wrap-step features-toc (#207 Chunk 3)', () => {
       // about why nothing happened.
       assert.match(result.output.reason, /every touched file was deleted/,
         'the skip reason must name deletion as the cause');
+    });
+  });
+
+  // #640: aged dangling citations (target deleted in an EARLIER session) must be
+  // healed — a dead auto-stub this step wrote is pruned; a hand-written / already-
+  // described one is reported, never silently rewritten. Otherwise the DOC-3K7Q
+  // citation contract reds the wrap PR while every step still reports success.
+  describe('_pruneDeadAutoStubs (#640)', () => {
+    const PROJ = '/proj';
+    let origExists;
+    beforeEach(() => { origExists = featuresToc._internal.existsSync; });
+    afterEach(() => { featuresToc._internal.existsSync = origExists; });
+
+    function withExisting(relPaths) {
+      const set = new Set(relPaths.map((r) => path.join(PROJ, r)));
+      featuresToc._internal.existsSync = (abs) => set.has(abs);
+    }
+
+    it('removes a dead auto-stub entry and drops the emptied TODO section + its separator blank', () => {
+      withExisting(['lib/widget.js']); // the hand-written entry survives; the stub target does not
+      const content = [
+        '# Feature Index',
+        '',
+        '## UI / Web',
+        '- **Widget** — `lib/widget.js`.',
+        '',
+        '## TODO (auto-stubbed 2026-07-01)',
+        '',
+        '- **TBD** — touched in this session: `lib/gone.js`. <!-- describe -->',
+        ''
+      ].join('\n');
+      const { content: out, prunedPaths } = featuresToc._pruneDeadAutoStubs(content, PROJ);
+      assert.deepEqual(prunedPaths, ['lib/gone.js']);
+      assert.ok(!out.includes('lib/gone.js'), 'dead stub line removed');
+      assert.ok(!out.includes('## TODO (auto-stubbed 2026-07-01)'), 'emptied TODO heading removed');
+      assert.ok(out.includes('## UI / Web'), 'unrelated section preserved');
+      assert.ok(out.includes('- **Widget** — `lib/widget.js`.'), 'hand-written entry untouched');
+      assert.ok(out.endsWith('\n'), 'trailing newline preserved');
+    });
+
+    it('prunes only the dead stub when a live stub shares the section — heading kept', () => {
+      withExisting(['lib/live.js']);
+      const content = [
+        '# Feature Index',
+        '',
+        '## TODO (auto-stubbed 2026-07-01)',
+        '',
+        '- **TBD** — touched in this session: `lib/live.js`. <!-- describe -->',
+        '- **TBD** — touched in this session: `lib/dead.js`. <!-- describe -->',
+        ''
+      ].join('\n');
+      const { content: out, prunedPaths } = featuresToc._pruneDeadAutoStubs(content, PROJ);
+      assert.deepEqual(prunedPaths, ['lib/dead.js']);
+      assert.ok(out.includes('lib/live.js'), 'live stub kept');
+      assert.ok(!out.includes('lib/dead.js'), 'dead stub removed');
+      assert.ok(out.includes('## TODO (auto-stubbed 2026-07-01)'), 'heading kept — section still has a live stub');
+    });
+
+    it('keeps a section (and its dead stub) when operator prose shares it — prose is not ours to delete', () => {
+      withExisting([]); // stub target absent
+      const content = [
+        '# Feature Index',
+        '',
+        '## TODO (auto-stubbed 2026-07-01)',
+        '',
+        '- **TBD** — touched in this session: `lib/dead.js`. <!-- describe -->',
+        'Operator note: revisit this batch after the refactor.',
+        ''
+      ].join('\n');
+      const { content: out, prunedPaths } = featuresToc._pruneDeadAutoStubs(content, PROJ);
+      assert.deepEqual(prunedPaths, ['lib/dead.js'], 'the dead stub line itself is still pruned');
+      assert.ok(out.includes('## TODO (auto-stubbed 2026-07-01)'), 'heading kept — operator prose present');
+      assert.ok(out.includes('Operator note: revisit'), 'operator prose preserved');
+    });
+
+    it('does not touch a described/graduated entry pointing at a deleted file (reported, not pruned)', () => {
+      withExisting([]); // lib/graduated.js is gone
+      const content = [
+        '# Feature Index',
+        '',
+        '## Server / API',
+        '- **Graduated** — `lib/graduated.js` does the thing.',
+        ''
+      ].join('\n');
+      const { content: out, prunedPaths } = featuresToc._pruneDeadAutoStubs(content, PROJ);
+      assert.deepEqual(prunedPaths, [], 'a graduated entry is not the auto-stub format — pruning leaves it');
+      assert.ok(out.includes('lib/graduated.js'), 'entry preserved for the report path to surface');
+    });
+
+    it('returns content unchanged when there are no auto-stub sections', () => {
+      withExisting([]);
+      const content = '# Feature Index\n\n## UI\n- **A** — `lib/a.js`.\n';
+      const { content: out, prunedPaths } = featuresToc._pruneDeadAutoStubs(content, PROJ);
+      assert.equal(out, content, 'byte-identical when nothing to prune');
+      assert.deepEqual(prunedPaths, []);
+    });
+  });
+
+  describe('_findDanglingCitations (#640)', () => {
+    const PROJ = '/proj';
+    let origExists;
+    beforeEach(() => { origExists = featuresToc._internal.existsSync; });
+    afterEach(() => { featuresToc._internal.existsSync = origExists; });
+
+    function withExisting(relPaths) {
+      const set = new Set(relPaths.map((r) => path.join(PROJ, r)));
+      featuresToc._internal.existsSync = (abs) => set.has(abs);
+    }
+
+    it('reports a hand-written citation whose file is gone, and not one that exists', () => {
+      withExisting(['lib/here.js']);
+      const content = '- **Here** — `lib/here.js`.\n- **Gone** — `lib/gone.js`.\n';
+      assert.deepEqual(featuresToc._findDanglingCitations(content, PROJ), ['lib/gone.js']);
+    });
+
+    it('reports a dangling `path#symbol` anchor as its full token', () => {
+      withExisting([]);
+      const content = '- **X** — `lib/gone.js#doThing`.\n';
+      assert.deepEqual(featuresToc._findDanglingCitations(content, PROJ), ['lib/gone.js#doThing']);
+    });
+
+    it('skips globs, placeholders, non-path tokens, and vendored prefixes', () => {
+      withExisting([]);
+      const content = [
+        '`lib/*.js`',          // glob
+        '`<lib/foo.js>`',      // placeholder
+        '`file.js`',           // no slash → not a repo path
+        '`node_modules/x.js`', // excluded prefix
+        '`and/or`'             // has slash but no indexable ext / symbol
+      ].join(' ');
+      assert.deepEqual(featuresToc._findDanglingCitations(content, PROJ), []);
+    });
+
+    it('dedupes a repeated dangling token', () => {
+      withExisting([]);
+      const content = '`lib/gone.js` … `lib/gone.js`';
+      assert.deepEqual(featuresToc._findDanglingCitations(content, PROJ), ['lib/gone.js']);
+    });
+  });
+
+  describe('commit-step body-line — pruned dead stubs (#640)', () => {
+    it('emits "- Feature Index: pruned N dead stub(s)" when prunedCount > 0', () => {
+      const staged = {
+        'features-toc:append': {
+          primingPath: '/p/FEATURES.md',
+          newContent: '# Feature Index\n',
+          changed: true,
+          featuresToc: true,
+          addedCount: 0,
+          addedFiles: [],
+          prunedCount: 2,
+          prunedFiles: ['lib/a.js', 'lib/b.js'],
+          todoDate: null
+        }
+      };
+      const lines = commitStep._buildBodyLines(staged);
+      assert.ok(lines.includes('- Feature Index: pruned 2 dead stub(s)'),
+        'the prune count gets its own audit line');
+    });
+
+    it('emits BOTH the append and the prune line when a wrap did both', () => {
+      const staged = {
+        'features-toc:append': {
+          primingPath: '/p/FEATURES.md',
+          newContent: '...',
+          changed: true,
+          featuresToc: true,
+          addedCount: 1,
+          addedFiles: ['lib/fresh.js'],
+          prunedCount: 1,
+          prunedFiles: ['lib/dead.js'],
+          todoDate: '2026-07-22'
+        }
+      };
+      const lines = commitStep._buildBodyLines(staged);
+      assert.ok(lines.some((l) => l.includes('1 stub(s) appended')), 'append line present');
+      assert.ok(lines.includes('- Feature Index: pruned 1 dead stub(s)'), 'prune line present');
+    });
+  });
+
+  describe('handler — dangling-citation heal (#640)', () => {
+    let tmpDir;
+    let projectPath;
+    let createdProject;
+
+    before(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-features-toc-640-'));
+      store._setBasePath(path.join(tmpDir, 'tangleclaw'));
+      store.init();
+      const projectsDir = path.join(tmpDir, 'projects');
+      fs.mkdirSync(projectsDir, { recursive: true });
+      const cfg = store.config.load();
+      cfg.projectsDir = projectsDir;
+      store.config.save(cfg);
+      projectPath = path.join(projectsDir, 'features-toc-640');
+      fs.mkdirSync(projectPath, { recursive: true });
+      createdProject = store.projects.create({ name: 'features-toc-640', path: projectPath, engine: 'claude' });
+      store.projectConfig.save(projectPath, { engine: 'claude', featureIndexEnabled: true });
+      // lib/fresh.js is the only file that exists on disk; every cited-but-absent
+      // path below is a genuine dangling citation.
+      materialize(projectPath, 'lib/fresh.js');
+    });
+
+    after(() => {
+      store.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    /** Stub execSync so the range resolves and `git diff` returns `diffOut`. */
+    function stubDiff(diffOut) {
+      featuresToc._internal.execSync = (cmd) => {
+        if (cmd.startsWith('git rev-parse')) return Buffer.from('');
+        if (cmd.startsWith('git diff')) return Buffer.from(diffOut);
+        throw new Error(`unexpected command: ${cmd}`);
+      };
+    }
+
+    it('prunes a dead auto-stub and stages the healed content even with no drift', async () => {
+      fs.writeFileSync(path.join(projectPath, 'FEATURES.md'), [
+        '# Feature Index',
+        '',
+        '## TODO (auto-stubbed 2026-06-01)',
+        '',
+        '- **TBD** — touched in this session: `lib/deleted.js`. <!-- describe -->',
+        ''
+      ].join('\n'));
+      const origExec = featuresToc._internal.execSync;
+      stubDiff(''); // empty diff → no drift; the prune alone must produce a staged write
+      const staged = {};
+      try {
+        const result = await featuresToc.run({ project: createdProject, staged });
+        assert.equal(result.status, 'done');
+        assert.equal(result.output.prunedCount, 1);
+        assert.deepEqual(result.output.prunedFiles, ['lib/deleted.js']);
+        assert.match(result.output.detail, /pruned 1 dead auto-stub/);
+        const entry = staged['features-toc:append'];
+        assert.ok(entry, 'a prune with no drift still stages the healed content');
+        assert.ok(!entry.newContent.includes('lib/deleted.js'), 'dead stub gone from staged content');
+        assert.ok(!entry.newContent.includes('auto-stubbed 2026-06-01'), 'emptied TODO section gone');
+      } finally {
+        featuresToc._internal.execSync = origExec;
+      }
+    });
+
+    it('reports a dangling hand-written citation without editing the file (non-blocking)', async () => {
+      const featuresPath = path.join(projectPath, 'FEATURES.md');
+      const original = [
+        '# Feature Index',
+        '',
+        '## Server / API',
+        '- **Old thing** — `lib/handgone.js` used to live here.',
+        ''
+      ].join('\n');
+      fs.writeFileSync(featuresPath, original);
+      const origExec = featuresToc._internal.execSync;
+      stubDiff('');
+      const staged = {};
+      try {
+        const result = await featuresToc.run({ project: createdProject, staged });
+        assert.equal(result.ok, true, 'never blocks');
+        assert.equal(result.status, 'done', 'surfaced as a visible finding, not a silent skip');
+        assert.deepEqual(result.output.danglingHandwritten, ['lib/handgone.js']);
+        assert.match(result.output.detail, /dangling hand-written citation/);
+        assert.equal(staged['features-toc:append'], undefined, 'operator prose is not rewritten');
+        assert.equal(fs.readFileSync(featuresPath, 'utf8'), original, 'file on disk untouched');
+      } finally {
+        featuresToc._internal.execSync = origExec;
+      }
+    });
+
+    it('composes a prune with a drift append in one wrap', async () => {
+      fs.writeFileSync(path.join(projectPath, 'FEATURES.md'), [
+        '# Feature Index',
+        '',
+        '## TODO (auto-stubbed 2026-06-01)',
+        '',
+        '- **TBD** — touched in this session: `lib/deleted.js`. <!-- describe -->',
+        ''
+      ].join('\n'));
+      const origExec = featuresToc._internal.execSync;
+      const origToday = featuresToc._internal.todayIso;
+      stubDiff('lib/fresh.js\n'); // lib/fresh.js exists → drift to append
+      featuresToc._internal.todayIso = () => '2026-07-22';
+      const staged = {};
+      try {
+        const result = await featuresToc.run({ project: createdProject, staged });
+        assert.equal(result.status, 'done');
+        assert.equal(result.output.prunedCount, 1);
+        assert.equal(result.output.addedCount, 1);
+        assert.deepEqual(result.output.addedFiles, ['lib/fresh.js']);
+        const entry = staged['features-toc:append'];
+        assert.ok(!entry.newContent.includes('lib/deleted.js'), 'dead stub pruned');
+        assert.ok(entry.newContent.includes('- **TBD** — touched in this session: `lib/fresh.js`.'), 'fresh drift appended');
+      } finally {
+        featuresToc._internal.execSync = origExec;
+        featuresToc._internal.todayIso = origToday;
+      }
     });
   });
 });

--- a/test/wrap-step-features-toc.test.js
+++ b/test/wrap-step-features-toc.test.js
@@ -1121,6 +1121,21 @@ describe('wrap-step features-toc (#207 Chunk 3)', () => {
       const content = '`lib/gone.js` … `lib/gone.js`';
       assert.deepEqual(featuresToc._findDanglingCitations(content, PROJ), ['lib/gone.js']);
     });
+
+    it('reports a dangling non-indexable-extension citation (it reds the same required check)', () => {
+      withExisting([]);
+      const content = '- **Schema** — `data/schema.sql`.\n- **Logo** — `docs/logo.png`.\n';
+      assert.deepEqual(
+        featuresToc._findDanglingCitations(content, PROJ),
+        ['data/schema.sql', 'docs/logo.png']
+      );
+    });
+
+    it('does not misreport a URL as a dangling repo path', () => {
+      withExisting([]);
+      const content = '- **Docs** — see `https://example.com/guide.html`.\n';
+      assert.deepEqual(featuresToc._findDanglingCitations(content, PROJ), []);
+    });
   });
 
   describe('commit-step body-line — pruned dead stubs (#640)', () => {


### PR DESCRIPTION
## What
`features-toc` now heals citations already in `FEATURES.md` whose target was deleted in an **earlier** session — the case #637's write-path guard doesn't cover. Two treatments (operator-ratified **Hybrid**):

- **Prune** a dead **auto-stub** the step wrote itself (the `- **TBD** … ` line under a `## TODO (auto-stubbed …)` section) — self-healing our own output; emptied sections + their separator blank are removed too.
- **Report** a dead **hand-written / already-described** citation as a named, non-blocking finding, leaving the file untouched — operator prose is never rewritten to make a required check pass.

The scan runs independent of drift/range (a citation dangles even when the session touched nothing indexable), so a prune with no new drift still stages a healed write. `commit.js` gains a `- Feature Index: pruned N dead stub(s)` audit line.

## Why
TC's own `DOC-3K7Q` contract test asserts every cited committed path exists on disk. An aged dangling citation reddened the required `test` check on the wrap's **own** PR while every wrap step still reported `[Done]` — stranding the version bump on an unmerged branch (silent symptom, same shape as #637's fresh-stub case). Fixes #640.

## Scope note
The `DOC-3K7Q` contract test is **TangleClaw-repo-only** — not seeded into managed projects — so this is a TC self-dogfooding fix. Managed-project wraps (TiLT v2, RentalClaw) can't hit #640.

## Test plan
- 9 new tests: `_pruneDeadAutoStubs` units (dead-stub prune, live+dead split, operator-prose preservation, graduated-entry left alone, no-op), `_findDanglingCitations` units (report/skip/dedupe, non-indexable extension reported, URL not misreported), commit body-line, and 3 handler-integration cases (prune-only stages, report-only doesn't rewrite, prune+append compose).
- Full suite: **4691 pass / 0 fail / 1 skipped** (pre-existing).

## Review
- Critic `cumulative`: 0 blocking / 0 warning / 1 note → note resolved (broadened reporter to any-extension + URL guard, which also fixed a pre-existing URL false-positive); `verify-resolutions`: 0/0/0.
- Independent PR reviewer: 0 blocking / 0 warning / 0 note.