### PR TITLE
Derive the server port from one place so bind and report can't diverge (#654)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,49 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **What TangleClaw reports as its port now matches what it binds (#654).** The installed launchd
+  plist sets `TANGLECLAW_PORT=3102` and never touches `config.serverPort`, which stays at the shipped
+  `3101` default. The listen call in `server.js` main already honored the env var — the bug was that
+  three *reporting* sites did not, so they named a port nothing was listening on: the post-HTTPS-
+  restart `redirectUrl`, the API base URL injected into managed projects' `CLAUDE.md`
+  (`lib/engines.js`), and the Project Master identity file (`lib/master.js`). New
+  `httpsSetup.effectiveServerPort(config)` is now the one derivation all four share (the sibling of
+  `effectiveServerProtocol` from #497 / ENG-5R2W, same report-reality-not-intent shape). Field-
+  confirmed on a first-time install: choosing HTTPS in the setup wizard restarted the server and
+  redirected the operator to a dead `:3101`, which read as "HTTPS setup is broken" rather than a
+  wrong URL. The injected-config sites were the quieter half — affected projects told their agent
+  PortHub lived on `:3101`, so lease and heartbeat calls failed with nothing surfaced anywhere.
+  Note this reaches only projects TangleClaw generates configs for: plugin-governed projects are
+  skipped wholesale by `writeEngineConfig` (#330), so their `CLAUDE.md` is the plugin's to fix.
+  `scripts/ingress-cutover.js` deliberately keeps its own plist-then-config precedence and does
+  *not* consult the environment — it runs out-of-process, where `TANGLECLAW_PORT` describes whoever
+  launched the shell rather than the installed service Caddy proxies to — now pinned by a test so a
+  later unification onto the shared helper fails loudly. **Already-generated configs heal on the next
+  server start**: boot runs `projects.syncAllProjects()`, which regenerates every managed project's
+  config, so operators need no manual step beyond the restart this ships with.
+- An unbindable `TANGLECLAW_PORT` no longer silently changes which port the server binds (#654).
+  The shared derivation falls back to the configured port instead of propagating a malformed
+  `localhost:NaN` into generated content, but a silent fallback at the *bind* site would have
+  replaced the hard `ERR_SOCKET_BAD_PORT` that `server.listen('<typo>')` used to raise with a server
+  quietly listening where the plist, `install.sh`'s health check, and any Caddy upstream would not
+  find it. Boot now logs an error naming the bad value and the port actually in use, while the
+  helper stays pure and silent for the config-regeneration path that runs it constantly.
+
+### Internal
+- The resolved server port is now a number rather than sometimes a string (#654). Under launchd the
+  port came from `process.env.TANGLECLAW_PORT` as a string, which made
+  `portScanner.isPortInUseBySystem`'s strict `e.port === port` comparison permanently false for
+  TangleClaw's own port — so PortHub's "port is in use by a system process, registering anyway" warn
+  could never fire for it. It can now. The lease itself is unaffected (SQLite integer affinity stored
+  the string as an integer either way).
+- Port-derivation tests no longer depend on how the test runner was started (#654). A dev session
+  launched *by* TangleClaw inherits `TANGLECLAW_PORT` from the server process, which silently
+  overrode config-driven assertions in `master.test.js`, `engines.test.js`, and
+  `api-setup-https.test.js` — invisible in CI, which has no such parent. Those files now neutralize
+  the ambient value, and every test that means to exercise the override sets and restores it
+  explicitly.
+
 ## [4.32.0] - 2026-07-26
 
 ### Added

--- a/lib/engines.js
+++ b/lib/engines.js
@@ -6,7 +6,7 @@ const os = require('node:os');
 const { execSync } = require('node:child_process');
 const store = require('./store');
 const { createLogger } = require('./logger');
-const { effectiveServerProtocol } = require('./https-setup');
+const { effectiveServerProtocol, effectiveServerPort } = require('./https-setup');
 
 const log = createLogger('engines');
 
@@ -325,9 +325,11 @@ function _getRulesContent(projectConfig) {
   }
 
   const config = store.config.load();
-  const serverPort = config.serverPort || 3101;
-  // ENG-5R2W: must match what the server actually serves (caddy mode / no-cert
-  // installs bind plain HTTP even with httpsEnabled), not the raw flag.
+  // Both halves of the injected base URL must match what the server actually
+  // serves, not what config intends: the plist's TANGLECLAW_PORT overrides
+  // config.serverPort, and caddy mode / no-cert installs bind plain HTTP even
+  // with httpsEnabled (ENG-5R2W).
+  const serverPort = effectiveServerPort(config);
   const serverProtocol = effectiveServerProtocol(config);
 
   // AUTH-4b — when the M2M service-token gate is on, the PortHub + shared-docs

--- a/lib/https-setup.js
+++ b/lib/https-setup.js
@@ -6,6 +6,13 @@
 // the rollback target (and the cutover reuses the mkcert cert it generates for
 // Caddy's local site). Do not delete until the Caddy cutover has soaked. See
 // lib/caddy.js and deploy/INGRESS.md.
+//
+// NOTE for whoever retires this module after the soak: `effectiveServerProtocol`
+// and `effectiveServerPort` are NOT TLS logic. They answer "what is the server
+// actually serving, and where" for every localhost API base URL TangleClaw
+// injects, and they live here only because the protocol half was born beside the
+// cert code. They must be RELOCATED (together — callers read them as a pair),
+// never dropped with the rest of the module.
 
 const fs = require('node:fs');
 const path = require('node:path');
@@ -260,6 +267,58 @@ function effectiveServerProtocol(config) {
 }
 
 /**
+ * Whether a raw `TANGLECLAW_PORT` value names a port the server could bind.
+ * Digits only — `Number()` alone would accept `'0x10'` as 16 and `'1e3'` as
+ * 1000, which no plist would ever mean.
+ * @param {*} raw - Unparsed environment value.
+ * @returns {boolean}
+ */
+function isBindableServerPort(raw) {
+  if (raw === undefined || raw === null) return false;
+  const s = String(raw).trim();
+  if (!/^\d+$/.test(s)) return false;
+  const n = Number(s);
+  return n > 0 && n <= 65535;
+}
+
+/**
+ * Resolve the port the server is actually listening on — the sibling of
+ * `effectiveServerProtocol` (#497 / ENG-5R2W) for the other half of every
+ * localhost API base URL, and the one derivation shared by the listen call in
+ * `server.js` main, engine configs via `engines._getRulesContent`, the master
+ * identity file via `master.buildMasterClaudeMd`, and the post-HTTPS-restart
+ * redirect.
+ *
+ * Deliberately NOT used by `scripts/ingress-cutover.js`: that runs
+ * out-of-process, where `TANGLECLAW_PORT` describes whoever launched the shell
+ * rather than the installed service, so it reads the plist directly.
+ *
+ * `TANGLECLAW_PORT` wins over config because the installed launchd plist sets
+ * it to 3102 and never touches `config.serverPort`, which stays at the shipped
+ * default of 3101. Deriving the port from config alone therefore names a port
+ * nothing is listening on for every standard install: the post-setup restart
+ * redirected operators to a connection-refused page, and generated project
+ * configs told their agents the PortHub API lived on 3101, so lease and
+ * heartbeat calls failed silently.
+ *
+ * An unbindable `TANGLECLAW_PORT` falls back rather than propagating a
+ * malformed `localhost:NaN` into generated content. This function is pure and
+ * silent by design — it runs on every config regeneration, so it must not log.
+ * Boot is responsible for saying so loudly once: `server.js` main checks
+ * `isBindableServerPort` and logs before binding, which is what preserves the
+ * hard failure `server.listen('typo')` used to raise.
+ *
+ * @param {object} config - Global config (`store.config.load()`).
+ * @param {object} [env] - Environment to read; injectable for tests, defaults to `process.env`.
+ * @returns {number} Port for localhost API base URLs and for binding.
+ */
+function effectiveServerPort(config, env) {
+  const raw = (env || process.env).TANGLECLAW_PORT;
+  if (isBindableServerPort(raw)) return Number(String(raw).trim());
+  return (config && config.serverPort) || store.DEFAULT_CONFIG.serverPort;
+}
+
+/**
  * Attempt to read a certificate's "valid to" timestamp. Returns null on failure.
  * @param {string} certPath
  * @returns {string|null}
@@ -281,5 +340,7 @@ module.exports = {
   validateCertFiles,
   getRemoteTrustInstructions,
   getCertsDir,
-  effectiveServerProtocol
+  effectiveServerProtocol,
+  effectiveServerPort,
+  isBindableServerPort
 };

--- a/lib/master.js
+++ b/lib/master.js
@@ -38,7 +38,7 @@ const store = require('./store');
 const engines = require('./engines');
 const sessions = require('./sessions');
 const { createLogger } = require('./logger');
-const { effectiveServerProtocol } = require('./https-setup');
+const { effectiveServerProtocol, effectiveServerPort } = require('./https-setup');
 
 const log = createLogger('master');
 
@@ -225,9 +225,11 @@ function _renderRuleBullets(contents) {
  * @returns {string} CLAUDE.md content
  */
 function buildMasterClaudeMd(config, extras = {}) {
-  const serverPort = config.serverPort || 3101;
-  // ENG-5R2W: must match what the server actually serves (caddy mode / no-cert
-  // installs bind plain HTTP even with httpsEnabled), not the raw flag.
+  // Both halves of the base URL must match what the server actually serves, not
+  // what config intends: the plist's TANGLECLAW_PORT overrides config.serverPort,
+  // and caddy mode / no-cert installs bind plain HTTP even with httpsEnabled
+  // (ENG-5R2W).
+  const serverPort = effectiveServerPort(config);
   const serverProtocol = effectiveServerProtocol(config);
   const baseUrl = `${serverProtocol}://localhost:${serverPort}`;
   const tokenActive = !!(config.serviceTokenEnabled && config.serviceToken);

--- a/scripts/ingress-cutover.js
+++ b/scripts/ingress-cutover.js
@@ -32,6 +32,7 @@ const { execFileSync } = require('node:child_process');
 const REPO_DIR = path.resolve(__dirname, '..');
 const caddy = require(path.join(REPO_DIR, 'lib', 'caddy'));
 const ttydAttach = require(path.join(REPO_DIR, 'lib', 'ttyd-attach'));
+const store = require(path.join(REPO_DIR, 'lib', 'store'));
 
 const DEPLOY_DIR = path.join(REPO_DIR, 'deploy');
 const SERVER_LABEL = 'com.tangleclaw.server';
@@ -238,7 +239,14 @@ function resolveUpstreamPort(serverPlistPath, config) {
     const m = xml.match(/<key>TANGLECLAW_PORT<\/key>\s*<string>(\d+)<\/string>/);
     if (m) return Number(m[1]);
   } catch { /* not installed yet — fall through */ }
-  return config.serverPort || 3101;
+  // Config, then the shipped default — deliberately NOT `effectiveServerPort`.
+  // This script runs out-of-process, so a TANGLECLAW_PORT in its environment
+  // describes whoever launched the shell (a TangleClaw-spawned session inherits
+  // it from the server), not the installed service Caddy must proxy to. The
+  // plist above is that authority; config is the better second guess than an
+  // ambient variable. Pinned by a test that sets the variable and asserts it is
+  // ignored, so a later "unification" onto the helper fails loudly.
+  return config.serverPort || store.DEFAULT_CONFIG.serverPort;
 }
 
 function which(bin) {
@@ -253,7 +261,6 @@ function main() {
     process.exit(2);
   }
 
-  const store = require(path.join(REPO_DIR, 'lib', 'store'));
   store.init();
   const config = store.config.load();
   const home = require('node:os').homedir();

--- a/server.js
+++ b/server.js
@@ -1102,7 +1102,7 @@ route('POST', '/api/setup/complete', (req, res, _params, body) => {
   if (shouldRestart) {
     const hostHeader = (req.headers && req.headers.host) ? String(req.headers.host) : '';
     const hostname = hostHeader.split(':')[0] || 'localhost';
-    const port = config.serverPort || 3101;
+    const port = httpsSetup.effectiveServerPort(config);
     const protocol = willServeHttps ? 'https' : 'http';
     redirectUrl = `${protocol}://${hostname}:${port}`;
     _scheduleRestart();
@@ -4511,6 +4511,41 @@ function serverProtocol(server) {
 }
 
 /**
+ * Say once, loudly, when `TANGLECLAW_PORT` is set to something unbindable.
+ *
+ * `httpsSetup.effectiveServerPort` falls back silently by design — it also runs
+ * on every config regeneration, so it must not log. That leaves boot responsible
+ * for the noise, and boot is where it matters: a silent fallback here would
+ * replace the hard `ERR_SOCKET_BAD_PORT` that `server.listen('<typo>')` used to
+ * raise with a server quietly listening on a port the plist, `install.sh`'s
+ * health check, and any Caddy upstream all disagree with. Same posture as the
+ * `httpsFallback` WARN on the listen line (#616): report the fallback, don't
+ * hide it.
+ *
+ * An unset OR empty value is "no override" — not a misconfiguration — so it says
+ * nothing. Only a non-empty value the server could never bind is worth an error.
+ *
+ * Extracted from `main` so the branch is testable (the #616 seam pattern).
+ *
+ * @param {number} portInUse - The port actually resolved for binding.
+ * @param {object} [env] - Environment to read; defaults to `process.env`.
+ * @param {object} [logger] - Logger to use; defaults to the module logger.
+ * @returns {boolean} Whether a warning was emitted.
+ */
+function warnUnbindablePortEnv(portInUse, env, logger) {
+  const raw = (env || process.env).TANGLECLAW_PORT;
+  if (raw === undefined || raw === null || String(raw).trim() === '') return false;
+  if (httpsSetup.isBindableServerPort(raw)) return false;
+  (logger || log).error(
+    'TANGLECLAW_PORT is not a bindable port — ignoring it and using the configured port instead. '
+    + 'Fix the value in ~/Library/LaunchAgents/com.tangleclaw.server.plist; until then anything that '
+    + 'expects the plist port (health checks, Caddy upstream) will not reach this server.',
+    { tangleclawPortEnv: String(raw), portInUse }
+  );
+  return true;
+}
+
+/**
  * Create and configure the HTTP/HTTPS server (does not start listening).
  * @param {object} [options]
  * @param {boolean} [options.httpsEnabled] - Use HTTPS
@@ -4599,8 +4634,12 @@ if (require.main === module) {
   // the ensuing restart. Idempotent + non-throwing.
   ttydAttach.syncAttachScript({ repoDir: __dirname, home: os.homedir() });
 
-  // Bootstrap port management — resolve actual port (env var takes precedence)
-  const port = process.env.TANGLECLAW_PORT || config.serverPort || 3101;
+  // Bootstrap port management — resolve actual port (env var takes precedence).
+  // Shares the one derivation with every consumer that reports or injects this
+  // port, so what we bind and what we tell operators/agents cannot diverge.
+  const port = httpsSetup.effectiveServerPort(config);
+
+  warnUnbindablePortEnv(port);
   // AUTH-1 (#395): the ttydPort lease is kept even in caddy mode, where ttyd is
   // socket-bound and nothing listens on :3100. This is deliberate — reserving the
   // port keeps it free so a rollback to direct mode rebinds cleanly, rather than
@@ -4786,4 +4825,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { createServer, serverProtocol, handleRequest, handleUpgrade, route, matchRoute, jsonResponse, errorResponse, parseBody, parseQuery, reqUrl, MAX_BODY_SIZE, _setRestartScheduler, _openclawProxyHeaders, _openclawWsRequestLines };
+module.exports = { createServer, serverProtocol, warnUnbindablePortEnv, handleRequest, handleUpgrade, route, matchRoute, jsonResponse, errorResponse, parseBody, parseQuery, reqUrl, MAX_BODY_SIZE, _setRestartScheduler, _openclawProxyHeaders, _openclawWsRequestLines };

--- a/test/api-setup-https.test.js
+++ b/test/api-setup-https.test.js
@@ -12,6 +12,12 @@ const store = require('../lib/store');
 
 setLevel('error');
 
+// See the note in test/master.test.js: the redirect URL derives its port from
+// TANGLECLAW_PORT before config (#654), and a TangleClaw-launched dev session
+// inherits that variable, so the ambient value has to go or config-driven
+// assertions depend on how the runner was started.
+delete process.env.TANGLECLAW_PORT;
+
 function request(server, method, urlPath, body) {
   return new Promise((resolve, reject) => {
     const addr = server.address();
@@ -242,6 +248,42 @@ describe('HTTPS Setup API', () => {
       assert.equal(cfg.httpsEnabled, true);
       assert.equal(cfg.httpsCertPath, fixture.certPath);
       assert.equal(cfg.httpsKeyPath, fixture.keyPath);
+    });
+
+    it('builds redirectUrl from the bound port, not config.serverPort (#654)', async (t) => {
+      if (!hasOpenssl) return t.skip('openssl not available');
+
+      // The standard install: config keeps the shipped 3101 default while the
+      // launchd plist binds 3102. Deriving the redirect from config sent the
+      // operator to a connection-refused page immediately after a *successful*
+      // HTTPS configuration — the failure looked like the restart, not the URL.
+      await request(server, 'PATCH', '/api/config', {
+        httpsEnabled: false, httpsCertPath: '', httpsKeyPath: ''
+      });
+      store.config.save(Object.assign(store.config.load(), { serverPort: 3101 }));
+      restartCalls = 0;
+
+      const had = Object.prototype.hasOwnProperty.call(process.env, 'TANGLECLAW_PORT');
+      const prev = process.env.TANGLECLAW_PORT;
+      try {
+        process.env.TANGLECLAW_PORT = '3102';
+        const { status, data } = await request(server, 'POST', '/api/setup/complete', {
+          httpsEnabled: true,
+          httpsCertPath: fixture.certPath,
+          httpsKeyPath: fixture.keyPath
+        });
+
+        assert.equal(status, 200);
+        assert.equal(data.restart, true);
+        assert.match(data.redirectUrl, /^https:\/\/[^:/]+:3102$/);
+        assert.ok(
+          !data.redirectUrl.endsWith(':3101'),
+          'must not redirect to the config port when the environment overrides it'
+        );
+      } finally {
+        if (had) process.env.TANGLECLAW_PORT = prev;
+        else delete process.env.TANGLECLAW_PORT;
+      }
     });
 
     it('returns 400 when cert files are invalid', async () => {

--- a/test/engines.test.js
+++ b/test/engines.test.js
@@ -10,6 +10,12 @@ const engines = require('../lib/engines');
 const portScanner = require('../lib/port-scanner');
 const porthub = require('../lib/porthub');
 
+// See the note in test/master.test.js: the injected base URL derives its port
+// from TANGLECLAW_PORT before config (#654), and a TangleClaw-launched dev
+// session inherits that variable, so the ambient value has to go or config-driven
+// assertions depend on how the runner was started.
+delete process.env.TANGLECLAW_PORT;
+
 describe('engines', () => {
   let tempDir;
   let tempRulesPath;
@@ -539,6 +545,34 @@ describe('engines', () => {
         !content.includes('**TangleClaw API base URL**: `https://'),
         'must not inject an https base URL nothing serves'
       );
+    });
+
+    it('injects the port the server actually binds, not config.serverPort (#654)', () => {
+      // The standard install: plist binds TANGLECLAW_PORT=3102 while config keeps
+      // the shipped 3101 default. Injecting the config port told every agent on
+      // the machine that PortHub lived on a port nothing was listening on, so
+      // every lease/heartbeat call failed with no error surfaced anywhere.
+      patchConfig({
+        ingressMode: 'direct', httpsEnabled: false,
+        httpsCertPath: null, httpsKeyPath: null, serverPort: 3101
+      });
+      const had = Object.prototype.hasOwnProperty.call(process.env, 'TANGLECLAW_PORT');
+      const prev = process.env.TANGLECLAW_PORT;
+      try {
+        process.env.TANGLECLAW_PORT = '3102';
+        const content = engines._generateClaudeMd(proj);
+        assert.ok(
+          content.includes('**TangleClaw API base URL**: `http://localhost:3102`'),
+          'injected base URL must name the bound port'
+        );
+        assert.ok(
+          !content.includes('localhost:3101'),
+          'must not inject the config port when the environment overrides it'
+        );
+      } finally {
+        if (had) process.env.TANGLECLAW_PORT = prev;
+        else delete process.env.TANGLECLAW_PORT;
+      }
     });
 
     it('injects https:// in direct mode only with the full willServeHttps conjunction', () => {

--- a/test/https-setup.test.js
+++ b/test/https-setup.test.js
@@ -153,6 +153,81 @@ describe('https-setup', () => {
     });
   });
 
+  describe('effectiveServerPort (#654)', () => {
+    it('lets TANGLECLAW_PORT win over config — the standard-install case', () => {
+      // The installed launchd plist sets TANGLECLAW_PORT=3102 and never touches
+      // config.serverPort, which stays at the shipped 3101 default. Deriving from
+      // config alone is what pointed the post-setup redirect and every injected
+      // project config at a dead port.
+      assert.equal(
+        httpsSetup.effectiveServerPort({ serverPort: 3101 }, { TANGLECLAW_PORT: '3102' }),
+        3102
+      );
+    });
+
+    it('returns a number, not the raw env string', () => {
+      const port = httpsSetup.effectiveServerPort({}, { TANGLECLAW_PORT: '3102' });
+      assert.equal(typeof port, 'number');
+      assert.equal(port, 3102);
+    });
+
+    it('falls back to config.serverPort when the environment names no port', () => {
+      assert.equal(httpsSetup.effectiveServerPort({ serverPort: 3200 }, {}), 3200);
+    });
+
+    it('falls back to the 3101 code default when neither names a port', () => {
+      assert.equal(httpsSetup.effectiveServerPort({}, {}), 3101);
+      assert.equal(httpsSetup.effectiveServerPort({ serverPort: null }, {}), 3101);
+    });
+
+    it('never throws on a degenerate config', () => {
+      assert.equal(httpsSetup.effectiveServerPort(null, {}), 3101);
+      assert.equal(httpsSetup.effectiveServerPort(undefined, {}), 3101);
+    });
+
+    it('ignores a TANGLECLAW_PORT that is not a bindable port, rather than propagating it', () => {
+      // A value the server could never have bound cannot be the live port, so
+      // config is the better guess — propagating it would yield localhost:NaN.
+      // '0x10' and '1e3' are why the guard is a digits-only test rather than a
+      // bare Number(): both parse to plausible integers no plist would mean.
+      for (const bad of ['', '   ', 'abc', '0', '-1', '65536', '3102.5', '3102abc', '0x10', '1e3', '+3102', ' -3102 ']) {
+        assert.equal(
+          httpsSetup.effectiveServerPort({ serverPort: 3200 }, { TANGLECLAW_PORT: bad }),
+          3200,
+          `TANGLECLAW_PORT=${JSON.stringify(bad)} must not survive`
+        );
+      }
+    });
+
+    it('exposes the same predicate boot uses to warn about an unbindable plist value', () => {
+      // server.js main logs on !isBindableServerPort before binding; if the two
+      // ever disagreed, boot would either warn about a port it then used or bind
+      // a fallback with no warning at all.
+      for (const good of ['3102', ' 3102 ', '1', '65535']) {
+        assert.equal(httpsSetup.isBindableServerPort(good), true, `${JSON.stringify(good)} is bindable`);
+      }
+      for (const bad of ['', 'abc', '0', '-1', '65536', '3102.5', '0x10', '1e3', undefined, null]) {
+        assert.equal(httpsSetup.isBindableServerPort(bad), false, `${JSON.stringify(bad)} is not bindable`);
+        // The predicate and the resolver must agree on every rejected value.
+        assert.equal(httpsSetup.effectiveServerPort({ serverPort: 3200 }, { TANGLECLAW_PORT: bad }), 3200);
+      }
+    });
+
+    it('reads process.env when no env is injected', () => {
+      const had = Object.prototype.hasOwnProperty.call(process.env, 'TANGLECLAW_PORT');
+      const prev = process.env.TANGLECLAW_PORT;
+      try {
+        process.env.TANGLECLAW_PORT = '3405';
+        assert.equal(httpsSetup.effectiveServerPort({ serverPort: 3101 }), 3405);
+        delete process.env.TANGLECLAW_PORT;
+        assert.equal(httpsSetup.effectiveServerPort({ serverPort: 3101 }), 3101);
+      } finally {
+        if (had) process.env.TANGLECLAW_PORT = prev;
+        else delete process.env.TANGLECLAW_PORT;
+      }
+    });
+  });
+
   describe('detectMkcert', () => {
     it('reports available: true when mkcert stub is on PATH', (t) => {
       if (!hasOpenssl) return t.skip('openssl not available');

--- a/test/ingress-cutover.test.js
+++ b/test/ingress-cutover.test.js
@@ -82,6 +82,34 @@ describe('ingress-cutover', () => {
     it('falls back to 3101 when neither is available', () => {
       assert.equal(cutover.resolveUpstreamPort(path.join(tmpDir, 'nope.plist'), {}), 3101);
     });
+    it('ignores TANGLECLAW_PORT — out-of-process, so the env describes the shell, not the service (#654)', () => {
+      // This script is run by an operator, often from a TangleClaw-spawned shell
+      // that inherited TANGLECLAW_PORT from the server. Caddy must proxy to the
+      // *installed service*, whose port only the plist (or config) can attest.
+      // Pins the deliberate abstention from httpsSetup.effectiveServerPort so a
+      // later unification onto the shared helper fails here instead of in
+      // production, where it would only misfire for some operators' shells.
+      const had = Object.prototype.hasOwnProperty.call(process.env, 'TANGLECLAW_PORT');
+      const prev = process.env.TANGLECLAW_PORT;
+      try {
+        process.env.TANGLECLAW_PORT = '3999';
+        assert.equal(
+          cutover.resolveUpstreamPort(path.join(tmpDir, 'nope.plist'), { serverPort: 3201 }),
+          3201,
+          'config must win over an ambient TANGLECLAW_PORT'
+        );
+        const p = path.join(tmpDir, 'server-env.plist');
+        fs.writeFileSync(p, '<dict><key>TANGLECLAW_PORT</key>\n<string>3102</string></dict>');
+        assert.equal(
+          cutover.resolveUpstreamPort(p, { serverPort: 3201 }),
+          3102,
+          'the plist must win over an ambient TANGLECLAW_PORT'
+        );
+      } finally {
+        if (had) process.env.TANGLECLAW_PORT = prev;
+        else delete process.env.TANGLECLAW_PORT;
+      }
+    });
   });
 
   describe('caddyfileIsHandEdited (#397 clobber-guard, shared by dry-run + executor)', () => {

--- a/test/master.test.js
+++ b/test/master.test.js
@@ -16,6 +16,14 @@ const { setLevel } = require('../lib/logger');
 
 setLevel('error');
 
+// The generated base URL derives its port from TANGLECLAW_PORT before config
+// (#654), and a dev session launched *by* TangleClaw inherits that variable from
+// the server process — which would silently override every config-driven port
+// assertion below and make results depend on how the test runner was started.
+// Neutralize the ambient value; tests that mean to exercise the override set it
+// explicitly and restore it.
+delete process.env.TANGLECLAW_PORT;
+
 const store = require('../lib/store');
 const master = require('../lib/master');
 
@@ -67,6 +75,23 @@ describe('buildMasterClaudeMd', () => {
     // HTTP (createServer fallback), so the base URL must say http.
     const md3 = master.buildMasterClaudeMd({ serverPort: 3102, httpsEnabled: true });
     assert.match(md3, /http:\/\/localhost:3102/);
+  });
+
+  it('renders the port the server actually binds, not config.serverPort (#654)', () => {
+    // Same drift as the injected project configs: the plist binds 3102 while
+    // config keeps the 3101 default, so the master identity file handed the
+    // Project Master session a base URL nothing was serving.
+    const had = Object.prototype.hasOwnProperty.call(process.env, 'TANGLECLAW_PORT');
+    const prev = process.env.TANGLECLAW_PORT;
+    try {
+      process.env.TANGLECLAW_PORT = '3102';
+      const md = master.buildMasterClaudeMd({ serverPort: 3101 });
+      assert.match(md, /http:\/\/localhost:3102/);
+      assert.doesNotMatch(md, /localhost:3101/);
+    } finally {
+      if (had) process.env.TANGLECLAW_PORT = prev;
+      else delete process.env.TANGLECLAW_PORT;
+    }
   });
 
   it('renders an http base URL in caddy ingress mode even with full HTTPS config (ENG-5R2W)', () => {

--- a/test/server-listen-protocol.test.js
+++ b/test/server-listen-protocol.test.js
@@ -105,4 +105,62 @@ describe('startup protocol reporting (#616)', () => {
         'the banner must mark the intent-vs-reality divergence');
     });
   });
+
+  // Same principle on the port axis (#654): the shared port derivation falls back
+  // silently on an unbindable TANGLECLAW_PORT because it also runs on every config
+  // regeneration. That silence would otherwise swallow the hard
+  // ERR_SOCKET_BAD_PORT the old raw-string `listen()` raised, leaving the server
+  // bound where the plist, install.sh's health check, and any Caddy upstream would
+  // not find it. Boot is where the noise belongs, so boot is what these pin.
+  describe('warnUnbindablePortEnv (#654)', () => {
+    const { warnUnbindablePortEnv } = require('../server');
+
+    /** Collect log.error calls instead of emitting them. */
+    function spyLogger() {
+      const calls = [];
+      return { calls, error: (msg, meta) => calls.push({ msg, meta }) };
+    }
+
+    it('errors on a non-empty TANGLECLAW_PORT the server could never bind', () => {
+      for (const bad of ['abc', '0', '-1', '65536', '3102.5', '0x10', '1e3']) {
+        const spy = spyLogger();
+        assert.equal(warnUnbindablePortEnv(3101, { TANGLECLAW_PORT: bad }, spy), true,
+          `${JSON.stringify(bad)} must be reported`);
+        assert.equal(spy.calls.length, 1);
+        assert.equal(spy.calls[0].meta.tangleclawPortEnv, bad);
+        assert.equal(spy.calls[0].meta.portInUse, 3101,
+          'the operator needs the port actually in use, not just the bad value');
+        assert.match(spy.calls[0].msg, /com\.tangleclaw\.server\.plist/,
+          'must name the file to edit — the plist is where this value comes from');
+      }
+    });
+
+    it('stays silent when TANGLECLAW_PORT names a bindable port', () => {
+      const spy = spyLogger();
+      assert.equal(warnUnbindablePortEnv(3102, { TANGLECLAW_PORT: '3102' }, spy), false);
+      assert.equal(spy.calls.length, 0);
+    });
+
+    it('treats unset or empty as no override, not as a misconfiguration', () => {
+      // An empty value is what an unset plist key looks like; warning about it
+      // would point the operator at a plist line that is fine.
+      for (const env of [{}, { TANGLECLAW_PORT: '' }, { TANGLECLAW_PORT: '   ' }]) {
+        const spy = spyLogger();
+        assert.equal(warnUnbindablePortEnv(3101, env, spy), false, JSON.stringify(env));
+        assert.equal(spy.calls.length, 0);
+      }
+    });
+
+    it('is wired into boot before the port is used', () => {
+      // Structural: the call sits inside `require.main === module`, so it cannot
+      // be exercised directly. Pin that it is called with the resolved port and
+      // that it precedes the PortHub bootstrap which consumes that port.
+      const src = require('node:fs').readFileSync(path.join(__dirname, '..', 'server.js'), 'utf8');
+      const callIdx = src.indexOf('warnUnbindablePortEnv(port)');
+      const bootstrapIdx = src.indexOf('porthub.bootstrap(');
+      assert.ok(callIdx > 0, 'boot must call warnUnbindablePortEnv with the resolved port');
+      assert.ok(callIdx < bootstrapIdx,
+        'the warning must precede the bootstrap that consumes the port');
+    });
+  });
 });


### PR DESCRIPTION
## What

Introduces `httpsSetup.effectiveServerPort(config)` as the one derivation of the port the server is actually listening on, and routes every consumer through it.

`TANGLECLAW_PORT` (set to 3102 by the installed launchd plist) wins over `config.serverPort` (which stays at the shipped 3101 default, because nothing ever writes the real port into config).

| Site | State before | Symptom on a standard install |
|---|---|---|
| `server.js` main — the listen call | **already correct** (`process.env.TANGLECLAW_PORT \|\| …`) | none — this was the derivation the others failed to mirror |
| `server.js` — post-HTTPS-restart `redirectUrl` | config only | operator sent to a connection-refused page right after a *successful* HTTPS setup |
| `lib/engines.js` — API base URL injected into project `CLAUDE.md` | config only | affected agents told PortHub lives on `:3101`; all lease/heartbeat calls fail silently |
| `lib/master.js` — Project Master identity file | config only | same wrong base URL for the master session |

Three reporting sites were wrong, not four. `scripts/ingress-cutover.js` is deliberately excluded — see below.

**Scope limit worth knowing:** the injected-config fix reaches only projects TangleClaw generates configs for. `writeEngineConfig` returns early for plugin-governed projects (#330), so their `CLAUDE.md` is the plugin's to fix — including TangleClaw's own.

## Why

Fixes #654. Field-confirmed on a first-time install this week: a new user completed the setup wizard with HTTPS enabled, the server restarted, and the redirect dropped them on a dead `:3101`. From their chair that read as "HTTPS setup is broken" rather than "the redirect URL is wrong" — so they recovered by *disabling HTTPS*, the opposite of what the wizard was for.

The injected-config sites are the quieter and more damaging half: they fail silently and permanently, so PortHub's conflict-prevention guarantee is void on affected installs with no error surfaced anywhere.

Same defect shape as `effectiveServerProtocol` (#497 / ENG-5R2W) on the port axis instead of the protocol axis, so the fix mirrors it deliberately — the two now sit together and are read as a pair at all three reporting sites.

## Three decisions worth reviewing

**1. The helper is pure and silent; boot carries the loudness.** An unbindable `TANGLECLAW_PORT` falls back rather than propagating `localhost:NaN` into generated content. But a silent fallback at the *bind* site would have swallowed the hard `ERR_SOCKET_BAD_PORT` that `server.listen('<typo>')` used to raise, leaving the server listening where the plist, `install.sh`'s hardcoded `:3102` health check, and any Caddy upstream would not find it. So boot calls the exported `warnUnbindablePortEnv` (the #616 seam pattern) and logs an error naming the bad value and the port actually in use, while the helper stays silent because it runs on every config regeneration. An unset *or empty* value is "no override", not a misconfiguration, and says nothing. Three Critic reviewers converged on this regression independently from correctness, design, and observability angles — it was not in the first pass.

**2. The cutover script is deliberately excluded.** #654 lists `scripts/ingress-cutover.js` as a fourth site. It runs *out-of-process*, where `TANGLECLAW_PORT` describes whoever launched the shell (a TangleClaw-spawned session inherits it from the server) rather than the installed service Caddy must proxy to. Its plist-then-config precedence was already right. A new test sets the variable and asserts it's ignored, so a later "helpful unification" onto the shared helper fails in CI instead of misfiring only for operators whose shells happen to carry the variable.

**3. The derivation lives in a module marked for deletion.** `lib/https-setup.js`'s header says it is "RETAINED as the rollback target… Do not delete until the Caddy cutover has soaked." Both `effective*` helpers are co-located because callers read them as a pair, and the module header now carries an explicit note that they must be *relocated*, not dropped, when it's retired. Extracting both into their own module is the cleaner end state and is deliberately not done here — it would expand a bugfix into a refactor of the protocol path.

## Test plan

- **Unit** (`test/https-setup.test.js`): env-over-config precedence, config fallback, shipped-default fallback, degenerate config, numeric return type, digits-only bindability guard (`''`, whitespace, `abc`, `0`, `-1`, `65536`, `3102.5`, `3102abc`, `0x10`, `1e3`, `+3102`, `-3102`), and predicate/resolver agreement on every rejected value.
- **Regression, on rendered output** (`test/engines.test.js`, `test/master.test.js`, `test/api-setup-https.test.js`): with config at 3101 and `TANGLECLAW_PORT=3102`, the injected project `CLAUDE.md`, the master identity file, and `redirectUrl` all name 3102 and none contains `:3101`. Asserts the generated artifact, not the helper, so the injection path itself is pinned.
- **Abstention pinned** (`test/ingress-cutover.test.js`): plist wins, config beats an ambient env var, env alone never wins.
- **Boot guard** (`test/server-listen-protocol.test.js`): seven unbindable values each log exactly once carrying the bad value, the port actually in use, and the plist path; bindable stays silent; unset/empty/whitespace stay silent; plus a structural pin that boot calls it with the resolved port *before* the PortHub bootstrap consumes that port.
- **Full suite green in both environments** — 4753 pass / 0 fail / 1 skip (TAP totals), with `TANGLECLAW_PORT` set and unset. CI only ever exercises one of those.
- **Live invocation** against real config, not fixtures: `buildMasterClaudeMd(store.config.load())` renders `localhost:3105` under `TANGLECLAW_PORT=3105` with config at 3102, and `localhost:3102` with no env var. The running server was also restarted onto this branch and came up healthy (`startupSha 81a49de` lineage, database/ttyd/tmux ok, still on 3102).

### Honest coverage gaps

- **The generated-config half has no post-restart confirmation on an affected machine.** The development machine has `config.serverPort: 3102`, so it cannot reproduce the drift — its injected URLs were always correct. The rendered-output regression tests cover the logic, and boot's `syncAllProjects()` is verified to run, but "a standard install's project configs now say 3102 after restarting" is confirmed by construction, not observation. It wants one check on a machine where `config.serverPort` is the 3101 default. (TangleClaw's own `CLAUDE.md` can't serve as evidence — it's plugin-governed and hand-edited.)
- **One composed claim is inspection-verified only.** The `### Internal` note says the PortHub system-process warn "can now" fire for TangleClaw's own port. The numeric type is pinned at the source and the intermediate hop has a mocked test, but nothing asserts the full chain.
- **Recorded evidence reads 2490 passed, not 4753.** Expected reporter semantics, documented in this repo's own learnings: `test_command` uses the JUnit reporter, which counts only top-level cases, while the CHANGELOG convention quotes TAP totals including subtests. Both report 0 failures on the same suite, and both counts tracked the tests added across the Critic passes.

## Not in scope

The related honesty gap #654's notes raise — `/api/health` and `/api/config` reporting `httpsEnabled` *intent* rather than what the socket is doing — is untouched and still open under that issue.
