### PR TITLE
Wrap drawer: don't imply a manual step ships an armed auto-merge (#700)

### DIFF
--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -26,6 +26,30 @@ Tag-line conventions (ART-4K9M, ratified 2026-07-17):
 -->
 
 
+## 2026-07-22: Wrap drawer — don't imply a manual step ships an armed auto-merge (#700)
+
+<!-- prawduct: type=bugfix | scope=wrap-700 | status=shipped -->
+
+**Why:** When a wrap commit opens a PR with GitHub **auto-merge armed**, the release lands
+server-side the instant checks pass — no operator action. But the drawer painted a prominent,
+action-styled **"Recheck release"** button beside "release pending checks" with copy *"it lands
+when its checks pass,"* reading as though a click was required to finish shipping. Surfaced live:
+an operator closed the drawer believing they'd skipped a step; the wrap PR (#699) had already
+auto-merged one minute after the commit. The "Recheck release" button is in fact a **read-only**
+status poll (`resolveWrapPrStatus` → `GET /wrap/pr-status`) that never ships anything.
+
+**What:** Rename the button **"Refresh status"** and retitle it as an optional read-only re-poll
+(`public/session.js`). Thread the pipeline's own `pr.armed` into **both** the pending banner
+(`prOutcomeBanner`/`composeReleaseBanner`, `public/wrap-drawer.js`) and the button tooltip: an
+armed pending now reads *"auto-merge is armed … Nothing more to do; you can close this,"* while an
+unknown/unarmed pending keeps the honest hedge — that path can genuinely need a manual merge, and
+promising "it lands on its own" there would be #700 inverted (the arming gate on the tooltip was a
+Critic-caught asymmetry, resolved before merge). The read-only probe can't see arming; only the
+pipeline knows it. Tests: +3 require()-able unit tests (armed/unarmed banner + the arming thread
+through `composeReleaseBanner`); `session.js` label/tooltip is source-level per the zero-dep/no-jsdom
+convention. Sibling of the wrap-drawer honesty family #636/#638/#686/#693/#695/#696. Full suite
+green (4728 pass / 1 skipped).
+
 ## 2026-07-22: Wrap drawer — "Skip & continue" relabel on the blocked-step skip box (#696)
 
 <!-- prawduct: type=bugfix | scope=wrap-696 | status=shipped -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,17 @@ All notable changes to TangleClaw are documented in this file.
   skipped step), but the "Retry" label gave no signal it would proceed rather than re-attempt the
   step. `syncRetryLabel` relabels live on toggle and resets on each render; covers the ai-content
   "Skip & note" and the test-skip boxes. Label only — no behavior change. (`public/session.js`)
+- Wrap drawer no longer implies a manual step is needed to ship an auto-merging release (#700).
+  When a wrap commit opens a PR with GitHub **auto-merge armed**, the release lands server-side the
+  instant checks pass — no operator action — but the drawer painted a prominent, action-styled
+  **"Recheck release"** button beside "release pending checks" with the copy *"it lands when its
+  checks pass"*, reading as *a click is required to finish shipping*. (One operator closed the
+  drawer believing they'd skipped a step; the PR had already auto-merged.) The button is renamed
+  **"Refresh status"** and retitled as an optional read-only re-poll, and the pending banner now
+  threads the pipeline's own `pr.armed` knowledge (the read-only probe can't see arming) so an
+  armed pending reads *"auto-merge is armed … Nothing more to do; you can close this."* An
+  unknown/unarmed pending keeps the honest hedge — that path can genuinely need action.
+  (`public/wrap-drawer.js`, `public/session.js`)
 
 ### Security
 - `POST /api/ports/release` and `/api/ports/heartbeat` now verify lease ownership when the caller

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,10 +52,11 @@ All notable changes to TangleClaw are documented in this file.
   **"Recheck release"** button beside "release pending checks" with the copy *"it lands when its
   checks pass"*, reading as *a click is required to finish shipping*. (One operator closed the
   drawer believing they'd skipped a step; the PR had already auto-merged.) The button is renamed
