### PR TITLE
Detect a downloaded-but-not-restarted update by version, not just git SHA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to TangleClaw are documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- **A downloaded update that hasn't restarted yet now says so, instead of looking like nothing
+  happened.** Staleness was detected only by comparing the process's boot git SHA against the
+  on-disk SHA (`lib/server-info.js`, #199). That check is entirely git-dependent, and it fails
+  *silently in the safe-looking direction*: if `git rev-parse` errors or times out,
+  `currentDiskSha` is `null`, `bothPresent` is false, and `isStale` reduces to `false` — no banner,
+  while the disk has in fact moved. The result is indistinguishable from a healthy server, and it is
+  exactly what a self-update whose restart didn't take looks like from the dashboard: the version
+  number appears unchanged, with nothing explaining why. Field-reported on a first-time install that
+  clicked **Update & restart**, saw the server restart, refreshed, and still read the old version.
+  `getServerInfo()` now carries a second, independent signal — `runningVersion` (captured at boot)
+  versus `diskVersion` (re-read on every call, never cached, because the updater rewrites
+  `version.json` under a live process). `isStale` is the OR of the two, so the banner still appears
+  when git detection is unavailable. The version comparison is coarser — it only moves on a release —
+  which is precisely the case the self-updater produces, so the two signals cover each other rather
+  than overlap. Unknown state is still never rendered as stale: when neither version can be read,
+  `isStale` stays false rather than guessing.
+  The banner now leads with what the operator can act on — "v4.32.2 is downloaded — restart to
+  finish. This server is still running v4.32.1." — rather than two abbreviated SHAs, which named the
+  right condition in a form nobody could act on. The SHA wording is retained for the
+  merged-commits-without-a-version-bump case that #199 originally targeted.
 - **Releases now tag themselves, so a merged fix actually reaches installed copies (#713).** The wrap
   bumps `version.json` and promotes the `[Unreleased]` CHANGELOG section, then stopped — nothing
   created a tag. Both halves of the update path (`lib/update-checker.js`, `lib/update-applier.js`)

--- a/lib/server-info.js
+++ b/lib/server-info.js
@@ -42,6 +42,7 @@ const _repoRoot = path.resolve(__dirname, '..');
 // `_resetForTest()` to clear state between cases.
 let _startupSha = null;
 let _startupTs = null;
+let _startupVersion = null;
 let _restartMechanism = undefined; // undefined = not yet detected; null = no mechanism available
 
 const GIT_TIMEOUT_MS = 5000;
@@ -70,6 +71,27 @@ function _detectSha() {
     });
     const trimmed = String(out || '').trim();
     return trimmed.length > 0 ? trimmed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read the version from `version.json` at the repo root. Returns `null`
+ * on any failure. Never throws.
+ *
+ * Deliberately re-read on every call rather than cached: the self-updater
+ * rewrites this file by checking out a release tag while the process keeps
+ * running, so a cached value would describe the process, not the disk.
+ *
+ * @returns {string|null}
+ */
+function _readDiskVersion() {
+  try {
+    const raw = _internal.readFileSync(path.join(_internal.repoRoot, 'version.json'), 'utf8');
+    const parsed = JSON.parse(raw);
+    const v = parsed && parsed.version;
+    return (typeof v === 'string' && v.length > 0) ? v : null;
   } catch {
     return null;
   }
@@ -113,6 +135,7 @@ function captureStartup() {
   }
   _startupTs = new Date().toISOString();
   _startupSha = _detectSha();
+  _startupVersion = _readDiskVersion();
   return { startupSha: _startupSha, startedAt: _startupTs };
 }
 
@@ -180,8 +203,25 @@ function getServerInfo() {
   const startupSha = _startupSha;
   const currentDiskSha = _detectSha();
   const bothPresent = !!(startupSha && currentDiskSha);
-  const isStale = bothPresent && startupSha !== currentDiskSha;
-  const commitsAhead = isStale ? _countCommitsAhead(startupSha, currentDiskSha) : 0;
+  const shaStale = bothPresent && startupSha !== currentDiskSha;
+
+  // Second, independent staleness signal (#713 follow-up). The SHA check is
+  // the more precise one but it is entirely git-dependent: if `git rev-parse`
+  // fails or times out, `currentDiskSha` is null, `bothPresent` is false, and
+  // staleness silently reduces to false — no banner, while the disk has in
+  // fact moved. That is indistinguishable from a healthy server, and it is
+  // what a self-update whose restart did not take looks like: the operator
+  // sees an unchanged version number and no explanation.
+  //
+  // Comparing version.json needs no git at all, so it still fires when SHA
+  // detection is unavailable. It is coarser — it only moves on a release —
+  // which is exactly the case the self-updater produces.
+  const runningVersion = _startupVersion;
+  const diskVersion = _readDiskVersion();
+  const versionStale = !!(runningVersion && diskVersion && runningVersion !== diskVersion);
+
+  const isStale = shaStale || versionStale;
+  const commitsAhead = shaStale ? _countCommitsAhead(startupSha, currentDiskSha) : 0;
   const uptimeSeconds = _startupTs
     ? Math.floor((Date.now() - new Date(_startupTs).getTime()) / 1000)
     : null;
@@ -190,6 +230,8 @@ function getServerInfo() {
     currentDiskSha,
     isStale,
     commitsAhead,
+    runningVersion,
+    diskVersion,
     startedAt: _startupTs,
     uptimeSeconds,
     restartMechanism: detectRestartMechanism()
@@ -205,6 +247,7 @@ function getServerInfo() {
 function __unsafeResetForTest() {
   _startupSha = null;
   _startupTs = null;
+  _startupVersion = null;
   _restartMechanism = undefined;
 }
 
@@ -212,7 +255,8 @@ const _internal = {
   execSync,
   repoRoot: _repoRoot,
   platform: () => process.platform,
-  existsSync: fs.existsSync
+  existsSync: fs.existsSync,
+  readFileSync: fs.readFileSync
 };
 
 module.exports = {

--- a/public/landing.js
+++ b/public/landing.js
@@ -222,10 +222,25 @@ function renderStaleServerBanner(info) {
     ? ` Running for ${esc(formatUptime(info.uptimeSeconds))}.`
     : '';
 
-  textEl.innerHTML =
-    '⚠ <strong>TC server is out of date.</strong> ' +
-    `Running <code>${shortStartup}</code>; <code>${shortDisk}</code> on disk ` +
-    `(${aheadStr}).${uptimeStr} Restart TC to load the latest code.`;
+  // When the on-disk version differs from the running one, lead with that
+  // rather than SHAs. It is the form an operator can act on — it names the
+  // release they were trying to install and says plainly that the download
+  // succeeded and only the restart is outstanding, instead of leaving them
+  // to infer it from a version number that appears not to have changed.
+  const runningVer = typeof info.runningVersion === 'string' ? info.runningVersion : null;
+  const diskVer = typeof info.diskVersion === 'string' ? info.diskVersion : null;
+
+  if (runningVer && diskVer && runningVer !== diskVer) {
+    textEl.innerHTML =
+      `⚠ <strong>v${esc(diskVer)} is downloaded — restart to finish.</strong> ` +
+      `This server is still running v${esc(runningVer)}.${uptimeStr} ` +
+      'The update is already on disk; restarting is the last step.';
+  } else {
+    textEl.innerHTML =
+      '⚠ <strong>TC server is out of date.</strong> ' +
+      `Running <code>${shortStartup}</code>; <code>${shortDisk}</code> on disk ` +
+      `(${aheadStr}).${uptimeStr} Restart TC to load the latest code.`;
+  }
   banner.classList.remove('hidden');
 
   // #235 — toggle the restart button visibility based on the

--- a/test/server-info.test.js
+++ b/test/server-info.test.js
@@ -417,3 +417,98 @@ describe('lib/server-info (#199 stale-server detection)', () => {
     });
   });
 });
+
+describe('version-based staleness (independent of git)', () => {
+  let origInternal;
+
+  beforeEach(() => {
+    origInternal = { ...serverInfo._internal };
+    serverInfo.__unsafeResetForTest();
+  });
+
+  function restore() {
+    Object.assign(serverInfo._internal, origInternal);
+  }
+
+  function stubVersion(v) {
+    serverInfo._internal.readFileSync = () => JSON.stringify({ version: v });
+  }
+
+  it('reports stale when version.json moved even though git detection fails', () => {
+    // The case that matters: a self-update rewrote version.json, the restart
+    // did not take, and git is unavailable — so the SHA check cannot fire.
+    serverInfo._internal.execSync = () => { throw new Error('git unavailable'); };
+    stubVersion('4.32.0');
+    try {
+      serverInfo.captureStartup();
+      stubVersion('4.32.1');
+      const info = serverInfo.getServerInfo();
+      assert.equal(info.isStale, true, 'disk moved but no banner would show');
+      assert.equal(info.runningVersion, '4.32.0');
+      assert.equal(info.diskVersion, '4.32.1');
+      assert.equal(info.commitsAhead, 0, 'no git means no commit count to claim');
+    } finally {
+      restore();
+    }
+  });
+
+  it('is not stale when the version is unchanged and git agrees', () => {
+    serverInfo._internal.execSync = () => 'samesha\n';
+    stubVersion('4.32.1');
+    try {
+      serverInfo.captureStartup();
+      const info = serverInfo.getServerInfo();
+      assert.equal(info.isStale, false);
+      assert.equal(info.runningVersion, '4.32.1');
+      assert.equal(info.diskVersion, '4.32.1');
+    } finally {
+      restore();
+    }
+  });
+
+  it('still reports stale from the SHA check when the version is unchanged', () => {
+    // A merge that does not bump the version must keep the original signal.
+    let n = 0;
+    serverInfo._internal.execSync = (cmd) => {
+      if (String(cmd).includes('rev-list')) return '3\n';
+      n += 1;
+      return n === 1 ? 'oldsha\n' : 'newsha\n';
+    };
+    stubVersion('4.32.1');
+    try {
+      serverInfo.captureStartup();
+      const info = serverInfo.getServerInfo();
+      assert.equal(info.isStale, true);
+      assert.equal(info.commitsAhead, 3);
+    } finally {
+      restore();
+    }
+  });
+
+  it('does not claim staleness when the version cannot be read at all', () => {
+    serverInfo._internal.execSync = () => { throw new Error('no git'); };
+    serverInfo._internal.readFileSync = () => { throw new Error('no version.json'); };
+    try {
+      serverInfo.captureStartup();
+      const info = serverInfo.getServerInfo();
+      assert.equal(info.isStale, false, 'unknown state must not render as stale');
+      assert.equal(info.runningVersion, null);
+      assert.equal(info.diskVersion, null);
+    } finally {
+      restore();
+    }
+  });
+
+  it('tolerates malformed version.json without throwing', () => {
+    serverInfo._internal.execSync = () => { throw new Error('no git'); };
+    serverInfo._internal.readFileSync = () => '{ not json';
+    try {
+      serverInfo.captureStartup();
+      const info = serverInfo.getServerInfo();
+      assert.equal(info.diskVersion, null);
+      assert.equal(info.isStale, false);
+    } finally {
+      restore();
+    }
+  });
+});


### PR DESCRIPTION
## What

`getServerInfo()` gains a second, independent staleness signal: `runningVersion` (captured at boot) versus `diskVersion` (re-read on every call). `isStale` is now the OR of the version check and the existing git-SHA check, and the stale-server banner leads with the actionable form when the two versions differ.

## Why

The stale-server banner (#199) detected staleness *only* by comparing the process's boot SHA against the on-disk SHA. That check is entirely git-dependent, and it fails **silently in the safe-looking direction**:

```js
const bothPresent = !!(startupSha && currentDiskSha);
const isStale = bothPresent && startupSha !== currentDiskSha;
```

If `git rev-parse` errors or times out, `currentDiskSha` is `null`, `bothPresent` is `false`, and `isStale` reduces to `false`. No banner — while the disk has in fact moved. That state is indistinguishable from a healthy server, and it is precisely what a self-update whose restart didn't take looks like from the dashboard: an apparently unchanged version number and nothing explaining why.

Field-reported on a first-time install: the operator clicked **Update & restart**, watched the server restart, refreshed the page, and still saw the old version. That install is currently unreachable for diagnosis, which is the point — the product should explain this state without anyone having to read a server log to find out what happened.

Note `/api/version` is *correct* to report the running version rather than the disk version — it describes the process that is executing. The defect was never that number; it was that nothing surfaced the disagreement between it and the disk.

## Design notes

- **`diskVersion` is deliberately never cached.** The self-updater rewrites `version.json` by checking out a release tag while the process keeps running, so a cached read would describe the process rather than the disk — reintroducing the bug.
- **The two signals cover each other rather than overlap.** The SHA check is more precise and catches merged commits with no version bump; the version check is coarser, needs no git at all, and moves exactly when a release lands, which is the self-updater's case.
- **Unknown state is never rendered as stale.** When neither version can be read, `isStale` stays `false` rather than guessing — an unread file must not manifest as a warning banner.
- **`commitsAhead` stays gated on the SHA path**, so a version-only detection never claims a commit count it cannot compute.

## Test plan

- Full suite: **4778 passing, 0 failing, 1 skipped**.
- 5 new tests in `test/server-info.test.js`: version moved while git detection throws (the case that motivated this — asserts the banner would now fire); unchanged version with git agreeing; SHA-stale with an unchanged version (pins that the original #199 signal still works); neither version readable (must not render stale); malformed `version.json` (must not throw).