### PR TITLE
Document HTTP/HTTPS refresh-loop recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Documentation
+- Documented the apparent dashboard refresh loop caused by opening
+  `http://localhost:3102` after direct HTTPS has been enabled. The quick start
+  now states that port 3102 serves one protocol at a time, and the troubleshooting
+  guide gives recovery steps for switching a localhost-only installation back to
+  HTTP and restarting the launchd service.
+
 ## [4.32.0] - 2026-07-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
-### Documentation
+### Internal
 - Documented the apparent dashboard refresh loop caused by opening
   `http://localhost:3102` after direct HTTPS has been enabled. The quick start
   now states that port 3102 serves one protocol at a time, and the troubleshooting

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ The install script:
 3. Installs and loads the services
 4. Runs a health check
 
-Access the landing page at **http://localhost:3102**. (That is the port the installed launchd service uses — the plist sets `TANGLECLAW_PORT=3102`. Running `node server.js` by hand instead skips launchd and listens on the code default, **3101**.) On first launch, a setup wizard walks you through configuration — including choosing your **projects directory**. This is a single folder where all your managed projects live (e.g., `~/Projects`). TangleClaw scans this directory, detects existing repos and engines, and lets you attach them as managed projects.
+Access the landing page at **http://localhost:3102** on a new or HTTP-only install, or **https://localhost:3102** after enabling HTTPS. Port 3102 serves one protocol at a time; opening the HTTP URL after HTTPS is enabled produces empty responses and can look like a dashboard refresh loop. See [Troubleshooting](docs/user-guide.md#dashboard-constantly-refreshes-after-enabling-https) to verify the protocol or return a localhost-only install to HTTP. (The installed launchd service uses port 3102; running `node server.js` by hand instead listens on the code default, **3101**.) On first launch, a setup wizard walks you through configuration — including choosing your **projects directory**. This is a single folder where all your managed projects live (e.g., `~/Projects`). TangleClaw scans this directory, detects existing repos and engines, and lets you attach them as managed projects.
 
 ### Prerequisites
 
@@ -317,7 +317,7 @@ launchctl unload ~/Library/LaunchAgents/com.tangleclaw.ttyd.plist
 # View logs
 tail -f ~/.tangleclaw/logs/tangleclaw.log
 
-# Health check
+# Health check (use https:// and curl -k when HTTPS is enabled)
 curl -s http://localhost:3102/api/health | python3 -m json.tool
 ```
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -21,7 +21,8 @@ cd TangleClaw
 
 The install script verifies prerequisites, generates launchd plists, loads the services, and runs a health check. On success, you'll see:
 
-- **Landing page**: http://localhost:3102
+- **Landing page**: http://localhost:3102 on a new or HTTP-only install, or
+  https://localhost:3102 when HTTPS is configured
 - **Terminal (ttyd)**: http://localhost:3100
 
 Both services auto-restart on crash via launchd KeepAlive.
@@ -34,14 +35,15 @@ On first launch, TangleClaw creates `~/.tangleclaw/` with:
 - `engines/` — engine profile JSON files
 - `tangleclaw.db` — SQLite database for runtime state
 
-Open http://localhost:3102 in your browser. On a fresh install, a **setup wizard** will guide you through initial configuration:
+Open http://localhost:3102 in your browser. On a fresh install, a **setup wizard** will guide you through initial configuration. If you enable HTTPS in the wizard, use https://localhost:3102 after setup completes:
 
 1. **Welcome** — overview of what TangleClaw does
 2. **Projects Directory** — set where your project folders live (defaults to `~/Documents/Projects`)
 3. **Detect Projects** — scans the directory for existing projects (git repos, TangleClaw or Prawduct markers) and lets you select which to attach
 4. **Engines** — shows which AI engines are detected on your system and lets you pick a default
 5. **Preferences** — delete protection password, idle chime toggle
-6. **Confirm** — summary of all selections, then "Complete Setup"
+6. **HTTPS** — generate or select a certificate, or keep local HTTP
+7. **Confirm** — summary of all selections, then "Complete Setup"
 
 You can **skip the wizard** at any step — it will use sensible defaults. The wizard only appears once; subsequent launches go straight to the landing page.
 
@@ -325,6 +327,36 @@ Locks expire after 30 minutes and are auto-released when sessions wrap or are ki
 - **Long press** — not used (avoids conflicts with browser gestures)
 
 ## Troubleshooting
+
+### Dashboard Constantly Refreshes After Enabling HTTPS
+
+Port 3102 serves either HTTP or HTTPS, not both. If HTTPS is enabled but the
+browser opens `http://localhost:3102`, the server receives plain HTTP on its TLS
+socket and returns an empty response. The dashboard can look as though it is
+constantly refreshing while its requests retry.
+
+First, open https://localhost:3102. If the browser warns about the certificate,
+install/trust the mkcert root CA or accept the local certificate as appropriate.
+
+To return a localhost-only installation to HTTP instead:
+
+1. Set `"httpsEnabled": false` in `~/.tangleclaw/config.json`.
+2. Restart the service:
+
+   ```bash
+   launchctl kickstart -k gui/$(id -u)/com.tangleclaw.server
+   ```
+
+3. Verify the configured protocol in `~/.tangleclaw/logs/tangleclaw.log`, then
+   open http://localhost:3102:
+
+   ```bash
+   tail -20 ~/.tangleclaw/logs/tangleclaw.log
+   curl -s http://localhost:3102/api/health | python3 -m json.tool
+   ```
+
+Do not disable HTTPS for access from another machine; use HTTPS or the Caddy
+ingress for non-localhost traffic.
 
 ### Server Won't Start
 


### PR DESCRIPTION
## Summary

- clarify that port 3102 serves either HTTP or HTTPS, not both
- document the apparent refresh loop caused by opening the HTTP URL after enabling HTTPS
- add the localhost-only recovery procedure used in the live incident
- correct the setup-wizard step list and protocol-aware health-check guidance

## Incident

On 2026-07-26, a local v4.32.0 install was serving HTTPS on port 3102 while the dashboard was opened at http://localhost:3102. Plain HTTP received an empty response from the TLS socket, and the dashboard appeared to refresh continuously. Setting httpsEnabled to false, restarting com.tangleclaw.server, and verifying /api/health restored the documented HTTP URL.

## Verification

- git diff --check: passed
- full node test suite: not completed in the managed sandbox because socket-binding tests fail with listen EPERM on 127.0.0.1; change is documentation-only