### PR TITLE
Catch uncommitted work that would ship unlogged at wrap (#659)

### DIFF
--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -26,6 +26,32 @@ Tag-line conventions (ART-4K9M, ratified 2026-07-17):
 -->
 
 
+## 2026-07-22: Wrap changelog gate catches uncommitted work that would ship unlogged (#659)
+
+<!-- prawduct: type=bugfix | scope=wrap-659 | status=shipped -->
+
+**Why:** `changelog-coverage.evaluate()` judged committed history + the changelog's own dirty
+state, but never the rest of the dirty tree. A source file left uncommitted at wrap is swept
+into the wrap's own commit by `git add -A`, and the next session's range starts after that
+commit — so unlogged uncommitted work could never be judged and shipped silently (verdict
+`covered`). The naive "any dirty file → unlogged" rule was tried and reverted (#645): sessions
+dirty tracked bookkeeping (`.prawduct/change-log.md`) routinely, so it blocked the compliant
+sessions the predicate exists to unblock.
+
+**What:** Tell work from bookkeeping with a shared classifier. Extracted `features-toc`'s
+source-file signal (`_isIndexableCandidate` + its extension/basename/prefix constants) into a new
+`lib/wrap-steps/_source-paths.js` (`isSourceFile`), re-exported from `features-toc` so its surface
+is unchanged — one source of truth, no drift. `changelog-coverage` now filters the dirty set
+through `isSourceFile`: a dirty **source** file with a clean changelog → `uncovered` carrying a new
+`uncommittedWork` field (the offending paths), fired BEFORE the committed-history check (an entry
+for committed work doesn't cover new uncommitted work — the #659 repro). Bookkeeping churn is
+excluded via the leading-dot-segment rule, and an uncommitted changelog edit still short-circuits
+to `covered`. `ai-content` renders the uncommitted-work block with its own message (the commit
+renderer's `sha.slice()` would throw on the null-sha rows). Boundary: changelog-coverage →
+ai-content contract, single consumer updated + tested. Full suite 4702 pass / 0 fail. Two
+pre-#659 tests that encoded the reverted-gap contract were updated to the new (ratified) contract,
+preserving their bookkeeping-exclusion assertions.
+
 ## 2026-07-22: Heal aged dangling FEATURES.md citations at wrap instead of stranding (#640)
 
 <!-- prawduct: type=bugfix | scope=wrap-640 | status=shipped -->

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -48,8 +48,12 @@ for committed work doesn't cover new uncommitted work — the #659 repro). Bookk
 excluded via the leading-dot-segment rule, and an uncommitted changelog edit still short-circuits
 to `covered`. `ai-content` renders the uncommitted-work block with its own message (the commit
 renderer's `sha.slice()` would throw on the null-sha rows). Boundary: changelog-coverage →
-ai-content contract, single consumer updated + tested. Full suite 4702 pass / 0 fail. Two
-pre-#659 tests that encoded the reverted-gap contract were updated to the new (ratified) contract,
+ai-content contract, single consumer updated + tested. Also catches an UNTRACKED new source file
+(Critic-caught): `_dirtyPaths` now unions `git ls-files --others --exclude-standard` with the
+modified-tracked set, since `git add -A` sweeps untracked files too and `git diff HEAD` never
+lists them — a brand-new source file is the most common new work. Full suite green, 0 fail
+(4705 TAP subtests / 2462 JUnit cases — reporter semantics, not deleted tests). Two pre-#659
+tests that encoded the reverted-gap contract were updated to the new (ratified) contract,
 preserving their bookkeeping-exclusion assertions.
 
 ## 2026-07-22: Heal aged dangling FEATURES.md citations at wrap instead of stranding (#640)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ All notable changes to TangleClaw are documented in this file.
   the version bump stranded on an unmerged branch. Commit body gains a
   `- Feature Index: pruned N dead stub(s)` audit line. (`lib/wrap-steps/features-toc.js`,
   `lib/wrap-steps/commit.js`)
+- Wrap changelog gate now catches uncommitted **work** that would ship unlogged (#659). The
+  coverage predicate previously judged only committed history and the changelog's own dirty
+  state, so a source file left uncommitted at wrap — which `git add -A` sweeps into the wrap's
+  own commit — shipped with no entry and the gate stayed quiet. It now classifies the dirty tree
+  with a shared source-file signal (`lib/wrap-steps/_source-paths.js`, extracted from
+  `features-toc` so the two can't drift): a dirty **source** file with a clean changelog →
+  `uncovered` (blocks, naming the files), while routine **bookkeeping** churn (`.prawduct/`,
+  `.tangleclaw/`, build output) is excluded — so the compliant sessions #645 unblocked stay
+  unblocked. An uncommitted changelog edit still short-circuits to covered.
+  (`lib/wrap-steps/changelog-coverage.js`, `lib/wrap-steps/ai-content.js`,
+  `lib/wrap-steps/_source-paths.js`, `lib/wrap-steps/features-toc.js`)
 
 ## [4.31.4] - 2026-07-22
 

--- a/lib/wrap-steps/_source-paths.js
+++ b/lib/wrap-steps/_source-paths.js
@@ -1,0 +1,94 @@
+'use strict';
+
+/**
+ * Shared "is this a source file?" classifier for wrap steps (#659).
+ *
+ * Two wrap steps need the same notion of a source file — as opposed to vendored
+ * code, build output, hidden/bookkeeping state, or a high-churn root doc:
+ *
+ *   - `features-toc` asks "is this path worth an index stub?" (its original home
+ *     for this logic, #207).
+ *   - `changelog-coverage` asks "is this dirty path *work* that must be logged, or
+ *     the bookkeeping a wrap routinely dirties?" — the discriminator that lets the
+ *     gate flag uncommitted work without re-blocking compliant sessions the way the
+ *     reverted #645 "any dirty file" rule did.
+ *
+ * Both are the same question, so the answer lives in ONE place. The leading-dot
+ * segment rule is load-bearing for the second caller: it excludes `.prawduct/…`
+ * and `.tangleclaw/…` bookkeeping without either needing to be enumerated as a
+ * prefix.
+ *
+ * @module lib/wrap-steps/_source-paths
+ */
+
+const path = require('node:path');
+
+/**
+ * Extension allowlist — narrow to source-ish files. Future widening belongs in
+ * this constant only, and both callers inherit it.
+ */
+const INDEXABLE_EXTENSIONS = new Set([
+  '.js', '.jsx', '.ts', '.tsx',
+  '.json', '.md', '.html', '.css',
+  '.yaml', '.yml', '.sh'
+]);
+
+/**
+ * Paths whose names match an indexable extension but whose change rate makes them
+ * poor source signals (a root changelog/readme/index changes on nearly every
+ * session). Matched against the basename. `CHANGELOG.md` is excluded here so the
+ * changelog file itself is never counted as unlogged *work* by the coverage gate —
+ * its own maintenance is judged by the gate's other routes.
+ */
+const EXCLUDED_BASENAMES = new Set([
+  'CHANGELOG.md',
+  'README.md',
+  'FEATURES.md'
+]);
+
+/**
+ * Prefix exclusions — applied to the full relative path. Anything rooted under one
+ * of these is not a source file (vendored, build output, git internals, TC state).
+ */
+const EXCLUDED_PREFIXES = [
+  'node_modules/',
+  'dist/',
+  'coverage/',
+  'build/',
+  '.git/',
+  '.tangleclaw/'
+];
+
+/**
+ * Decide whether a relative path is a source file. Applies the extension
+ * allowlist, prefix exclusions, basename exclusions, and a leading-dot-segment
+ * exclusion (top-level dotfiles + any path with a hidden directory in its chain,
+ * e.g. `.prawduct/change-log.md` or `foo/.cache/bar.js`).
+ *
+ * @param {string} relativePath
+ * @returns {boolean}
+ */
+function isSourceFile(relativePath) {
+  if (!relativePath || typeof relativePath !== 'string') return false;
+  for (const prefix of EXCLUDED_PREFIXES) {
+    if (relativePath.startsWith(prefix)) return false;
+  }
+  // Any leading-dot segment signals hidden / bookkeeping content — exclude
+  // defensively. This is what keeps `.prawduct/` and `.tangleclaw/` out for the
+  // coverage gate without enumerating every such directory.
+  for (const segment of relativePath.split('/')) {
+    if (segment.startsWith('.') && segment.length > 1) return false;
+  }
+  const ext = path.extname(relativePath).toLowerCase();
+  if (!INDEXABLE_EXTENSIONS.has(ext)) return false;
+  const base = path.basename(relativePath);
+  if (EXCLUDED_BASENAMES.has(base)) return false;
+  return true;
+}
+
+module.exports = {
+  INDEXABLE_EXTENSIONS,
+  EXCLUDED_BASENAMES,
+  EXCLUDED_PREFIXES,
+  isSourceFile
+};

--- a/lib/wrap-steps/ai-content.js
+++ b/lib/wrap-steps/ai-content.js
@@ -1012,6 +1012,23 @@ function _satisfactionPredicateGate(projectPath, step, paths) {
     // the two differ if a step declares a blank path, and a message naming a file
     // the gate never looked at would send the operator to the wrong place.
     const names = paths.join(', ');
+
+    // #659: an `uncovered` verdict has two shapes and they render differently. When
+    // it names uncommitted work (files that `git add -A` will sweep into this wrap's
+    // own commit with no entry) the rows are paths, not commits — the commit
+    // renderer below would throw on their null sha.
+    const uncommittedWork = Array.isArray(result.uncommittedWork) ? result.uncommittedWork : [];
+    if (uncommittedWork.length > 0) {
+      const listed = uncommittedWork.join('\n  - ');
+      return {
+        ok: false,
+        block: {
+          blocker: `${step.id}: ${names} is unchanged, and ${uncommittedWork.length} uncommitted work file(s) will ship in this wrap's commit with no entry`,
+          remediation: `These uncommitted files will be committed by this wrap with no ${names} entry:\n  - ${listed}\nWrite the entry into ${names} (an uncommitted entry counts, so it does not matter whether you write it now or the session writes it on retry), then Retry. If that work genuinely warrants no entry, tick "Skip & note" to record that decision.`
+        }
+      };
+    }
+
     const listed = result.uncovered
       .map((c) => `${c.sha.slice(0, 7)} ${c.subject}`)
       .join('\n  - ');

--- a/lib/wrap-steps/changelog-coverage.js
+++ b/lib/wrap-steps/changelog-coverage.js
@@ -375,32 +375,46 @@ function _parseRecord(chunk) {
 }
 
 /**
- * List tracked paths modified in the working tree relative to `HEAD`, staged or
- * not, as paths relative to `cwd`.
+ * List the paths the wrap's own `git add -A` will commit — modified tracked files
+ * AND untracked (non-ignored) files — as paths relative to `cwd`, deduped.
  *
- * `--relative` for the same reason the commit listing needs it: git reports
- * repository-root-relative paths by default, and a project rooted in a
- * subdirectory of its repo would then match none of its own declared paths.
+ * Both halves are needed because that is precisely the set the wrap sweeps into its
+ * own commit, which is the set the uncommitted-work check (#659) must judge. A NEW
+ * source file is the most common form of new work, and `git diff HEAD` never lists
+ * an untracked file (it has no `HEAD` version to differ from) — so the modified-only
+ * view missed exactly the case #659 exists to catch.
  *
- * Untracked files are deliberately excluded. A brand-new file has no `HEAD`
- * version to differ from, and a tree full of scratch files should not read as
- * unlogged work.
+ * - `git diff --name-only --relative HEAD` — modified tracked files. `--relative`
+ *   because git reports repository-root-relative paths by default, and a project
+ *   rooted in a subdirectory would then match none of its own declared paths.
+ * - `git ls-files --others --exclude-standard` — untracked files that are NOT
+ *   gitignored, i.e. exactly what `git add -A` would newly stage (a gitignored
+ *   scratch file is added by neither). Its output is already cwd-relative, so no
+ *   `--relative` flag is needed (nor accepted). The caller then filters this set
+ *   through `isSourceFile`, so genuine scratch that slips past `.gitignore` still
+ *   only counts when it is a source file.
  *
  * @param {string} cwd - Absolute project root.
  * @returns {string[]}
  */
 function _dirtyPaths(cwd) {
-  const stdout = _internal.execSync('git diff --name-only --relative HEAD', {
+  const opts = {
     cwd,
     encoding: 'utf8',
     timeout: GIT_EXEC_TIMEOUT_MS,
     maxBuffer: GIT_MAX_BUFFER_BYTES,
     stdio: ['ignore', 'pipe', 'ignore']
-  });
-  return String(stdout || '')
-    .split('\n')
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0);
+  };
+  const modified = _internal.execSync('git diff --name-only --relative HEAD', opts);
+  const untracked = _internal.execSync('git ls-files --others --exclude-standard', opts);
+  const out = new Set();
+  for (const stdout of [modified, untracked]) {
+    for (const line of String(stdout || '').split('\n')) {
+      const trimmed = line.trim();
+      if (trimmed.length > 0) out.add(trimmed);
+    }
+  }
+  return [...out];
 }
 
 /**

--- a/lib/wrap-steps/changelog-coverage.js
+++ b/lib/wrap-steps/changelog-coverage.js
@@ -40,14 +40,21 @@
  * block's remediation honest: writing the missing entry clears it, with no need to
  * commit first.
  *
- * **Known gap: work still uncommitted at wrap time is not judged.** It gets swept
- * into the wrap's own commit, which the next session's range starts after, so no
- * later run sees it either. Demanding an entry for any dirty file was tried and
- * reverted: a session dirties tracked bookkeeping files (`.prawduct/change-log.md`
- * on this repo) as a matter of course, so that rule blocked exactly the compliant
- * sessions #645 is about — the original defect in a narrower costume. The mutation
- * route still covers the case where the session edits the changelog during the
- * step. Tracked as a follow-up rather than closed with a rule that misfires.
+ * **Uncommitted work IS judged, by kind (#659).** Work left uncommitted at wrap is
+ * swept into the wrap's own commit by `git add -A`, and the next session's range
+ * starts after that commit — so if it isn't caught here, it ships unlogged forever.
+ * Demanding an entry for *any* dirty file was tried and reverted (#645): a session
+ * dirties tracked bookkeeping files (`.prawduct/change-log.md` on this repo) as a
+ * matter of course, so that rule blocked exactly the compliant sessions this
+ * predicate exists to unblock. The fix is to tell work from bookkeeping: a dirty
+ * path counts as unlogged work only when the shared source-file classifier
+ * (`./_source-paths` `isSourceFile`) says so, which excludes `.prawduct/`,
+ * `.tangleclaw/`, build output, and the changelog/readme themselves. When such work
+ * is dirty and the changelog is not, the verdict is `uncovered` with the offending
+ * paths in `uncommittedWork` — and this check runs BEFORE the committed-history one,
+ * because an entry logged for the session's committed work does not cover new
+ * uncommitted work. A dirty changelog still short-circuits to `covered` above, so a
+ * mid-edit session is never caught.
  *
  * **Why not match issue references.** The obvious predicate — every commit's `#N`
  * appears under `[Unreleased]` — does not survive contact with real history. A
@@ -72,6 +79,7 @@ const { execSync } = require('node:child_process');
 const { createLogger } = require('../logger');
 const store = require('../store');
 const gitRange = require('./_git-range');
+const { isSourceFile } = require('./_source-paths');
 
 const log = createLogger('wrap-steps:changelog-coverage');
 
@@ -132,12 +140,13 @@ const VERDICTS = Object.freeze({
  *   satisfy coverage (e.g. a per-package nested changelog). Purely additive:
  *   omitting them, or passing a non-array, leaves exact-match behavior unchanged.
  *   Grammar in {@link _globToRegExp}.
- * @returns {{verdict:string, uncovered:Array<{sha:string, subject:string}>, checkedCount:number, range:(string|null), reason:(string|null)}}
- *   `verdict` is one of `covered` | `uncovered` | `unavailable`. `uncovered` is
- *   empty when covered; on an `uncovered` verdict it lists every judged commit,
- *   since none maintained the changelog. `checkedCount` is how many commits the
- *   verdict was computed over.
- *   `reason` explains an `unavailable` verdict and is null otherwise.
+ * @returns {{verdict:string, uncovered:Array<{sha:string, subject:string}>, uncommittedWork:string[], checkedCount:number, range:(string|null), reason:(string|null)}}
+ *   `verdict` is one of `covered` | `uncovered` | `unavailable`. On an `uncovered`
+ *   verdict EITHER `uncovered` lists every judged commit (none maintained the
+ *   changelog) OR `uncommittedWork` lists the dirty source files that will ship in
+ *   the wrap's own commit with no entry (#659) — never both; the other is empty.
+ *   Both are empty when covered. `checkedCount` is how many commits the verdict was
+ *   computed over. `reason` explains an `unavailable` verdict and is null otherwise.
  */
 function evaluate(projectPath, paths, coveragePaths) {
   const wanted = (Array.isArray(paths) ? paths : []).filter((p) => typeof p === 'string' && p.trim());
@@ -184,14 +193,12 @@ function evaluate(projectPath, paths, coveragePaths) {
   const isCovered = (f) => wantedSet.has(f) || globs.some((re) => re.test(f));
 
   // Committed history alone would miss an entry written earlier in the session but
-  // not yet committed, so the declared paths' working-tree state is read too.
-  //
-  // This reads the declared paths ONLY. Judging the rest of the dirty tree — the
-  // symmetric "uncommitted work with no entry is unlogged" rule — was implemented
-  // and reverted: a session dirties tracked bookkeeping files as a matter of
-  // course, so it blocked the compliant sessions this predicate exists to unblock.
-  // Do not re-add it without a way to tell work from bookkeeping (see #659 and the
-  // module header). This is not an oversight to be tidied up.
+  // not yet committed, so the working-tree state is read too. `declaredDirty` below
+  // (the changelog itself) satisfies coverage; the rest of the dirty tree is judged
+  // by kind for the uncommitted-work check (#659) — a source file counts as unlogged
+  // work, tracked bookkeeping does not. The classifier is the shared `isSourceFile`,
+  // which is what keeps the reverted #645 "any dirty file" false-block from
+  // returning (see the module header).
   let dirty;
   try {
     dirty = _dirtyPaths(projectPath);
@@ -208,7 +215,33 @@ function evaluate(projectPath, paths, coveragePaths) {
       range, declaredDirty
     });
     return {
-      verdict: VERDICTS.COVERED, uncovered: [], checkedCount: 0, range, reason: null
+      verdict: VERDICTS.COVERED, uncovered: [], uncommittedWork: [], checkedCount: 0, range, reason: null
+    };
+  }
+
+  // #659: uncommitted WORK is swept into the wrap's own commit by `git add -A`. The
+  // changelog is not being maintained for it here — declaredDirty was empty, so the
+  // changelog file is not dirty — which means that work ships unlogged. Classify the
+  // dirty set with the shared source-file signal so a wrap's routine bookkeeping
+  // churn (`.prawduct/`, `.tangleclaw/`, build output) is NOT mistaken for work:
+  // that misclassification is exactly what forced the revert of the first "any dirty
+  // file" rule (#645). This precedes the committed-history check on purpose — an
+  // entry logged for the session's COMMITTED work does not cover NEW uncommitted
+  // work, so dirty work must block even when an earlier commit touched the changelog
+  // (the #659 repro). An uncommitted changelog edit still wins via declaredDirty
+  // above, so a mid-edit session is never caught here.
+  const dirtyWork = dirty.filter(isSourceFile);
+  if (dirtyWork.length > 0) {
+    log.warn('changelog coverage incomplete — uncommitted work with no changelog entry', {
+      range, dirtyWork
+    });
+    return {
+      verdict: VERDICTS.UNCOVERED,
+      uncovered: [],
+      uncommittedWork: dirtyWork,
+      checkedCount: 0,
+      range,
+      reason: null
     };
   }
 
@@ -237,7 +270,7 @@ function evaluate(projectPath, paths, coveragePaths) {
   // predicate only confirms the changelog was maintained at all.
   if (checkable.some((c) => c.files.some(isCovered))) {
     log.info('changelog coverage satisfied', { range, checkedCount });
-    return { verdict: VERDICTS.COVERED, uncovered: [], checkedCount, range, reason: null };
+    return { verdict: VERDICTS.COVERED, uncovered: [], uncommittedWork: [], checkedCount, range, reason: null };
   }
 
   // No judged commit touched the changelog and no uncommitted edit maintains it —
@@ -249,7 +282,7 @@ function evaluate(projectPath, paths, coveragePaths) {
     checkedCount,
     coveragePaths: globSources
   });
-  return { verdict: VERDICTS.UNCOVERED, uncovered, checkedCount, range, reason: null };
+  return { verdict: VERDICTS.UNCOVERED, uncovered, uncommittedWork: [], checkedCount, range, reason: null };
 }
 
 /**
@@ -265,7 +298,7 @@ function _unavailable(reason, range) {
   // where the operator gets the old mutation blocker with no sign the predicate
   // ran. Silent abstention is indistinguishable from the feature not existing.
   log.info('changelog coverage unavailable — falling back to the mutation check', { reason, range });
-  return { verdict: VERDICTS.UNAVAILABLE, uncovered: [], checkedCount: 0, range, reason };
+  return { verdict: VERDICTS.UNAVAILABLE, uncovered: [], uncommittedWork: [], checkedCount: 0, range, reason };
 }
 
 /**

--- a/lib/wrap-steps/features-toc.js
+++ b/lib/wrap-steps/features-toc.js
@@ -109,42 +109,24 @@ const { createLogger } = require('../logger');
 const store = require('../store');
 const { makePathTokenRegex } = require('../path-tokens');
 const gitRange = require('./_git-range');
+// Source-file classifier shared with `changelog-coverage` (#659) — one source of
+// truth for "is this a source file vs vendored/build/bookkeeping" so the two
+// callers' notions can't drift. Re-exported below under this module's historical
+// names to keep its public surface (and its tests) unchanged.
+const {
+  INDEXABLE_EXTENSIONS,
+  EXCLUDED_BASENAMES,
+  EXCLUDED_PREFIXES,
+  isSourceFile
+} = require('./_source-paths');
 
 const log = createLogger('wrap-step-features-toc');
 
 const FEATURES_FILENAME = 'FEATURES.md';
 
-// Extension allowlist — narrow to source-ish files. Future widening
-// belongs in this constant only.
-const INDEXABLE_EXTENSIONS = new Set([
-  '.js', '.jsx', '.ts', '.tsx',
-  '.json', '.md', '.html', '.css',
-  '.yaml', '.yml', '.sh'
-]);
-
-// Paths whose names match an indexable extension but whose change
-// rate makes them poor feature pointers. Matched against the
-// basename of each diff entry.
-// LICENSE has no extension so the allowlist check rejects it before we
-// reach this set — basename matches here are only meaningful for paths
-// that survived the extension check.
-const EXCLUDED_BASENAMES = new Set([
-  'CHANGELOG.md',
-  'README.md',
-  FEATURES_FILENAME
-]);
-
-// Prefix exclusions — applied to the full relative path. Anything
-// rooted under one of these prefixes is dropped before drift
-// detection.
-const EXCLUDED_PREFIXES = [
-  'node_modules/',
-  'dist/',
-  'coverage/',
-  'build/',
-  '.git/',
-  '.tangleclaw/'
-];
+// `INDEXABLE_EXTENSIONS`, `EXCLUDED_BASENAMES`, `EXCLUDED_PREFIXES` are imported
+// from `./_source-paths` (the shared source-file classifier, #659) and re-exported
+// unchanged below. Widen the allowlist there, not here.
 
 // #640 dangling-citation heal. An auto-stubbed TODO section heading and the
 // literal stub-entry line this step writes (see `_appendTodoSection`), plus a
@@ -624,29 +606,15 @@ function _diffNameOnly(cwd, range) {
 }
 
 /**
- * Decide whether a relative path is worth indexing. Applies the
- * extension allowlist, prefix exclusions, basename exclusions, and a
- * leading-dot-segment exclusion (top-level dotfiles + any path with
- * a hidden directory in its chain).
+ * Decide whether a relative path is worth indexing — delegates to the shared
+ * source-file classifier (`./_source-paths` `isSourceFile`, #659). Kept as a named
+ * function so this module's historical export and its tests are unchanged.
  *
  * @param {string} relativePath
  * @returns {boolean}
  */
 function _isIndexableCandidate(relativePath) {
-  if (!relativePath || typeof relativePath !== 'string') return false;
-  for (const prefix of EXCLUDED_PREFIXES) {
-    if (relativePath.startsWith(prefix)) return false;
-  }
-  // Any leading-dot segment in the path (e.g. `foo/.cache/bar.js`)
-  // signals hidden content — exclude defensively.
-  for (const segment of relativePath.split('/')) {
-    if (segment.startsWith('.') && segment.length > 1) return false;
-  }
-  const ext = path.extname(relativePath).toLowerCase();
-  if (!INDEXABLE_EXTENSIONS.has(ext)) return false;
-  const base = path.basename(relativePath);
-  if (EXCLUDED_BASENAMES.has(base)) return false;
-  return true;
+  return isSourceFile(relativePath);
 }
 
 /**

--- a/test/wrap-changelog-coverage.test.js
+++ b/test/wrap-changelog-coverage.test.js
@@ -328,21 +328,40 @@ describe('changelog-coverage — evaluate()', () => {
     assert.equal(cov.evaluate('/p', PATHS).verdict, cov.VERDICTS.COVERED);
   });
 
-  it('does NOT demand an entry merely because other files are dirty', () => {
-    // Tried and reverted: a session dirties tracked bookkeeping files as a matter
-    // of course (`.prawduct/change-log.md` on this repo), so blocking on any dirty
-    // file blocked exactly the compliant sessions #645 is about. Uncommitted work
-    // is a documented gap, not a thing to block on.
+  it('does NOT demand an entry when only bookkeeping files are dirty (#645 stays fixed)', () => {
+    // A wrap dirties tracked bookkeeping (`.prawduct/change-log.md`) as a matter of
+    // course; classifying it as work would re-block exactly the compliant sessions
+    // #645 is about. Only source files count as unlogged work (#659).
     scenario([{ sha: 'aaa1111', subject: 'Logged work (#1)', files: ['CHANGELOG.md'] }],
-      ['.prawduct/change-log.md', 'lib/a.js']);
+      ['.prawduct/change-log.md']);
     assert.equal(cov.evaluate('/p', PATHS).verdict, cov.VERDICTS.COVERED);
   });
 
-  it('stays UNAVAILABLE with no commits, dirty tree or not', () => {
+  it('DOES demand an entry when uncommitted source work is dirty and the changelog is clean (#659)', () => {
+    // The work will be swept into the wrap's own commit; an entry logged for the
+    // session's COMMITTED work does not cover it, so this blocks even though a
+    // committed commit touched the changelog. Bookkeeping dirt is excluded.
+    scenario([{ sha: 'aaa1111', subject: 'Logged work (#1)', files: ['CHANGELOG.md'] }],
+      ['.prawduct/change-log.md', 'lib/a.js']);
+    const out = cov.evaluate('/p', PATHS);
+    assert.equal(out.verdict, cov.VERDICTS.UNCOVERED);
+    assert.deepEqual(out.uncommittedWork, ['lib/a.js'], 'names the work, excludes the bookkeeping');
+    assert.deepEqual(out.uncovered, [], 'an uncommitted-work verdict does not populate the commit list');
+  });
+
+  it('with no commits: UNAVAILABLE when the tree is clean or only bookkeeping is dirty', () => {
     scenario([], []);
     assert.equal(cov.evaluate('/p', PATHS).verdict, cov.VERDICTS.UNAVAILABLE);
+    scenario([], ['.prawduct/change-log.md']);
+    assert.equal(cov.evaluate('/p', PATHS).verdict, cov.VERDICTS.UNAVAILABLE,
+      'bookkeeping-only dirt is not unlogged work');
+  });
+
+  it('with no commits but dirty source work: UNCOVERED — the work ships unlogged (#659)', () => {
     scenario([], ['lib/a.js']);
-    assert.equal(cov.evaluate('/p', PATHS).verdict, cov.VERDICTS.UNAVAILABLE);
+    const out = cov.evaluate('/p', PATHS);
+    assert.equal(out.verdict, cov.VERDICTS.UNCOVERED);
+    assert.deepEqual(out.uncommittedWork, ['lib/a.js']);
   });
 
   it('exempts a commit that touched nothing IN SCOPE — a subdir project\'s sibling-only commit', () => {
@@ -494,8 +513,14 @@ describe('changelog-coverage — against this repository\'s real history', () =>
       // counted. Demand a judged commit only when the verdict came from committed
       // history. The real-git-parsing guarantee this suite exists for is pinned
       // independently by the next test, over `_listCommits` directly.
-      const fromDirtyShortCircuit = out.verdict === cov.VERDICTS.COVERED && out.checkedCount === 0;
-      if (!fromDirtyShortCircuit) {
+      // Two working-tree short-circuits legitimately judge zero commits: a dirty
+      // declared path → COVERED, and dirty uncommitted source work → UNCOVERED
+      // (#659, which is exactly the state this suite runs in during active
+      // development). Demand a judged commit only for a committed-history verdict.
+      const fromWorkingTreeShortCircuit =
+        (out.verdict === cov.VERDICTS.COVERED && out.checkedCount === 0) ||
+        (out.verdict === cov.VERDICTS.UNCOVERED && out.uncommittedWork.length > 0);
+      if (!fromWorkingTreeShortCircuit) {
         assert.ok(out.checkedCount > 0, 'a committed-history verdict must have judged something');
       }
     }

--- a/test/wrap-changelog-coverage.test.js
+++ b/test/wrap-changelog-coverage.test.js
@@ -184,10 +184,11 @@ describe('changelog-coverage — evaluate()', () => {
    *
    * @param {Array<{sha:string, subject:string, files?:string[], parents?:string}>} records
    */
-  function scenario(records, dirty = []) {
+  function scenario(records, dirty = [], untracked = []) {
     cov._internal.execSync = (cmd) => {
       if (cmd.startsWith('git log')) return gitLog(records);
       if (cmd.startsWith('git diff')) return dirty.join('\n');
+      if (cmd.startsWith('git ls-files')) return untracked.join('\n');
       return '';
     };
   }
@@ -364,6 +365,30 @@ describe('changelog-coverage — evaluate()', () => {
     assert.deepEqual(out.uncommittedWork, ['lib/a.js']);
   });
 
+  it('catches an UNTRACKED new source file that git add -A will commit unlogged (#659)', () => {
+    // `git diff HEAD` never lists an untracked file, but the wrap's `git add -A`
+    // commits it. A brand-new file is the most common form of new work — the
+    // modified-only view missed exactly this class.
+    scenario([], [], ['lib/brand-new.js']);
+    const out = cov.evaluate('/p', PATHS);
+    assert.equal(out.verdict, cov.VERDICTS.UNCOVERED);
+    assert.deepEqual(out.uncommittedWork, ['lib/brand-new.js']);
+  });
+
+  it('does not count an untracked bookkeeping file as work', () => {
+    scenario([{ sha: 'aaa1111', subject: 'Logged (#1)', files: ['CHANGELOG.md'] }],
+      [], ['.prawduct/scratch.md']);
+    assert.equal(cov.evaluate('/p', PATHS).verdict, cov.VERDICTS.COVERED,
+      'untracked bookkeeping is excluded by the leading-dot rule');
+  });
+
+  it('an untracked (brand-new) CHANGELOG satisfies coverage via the dirty route', () => {
+    scenario([{ sha: 'aaa1111', subject: 'work (#1)', files: ['lib/a.js'] }],
+      [], ['CHANGELOG.md']);
+    assert.equal(cov.evaluate('/p', PATHS).verdict, cov.VERDICTS.COVERED,
+      'a brand-new dirty changelog is the changelog being maintained');
+  });
+
   it('exempts a commit that touched nothing IN SCOPE — a subdir project\'s sibling-only commit', () => {
     // With --relative, a commit touching only paths outside the project root parses
     // with an empty file list. It is not the project's concern, and must not read as
@@ -435,10 +460,11 @@ describe('changelog-coverage — coverage globs (nested changelogs)', () => {
   });
   afterEach(() => { Object.assign(cov._internal, saved); });
 
-  function scenario(records, dirty = []) {
+  function scenario(records, dirty = [], untracked = []) {
     cov._internal.execSync = (cmd) => {
       if (cmd.startsWith('git log')) return gitLog(records);
       if (cmd.startsWith('git diff')) return dirty.join('\n');
+      if (cmd.startsWith('git ls-files')) return untracked.join('\n');
       return '';
     };
   }

--- a/test/wrap-step-ai-content.test.js
+++ b/test/wrap-step-ai-content.test.js
@@ -871,6 +871,29 @@ describe('wrap-step ai-content — D6 verifyChanged file-edit gate', () => {
       assert.doesNotMatch(res.blockers[0], /byte-identical/, 'must not report the mutation cause');
     });
 
+    it('BLOCKS with the uncommitted-work message when dirty work will ship unlogged (#659)', async () => {
+      // The uncovered verdict here carries `uncommittedWork` (paths), not commits.
+      // The rows have no sha, so the commit renderer's `c.sha.slice(0,7)` would
+      // throw — a clean blocker string proves the dedicated branch handled it.
+      aic._internal.readForVerify = () => 'identical content';
+      aic._internal.changelogCoverage = () => ({
+        verdict: 'uncovered',
+        uncovered: [],
+        uncommittedWork: ['lib/foo.js', 'test/foo.test.js'],
+        checkedCount: 0,
+        range: 'abc..HEAD',
+        reason: null
+      });
+      const res = await aic.run(coverageCtx());
+      assert.equal(res.ok, false);
+      assert.equal(res.status, 'blocked');
+      assert.match(res.blockers[0], /2 uncommitted work file\(s\) will ship in this wrap's commit with no entry/);
+      assert.match(res.blockers[0], /CHANGELOG\.md/);
+      assert.match(res.output.remediation, /lib\/foo\.js/, 'names the offending files');
+      assert.match(res.output.remediation, /test\/foo\.test\.js/);
+      assert.doesNotMatch(res.blockers[0], /undefined/, 'the null-sha commit renderer never ran');
+    });
+
     it('tells the operator that WRITING THE ENTRY clears the block', async () => {
       // The remediation must name the action that actually clears it. Writing the
       // entry works through either route — during the retry turn it trips the

--- a/test/wrap-step-source-paths.test.js
+++ b/test/wrap-step-source-paths.test.js
@@ -1,0 +1,80 @@
+'use strict';
+
+/**
+ * Tests for the shared source-file classifier (#659) — the single source of truth
+ * `features-toc` (indexing) and `changelog-coverage` (uncommitted-work detection)
+ * both rely on. The load-bearing property for the second caller is that tracked
+ * bookkeeping (`.prawduct/…`) is NOT a source file, so the gate can flag real work
+ * without re-introducing the reverted #645 false-block.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  isSourceFile,
+  INDEXABLE_EXTENSIONS,
+  EXCLUDED_BASENAMES,
+  EXCLUDED_PREFIXES
+} = require('../lib/wrap-steps/_source-paths');
+
+describe('_source-paths — isSourceFile', () => {
+  it('accepts ordinary source files across the indexable extensions', () => {
+    for (const p of ['lib/a.js', 'src/b.ts', 'public/app.jsx', 'x/y.tsx',
+      'data/c.json', 'docs/d.md', 'p/e.html', 's/f.css', 'k/g.yaml', 'k/h.yml', 'scripts/i.sh']) {
+      assert.equal(isSourceFile(p), true, `${p} should be a source file`);
+    }
+  });
+
+  it('rejects tracked bookkeeping via the leading-dot-segment rule (keeps #645 fixed)', () => {
+    assert.equal(isSourceFile('.prawduct/change-log.md'), false);
+    assert.equal(isSourceFile('.tangleclaw/memories/MEMORY.md'), false);
+    assert.equal(isSourceFile('foo/.cache/bar.js'), false, 'a hidden dir anywhere in the chain excludes');
+    assert.equal(isSourceFile('.github/workflows/ci.yml'), false, 'a leading-dot top segment excludes');
+  });
+
+  it('rejects vendored / build output via the prefix list', () => {
+    assert.equal(isSourceFile('node_modules/pkg/index.js'), false);
+    assert.equal(isSourceFile('dist/bundle.js'), false);
+    assert.equal(isSourceFile('coverage/lcov.js'), false);
+    assert.equal(isSourceFile('build/out.js'), false);
+  });
+
+  it('rejects the high-churn root docs by basename (changelog/readme/index are not "work")', () => {
+    assert.equal(isSourceFile('CHANGELOG.md'), false);
+    assert.equal(isSourceFile('README.md'), false);
+    assert.equal(isSourceFile('FEATURES.md'), false);
+  });
+
+  it('rejects non-indexable extensions and extensionless paths', () => {
+    assert.equal(isSourceFile('data/schema.sql'), false);
+    assert.equal(isSourceFile('docs/logo.png'), false);
+    assert.equal(isSourceFile('LICENSE'), false);
+    assert.equal(isSourceFile('bin/tool'), false);
+  });
+
+  it('is defensive about non-string / empty input', () => {
+    assert.equal(isSourceFile(''), false);
+    assert.equal(isSourceFile(null), false);
+    assert.equal(isSourceFile(undefined), false);
+    assert.equal(isSourceFile(42), false);
+  });
+
+  it('exposes the constants it classifies with', () => {
+    assert.ok(INDEXABLE_EXTENSIONS.has('.js'));
+    assert.ok(EXCLUDED_BASENAMES.has('CHANGELOG.md'));
+    assert.ok(EXCLUDED_PREFIXES.includes('node_modules/'));
+  });
+});
+
+describe('_source-paths — shared with features-toc (no drift)', () => {
+  it('features-toc._isIndexableCandidate is the same classifier', () => {
+    const featuresToc = require('../lib/wrap-steps/features-toc');
+    // Same instance re-exported, and same verdicts — the whole point of the extraction.
+    assert.equal(featuresToc.INDEXABLE_EXTENSIONS, INDEXABLE_EXTENSIONS);
+    assert.equal(featuresToc.EXCLUDED_PREFIXES, EXCLUDED_PREFIXES);
+    for (const p of ['lib/a.js', '.prawduct/x.md', 'node_modules/y.js', 'CHANGELOG.md', 'data/z.sql']) {
+      assert.equal(featuresToc._isIndexableCandidate(p), isSourceFile(p), `mismatch on ${p}`);
+    }
+  });
+});


### PR DESCRIPTION
## What
The wrap `changelog-update` gate's coverage predicate now catches uncommitted **work** that `git add -A` sweeps into the wrap's own commit and ships unlogged. Previously it judged only committed history and the changelog's own dirty state, so a source file left uncommitted at wrap shipped with no entry and the gate stayed quiet (`covered`).

It now classifies the dirty tree with a **shared source-file signal** (`lib/wrap-steps/_source-paths.js`, extracted from `features-toc` so the two can't drift):
- A dirty **source** file with a clean changelog → `uncovered` (blocks, naming the files via a new `uncommittedWork` field).
- Routine **bookkeeping** churn (`.prawduct/`, `.tangleclaw/`, build output) is excluded via the leading-dot-segment rule — so the compliant sessions #645 unblocked stay unblocked (the reverted "any dirty file" rule's false-block does not return).
- An uncommitted **changelog** edit still short-circuits to `covered`.
- The check fires **before** the committed-history route (an entry logged for committed work doesn't cover new uncommitted work — the issue's exact repro).

Dirty set = modified-tracked **∪ untracked-non-ignored** (`git ls-files --others --exclude-standard`), because `git add -A` commits untracked new files too and `git diff HEAD` never lists them (a brand-new source file is the most common new work).

## Why
`changelog-coverage` is the second satisfaction route for the `changelog-update` gate. Its known gap (documented in the module) let real work ship unlogged. The naive fix was reverted (#645); the real fix needed a way to tell work from bookkeeping — now the shared `isSourceFile`. Fixes #659.

## Test plan
- New `_source-paths.js` unit suite (source vs vendored/build/bookkeeping/leading-dot/basename/extension).
- `changelog-coverage`: dirty work + clean changelog → uncovered; bookkeeping-only → covered; dirty changelog wins; untracked new source → uncovered; untracked bookkeeping excluded; untracked brand-new CHANGELOG satisfies.
- `ai-content`: renders the uncommitted-work block (null-sha safe — the commit renderer's `sha.slice()` can't run).
- Two pre-#659 tests that encoded the reverted-gap contract updated to the new (ratified) contract, preserving their bookkeeping-exclusion assertions.
- Full suite: **4705 pass / 0 fail / 1 skipped**.

## Review
- Critic `cumulative`: 0 blocking / 1 warning (untracked new source files escape) / 1 note → warning fixed (`git ls-files` union) + note reconciled; `verify-resolutions`: 0/0/0.
- Independent PR reviewer: 0/0/0.