### PR TITLE
Include the skip rollup in the wrap drawer Copy report (#693)

### DIFF
--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -26,6 +26,24 @@ Tag-line conventions (ART-4K9M, ratified 2026-07-17):
 -->
 
 
+## 2026-07-22: Copy report includes the "Skipped N of M steps" rollup (#693)
+
+<!-- prawduct: type=bugfix | scope=wrap-copy-report | status=shipped -->
+
+**Why:** The wrap drawer's "Copy report" (`buildReportText`, `public/wrap-drawer.js`) serialized the
+status banner + per-step lines but omitted the "Skipped N of M steps:" summary block that
+`renderSkipRoll` (#571) paints under the banner — so a copied report was a subset of the on-screen
+report. The operator wants Copy report to be a faithful text twin they can paste instead of
+screenshotting each wrap. Surfaced live comparing a RentalClaw wrap's screenshot to its copied text.
+
+**What:** `buildReportText` now emits the skip rollup between the banner and the step list, reusing
+the same `summarizeSkips` helper `renderSkipRoll` renders from (one source of truth — copy and
+render can't diverge). Rendered only when something was skipped. Tests: +2 (rollup present with
+head + per-skip `kind (id) — reason` lines, positioned above the step blocks; absent when nothing
+skipped). Frontend-only; full suite 4721 pass / 0 fail. Sibling wrap-drawer finding filed
+separately: the blocked-step "Skip & note" action button is labeled "Retry" with no
+"Skip & continue" relabel.
+
 ## 2026-07-22: Verify lease ownership on ports release/heartbeat (#656)
 
 <!-- prawduct: type=bugfix | scope=porthub-ownership | status=shipped -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ All notable changes to TangleClaw are documented in this file.
   unblocked. An uncommitted changelog edit still short-circuits to covered.
   (`lib/wrap-steps/changelog-coverage.js`, `lib/wrap-steps/ai-content.js`,
   `lib/wrap-steps/_source-paths.js`, `lib/wrap-steps/features-toc.js`)
+- Wrap drawer's **Copy report** now includes the "Skipped N of M steps:" summary block (#693).
+  It previously serialized the status banner + per-step lines but dropped the honest skip rollup
+  (`renderSkipRoll`, #571) the drawer paints under the banner, so a copied report was a subset of
+  what's on screen. `buildReportText` now emits the rollup between the banner and the step list,
+  reusing the same `summarizeSkips` helper the drawer renders from, so copy and render can't
+  diverge — an operator can paste the report instead of screenshotting. (`public/wrap-drawer.js`)
 
 ### Security
 - `POST /api/ports/release` and `/api/ports/heartbeat` now verify lease ownership when the caller

--- a/public/wrap-drawer.js
+++ b/public/wrap-drawer.js
@@ -616,9 +616,12 @@
   /**
    * Serialize a pipeline result into a plain-text report the operator can
    * copy to the clipboard (paste into an issue, share with a collaborator).
-   * Mirrors what the drawer renders — the status banner plus one block per
-   * step (status, label, detail, and the full blocker output) — so the
-   * copied text is the same source of truth as the on-screen report (#268).
+   * Mirrors what the drawer renders — the status banner, the honest skip
+   * rollup, and one block per step (status, label, detail, and the full
+   * blocker output) — so the copied text is the same source of truth as the
+   * on-screen report (#268, #693). The skip rollup reuses `summarizeSkips`,
+   * the same helper `renderSkipRoll` paints from, so copy and render can't
+   * diverge.
    *
    * @param {object} pipelineResult - Runner return (`POST /wrap` body).
    * @param {{label: string, detail: (string|null)}} [displayedStatus] - The banner
@@ -635,6 +638,18 @@
       : summarizePipelineStatus(pipelineResult);
     const lines = [`Session Wrap — ${status.label}`];
     if (status.detail) lines.push(status.detail);
+
+    // #693 — mirror the drawer's skip rollup (`renderSkipRoll`) so the copied
+    // report is a faithful text twin, not a subset that drops the "N of M
+    // skipped, and why" digest a pasting operator relies on.
+    const skips = summarizeSkips(pipelineResult);
+    if (skips.skipped > 0) {
+      lines.push('');
+      lines.push(`Skipped ${skips.skipped} of ${skips.total} steps:`);
+      for (const s of skips.skips) {
+        lines.push(`- ${KIND_LABELS[s.kind] || s.kind} (${s.id}) — ${s.reason}`);
+      }
+    }
 
     const results = pipelineResult && Array.isArray(pipelineResult.results)
       ? pipelineResult.results

--- a/test/wrap-drawer.test.js
+++ b/test/wrap-drawer.test.js
@@ -860,6 +860,36 @@ describe('wrap-drawer helpers — buildReportText (#268)', () => {
     assert.equal(H.buildReportText(pipelineResult, { tone: 'success' }), fromPipeline);
     assert.equal(H.buildReportText(pipelineResult, null), fromPipeline);
   });
+
+  it('includes the "Skipped N of M steps" rollup so the copy matches the render (#693)', () => {
+    const text = H.buildReportText({
+      commitSha: 'aa11bb22cc33',
+      results: [
+        { stepId: 'open-pr-check', kind: 'pr-check', status: 'done', output: {}, blockers: [] },
+        { stepId: 'changelog-update', kind: 'ai-content', status: 'skipped', output: { reason: 'user opted to skip changelog-update (recorded in commit body)' }, blockers: [] },
+        { stepId: 'version-bump', kind: 'version-bump', status: 'skipped', output: { reason: '[Unreleased] has no entries to promote (already released or empty)' }, blockers: [] },
+        { stepId: 'commit', kind: 'commit', status: 'done', output: {}, blockers: [] }
+      ]
+    });
+    // The rollup head names the honest count, mirroring renderSkipRoll.
+    assert.match(text, /Skipped 2 of 4 steps:/);
+    // Each skip is listed with its kind label, id, and reason.
+    assert.match(text, /- AI content \(changelog-update\) — user opted to skip changelog-update/);
+    assert.match(text, /- Version bump \(version-bump\) — \[Unreleased\] has no entries to promote/);
+    // The rollup sits above the per-step list, not instead of it.
+    assert.ok(text.indexOf('Skipped 2 of 4 steps:') < text.indexOf('[Done] Commit — commit'),
+      'the rollup heads the report, before the step blocks');
+  });
+
+  it('omits the skip rollup entirely when nothing was skipped', () => {
+    const text = H.buildReportText({
+      commitSha: 'dd44ee55ff66',
+      results: [
+        { stepId: 'commit', kind: 'commit', status: 'done', output: {}, blockers: [] }
+      ]
+    });
+    assert.doesNotMatch(text, /Skipped \d+ of \d+ steps/);
+  });
 });
 
 describe('wrap-drawer helpers — shouldStartEndedCountdown (#268)', () => {


### PR DESCRIPTION
## What
The wrap drawer's **Copy report** now includes the **"Skipped N of M steps:"** summary block. It previously serialized the status banner + per-step lines but dropped the honest skip rollup (`renderSkipRoll`, #571) the drawer paints under the banner — so a copied report was a *subset* of what's on screen.

`buildReportText` now emits the rollup between the banner and the step list, reusing the same `summarizeSkips` helper the drawer renders from (one source of truth — copy and render can't diverge). Rendered only when something was skipped.

## Why
Copy report is meant to be the text twin of the drawer so an operator can **paste it instead of screenshotting** each wrap. The missing skip digest ("6 of 14 skipped, and why") was exactly the honest-inertness signal #571 added. Surfaced live comparing a RentalClaw wrap's screenshot to its copied text. Fixes #693.

## Test plan
- +2 `buildReportText` tests: rollup present (head + per-skip `kind (id) — reason` lines, positioned above the step blocks); rollup absent when nothing skipped.
- Full suite: **4721 pass / 0 fail / 1 skipped**.

## Scope
Frontend-only (`public/wrap-drawer.js`). Sibling wrap-drawer finding filed separately (#693 notes): the blocked-step "Skip & note" action button is labeled "Retry" with no "Skip & continue" relabel — deliberately out of scope here.

## Review
- Critic `cumulative`: 0/0/0.
- Independent PR reviewer: 0/0/0.