-  **"Refresh status"** and retitled as an optional read-only re-poll, and the pending banner now
-  threads the pipeline's own `pr.armed` knowledge (the read-only probe can't see arming) so an
-  armed pending reads *"auto-merge is armed … Nothing more to do; you can close this."* An
-  unknown/unarmed pending keeps the honest hedge — that path can genuinely need action.
+  **"Refresh status"** and retitled as an optional read-only re-poll. Both the pending banner and
+  the button's tooltip now thread the pipeline's own `pr.armed` knowledge (the read-only probe
+  can't see arming) so an armed pending reads *"auto-merge is armed … Nothing more to do; you can
+  close this"* while an unknown/unarmed pending keeps the honest hedge — that path can genuinely
+  need a manual merge, and promising "it lands on its own" there would be #700 inverted.
   (`public/wrap-drawer.js`, `public/session.js`)
 
 ### Security

--- a/public/session.js
+++ b/public/session.js
@@ -3030,7 +3030,7 @@ let currentWrapBaseStatus = null;
 
 /**
  * The status banner currently PAINTED in the drawer — the pipeline's own verdict
- * until the #638 release resolution (or a "Recheck release") repaints it to the
+ * until the #638 release resolution (or a manual "Refresh status") repaints it to the
  * merged/pending/blocked outcome. Held so the copied report reflects what the
  * operator is looking at: without it, `buildReportText` re-derives the header from
  * the frozen pipeline result and reports "release pending" even after the PR merged
@@ -3109,8 +3109,10 @@ async function copyWrapReport() {
 /**
  * Paint the wrap-drawer status banner from a `{label, tone, detail}` view-model
  * — factored out so the #638 release-state resolution can repaint it in place.
- * When a wrap PR is passed, a "Recheck release" button is appended so the
- * operator can re-probe the merge outcome on demand (explicit action, no timer).
+ * When a wrap PR is passed, an optional "Refresh status" button is appended so
+ * the operator can re-probe the merge outcome on demand (explicit action, no
+ * timer). It is a read-only poll, never what ships the release — armed
+ * auto-merge lands the PR server-side with no click (#700).
  *
  * @param {{label: string, tone: string, detail: string|null}} status - The banner to paint.
  * @param {{prUrl: string|null}|null} [prForRecheck] - Wrap PR to offer a recheck for.
@@ -3123,7 +3125,7 @@ async function copyWrapReport() {
 function paintWrapStatus(status, prForRecheck, baseStatus) {
   // Mirror the painted banner so the copied report matches what's on screen. This
   // is the primary paint path (initial verdict, the #638 release resolution, a
-  // manual "Recheck release"); the error and notice paths below paint the same
+  // manual "Refresh status"); the error and notice paths below paint the same
   // element directly and update this mirror themselves, so the report never lags
   // any state the banner can show.
   currentWrapDisplayedStatus = status;
@@ -3137,8 +3139,13 @@ function paintWrapStatus(status, prForRecheck, baseStatus) {
     const btn = document.createElement('button');
     btn.type = 'button';
     btn.className = 'wrap-drawer-recheck';
-    btn.textContent = 'Recheck release';
-    btn.title = 'Re-query GitHub for this wrap PR’s merge outcome.';
+    // #700 — "Refresh status", not "Recheck release": this is a read-only re-poll
+    // of the merge outcome, never the thing that ships the release. Armed
+    // auto-merge lands the PR server-side with no click, so an imperative
+    // "Recheck release" label wrongly trained operators that a manual step
+    // remained (they closed the drawer thinking they'd skipped shipping).
+    btn.textContent = 'Refresh status';
+    btn.title = 'Optional — re-query GitHub for this wrap PR’s merge outcome. The release lands on its own when checks pass; you don’t need to click this.';
     // Pass the ORIGINAL pipeline status, not the currently-painted one, so
     // repeated rechecks compose against the pipeline's own verdict rather than
     // compounding a previous release banner.
@@ -3233,8 +3240,8 @@ function renderWrapDrawer(pipelineResult) {
   // #638 — one automatic release-state resolution when the commit opened a wrap
   // PR. The pipeline returns before GitHub merges, so `summarizePipelineStatus`
   // paints "release pending"; this resolves it to merged/pending/blocked. A
-  // single event-triggered fetch (not a repeating timer), with an explicit
-  // "Recheck release" button for re-polling — honoring the no-timer-driven-UI
+  // single event-triggered fetch (not a repeating timer), with an optional
+  // "Refresh status" button for re-polling — honoring the no-timer-driven-UI
   // rule (#98/#268).
   if (status.pr && status.pr.prUrl) resolveWrapPrStatus(status.pr, null, status);
 

--- a/public/session.js
+++ b/public/session.js
@@ -3115,7 +3115,8 @@ async function copyWrapReport() {
  * auto-merge lands the PR server-side with no click (#700).
  *
  * @param {{label: string, tone: string, detail: string|null}} status - The banner to paint.
- * @param {{prUrl: string|null}|null} [prForRecheck] - Wrap PR to offer a recheck for.
+ * @param {{prUrl: string|null, armed?: boolean}|null} [prForRecheck] - Wrap PR to
+ *   offer a status refresh for; `armed` gates the tooltip's "no action needed" copy.
  * @param {{label: string, tone: string, detail: string|null}|null} [baseStatus] - The
  *   PIPELINE's own verdict, carried through to the recheck handler so every
  *   re-probe composes against it rather than against the currently-painted
@@ -3145,7 +3146,14 @@ function paintWrapStatus(status, prForRecheck, baseStatus) {
     // "Recheck release" label wrongly trained operators that a manual step
     // remained (they closed the drawer thinking they'd skipped shipping).
     btn.textContent = 'Refresh status';
-    btn.title = 'Optional — re-query GitHub for this wrap PR’s merge outcome. The release lands on its own when checks pass; you don’t need to click this.';
+    // The tooltip's "no action needed" claim is arming-dependent, exactly like
+    // the banner copy: an UNARMED wrap PR (release-not-armed, or an unarmed
+    // pending) can still need a manual merge, so promising "it lands on its own"
+    // there would re-create #700 inverted. Thread `pr.armed` so the reassurance
+    // only appears when it is true; otherwise the neutral pre-#700 wording.
+    btn.title = prForRecheck.armed
+      ? 'Optional — re-query GitHub for this wrap PR’s merge outcome. The release lands on its own when checks pass; you don’t need to click this.'
+      : 'Re-query GitHub for this wrap PR’s merge outcome.';
     // Pass the ORIGINAL pipeline status, not the currently-painted one, so
     // repeated rechecks compose against the pipeline's own verdict rather than
     // compounding a previous release banner.

--- a/public/wrap-drawer.js
+++ b/public/wrap-drawer.js
@@ -334,9 +334,15 @@
    * gh, probe failure) stays provisional rather than claiming either result.
    *
    * @param {{outcome: string, state?: string, mergeStateStatus?: string, reason?: string}} status
+   * @param {boolean} [armed] - Whether the commit step armed GitHub auto-merge
+   *   for this wrap PR (known from the pipeline's own `pr.armed`, not the probe).
+   *   When true, a `pending` release is a done deal — GitHub lands it server-side
+   *   the instant checks pass, no operator action — so the copy says so rather
+   *   than implying a manual step (#700). When false/unknown, the honest hedge
+   *   stands: arming is not something the read-only probe can see on its own.
    * @returns {{label: string, tone: 'success'|'error'|'provisional', detail: string}}
    */
-  function prOutcomeBanner(status) {
+  function prOutcomeBanner(status, armed) {
     const outcome = status && status.outcome;
     if (outcome === 'merged') {
       return { label: 'Wrap shipped — PR merged', tone: 'success', detail: 'the release landed on the base branch' };
@@ -354,8 +360,16 @@
       return { label: 'Wrap committed — release BLOCKED, did not ship', tone: 'error', detail: why };
     }
     if (outcome === 'pending') {
-      // Deliberately does NOT claim auto-merge is armed: the probe reads
-      // `state`/`mergeStateStatus` only, so arming is not something this knows.
+      // #700 — when auto-merge is armed, a pending release needs NO operator
+      // action: GitHub merges the PR the instant its checks pass. Say so, so the
+      // provisional banner reads as "done, just waiting" instead of "a manual
+      // step remains" (the false-alarm the imperative "Recheck release" button
+      // trained). Arming comes from the pipeline (`pr.armed`), threaded in by
+      // `composeReleaseBanner` — the read-only probe can't see it on its own, so
+      // an unknown/unarmed pending keeps the honest hedge.
+      if (armed) {
+        return { label: 'Wrap committed — release pending checks', tone: 'provisional', detail: 'auto-merge is armed — the PR lands on its own when its checks pass. Nothing more to do; you can close this.' };
+      }
       return { label: 'Wrap committed — release pending checks', tone: 'provisional', detail: 'the PR has not merged yet; it lands when its checks pass' };
     }
     return { label: 'Wrap committed — release not confirmed', tone: 'provisional', detail: (status && status.reason) || 'could not confirm the PR state' };
@@ -379,8 +393,12 @@
    * @returns {{label: string, tone: string, detail: string|null}}
    */
   function composeReleaseBanner(baseStatus, prStatus) {
-    const release = prOutcomeBanner(prStatus);
     const base = baseStatus || {};
+    // #700 — a pending release with auto-merge armed needs no operator action;
+    // pass the pipeline's own arming knowledge (the probe can't see it) so the
+    // banner can say "lands on its own" instead of implying a manual step.
+    const armed = !!(base.pr && base.pr.armed);
+    const release = prOutcomeBanner(prStatus, armed);
     if (release.tone === 'error') return release;
     if (base.tone === 'warning' || base.tone === 'error') {
       const outcome = (prStatus && prStatus.outcome) || 'unknown';

--- a/test/wrap-drawer.test.js
+++ b/test/wrap-drawer.test.js
@@ -1072,6 +1072,18 @@ describe('wrap-drawer helpers — #638 wrap-PR reporting', () => {
     it('pending → provisional', () => {
       assert.equal(H.prOutcomeBanner({ outcome: 'pending' }).tone, 'provisional');
     });
+    it('pending + armed → says it lands on its own with nothing to do (#700)', () => {
+      const b = H.prOutcomeBanner({ outcome: 'pending' }, true);
+      assert.equal(b.tone, 'provisional');
+      assert.match(b.detail, /auto-merge is armed/);
+      assert.match(b.detail, /Nothing more to do/i);
+    });
+    it('pending + NOT armed keeps the honest hedge — no false "nothing to do" (#700)', () => {
+      const b = H.prOutcomeBanner({ outcome: 'pending' }, false);
+      assert.equal(b.tone, 'provisional');
+      assert.doesNotMatch(b.detail, /Nothing more to do/i);
+      assert.match(b.detail, /lands when its checks pass/);
+    });
     it('unknown → provisional with the probe reason', () => {
       const b = H.prOutcomeBanner({ outcome: 'unknown', reason: 'gh not found' });
       assert.equal(b.tone, 'provisional');
@@ -1157,5 +1169,19 @@ describe('wrap-drawer helpers — composeReleaseBanner precedence', () => {
   it('tolerates a missing base status', () => {
     const out = H.composeReleaseBanner(null, { outcome: 'pending' });
     assert.equal(out.tone, 'provisional');
+  });
+
+  it('threads the pipeline arming into a pending banner (#700)', () => {
+    const armed = H.composeReleaseBanner(
+      { label: 'Wrap committed — release pending PR merge', tone: 'provisional', detail: 'sha', pr: { armed: true, prUrl: 'u' } },
+      { outcome: 'pending' }
+    );
+    assert.match(armed.detail, /auto-merge is armed/, 'armed pending says it lands on its own');
+
+    const unarmed = H.composeReleaseBanner(
+      { label: 'Wrap committed — release pending PR merge', tone: 'provisional', detail: 'sha', pr: { armed: false, prUrl: 'u' } },
+      { outcome: 'pending' }
+    );
+    assert.doesNotMatch(unarmed.detail, /Nothing more to do/i, 'unarmed pending keeps the hedge');
   });
 });


### PR DESCRIPTION
## What
A wrap commit that opens a PR with GitHub **auto-merge armed** lands the release server-side the instant checks pass — no operator action. But the Session Wrap drawer painted a prominent, action-styled **`Recheck release`** button beside "release pending checks" with copy *"it lands when its checks pass"*, reading as though a click was required to finish shipping.

This branch:
- Renames the button **`Refresh status`** and retitles it as an optional read-only re-poll (it never ships the release — it only re-queries `GET /wrap/pr-status`).
- Threads the pipeline's own `pr.armed` into **both** the pending banner and the button tooltip: an armed pending reads *"auto-merge is armed … Nothing more to do; you can close this."* An unknown/**unarmed** pending keeps the honest hedge — that path can genuinely need a manual merge, and promising "it lands on its own" there would be #700 inverted.

## Why
Observed 2026-07-22: the operator closed the drawer believing they'd skipped a required step; the wrap PR (#699) had in fact **auto-merged one minute after the commit**. The UI manufactured a false-alarm. `Recheck release` is a read-only poll (`resolveWrapPrStatus`), never the thing that merges.

## Test plan
- +3 require()-able unit tests in `test/wrap-drawer.test.js`: armed vs unarmed `prOutcomeBanner`, and the arming thread through `composeReleaseBanner`.
- `public/session.js` button label/tooltip is source-level (zero-dep/no-jsdom convention) — **operator visual check recommended**: hover the button and read the banner on an *armed* vs *unarmed* wrap (desktop; no hover tooltip on iPhone Safari, where the banner text is what matters).
- Full suite green: **4728 pass / 1 skipped**.

## Review
- Critic (verify-resolutions): 0 blocking, 0 warning — caught and resolved a tooltip/banner arming asymmetry pre-merge.
- PR reviewer (release-readiness): 0 blocking, 0 warning, 0 note.

Frontend files are network-first in the service worker (no cache bump needed). Sibling of the wrap-drawer honesty family #636/#638/#686/#693/#695/#696.

Fixes #700