### PR TITLE
Mobile: bump SW CACHE_NAME to evict stale worker blocking session-open (refs #380)

### DIFF
--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -26,6 +26,25 @@ Tag-line conventions (ART-4K9M, ratified 2026-07-17):
 -->
 
 
+## 2026-07-26: Mobile session-open — bump service-worker CACHE_NAME to evict a stale worker (refs #380)
+
+<!-- prawduct: type=bugfix | scope=mobile-stale-sw | status=shipped -->
+
+**Why:** On mobile, the project list loaded but opening a session failed with the service worker's
+`{"error":"network-unreachable","detail":"Load failed"}` — the stale worker served the cached
+landing page while its `fetch()` for `/session/<project>` rejected. Same symptom as #380 (mobile
+session-open returns null via the SW) but the ttyd PTY pool was **healthy** (36 ttys / 14 procs / 0
+leaked, vs #380's 230/153 exhaustion baseline), so the cause was a stale service worker, not PTY
+exhaustion. Confirmed by a Safari Private tab (no worker) loading sessions fine.
+
+**What:** Bumped `public/sw.js` `CACHE_NAME` `tangleclaw-v3-56` → `-57`. The install/activate
+lifecycle already calls `skipWaiting()` + `clients.claim()`, so a byte change to `sw.js` makes an
+existing worker install and take over the current one on the next navigation — the standing
+stale-worker remedy (#411 family). The three CACHE_NAME monotone-floor guards
+(`bridge-port-input`, `master-drawer-frontend`, `openclaw-cache`) all pass unchanged (57 > their
+floors). This is a one-time unblock; a durable fix for the recurring-stale-worker class (an
+automatic version-derived bump or an update nag) remains a follow-up. Refs #380.
+
 ## 2026-07-22: Wrap drawer — don't imply a manual step ships an armed auto-merge (#700)
 
 <!-- prawduct: type=bugfix | scope=wrap-700 | status=shipped -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Mobile: opening a session no longer fails with a `network-unreachable` service-worker error when
+  the phone holds a stale service worker. Bumped `CACHE_NAME` (`tangleclaw-v3-56` → `-57`) so an
+  existing worker installs the current one on next load (`skipWaiting` + `clients.claim` already
+  make it take over live). Diagnosed 2026-07-26: the project list loaded (served from the SW cache)
+  while `/session/<project>` failed because the stale worker's `fetch()` rejected — the same symptom
+  as #380 but with a **healthy** ttyd PTY pool (36 ttys vs #380's 230), so the cause was the stale
+  worker, not PTY exhaustion. A Safari Private tab (no worker) loaded sessions fine, confirming it.
+  The recurring-stale-worker class still wants a durable auto-bump/update-nag (follow-up); this is
+  the one-time unblock. (`public/sw.js`) (refs #380)
+
 ## [4.31.5] - 2026-07-22
 
 ### Fixed

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,7 +10,7 @@
 // even after they hit Cmd+Shift+R. The network-first carve-out below
 // is the structural fix; this bump is the one-time unblock for
 // existing installs.
-const CACHE_NAME = 'tangleclaw-v3-56';
+const CACHE_NAME = 'tangleclaw-v3-57';
 const STATIC_ASSETS = [
   '/',
   '/style.css',


### PR DESCRIPTION
## What
On mobile, the project list loads but **opening a session** fails with the service worker's `{"error":"network-unreachable","detail":"Load failed"}`. The stale worker serves the cached landing page while its `fetch()` for `/session/<project>` rejects. Bumps `public/sw.js` `CACHE_NAME` **v3-56 → v3-57** so an existing worker installs the current one on next navigation (`skipWaiting()` + `clients.claim()` already make it take over live).

## Why it's the stale worker, not #380's PTY exhaustion
#380 attributes this exact mobile symptom to ttyd PTY-pool exhaustion. But when diagnosed **2026-07-26** the pool was **healthy** — 36 ttys / 14 procs / 0 leaked children, vs #380's 230/153 exhaustion baseline — and a Safari **Private tab** (which runs no service worker) loaded sessions fine. So this instance was a stale service worker, a distinct trigger from PTY exhaustion. #380's durable PTY fix and a durable stale-worker auto-bump both remain open follow-ups.

## Test plan
- The three `CACHE_NAME` monotone-floor guards (`bridge-port-input`, `master-drawer-frontend`, `openclaw-cache`) pass unchanged (57 > their floors).
- Live-served `sw.js` confirmed serving `v3-57`; operator to verify a normal-tab mobile session-open now succeeds.

One-line config bump (incident unblock). Refs #380.