### PR TITLE
Wrap drawer: "Skip & continue" relabel on the blocked-step skip box (#696)

### DIFF
--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -26,6 +26,25 @@ Tag-line conventions (ART-4K9M, ratified 2026-07-17):
 -->
 
 
+## 2026-07-22: Wrap drawer — "Skip & continue" relabel on the blocked-step skip box (#696)
+
+<!-- prawduct: type=bugfix | scope=wrap-696 | status=shipped -->
+
+**Why:** When a wrap step blocks and offers a "Skip this step and note it in the commit body"
+checkbox, ticking it and clicking the action button skips-and-continues (`retryWrap` threads the
+skip through `skipAiContent`/accumulates it and re-runs the pipeline past the step). But the button
+is a static "Retry" (`session.html`), so the operator has no signal it will proceed rather than
+re-attempt the step. Surfaced live on a RentalClaw wrap — operator ticked Skip and saw only
+"Retry," unsure it would advance.
+
+**What:** New `syncRetryLabel()` in `session.js` sets the action button to "Skip & continue" when a
+"skip this step" box (`skipAiContent` or `skipTests`) is ticked, else "Retry". Wired to the skip
+checkbox's `change` event (live relabel on toggle) and called at the end of `renderWrapDrawer` (so a
+fresh re-render with unticked boxes resets to "Retry"). No behavior change — label only; the HTML
+default stays "Retry". Tests: +4 source-level pins (session.js DOM functions aren't require()-able,
+per the `wrap-rule-proposal-widget.test.js` convention). Sibling of #693 (both wrap-drawer UX). Full
+suite green, 0 fail (4725 TAP subtests).
+
 ## 2026-07-22: changelog-update no longer false-blocks a no-work session (#695)
 
 <!-- prawduct: type=bugfix | scope=wrap-695 | status=shipped -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ All notable changes to TangleClaw are documented in this file.
   ran") and forced a manual "Skip & note." It now returns `covered` (nothing shipped → nothing to
   log) for the no-commits case. Scoped so the "a glob only widens" nested-changelog contract (#663)
   and the uncommitted-source-work block (#659) are unchanged. (`lib/wrap-steps/changelog-coverage.js`)
+- Wrap drawer: a blocked step's action button now reads **"Skip & continue"** when its
+  "Skip this step" box is ticked, instead of the static **"Retry"** (#696). Ticking the box and
+  clicking the button already skipped-and-continued (`retryWrap` re-runs the pipeline past the
+  skipped step), but the "Retry" label gave no signal it would proceed rather than re-attempt the
+  step. `syncRetryLabel` relabels live on toggle and resets on each render; covers the ai-content
+  "Skip & note" and the test-skip boxes. Label only — no behavior change. (`public/session.js`)
 
 ### Security
 - `POST /api/ports/release` and `/api/ports/heartbeat` now verify lease ownership when the caller

--- a/public/session.js
+++ b/public/session.js
@@ -3350,6 +3350,29 @@ function renderWrapDrawer(pipelineResult) {
     doneBtn.classList.remove('hidden');
     cancelBtn.textContent = 'Close';
   }
+
+  // #696: name the action honestly. When a "skip this step" box is ticked, Retry
+  // re-runs the pipeline PAST the skipped step (skip-and-continue), so the button
+  // must not keep reading "Retry" — which reads as re-attempting the step. Called
+  // on every render so a fresh (unticked) drawer resets to "Retry".
+  syncRetryLabel();
+}
+
+/**
+ * Set the wrap drawer's action button to "Skip & continue" when a blocked-step
+ * "skip this step" box is ticked, else "Retry" (#696). Retry-with-skip re-runs the
+ * pipeline past the skipped step (`retryWrap` threads the skip through), so the
+ * label has to say so. Covers the ai-content "Skip & note" box and the test-skip
+ * box — both mean skip-and-proceed. No behavior change; label only.
+ */
+function syncRetryLabel() {
+  const retryBtn = document.getElementById('wrapDrawerRetryBtn');
+  if (!retryBtn) return;
+  const decisionEl = document.getElementById('wrapDrawerDecision');
+  const skipChecked = decisionEl && decisionEl.querySelector(
+    'input[data-options-key="skipAiContent"]:checked, input[data-options-key="skipTests"]:checked'
+  );
+  retryBtn.textContent = skipChecked ? 'Skip & continue' : 'Retry';
 }
 
 /**
@@ -3470,6 +3493,9 @@ function renderDecisionWidget(widget) {
     // #328: step-scoped overrides (ai-content Skip & note) carry the blocked
     // step id so retryWrap can thread `{[stepId]: true}` to the server.
     if (widget.stepId) input.dataset.stepId = widget.stepId;
+    // #696: ticking a "skip this step" box makes Retry skip-and-continue, so keep
+    // the action button's label honest as the box toggles.
+    input.addEventListener('change', syncRetryLabel);
     row.appendChild(input);
     const text = document.createElement('span');
     text.textContent = widget.label;

--- a/test/wrap-skip-continue-label.test.js
+++ b/test/wrap-skip-continue-label.test.js
@@ -1,0 +1,81 @@
+'use strict';
+
+/*
+ * #696 — the blocked-step "Skip & note" affordance's action button.
+ *
+ * When a wrap step blocks and offers a "skip this step" checkbox, ticking it and
+ * clicking the action button skips-and-continues (retryWrap threads the skip
+ * through and re-runs the pipeline past the step). The button, however, is a
+ * static "Retry", so the operator has no signal the action will proceed rather
+ * than re-attempt. This pins the honest relabel.
+ *
+ * session.js render functions are browser DOM code (not require()-able), so —
+ * per the test/wrap-rule-proposal-widget.test.js convention — these are
+ * source-level pins over the function bodies.
+ */
+
+const { describe, it, before } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+/**
+ * Slice out a top-level function body by brace-matching from its declaration.
+ * @param {string} src full source text
+ * @param {string} decl the function declaration to find
+ * @returns {string} the function body including its braces
+ */
+function functionBody(src, decl) {
+  const start = src.indexOf(decl);
+  assert.ok(start !== -1, `${decl} must exist`);
+  const bodyStart = src.indexOf('{', start);
+  let depth = 0;
+  for (let i = bodyStart; i < src.length; i += 1) {
+    if (src[i] === '{') depth += 1;
+    else if (src[i] === '}') {
+      depth -= 1;
+      if (depth === 0) return src.slice(bodyStart, i + 1);
+    }
+  }
+  throw new Error(`unbalanced braces for ${decl}`);
+}
+
+describe('wrap drawer — Skip & continue relabel (#696)', () => {
+  let src;
+  before(() => {
+    src = fs.readFileSync(path.join(__dirname, '..', 'public', 'session.js'), 'utf8');
+  });
+
+  it('defines syncRetryLabel that flips the action button on the skip-box state', () => {
+    const body = functionBody(src, 'function syncRetryLabel(');
+    // Reads the action button and the decision area.
+    assert.match(body, /wrapDrawerRetryBtn/);
+    assert.match(body, /wrapDrawerDecision/);
+    // Keys on the two "skip this step" checkboxes.
+    assert.match(body, /data-options-key="skipAiContent"\]:checked/);
+    assert.match(body, /data-options-key="skipTests"\]:checked/);
+    // The honest label swap: "Skip & continue" when a skip box is ticked, else "Retry".
+    assert.match(body, /'Skip & continue'/);
+    assert.match(body, /'Retry'/);
+    // Defensive: bails when the button isn't present.
+    assert.match(body, /if \(!retryBtn\) return/);
+  });
+
+  it('wires the skip checkbox to relabel on change', () => {
+    const body = functionBody(src, 'function renderDecisionWidget(');
+    assert.match(body, /addEventListener\('change', syncRetryLabel\)/,
+      'toggling the skip box must relabel the action button live');
+  });
+
+  it('re-syncs the label on every drawer render (so a fresh drawer resets to Retry)', () => {
+    const body = functionBody(src, 'function renderWrapDrawer(');
+    assert.match(body, /syncRetryLabel\(\)/,
+      'renderWrapDrawer must call syncRetryLabel so a re-render with unticked boxes reads "Retry"');
+  });
+
+  it('leaves the static HTML default as "Retry" (the unticked state)', () => {
+    const html = fs.readFileSync(path.join(__dirname, '..', 'public', 'session.html'), 'utf8');
+    assert.match(html, /id="wrapDrawerRetryBtn"[^>]*>Retry</,
+      'the button ships reading "Retry"; syncRetryLabel promotes it to "Skip & continue" when a skip box is ticked');
+  });
+});


