### PR TITLE
changelog-update: covered when nothing shipped this session (#695)

### DIFF
--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -45,8 +45,9 @@ returned for any uncommitted source work, that means nothing shipped that could 
 changelog still flows to the uncovered path, so the "a glob only widens" contract (#663) is
 untouched, and a source-work-without-entry commit still blocks (#659). Three #659-era tests that
 asserted "no commits → UNAVAILABLE" updated to the ratified "nothing to log → covered" contract;
-the real-history guard's zero-commit-short-circuit note extended. Same-family scope as #659 (the
-wrap changelog gate). Full suite 4721 pass / 0 fail.
+the real-history guard's zero-commit-short-circuit note extended. Sibling of #659 (the wrap
+changelog gate). Full suite green, 0 fail (4721 TAP subtests / 2473 JUnit cases — reporter
+semantics, not deleted tests).
 
 ## 2026-07-22: Copy report includes the "Skipped N of M steps" rollup (#693)
 

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -28,7 +28,7 @@ Tag-line conventions (ART-4K9M, ratified 2026-07-17):
 
 ## 2026-07-22: changelog-update no longer false-blocks a no-work session (#695)
 
-<!-- prawduct: type=bugfix | scope=wrap-659 | status=shipped -->
+<!-- prawduct: type=bugfix | scope=wrap-695 | status=shipped -->
 
 **Why:** A session that shipped no loggable work — no commits since the last wrap, only
 `.prawduct/`/`.tangleclaw/` bookkeeping dirty, CHANGELOG.md correctly unchanged — false-blocked at

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -26,6 +26,28 @@ Tag-line conventions (ART-4K9M, ratified 2026-07-17):
 -->
 
 
+## 2026-07-22: changelog-update no longer false-blocks a no-work session (#695)
+
+<!-- prawduct: type=bugfix | scope=wrap-659 | status=shipped -->
+
+**Why:** A session that shipped no loggable work — no commits since the last wrap, only
+`.prawduct/`/`.tangleclaw/` bookkeeping dirty, CHANGELOG.md correctly unchanged — false-blocked at
+`changelog-update`. The coverage predicate (#645) can't judge with no commits → returned
+`unavailable` → the mutation-check fallback blocked the compliant session ("byte-identical to
+before the AI ran") and forced a manual "Skip & note." This is the #645 false-block in its
+no-commits form, and the mirror of #659 (uncommitted source work → should block, and does).
+Surfaced live on a RentalClaw wrap.
+
+**What:** `changelog-coverage.evaluate()` returns `covered` when `checkable` is empty (no non-wrap,
+non-merge, file-touching commits) — combined with the existing dirtyWork check having already
+returned for any uncommitted source work, that means nothing shipped that could need logging.
+**Deliberately scoped to the empty-commit case**: a commit that touched only an undeclared nested
+changelog still flows to the uncovered path, so the "a glob only widens" contract (#663) is
+untouched, and a source-work-without-entry commit still blocks (#659). Three #659-era tests that
+asserted "no commits → UNAVAILABLE" updated to the ratified "nothing to log → covered" contract;
+the real-history guard's zero-commit-short-circuit note extended. Same-family scope as #659 (the
+wrap changelog gate). Full suite 4721 pass / 0 fail.
+
 ## 2026-07-22: Copy report includes the "Skipped N of M steps" rollup (#693)
 
 <!-- prawduct: type=bugfix | scope=wrap-copy-report | status=shipped -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,13 @@ All notable changes to TangleClaw are documented in this file.
   what's on screen. `buildReportText` now emits the rollup between the banner and the step list,
   reusing the same `summarizeSkips` helper the drawer renders from, so copy and render can't
   diverge — an operator can paste the report instead of screenshotting. (`public/wrap-drawer.js`)
+- Wrap `changelog-update` no longer false-blocks a session with nothing to log (#695). When a
+  session made no commits and has no dirty source work — e.g. it only ran the last wrap and churned
+  `.prawduct/`/`.tangleclaw/` bookkeeping — the coverage predicate returned `unavailable`, falling
+  back to the mutation check, which blocked the compliant session ("byte-identical to before the AI
+  ran") and forced a manual "Skip & note." It now returns `covered` (nothing shipped → nothing to
+  log) for the no-commits case. Scoped so the "a glob only widens" nested-changelog contract (#663)
+  and the uncommitted-source-work block (#659) are unchanged. (`lib/wrap-steps/changelog-coverage.js`)
 
 ### Security
 - `POST /api/ports/release` and `/api/ports/heartbeat` now verify lease ownership when the caller

--- a/lib/wrap-steps/changelog-coverage.js
+++ b/lib/wrap-steps/changelog-coverage.js
@@ -65,9 +65,13 @@
  * and a network dependency inside a wrap gate. What a commit TOUCHED is already
  * in the local repo and needs no convention at all.
  *
- * **Three-valued on purpose.** `unavailable` is not a failure: with no commits to
- * judge, this module cannot speak to whether the step did its job, and says so, so
- * the caller falls back to the mutation check rather than passing on no evidence.
+ * **Three-valued on purpose.** `unavailable` is not a failure: when the module
+ * genuinely cannot judge — no declared paths, no resolvable range, a failed git
+ * read — it says so, and the caller falls back to the mutation check rather than
+ * passing on no evidence. A session with NO commits to judge is NOT unavailable,
+ * though: with no commits and no dirty source work, nothing shipped that could need
+ * logging, so the verdict is `covered` (#695) — the mutation-check fallback there
+ * would false-block a compliant session that only churned bookkeeping.
  *
  * **Merge commits are exempt.** `git log --name-only` reports no paths for a true
  * merge, and a merge introduces no changelog obligation of its own — the
@@ -254,7 +258,17 @@ function evaluate(projectPath, paths, coveragePaths) {
     (c) => !_isWrapCommit(c.subject) && !c.isMerge && c.files.length > 0
   );
   if (checkable.length === 0) {
-    return _unavailable('the session range contains no commits this predicate can judge', range);
+    // #695: no commits to judge, and no uncommitted source work (the dirtyWork
+    // check above already returned UNCOVERED for that). So nothing shipped this
+    // session that could need logging — the changelog is trivially maintained.
+    // Return covered rather than UNAVAILABLE, whose mutation-check fallback
+    // false-blocks a compliant session that only churned bookkeeping / ran the
+    // last wrap (the reverted #645 false-block, in its no-commits form). Scoped to
+    // the empty-commit case on purpose: a commit that touched only an undeclared
+    // nested changelog still flows to the uncovered path below, so the "a glob only
+    // widens" contract (#663) is untouched.
+    log.info('changelog coverage satisfied — nothing shipped this session', { range });
+    return { verdict: VERDICTS.COVERED, uncovered: [], uncommittedWork: [], checkedCount: 0, range, reason: null };
   }
 
   const checkedCount = checkable.length;

--- a/test/wrap-changelog-coverage.test.js
+++ b/test/wrap-changelog-coverage.test.js
@@ -283,16 +283,16 @@ describe('changelog-coverage — evaluate()', () => {
     assert.equal(cov.evaluate('/p', ['CHANGELOG.md', 'NOTES.md']).verdict, cov.VERDICTS.COVERED);
   });
 
-  it('UNAVAILABLE when the range contains only wrap commits', () => {
+  it('COVERED when the range contains only wrap commits — nothing shipped to log (#695)', () => {
     scenario([{ sha: 'aaa1111', subject: 'Session wrap on wrap/2026-x', files: ['version.json'] }]);
     const out = cov.evaluate('/p', PATHS);
-    assert.equal(out.verdict, cov.VERDICTS.UNAVAILABLE);
+    assert.equal(out.verdict, cov.VERDICTS.COVERED);
     assert.equal(out.checkedCount, 0);
   });
 
-  it('UNAVAILABLE when the session made no commits at all', () => {
+  it('COVERED when the session made no commits at all — nothing to log (#695)', () => {
     scenario([]);
-    assert.equal(cov.evaluate('/p', PATHS).verdict, cov.VERDICTS.UNAVAILABLE);
+    assert.equal(cov.evaluate('/p', PATHS).verdict, cov.VERDICTS.COVERED);
   });
 
   it('UNAVAILABLE when no range resolves', () => {
@@ -350,12 +350,16 @@ describe('changelog-coverage — evaluate()', () => {
     assert.deepEqual(out.uncovered, [], 'an uncommitted-work verdict does not populate the commit list');
   });
 
-  it('with no commits: UNAVAILABLE when the tree is clean or only bookkeeping is dirty', () => {
+  it('with no commits: COVERED when the tree is clean or only bookkeeping is dirty — nothing to log (#695)', () => {
+    // The RentalClaw shape: a session that ran the last wrap and only churned
+    // framework state. Nothing shipped that needs a changelog entry, so the gate
+    // must not false-block it into a manual "Skip & note" (the #645 false-block in
+    // its no-commits form).
     scenario([], []);
-    assert.equal(cov.evaluate('/p', PATHS).verdict, cov.VERDICTS.UNAVAILABLE);
-    scenario([], ['.prawduct/change-log.md']);
-    assert.equal(cov.evaluate('/p', PATHS).verdict, cov.VERDICTS.UNAVAILABLE,
-      'bookkeeping-only dirt is not unlogged work');
+    assert.equal(cov.evaluate('/p', PATHS).verdict, cov.VERDICTS.COVERED);
+    scenario([], ['.prawduct/change-log.md', '.tangleclaw/project.json']);
+    assert.equal(cov.evaluate('/p', PATHS).verdict, cov.VERDICTS.COVERED,
+      'bookkeeping-only dirt with no commits is nothing to log');
   });
 
   it('with no commits but dirty source work: UNCOVERED — the work ships unlogged (#659)', () => {
@@ -533,16 +537,13 @@ describe('changelog-coverage — against this repository\'s real history', () =>
     assert.ok(Object.values(cov.VERDICTS).includes(out.verdict));
     if (out.verdict !== cov.VERDICTS.UNAVAILABLE) {
       assert.match(out.range, /\.\.HEAD$/);
-      // A COVERED verdict can legitimately judge zero commits: an uncommitted edit
-      // to a declared path (a dirty CHANGELOG.md during active development, which is
-      // exactly when this suite runs) short-circuits to COVERED before any commit is
-      // counted. Demand a judged commit only when the verdict came from committed
-      // history. The real-git-parsing guarantee this suite exists for is pinned
-      // independently by the next test, over `_listCommits` directly.
-      // Two working-tree short-circuits legitimately judge zero commits: a dirty
-      // declared path → COVERED, and dirty uncommitted source work → UNCOVERED
-      // (#659, which is exactly the state this suite runs in during active
-      // development). Demand a judged commit only for a committed-history verdict.
+      // Several verdicts legitimately judge zero commits, so demand a judged commit
+      // only for a committed-history verdict. Zero-commit short-circuits: a dirty
+      // declared path → COVERED; dirty uncommitted source work → UNCOVERED (#659,
+      // the state this suite runs in during active development); and no commits at
+      // all with nothing to log → COVERED (#695). The real-git-parsing guarantee
+      // this suite exists for is pinned independently by the next test, over
+      // `_listCommits` directly.
       const fromWorkingTreeShortCircuit =
         (out.verdict === cov.VERDICTS.COVERED && out.checkedCount === 0) ||
         (out.verdict === cov.VERDICTS.UNCOVERED && out.uncommittedWork.length > 0);


### PR DESCRIPTION
## What
The wrap `changelog-update` step no longer false-blocks a session with **nothing to log**. When a session made no commits since the last wrap and has no dirty source work — e.g. it only ran the last wrap and churned `.prawduct/`/`.tangleclaw/` bookkeeping, with `CHANGELOG.md` correctly unchanged — the coverage predicate returned `unavailable`, fell back to the mutation check, which blocked the compliant session ("byte-identical to before the AI ran") and forced a manual "Skip & note."

`changelog-coverage.evaluate()` now returns `covered` when `checkable` is empty (no non-wrap, non-merge, file-touching commit). Combined with the `dirtyWork` check (#659) having already returned for any uncommitted source work, an empty `checkable` means nothing shipped that could need logging.

## Why
This is the #645 false-block in its no-commits form, and the mirror of #659 (uncommitted *source* work → should block, and does). Surfaced live on a RentalClaw wrap: every dirty path was bookkeeping, no commits since the last wrap, and it blocked. Fixes #695.

## Scope discipline
**Deliberately scoped to the empty-commit case.** A commit that touched only an *undeclared nested changelog* still flows to the uncovered path, so the "a glob only widens" contract (#663) is untouched; a source-work-without-entry commit still blocks (#659). The `dirtyWork`→UNCOVERED and `declaredDirty`→COVERED short-circuits run before the changed branch, so nothing escapes to it.

## Test plan
- Three #659-era "no commits → UNAVAILABLE" assertions updated to the ratified "nothing to log → COVERED" contract (RentalClaw shape: no commits + bookkeeping dirty → covered); real-history zero-commit-short-circuit guard extended.
- Other UNAVAILABLE cases (no range / git-fail / no-paths / tree-read-fail) unchanged; #663 nested-changelog and #659 blocking tests retained.
- Full suite green, 0 fail (4721 TAP subtests / 2473 JUnit cases).

## Review
- Critic (composed over the bundle): 0/0/0.
- Independent PR reviewer: 0 blocking / 0 warning / 1 note (suite-count wording — reconciled).