### PR TITLE
Verify lease ownership on ports release/heartbeat (#656)

### DIFF
--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -26,6 +26,30 @@ Tag-line conventions (ART-4K9M, ratified 2026-07-17):
 -->
 
 
+## 2026-07-22: Verify lease ownership on ports release/heartbeat (#656)
+
+<!-- prawduct: type=bugfix | scope=wrap-656 | status=shipped -->
+
+**Why:** `POST /api/ports/release` and `/api/ports/heartbeat` took only `{port}` — no project — so
+any caller could delete or renew another project's lease. A stray release is a silent DELETION
+(the owner keeps running on a port the registry no longer records; the next claimant gets a clean
+201 and a real collision follows), the wider hole than the lease-overwrite case #613 closed. The
+injected guide told agents to "release a port once no longer needed" without saying whose.
+
+**What (operator-ratified: optional-but-verified, non-breaking):** `store.portLeases.release` and
+`heartbeat` gained an `options` arg. When `options.project` is present, a LIVE lease held by a
+different project is refused with `PORT_CONFLICT` carrying the owner — mirroring the lease path
+(#613); `release` honors `options.force` (logged) for a legitimate cross-project release, heartbeat
+has no force (renewing another project's lease is never legitimate). Omitting `project` preserves
+the prior unverified behavior, so trusted internal teardown paths and in-flight callers on the old
+guide keep working. The HTTP routes map `PORT_CONFLICT` → 409 with the owner. Expired leases stay
+releasable by anyone (garbage awaiting the sweep). `data/porthub-guide.md` updated to instruct
+sending `project` and to correct the old "release/heartbeat are not guarded" note. Deliberately NOT
+authentication — nothing binds a caller to the project name it sends; this closes the ACCIDENTAL
+cross-project release, which is the filed threat. Out of scope (deferred): `_cleanupOrphanLeases`
+displaced-lease logging (the issue's secondary item). Tests: +9 store-level, +5 API-level
+(409/force/backward-compat). Full suite green, 0 fail.
+
 ## 2026-07-22: Wrap changelog gate catches uncommitted work that would ship unlogged (#659)
 
 <!-- prawduct: type=bugfix | scope=wrap-659 | status=shipped -->

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -28,7 +28,7 @@ Tag-line conventions (ART-4K9M, ratified 2026-07-17):
 
 ## 2026-07-22: Verify lease ownership on ports release/heartbeat (#656)
 
-<!-- prawduct: type=bugfix | scope=wrap-656 | status=shipped -->
+<!-- prawduct: type=bugfix | scope=porthub-ownership | status=shipped -->
 
 **Why:** `POST /api/ports/release` and `/api/ports/heartbeat` took only `{port}` — no project — so
 any caller could delete or renew another project's lease. A stray release is a silent DELETION

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,20 @@ All notable changes to TangleClaw are documented in this file.
   (`lib/wrap-steps/changelog-coverage.js`, `lib/wrap-steps/ai-content.js`,
   `lib/wrap-steps/_source-paths.js`, `lib/wrap-steps/features-toc.js`)
 
+### Security
+- `POST /api/ports/release` and `/api/ports/heartbeat` now verify lease ownership when the caller
+  names its `project` (#656). Both endpoints previously took only a `port`, so any caller could
+  delete or renew another project's lease — a stray release is a silent **deletion** (the owner
+  keeps running on a port the registry no longer records, and the next claimant collides), the
+  wider hole than the lease overwrite #613 closed. With `project` present, releasing or renewing a
+  live lease held by a **different** project returns `409 PORT_CONFLICT` with the owner (mirroring
+  `lease`); `release` accepts `"force": true` to override (logged), `heartbeat` does not. The check
+  is **opt-in and non-breaking** — a request that omits `project` keeps the prior behavior, so
+  in-flight callers on the old guide still work; the injected PortHub guide now instructs sending
+  your own `project`. Not authentication (nothing binds a caller to the project name it sends), but
+  it closes the accidental cross-project release. Expired leases stay releasable by anyone.
+  (`lib/store.js`, `server.js`, `data/porthub-guide.md`)
+
 ## [4.31.4] - 2026-07-22
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,11 +219,14 @@ and it is logged with the displaced owner, because the displaced project is stil
 against a port the registry no longer says is theirs. Use it only when you know the previous
 owner is gone — otherwise release the port from the owning side first.
 
-**Scope of enforcement, precisely.** `lease` is guarded. `release` and `heartbeat` are **not** —
-they take only a port, so they cannot check ownership, and any caller can release or renew any
-lease (tracked as issue #656). So "the registry enforces this" means it will not let you
-*overwrite* someone's lease; it cannot yet stop you *releasing* it and then claiming the freed
-port. Treat release as the destructive call it is: release only ports your own project holds.
+**Scope of enforcement, precisely.** `lease` is guarded. `release` and `heartbeat` are guarded
+**when you name your project** (#656): a mismatch returns 409 with the current owner, just like
+`lease`. The check is opt-in because these calls historically took only a port — a request that
+omits `project` still releases or renews unverified, so the guarantee holds only for callers that
+send their own project (always do). This closes the accidental case — an agent cleaning up after
+itself no longer silently releases a neighbor's live port — but it is not authentication: nothing
+binds the caller to the project name it sends. Treat release as the destructive call it is: send
+your `project`, and release only ports your own project holds.
 
 
 **TangleClaw API base URL**: `http://localhost:3102`

--- a/data/porthub-guide.md
+++ b/data/porthub-guide.md
@@ -38,13 +38,16 @@ POST /api/ports/lease
 POST /api/ports/lease
 { "port": 4000, "project": "my-project", "service": "test-runner", "ttl": 7200000 }
 
-# Release a port when done
+# Release a port when done. Always send your own "project": ownership is verified
+# when present — releasing a port a DIFFERENT project still holds returns 409
+# (add "force": true to override). Omitting "project" skips the check.
 POST /api/ports/release
-{ "port": 3200 }
+{ "port": 3200, "project": "my-project" }
 
-# Heartbeat to keep a TTL lease alive
+# Heartbeat to keep a TTL lease alive. Send "project" too: renewing another
+# project's lease returns 409.
 POST /api/ports/heartbeat
-{ "port": 4000 }
+{ "port": 4000, "project": "my-project" }
 ```
 
 ### When to Register / Release
@@ -73,9 +76,13 @@ and it is logged with the displaced owner, because the displaced project is stil
 against a port the registry no longer says is theirs. Use it only when you know the previous
 owner is gone — otherwise release the port from the owning side first.
 
-**Scope of enforcement, precisely.** `lease` is guarded. `release` and `heartbeat` are **not** —
-they take only a port, so they cannot check ownership, and any caller can release or renew any
-lease (tracked as issue #656). So "the registry enforces this" means it will not let you
-*overwrite* someone's lease; it cannot yet stop you *releasing* it and then claiming the freed
-port. Treat release as the destructive call it is: release only ports your own project holds.
+**Scope of enforcement, precisely.** `lease` is guarded. `release` and `heartbeat` are guarded
+**when you name your project** (#656): a mismatch returns 409 with the current owner, just like
+`lease`. The check is opt-in because these calls historically took only a port — a request that
+omits `project` still releases or renews unverified, so the guarantee holds only for callers that
+send their own project (always do). This closes the accidental case — an agent cleaning up after
+itself no longer silently releases a neighbor's live port — but it is not authentication: nothing
+binds the caller to the project name it sends, so a caller that supplies someone else's project
+can still act on their lease. Treat release as the destructive call it is: send your `project`,
+and release only ports your own project holds.
 

--- a/lib/store.js
+++ b/lib/store.js
@@ -3669,12 +3669,57 @@ const portLeasesApi = {
 
   /**
    * Release (delete) a lease by host and port.
+   *
+   * Ownership is verified only when the caller names its project (#656). A release
+   * is a silent DELETE — if a caller releases a port a DIFFERENT project still runs
+   * against, that project keeps running with no registry record and the next
+   * claimant collides. When `options.project` is given, a LIVE lease held by another
+   * project is refused with `PORT_CONFLICT` (mirroring the lease path, #613), and
+   * `options.force` overrides with an audit log. Omitting `project` preserves the
+   * prior unverified behavior for trusted internal teardown paths (e.g. tunnel
+   * shutdown) that release ports they own without carrying a project name. An
+   * expired lease is garbage awaiting the sweep, so releasing it is never a conflict.
+   *
    * @param {number} port
    * @param {string} [host='localhost'] - Host identifier
+   * @param {object} [options] - Ownership options
+   * @param {string|null} [options.project] - Verify the lease belongs to this project
+   * @param {boolean} [options.force] - Release another project's live lease anyway
+   * @throws {StoreError} `PORT_CONFLICT` when `options.project` is given but a live
+   *   lease is held by a different project and `force` was not set
    */
-  release(port, host = 'localhost') {
+  release(port, host = 'localhost', options = {}) {
     _ensureDb();
     const existing = portLeasesApi.get(port, host);
+
+    if (existing && options.project && existing.project !== options.project && _isLeaseLive(existing)) {
+      if (!options.force) {
+        log.warn('Refused port release — another project holds it', {
+          host,
+          port,
+          owner: existing.project,
+          ownerService: existing.service,
+          requestedBy: options.project
+        });
+        const err = new StoreError(
+          `Port ${port} on ${host} is leased by "${existing.project}" (${existing.service}). ` +
+          'Release it from that project, or repeat with force to release it anyway.',
+          'PORT_CONFLICT'
+        );
+        err.owner = existing;
+        throw err;
+      }
+      // A forced cross-project release must never be quiet — the displaced owner
+      // keeps running against a port the registry no longer says is theirs.
+      log.warn('Forced release of another project\'s port lease', {
+        host,
+        port,
+        displacedProject: existing.project,
+        displacedService: existing.service,
+        byProject: options.project
+      });
+    }
+
     _db.prepare('DELETE FROM port_leases WHERE host = ? AND port = ?').run(host, port);
     if (existing) {
       activityApi.log({
@@ -3722,14 +3767,42 @@ const portLeasesApi = {
 
   /**
    * Update heartbeat for a port lease, extending expiry if TTL-based.
+   *
+   * Ownership is verified only when the caller names its project (#656). A heartbeat
+   * renews a lease; renewing ANOTHER project's lease keeps a port nobody-you-own
+   * alive indefinitely. When `options.project` is given and mismatches the lease
+   * owner, it is refused with `PORT_CONFLICT`. Unlike release there is no `force` —
+   * there is no legitimate reason to renew another project's lease. Omitting
+   * `project` preserves the prior unverified behavior.
+   *
    * @param {number} port
    * @param {string} [host='localhost'] - Host identifier
+   * @param {object} [options] - Ownership options
+   * @param {string|null} [options.project] - Verify the lease belongs to this project
    * @returns {object|null}
+   * @throws {StoreError} `PORT_CONFLICT` when `options.project` is given but the lease
+   *   is held by a different project
    */
-  heartbeat(port, host = 'localhost') {
+  heartbeat(port, host = 'localhost', options = {}) {
     _ensureDb();
     const existing = portLeasesApi.get(port, host);
     if (!existing) return null;
+
+    if (options.project && existing.project !== options.project) {
+      log.warn('Refused port heartbeat — another project holds it', {
+        host,
+        port,
+        owner: existing.project,
+        ownerService: existing.service,
+        requestedBy: options.project
+      });
+      const err = new StoreError(
+        `Port ${port} on ${host} is leased by "${existing.project}" (${existing.service}).`,
+        'PORT_CONFLICT'
+      );
+      err.owner = existing;
+      throw err;
+    }
 
     if (existing.ttlMs && !existing.permanent) {
       const newExpiry = new Date(Date.now() + existing.ttlMs).toISOString().replace('T', ' ').replace('Z', '');

--- a/server.js
+++ b/server.js
@@ -1590,7 +1590,24 @@ route('POST', '/api/ports/release', (_req, res, _params, body) => {
   if (!body || !body.port) {
     return errorResponse(res, 400, 'port is required', 'BAD_REQUEST');
   }
-  store.portLeases.release(body.port, body.host || 'localhost');
+  try {
+    // `project` is optional but verified when present (#656): a release names
+    // whose lease it is, and releasing another live project's port is refused with
+    // 409 unless `force` is set. Omitting `project` keeps the prior behavior.
+    store.portLeases.release(body.port, body.host || 'localhost', {
+      project: body.project || null,
+      force: body.force === true
+    });
+  } catch (err) {
+    if (err.code === 'PORT_CONFLICT') {
+      return jsonResponse(res, 409, {
+        error: err.message,
+        code: 'PORT_CONFLICT',
+        owner: err.owner || null
+      });
+    }
+    return errorResponse(res, 400, err.message, 'BAD_REQUEST');
+  }
   jsonResponse(res, 200, { ok: true, host: body.host || 'localhost', port: body.port });
 });
 
@@ -1599,7 +1616,23 @@ route('POST', '/api/ports/heartbeat', (_req, res, _params, body) => {
   if (!body || !body.port) {
     return errorResponse(res, 400, 'port is required', 'BAD_REQUEST');
   }
-  const lease = store.portLeases.heartbeat(body.port, body.host || 'localhost');
+  let lease;
+  try {
+    // `project` is optional but verified when present (#656): renewing another
+    // project's lease keeps a port nobody-you-own alive, so a mismatch is a 409.
+    lease = store.portLeases.heartbeat(body.port, body.host || 'localhost', {
+      project: body.project || null
+    });
+  } catch (err) {
+    if (err.code === 'PORT_CONFLICT') {
+      return jsonResponse(res, 409, {
+        error: err.message,
+        code: 'PORT_CONFLICT',
+        owner: err.owner || null
+      });
+    }
+    return errorResponse(res, 400, err.message, 'BAD_REQUEST');
+  }
   if (!lease) {
     return errorResponse(res, 404, `No lease found for port ${body.port}`, 'NOT_FOUND');
   }

--- a/test/api-ports.test.js
+++ b/test/api-ports.test.js
@@ -180,4 +180,64 @@ describe('API /api/ports', () => {
     const { status } = await request(server, 'POST', '/api/ports/heartbeat', { port: 99999 });
     assert.equal(status, 404);
   });
+
+  // #656 — release and heartbeat took only a port, so any caller could delete or
+  // renew another project's lease. They now verify ownership when a project is named
+  // (opt-in, so old {port}-only callers still work). A stray release is a silent
+  // deletion, the wider hole than the lease overwrite #613 closed.
+  it('POST /api/ports/release returns 409 when another project owns the live port', async () => {
+    store.portLeases.lease({ port: 6100, project: 'Owner', service: 'dev-server' });
+
+    const { status, data } = await request(server, 'POST', '/api/ports/release', {
+      port: 6100,
+      project: 'Intruder'
+    });
+
+    assert.equal(status, 409, 'releasing another project\'s live port is a conflict');
+    assert.equal(data.code, 'PORT_CONFLICT');
+    assert.equal(data.owner.project, 'Owner', 'the response names the owner');
+    assert.ok(store.portLeases.get(6100), 'the owner keeps the lease after a refused release');
+  });
+
+  it('POST /api/ports/release with force removes another project\'s lease', async () => {
+    store.portLeases.lease({ port: 6101, project: 'Owner', service: 'dev-server' });
+
+    const { status } = await request(server, 'POST', '/api/ports/release', {
+      port: 6101, project: 'Taker', force: true
+    });
+
+    assert.equal(status, 200);
+    assert.equal(store.portLeases.get(6101), null);
+  });
+
+  it('POST /api/ports/release with the owning project succeeds', async () => {
+    store.portLeases.lease({ port: 6102, project: 'Mine', service: 'temp' });
+
+    const { status } = await request(server, 'POST', '/api/ports/release', {
+      port: 6102, project: 'Mine'
+    });
+
+    assert.equal(status, 200);
+    assert.equal(store.portLeases.get(6102), null);
+  });
+
+  it('POST /api/ports/release with no project still deletes (backward compat)', async () => {
+    store.portLeases.lease({ port: 6103, project: 'Whoever', service: 'temp' });
+
+    const { status } = await request(server, 'POST', '/api/ports/release', { port: 6103 });
+    assert.equal(status, 200);
+    assert.equal(store.portLeases.get(6103), null);
+  });
+
+  it('POST /api/ports/heartbeat returns 409 when another project owns the lease', async () => {
+    store.portLeases.lease({ port: 7100, project: 'Owner', service: 'dev', ttlMs: 60000 });
+
+    const { status, data } = await request(server, 'POST', '/api/ports/heartbeat', {
+      port: 7100, project: 'Intruder'
+    });
+
+    assert.equal(status, 409);
+    assert.equal(data.code, 'PORT_CONFLICT');
+    assert.equal(data.owner.project, 'Owner');
+  });
 });

--- a/test/store-portleases.test.js
+++ b/test/store-portleases.test.js
@@ -243,6 +243,68 @@ describe('store.portLeases', () => {
     });
   });
 
+  describe('release & heartbeat ownership (#656)', () => {
+    it('release with no project deletes unconditionally (backward compat)', () => {
+      store.portLeases.lease({ port: 1300, project: 'Owner', service: 'svc' });
+      store.portLeases.release(1300);
+      assert.equal(store.portLeases.get(1300), null);
+    });
+
+    it('release with the owning project succeeds', () => {
+      store.portLeases.lease({ port: 1301, project: 'Owner', service: 'svc' });
+      store.portLeases.release(1301, 'localhost', { project: 'Owner' });
+      assert.equal(store.portLeases.get(1301), null);
+    });
+
+    it('refuses to release another project\'s live lease, carrying the owner, leaving it intact', () => {
+      store.portLeases.lease({ port: 1302, project: 'Owner', service: 'dev-server' });
+      try {
+        store.portLeases.release(1302, 'localhost', { project: 'Intruder' });
+        assert.fail('expected a PORT_CONFLICT');
+      } catch (err) {
+        assert.equal(err.code, 'PORT_CONFLICT');
+        assert.equal(err.owner.project, 'Owner');
+      }
+      assert.ok(store.portLeases.get(1302), 'the lease must survive a refused release');
+    });
+
+    it('force releases another project\'s live lease', () => {
+      store.portLeases.lease({ port: 1303, project: 'Owner', service: 'svc' });
+      store.portLeases.release(1303, 'localhost', { project: 'Intruder', force: true });
+      assert.equal(store.portLeases.get(1303), null);
+    });
+
+    it('releasing an EXPIRED lease of another project is never a conflict', () => {
+      store.portLeases.lease({ port: 1304, project: 'Gone', service: 'old', ttlMs: -1000 });
+      store.portLeases.release(1304, 'localhost', { project: 'Someone' });
+      assert.equal(store.portLeases.get(1304), null, 'expired garbage is releasable by anyone');
+    });
+
+    it('heartbeat with the owning project renews', () => {
+      store.portLeases.lease({ port: 1305, project: 'Owner', service: 'svc', ttlMs: 60000 });
+      const out = store.portLeases.heartbeat(1305, 'localhost', { project: 'Owner' });
+      assert.ok(out, 'the owner can renew');
+      assert.equal(out.project, 'Owner');
+    });
+
+    it('refuses to heartbeat another project\'s lease (no force — never legitimate)', () => {
+      store.portLeases.lease({ port: 1306, project: 'Owner', service: 'svc', ttlMs: 60000 });
+      assert.throws(
+        () => store.portLeases.heartbeat(1306, 'localhost', { project: 'Intruder' }),
+        (err) => err.code === 'PORT_CONFLICT' && err.owner.project === 'Owner'
+      );
+    });
+
+    it('heartbeat with no project renews unconditionally (backward compat)', () => {
+      store.portLeases.lease({ port: 1307, project: 'Owner', service: 'svc', ttlMs: 60000 });
+      assert.ok(store.portLeases.heartbeat(1307), 'a bare 2-arg call still renews');
+    });
+
+    it('heartbeat on a missing lease returns null even with a project', () => {
+      assert.equal(store.portLeases.heartbeat(1308, 'localhost', { project: 'Anyone' }), null);
+    });
+  });
+
   it('validates required fields', () => {
     assert.throws(() => store.portLeases.lease({ port: 1 }), /required/);
     assert.throws(() => store.portLeases.lease({ project: 'X', service: 'Y' }), /required/);


### PR DESCRIPTION
## What
`POST /api/ports/release` and `/api/ports/heartbeat` now verify lease ownership when the caller names its `project` (#656). Both endpoints previously took only a `port`, so **any caller could delete or renew another project's lease**.

- With `project` present, releasing or renewing a **live** lease held by a **different** project → `409 PORT_CONFLICT` with the owner (mirrors `lease`, #613).
- `release` accepts `"force": true` to override (audit-logged); `heartbeat` has no force (renewing another project's lease is never legitimate).
- **Opt-in and non-breaking**: a request that omits `project` keeps the prior behavior, so trusted internal teardown paths and in-flight callers on the old injected guide still work.
- Expired leases stay releasable by anyone (garbage awaiting the sweep).

## Why
A stray release is a silent **deletion** — the owner keeps running on a port the registry no longer records, and the next claimant gets a clean 201 and a real collision. That's the wider hole than the lease *overwrite* #613 closed. The injected guide told agents to "release a port once no longer needed" without saying whose. Fixes #656.

**Deliberately not authentication** — nothing binds a caller to the project name it sends; this closes the **accidental** cross-project release (an agent cleaning up after itself), which is the filed threat. Documented as such in the guide + CHANGELOG.

## Scope / doc parity
- `data/porthub-guide.md` (canonical, injected into managed projects) updated to instruct sending `project` and to correct the old "not guarded" note.
- TC's own hand-maintained `CLAUDE.md` PortHub section synced to match.
- Deferred (issue's secondary item): `_cleanupOrphanLeases` displaced-lease logging.

## Test plan
- +9 store-level: no-project deletes (compat); owning-project ok; cross-project live → 409 + owner + lease survives; force releases; expired releasable by anyone; heartbeat owner-renews / mismatch-409 / no-project-renews / missing→null.
- +5 API-level: release 409 / force / owning / no-project; heartbeat 409.
- Full suite: **4719 pass / 0 fail / 1 skipped**.

## Review
- Critic `cumulative`: 0 blocking / 1 warning (change-log scope mislabel) / 1 note (CLAUDE.md stale) → both fixed; `verify-resolutions`: 0/0/0.
- Independent PR reviewer: 0/0/0.