### PR DESCRIPTION
## What
When a wrap step blocks and offers a **"Skip this step and note it in the commit body"** checkbox, the action button now reads **"Skip & continue"** while the box is ticked (reverting to **"Retry"** when unticked), instead of the static "Retry."

Ticking the box + clicking the button already skipped-and-continued (`retryWrap` threads the skip through and re-runs the pipeline past the step), but the "Retry" label gave no signal it would proceed rather than re-attempt the step.

## Why
Surfaced live on a RentalClaw wrap — the operator ticked "Skip & note" and saw only "Retry," unsure it would advance. Fixes #696. Sibling of #693 (both wrap-drawer UX from the same wrap).

## How
New `syncRetryLabel()` in `public/session.js` derives the label from the live DOM checkbox state (`skipAiContent` / `skipTests` `:checked`), wired to the checkbox `change` event (live relabel on toggle) and called at the end of `renderWrapDrawer` (so a fresh render with unticked boxes resets to "Retry"). Label only — no behavior change; the HTML default stays "Retry."

## Test plan
- +4 source-level pin tests (session.js DOM functions aren't `require()`-able — per the `wrap-rule-proposal-widget.test.js` convention): `syncRetryLabel` label logic + skip-box selectors + `!retryBtn` guard; `renderDecisionWidget` wires the `change` listener; `renderWrapDrawer` re-syncs; HTML default stays "Retry."
- Full suite: **4725 pass / 0 fail / 1 skipped**.

## Notes
- Reaches operators on a plain reload — `/session.js` is in `sw.js` `NETWORK_FIRST_PATHS`, so no `CACHE_NAME` bump needed.
- The pins verify the logic, not the live DOM toggle — worth an operator eyeball after the next restart (the label swap on tick).

## Review
- Critic `cumulative`: 0 blocking / 0 warning / 2 notes (source-level tests — sanctioned convention; direct-to-main — resolved by moving to this branch).
- Independent PR reviewer: 0/0/0.