### PR TITLE
Ignore generated engine configs so TC can't dirty its own checkout (#708)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,20 @@
 # TangleClaw project config (dogfooding artifact)
 .tangleclaw/
 
+# Engine configs TangleClaw GENERATES when its own clone is attached as a managed
+# project (#708 — the first-run scan detects the clone and pre-selects it). These
+# are machine-generated, not source, and an untracked one here is not cosmetic: it
+# makes the working tree dirty, which trips `lib/update-applier.js`'s dirty-tree
+# guard and blocks the self-updater. A first-time installer hit exactly that —
+# TangleClaw generated `.codex.yaml` into its own clone, and the resulting dirty
+# tree stranded them on the version containing the bug they were working around.
+#
+# CLAUDE.md is deliberately NOT listed: this repo is plugin-governed, so its
+# CLAUDE.md is hand-authored and tracked (TC never regenerates it here).
+.codex.yaml
+.aider.conf.yml
+.antigravity.md
+
 # Internal design docs, build plans, and research notes
 INTAKE-BRIEF.md
 build-plan*.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,16 @@ All notable changes to TangleClaw are documented in this file.
   helper stays pure and silent for the config-regeneration path that runs it constantly.
 
 ### Internal
+- Generated engine configs are gitignored so TangleClaw can't dirty its own checkout (#708).
+  `.codex.yaml`, `.aider.conf.yml`, and `.antigravity.md` are written by `writeEngineConfig` into a
+  managed project's directory — and when TangleClaw's own clone is attached as a managed project
+  (which the first-run scan does by default, since the clone has both a git branch and a
+  `package.json`), that directory is this repo. The result isn't cosmetic: an untracked generated
+  file makes the tree dirty, which trips `lib/update-applier.js`'s `dirty-tree` guard and blocks the
+  self-updater entirely. Field-confirmed on a first-time install, where TangleClaw generated
+  `.codex.yaml` into its own clone and the resulting dirty tree stranded the operator on the version
+  containing the bug they were working around. `CLAUDE.md` is deliberately NOT ignored — this repo is
+  plugin-governed, so its `CLAUDE.md` is hand-authored and tracked.
 - The resolved server port is now a number rather than sometimes a string (#654). Under launchd the
   port came from `process.env.TANGLECLAW_PORT` as a string, which made
   `portScanner.isPortInUseBySystem`'s strict `e.port === port` comparison permanently false for


### PR DESCRIPTION
## What

Adds `.codex.yaml`, `.aider.conf.yml`, and `.antigravity.md` to `.gitignore`.

`CLAUDE.md` is deliberately **not** added — this repo is plugin-governed, so its `CLAUDE.md` is hand-authored and tracked, and TangleClaw never regenerates it here.

## Why

`writeEngineConfig` writes an engine's config file into a managed project's directory. When TangleClaw's own clone *is* the managed project — which the first-run scan does by default, since the clone has both a git branch and a `package.json` (#708) — that directory is this repo.

The consequence isn't cosmetic. An untracked generated file makes the working tree dirty, which trips `lib/update-applier.js`'s `dirty-tree` guard and **blocks the self-updater entirely**.

Field-confirmed on a first-time install: TangleClaw generated `.codex.yaml` into its own clone, and the resulting dirty tree left the operator unable to self-update — stranded on the version containing the bug they had been working around. That closes the loop on the second-order effect #708 predicted when it was filed.

## Scope

This is the containment half. The cause — the first-run scan attaching TangleClaw's own clone as a managed project — is still open under #708 and unchanged here. Ignoring the artifacts stops the bleeding for anyone who already has it attached (including deliberately, which stays supported: developing TangleClaw with TangleClaw is legitimate).

## Test plan

Documentation/config only; no code paths touched.

- `git check-ignore` confirms all three new patterns match.
- `git check-ignore CLAUDE.md` confirms it is still **not** ignored, so the tracked plugin-governed file is unaffected.
- `test/changelog-structure.test.js` passes; `[Unreleased]` has one `### Fixed` and one `### Internal` with no duplicate subsections, so the bump stays patch-tier.