### PR TITLE
Wrap drawer: "Ask the session to fix this" button on content blocks (#702)

### DIFF
--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -26,6 +26,31 @@ Tag-line conventions (ART-4K9M, ratified 2026-07-17):
 -->
 
 
+## 2026-07-24: Wrap drawer — "Ask the session to fix this" button on content-authoring blocks (#702)
+
+<!-- prawduct: type=feature | scope=wrap-702 | status=shipped -->
+
+**Why:** When a wrap blocks on a content-authoring step (`ai-content`: changelog-update /
+learnings-capture / memory-update), the operator had to leave the drawer, switch to the session
+pane, and hand-type the fix. Painful on mobile (the operator is almost never local). Lived
+2026-07-24: a TiLT wrap blocked at changelog-update and the fix had to be relayed to the session
+by hand — exactly what this button automates.
+
+**What:** Frontend-only, reusing the existing `POST /api/sessions/:project/command` injection path
+(`injectCommand` already enforces liveness: active session + live tmux). `buildStepRow` gains an
+`agentResolvable` flag (`isBlocker && kind === 'ai-content'`) so the affordance is scoped to blocks
+a session can resolve by writing content — never a structural block (failed test, merge conflict) a
+retry-prompt can't fix. New `composeHandbackPrompt(row)` builds the injected prompt from the
+blocked step's own remediation, flattened to a **single line** (tmux send-keys splits on newline)
+and length-capped under 4096, with a genuine-fix guard (write a real entry, never a placeholder to
+pass the gate — Tests Are Contracts applied to the wrap gate). `session.js` renders an "Ask the
+session to fix this" button inside the "How to fix this" panel; on click it POSTs the prompt, shows
+"Sent — resolve it in the session, then Retry", and surfaces a dead/absent session as a warn toast.
+v1 injects only — the operator still taps Retry (auto-retry deferred to v2 with a block→fix→block
+loop guard). Tests: +9 require()-able (agentResolvable matrix + composeHandbackPrompt line-flatten /
+cap / genuine-fix / no-self-trigger / blank-remediation). Full suite green (4737 pass / 1 skipped).
+Closes #702; the manual TiLT relay this session was the motivating case study.
+
 ## 2026-07-22: Wrap drawer — don't imply a manual step ships an armed auto-merge (#700)
 
 <!-- prawduct: type=bugfix | scope=wrap-700 | status=shipped -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Wrap drawer: **"Ask the session to fix this"** button on content-authoring blocks (#702). When a
+  wrap blocks on an `ai-content` step (changelog-update / learnings-capture / memory-update), the
+  blocked step's "How to fix this" panel now offers a button that injects the remediation into the
+  owning session via the existing command-injection endpoint — so the operator no longer has to
+  leave the drawer and hand-type the fix (painful on mobile). Scoped to `agentResolvable`
+  (`isBlocker && kind === 'ai-content'`) so it never appears on a structural block a retry-prompt
+  can't fix (a failed test, a merge conflict). The injected prompt is a single tmux-safe line
+  (newlines flattened, length-capped under the 4096 limit) and instructs a **genuine** entry, never
+  a placeholder to pass the gate. Liveness is enforced server-side by `injectCommand`; a
+  dead/absent session surfaces as a warn toast. v1 injects the fix only — the operator still taps
+  Retry (auto-retry deferred to v2 with a loop guard). (`public/wrap-drawer.js`, `public/session.js`,
+  `public/session.css`)
+
 ## [4.31.5] - 2026-07-22
 
 ### Fixed

--- a/public/session.css
+++ b/public/session.css
@@ -2026,6 +2026,22 @@ body {
   white-space: pre-wrap;
   word-break: break-word;
 }
+/* "Ask the session to fix this" — hand a content-authoring block back to the
+   owning session instead of hand-typing the fix (#702). */
+.wrap-step-handback {
+  display: inline-block;
+  margin: 8px 0 2px;
+  font-size: 0.8rem;
+  /* 44px minimum touch target — the drawer is used from a phone. */
+  min-height: 44px;
+  padding: 2px 12px;
+  cursor: pointer;
+  background: var(--elevated-bg);
+  color: var(--text-primary);
+  border: 1px solid var(--primary, #3b82f6);
+  border-radius: 4px;
+}
+.wrap-step-handback:disabled { opacity: 0.6; cursor: default; }
 /* Status badges carry a `title` tooltip (#222) — hint it's hoverable. */
 .wrap-step-status[title] { cursor: help; }
 .wrap-step-status {

--- a/public/session.js
+++ b/public/session.js
@@ -3468,6 +3468,12 @@ function renderStepRow(row) {
     body.className = 'wrap-step-remediation-body';
     body.textContent = row.remediation;
     fix.appendChild(body);
+    // #702 — for a content-authoring block (changelog/learnings/memory), offer
+    // to hand the fix to the owning session instead of making the operator
+    // leave the drawer and hand-type it (painful on mobile). Scoped to
+    // `agentResolvable` so it never appears on a structural block a retry-prompt
+    // can't fix. v1: it injects the fix; the operator still hits Retry.
+    if (row.agentResolvable) fix.appendChild(buildHandbackButton(row));
     main.appendChild(fix);
   }
 
@@ -3481,6 +3487,58 @@ function renderStepRow(row) {
   li.appendChild(main);
   li.appendChild(status);
   return li;
+}
+
+/**
+ * #702 — build the "Ask the session to fix this" button for a content-authoring
+ * block (`row.agentResolvable`). Injects the blocked step's remediation into the
+ * owning session via command injection so the operator doesn't have to leave the
+ * drawer and hand-type it — the pain point that recurs on mobile. v1 only
+ * *injects* the fix; the operator still taps Retry (no auto-retry — that's a v2
+ * concern needing a block→fix→block loop guard). Liveness is enforced server-side
+ * by `injectCommand` (active session + live tmux); a dead/absent session surfaces
+ * as a warn toast rather than a silent no-op.
+ *
+ * @param {{id: string, kindLabel: string, remediation: string|null, agentResolvable: boolean}} row
+ * @returns {HTMLButtonElement}
+ */
+function buildHandbackButton(row) {
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'wrap-step-handback';
+  btn.textContent = 'Ask the session to fix this';
+  btn.title = 'Send the fix to the session that ran the wrap. It writes the entry; you then hit Retry.';
+  btn.addEventListener('click', async () => {
+    btn.disabled = true;
+    btn.textContent = 'Sending…';
+    const prompt = window.tcWrapDrawerHelpers.composeHandbackPrompt(row);
+    const result = await apiMutate(
+      `/api/sessions/${encodeURIComponent(projectName)}/command`,
+      'POST',
+      { command: prompt }
+    );
+    const toast = document.getElementById('toast');
+    if (result && result.ok) {
+      // Stay disabled: the fix is in flight in the session. The operator's next
+      // action is Retry, not a second injection.
+      btn.textContent = 'Sent — resolve it in the session, then Retry';
+      if (toast) {
+        toast.textContent = 'Fix sent to the session — resolve it there, then Retry';
+        toast.className = 'toast toast-ok visible';
+        setTimeout(() => { toast.classList.remove('visible'); }, 5000);
+      }
+    } else {
+      // Re-enable so the operator can retry the injection once the session is live.
+      btn.disabled = false;
+      btn.textContent = 'Ask the session to fix this';
+      if (toast) {
+        toast.textContent = 'Could not reach the session — is it still active?';
+        toast.className = 'toast toast-warn visible';
+        setTimeout(() => { toast.classList.remove('visible'); }, 5000);
+      }
+    }
+  });
+  return btn;
 }
 
 /**

--- a/public/wrap-drawer.js
+++ b/public/wrap-drawer.js
@@ -105,6 +105,7 @@
    *   detail: string|null,
    *   remediation: string|null,
    *   isBlocker: boolean,
+   *   agentResolvable: boolean,
    *   warning: boolean
    * }}
    */
@@ -138,8 +139,49 @@
       detail: deriveDetail(stepResult),
       remediation,
       isBlocker: blockedAt !== null && stepResult.stepId === blockedAt,
+      // #702 — is THIS block one the owning session can resolve by writing
+      // content (a changelog/learnings/memory entry)? Only the `ai-content`
+      // kind authors content; a block on a structural step (a failed test, a
+      // merge conflict, a PortHub clash) is NOT something a retry-prompt to the
+      // session can fix, so the "Ask the session to fix this" affordance stays
+      // scoped to ai-content blocks. Requires `isBlocker` so it never shows on a
+      // historical/non-active row.
+      agentResolvable: blockedAt !== null && stepResult.stepId === blockedAt && stepResult.kind === 'ai-content',
       warning
     };
+  }
+
+  /**
+   * #702 — compose the single-line prompt the "Ask the session to fix this"
+   * button injects into the owning Claude session. Built from the blocked
+   * step's own remediation so the session gets the exact fix instructions the
+   * drawer shows the operator, plus a genuine-fix guard so the session writes a
+   * real entry rather than a placeholder to make the gate pass (Tests Are
+   * Contracts — the injected fix must not weaken the gate it satisfies).
+   *
+   * The result is deliberately ONE line: `injectCommand` sends it via tmux
+   * send-keys, where an embedded newline is an Enter that would submit the
+   * prompt half-typed — so every newline in the remediation is flattened to a
+   * space. Capped to stay well under injectCommand's 4096-char limit.
+   *
+   * @param {{id: string, kindLabel: string, remediation: string|null}} stepRow
+   *   A row view-model from `buildStepRow` (expected `agentResolvable`).
+   * @returns {string} A single-line prompt (no newlines), length-capped.
+   */
+  function composeHandbackPrompt(stepRow) {
+    const flatten = (s) => String(s == null ? '' : s).replace(/\s+/g, ' ').trim();
+    const step = flatten(stepRow && (stepRow.kindLabel || stepRow.id) ? (stepRow.kindLabel || stepRow.id) : 'a wrap step');
+    const stepId = flatten(stepRow && stepRow.id ? stepRow.id : '');
+    const fix = flatten(stepRow && stepRow.remediation ? stepRow.remediation : '');
+    const parts = [
+      `Your session wrap is blocked at the ${step}${stepId && stepId !== step ? ` (${stepId})` : ''} step.`,
+      fix ? `How to fix it: ${fix}` : '',
+      'Please resolve it properly — write a genuine entry, never a placeholder just to pass the gate; if the work truly warrants no entry, that is a decision to note, not to fake.',
+      'Then stop — do NOT trigger the wrap yourself; the operator will hit Retry.'
+    ].filter(Boolean);
+    const prompt = parts.join(' ');
+    // Hard cap below injectCommand's 4096 limit, leaving headroom.
+    return prompt.length > 3800 ? `${prompt.slice(0, 3797)}...` : prompt;
   }
 
   /**
@@ -736,6 +778,7 @@
     KIND_DESCRIPTIONS,
     STATUS_META,
     buildStepRow,
+    composeHandbackPrompt,
     deriveDetail,
     summarizePipelineStatus,
     wrapPrInfo,

--- a/test/wrap-drawer.test.js
+++ b/test/wrap-drawer.test.js
@@ -102,6 +102,30 @@ describe('wrap-drawer helpers — buildStepRow', () => {
     assert.deepEqual(row.blockers, ['Test suite failed (exit 1)']);
   });
 
+  it('agentResolvable: true only for a BLOCKED ai-content step (#702)', () => {
+    const row = H.buildStepRow({
+      stepId: 'changelog-update', kind: 'ai-content', status: 'blocked',
+      output: { remediation: 'Write the entry.' }, blockers: ['no entry']
+    }, { blockedAt: 'changelog-update' });
+    assert.equal(row.agentResolvable, true);
+  });
+
+  it('agentResolvable: false for a blocked NON-ai-content step — a session can\'t fix a failed test by writing (#702)', () => {
+    const row = H.buildStepRow({
+      stepId: 'test', kind: 'test', status: 'blocked',
+      output: { exitCode: 1 }, blockers: ['Test suite failed']
+    }, { blockedAt: 'test' });
+    assert.equal(row.agentResolvable, false);
+  });
+
+  it('agentResolvable: false for an ai-content step that is NOT the active blocker (#702)', () => {
+    const row = H.buildStepRow({
+      stepId: 'memory-update', kind: 'ai-content', status: 'done',
+      output: {}, blockers: []
+    }, { blockedAt: 'changelog-update' });
+    assert.equal(row.agentResolvable, false);
+  });
+
   it('flags warning rows from output.warning regardless of kind', () => {
     // `output.warning` is a kind-agnostic channel — any handler may set it.
     const row = H.buildStepRow({
@@ -1089,6 +1113,52 @@ describe('wrap-drawer helpers — #638 wrap-PR reporting', () => {
       assert.equal(b.tone, 'provisional');
       assert.match(b.detail, /gh not found/);
     });
+  });
+});
+
+// #702 — the prompt handed to the owning session must be a single tmux-safe
+// line, carry the fix, and never coach gate-gaming.
+describe('wrap-drawer helpers — composeHandbackPrompt (#702)', () => {
+  const H = loadHelpers();
+
+  it('flattens all newlines/whitespace to a single line (tmux send-keys splits on newline)', () => {
+    const p = H.composeHandbackPrompt({
+      id: 'changelog-update', kindLabel: 'AI content — changelog-update',
+      remediation: 'Line one.\nLine two.\n\n  Indented three.'
+    });
+    assert.ok(!/\n/.test(p), 'no newlines survive');
+    assert.ok(!/\s{2,}/.test(p), 'no runs of whitespace survive');
+  });
+
+  it('includes the step label and the remediation text', () => {
+    const p = H.composeHandbackPrompt({
+      id: 'changelog-update', kindLabel: 'AI content — changelog-update',
+      remediation: 'Write the entry into CHANGELOG.md.'
+    });
+    assert.match(p, /changelog-update/);
+    assert.match(p, /Write the entry into CHANGELOG\.md/);
+  });
+
+  it('instructs a genuine fix, not a placeholder to pass the gate', () => {
+    const p = H.composeHandbackPrompt({ id: 'x', kindLabel: 'x', remediation: 'do it' });
+    assert.match(p, /genuine|not a placeholder|never a placeholder/i);
+  });
+
+  it('tells the session not to trigger the wrap itself (v1 = operator retries)', () => {
+    const p = H.composeHandbackPrompt({ id: 'x', kindLabel: 'x', remediation: 'do it' });
+    assert.match(p, /do NOT trigger the wrap|Retry/i);
+  });
+
+  it('caps length below the injectCommand 4096 limit', () => {
+    const p = H.composeHandbackPrompt({ id: 'x', kindLabel: 'x', remediation: 'z'.repeat(9000) });
+    assert.ok(p.length <= 3800, `length ${p.length} within cap`);
+    assert.match(p, /\.\.\.$/);
+  });
+
+  it('tolerates a missing/blank remediation without throwing', () => {
+    const p = H.composeHandbackPrompt({ id: 'memory-update', kindLabel: 'AI content — memory-update', remediation: null });
+    assert.ok(!/\n/.test(p));
+    assert.match(p, /memory-update/);
   });
 });
 


### PR DESCRIPTION
## What
When a wrap blocks on a content-authoring step (`ai-content`: changelog-update / learnings-capture / memory-update), the blocked step's **"How to fix this"** panel now offers an **"Ask the session to fix this"** button. It injects the step's remediation into the owning Claude session via the existing `POST /api/sessions/:project/command` path, so the operator no longer has to leave the drawer and hand-type the fix.

**Frontend-only** — reuses the existing command-injection endpoint (`injectCommand` already enforces liveness: active session + live tmux). No backend change.

## Why
The operator is almost never at the local machine and can't hand-edit files from a phone. Lived **2026-07-24**: a TiLT wrap blocked at `changelog-update` and the fix had to be relayed to the session by hand — exactly what this button automates.

## Design (the four guardrails from #702)
1. **Content blocks only** — `agentResolvable = isBlocker && kind === 'ai-content'`; never shows on a structural block (failed test, merge conflict) a retry-prompt can't fix.
2. **Liveness** — enforced server-side by `injectCommand`; a dead/absent session surfaces as a warn toast. The button only appears on a *blocked* (halted) pipeline, so it can't collide with a live AI-content capture.
3. **Genuine fix, not gate-gaming** — `composeHandbackPrompt` instructs a real entry, never a placeholder to pass the gate.
4. **v1 = operator still taps Retry** — injects only; auto-retry deferred to v2 with a block→fix→block loop guard.

`composeHandbackPrompt` builds a **single tmux-safe line** (newlines flattened — send-keys splits on newline) capped at 3800 < the 4096 server limit.

## Test plan
- **+9 require()-able unit tests**: `agentResolvable` matrix (blocked ai-content → true; blocked non-ai-content → false; non-blocked ai-content → false) + `composeHandbackPrompt` (line-flatten / cap / genuine-fix / no-self-trigger / blank-remediation).
- `session.js` button glue is source-level (zero-dep/no-jsdom convention) — **operator smoke recommended**: on a real `changelog-update` block, tap the button and confirm the prompt reaches the session (mobile).
- Full suite green: **4737 pass / 1 skipped**.

## Review
- Critic (cumulative): 0 blocking, 0 warning, 1 note (recommends the operator mobile smoke above).
- PR reviewer: 0 blocking, 0 warning, 0 note. Security clean (no injection surface; cap < server limit; newlines flattened).

Frontend files are network-first in the SW (no cache bump). Sibling of the wrap-drawer family #636/#638/#686/#693/#695/#696/#700.

Fixes #702