### PR TITLE
Contributing: prefer issues over pull requests, and say why

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to TangleClaw are documented in this file.
 ## [Unreleased]
 
 ### Internal
+- `CONTRIBUTING.md` now states that **issues are preferred over pull requests**, with the reasoning:
+  a fix authored where the suite can't fully run isn't verifiable against the contract the tests
+  define; a modified checkout stops being the clean install that made the report valuable, and also
+  blocks the in-product self-update (which refuses rather than clobber local work); and the
+  diagnosis, not the patch, is the scarce part. Adds an install/first-run reporting section with the
+  exact commands whose output we actually need (`launchctl list`, `server.err.log`, config, health
+  probe, clone location) plus the macOS `~/Documents` privacy-boundary hazard and the
+  stale-code-vs-update banner distinction. Also documents the `CHANGELOG.md` subsection→bump table,
+  including that doc-only edits belong under `### Internal` and that an invented heading leaves the
+  release tooling unable to derive a bump level.
 - Documented the apparent dashboard refresh loop caused by opening
   `http://localhost:3102` after direct HTTPS has been enabled. The quick start
   now states that port 3102 serves one protocol at a time, and the troubleshooting

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,13 +73,40 @@ The sidecar currently shows read-only process status from [ClawBridge](https://g
 
 The current touch scroll shim for xterm.js works but has edge cases on iOS and Android. Better touch scroll handling or an alternative approach would improve the mobile experience significantly.
 
+## Issues Are Preferred Over Pull Requests
+
+**If you found a problem, please open an issue rather than a fix.** This is the opposite of the usual open-source advice, so here is the reasoning:
+
+- **A fix from an environment we can't reproduce is hard to trust.** TangleClaw drives launchd services, tmux, and real sockets, so much of the suite needs a machine configured the way a real install is. A patch written where the suite can't fully run — a container, a sandboxed agent, a machine mid-install — can't be validated against the contract the tests define, and we'd have to re-derive it anyway.
+- **Local fixes make your install diverge from what we ship.** The moment your checkout carries changes, it stops being a clean install, which is exactly what made your report valuable. A modified tree also blocks the in-product self-update, which refuses to run rather than clobber local work — so patching around a bug can strand you on the version that has it.
+- **The diagnosis is the scarce part, not the patch.** Once a problem is described precisely, fixing it here is usually quick. Working out *what* is wrong on a machine we've never seen is the expensive step, and only you can do it.
+
+**First-run and install problems are the most valuable reports of all** — we cannot reproduce first-boot state on a machine that is already installed.
+
+Pull requests are still welcome, especially for documentation, typos, and small self-contained changes. Two things to know if you send one:
+
+- **Open an issue first for anything non-trivial**, so we can agree on the approach before you invest the time.
+- **Prefer describing a workaround in the issue over documenting it in the repo.** A documented workaround has to be removed again once the underlying bug is fixed, and it can outlive the bug.
+
 ## Making Changes
 
 1. Create a branch from `main`
 2. Make your changes
 3. Run the full test suite: `node --test 'test/*.test.js'`
-4. Update `CHANGELOG.md` with a description of your changes
+4. Update `CHANGELOG.md` with a description of your changes — see the subsection convention below
 5. Submit a pull request
+
+### CHANGELOG Subsections
+
+`CHANGELOG.md` follows [Keep a Changelog](https://keepachangelog.com/) with one addition, and the subsection you choose is load-bearing: the release tooling derives the version bump from it.
+
+| Subsection | Use for | Bump |
+|---|---|---|
+| `### Added` / `### Changed` / `### Removed` / `### Deprecated` | user-visible behavior | minor |
+| `### Fixed` / `### Security` | bug and security fixes | patch |
+| `### Internal` | refactors, test-only changes, tooling, CI, **documentation** | patch |
+
+Pick by **user-visible impact**, not by how many files changed: a one-line behavior change is `### Changed`, a large refactor nobody notices is `### Internal`. Documentation-only edits go under `### Internal` — still logged for history, but patch-tier so doc churn doesn't inflate the minor version. Any other heading (`### Documentation`, `### Docs`) matches no bump rule and leaves the release tooling unable to derive a level.
 
 ### Commit Messages
 
@@ -102,6 +129,26 @@ Open an issue on GitHub with:
 - Steps to reproduce
 - TangleClaw version (`curl localhost:3102/api/version`)
 - Node.js version (`node --version`)
+
+### For Install, First-Run, and "It Won't Load" Problems
+
+These are the reports we most want and least able to reproduce, so raw output beats description. Paste whatever of this you can:
+
+```bash
+launchctl list | grep tangleclaw          # services: middle column is exit status, '-' PID means not running
+cat ~/.tangleclaw/logs/server.err.log     # startup crashes land here
+tail -50 ~/.tangleclaw/logs/tangleclaw.log
+cat ~/.tangleclaw/config.json             # redact any tokens before pasting
+curl -s -o /dev/null -w '%{http_code}\n' http://localhost:3102/api/health
+pwd                                       # where you cloned — matters on macOS, see below
+```
+
+Also worth mentioning:
+
+- **Where the repo is cloned.** On macOS, a clone under `~/Documents` or `~/Desktop` sits behind a privacy boundary the launchd-spawned server may not be able to read, which can make the server fail on startup with nothing obvious on screen.
+- **Whether the dashboard shows a banner**, and which one — "newer code on disk" (your checkout moved ahead of the running server) is a different problem from an update-available notification.
+- **Which URL you opened**, including `http://` vs `https://`. Port 3102 serves one protocol at a time.
+- **A screenshot** of anything visually wrong. It's often faster than describing it.
 
 ## License
 


### PR DESCRIPTION
## What

Adds a `## Issues Are Preferred Over Pull Requests` section to `CONTRIBUTING.md`, an install/first-run reporting checklist, and the `CHANGELOG.md` subsection→bump table.

## Why

A friend's first-time install this week produced six real bugs (#654 comment, #707–#711, #713). The most valuable output was his **notes**, not his patch — and the patch carried costs the usual "send a PR" advice doesn't mention:

- It was authored on a machine where the test suite couldn't finish (socket-binding tests fail with `listen EPERM` in his sandbox), so it wasn't verifiable against the contract the tests define.
- It left his checkout dirty, which trips `applyUpdate()`'s `dirty-tree` guard — so patching around a bug stranded him on the version containing it.
- His clean install was the scarce resource. Every local change made it less representative of the thing we couldn't otherwise observe.

Written as reasoning rather than a rule, so a contributor can tell when it doesn't apply. PRs stay welcome for docs, typos, and small self-contained changes — #712 was exactly that and it caught a real docs error (the wizard step list omitted the HTTPS step).

## What's in it

1. **Issues over PRs**, with the three reasons above, and an explicit note that first-run/install reports are the most valuable because we cannot reproduce first-boot state on an already-installed machine.
2. **Install/first-run reporting checklist** — the exact commands whose output this week's debugging actually turned on: `launchctl list | grep tangleclaw` (with how to read the exit-status column), `server.err.log`, `config.json` (redact tokens), a health probe, and the clone location. Plus two things invisible to someone who doesn't already know the failure modes: the macOS `~/Documents` privacy-boundary hazard, and that "newer code on disk" is a *different* banner from an update notification.
3. **CHANGELOG subsection→bump table.** #712 filed a doc change under `### Documentation`, which matches no bump rule and leaves the release tooling unable to derive a level. Better written where a contributor sees it than corrected per PR.

Also adds a "prefer describing a workaround in the issue over documenting it in the repo" note — a documented workaround has to be removed once the bug is fixed, and #712's recovery steps are already scheduled for deletion by #654 and #709.

## Test plan

Documentation only; no code paths touched. `CHANGELOG.md` structure verified intact (`## [Unreleased]` → `### Internal` → `## [4.32.0]`), and the entry is `### Internal` so the bump stays patch-tier — which is also the convention this PR documents.