### PR TITLE
Check for updates every 4 hours, and validate the configured interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- **A running server now checks for a release every 4 hours instead of every 24 (#720).** 24h was
+  chosen for a quieter release cadence than this project has: a long-running server could sit through
+  most of a release's life without noticing it, and there is still no manual "check now" (#716), so
+  the interval was the only lever. One check is a single `git ls-remote`, so six a day instead of one
+  costs nothing measurable. The first check still runs 60s after boot.
+  `updateCheckIntervalMs` was already read by `server.js` but was undocumented, unvalidated, and had
+  no surfaced default; it is now documented in the configuration reference and resolved through
+  `updateChecker.resolveCheckInterval`. A non-number, `NaN`/`Infinity`, or a value under the
+  60-second floor falls back to the default **with a logged warning** rather than reaching
+  `setInterval` — an operator who set it deserves to know it did not take, and a units typo must not
+  become a tight poll against origin.
+
 ## [4.32.2] - 2026-07-26
 
 ### Fixed

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -19,6 +19,7 @@ Auto-created on first run with defaults. Editable directly or via `PATCH /api/co
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `serverPort` | number | `3101` | Landing page HTTP server port. The install script sets `TANGLECLAW_PORT=3102` via launchd, so the effective default after installation is **3102**. |
+| `updateCheckIntervalMs` | number | `14400000` (4h) | How often a running server re-checks origin for a new release. The first check runs 60s after boot regardless. Values below 60000 (1 minute), or non-numbers, are rejected with a logged warning and the default is used — a typo must not become a tight poll against origin. There is no manual "check now" yet (#716), so this interval is currently the only way to shorten notification latency. |
 | `ttydPort` | number | `3100` | ttyd terminal emulator port. `install.sh` installs the direct-mode bind (`--port 3100`); in `caddy` ingress mode `ingress-cutover.js` swaps it for a Unix socket so ttyd is reachable only through the proxy. |
 | `defaultEngine` | string | `"claude"` | Default engine for new projects |
 | `projectsDir` | string | `"~/Documents/Projects"` | Root directory for managed projects |

--- a/lib/update-checker.js
+++ b/lib/update-checker.js
@@ -243,15 +243,59 @@ function getCachedStatus() {
   return { updateAvailable: false, currentVersion: _getCurrentVersion(), latestVersion: null, releaseUrl: null, repoRoot: _repoRoot, checkedAt: null };
 }
 
+// How often a running server re-checks for a release. Four hours, not the
+// twenty-four this shipped with: 24h was chosen for a quieter release cadence
+// than this project has, and it meant a long-running server could sit most of a
+// release's life without noticing it. One check is a single `git ls-remote`, so
+// six a day instead of one costs nothing measurable.
+const DEFAULT_CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000;
+
+// Floor for an operator-supplied interval. Guards against a typo (a stray unit,
+// a value in seconds) turning into a tight poll against origin.
+const MIN_CHECK_INTERVAL_MS = 60 * 1000;
+
+/**
+ * Resolve the configured update-check interval to a usable value.
+ *
+ * Falls back to the default for anything missing, non-numeric, or below the
+ * floor, rather than propagating it into `setInterval` — a malformed value there
+ * would either poll origin continuously or (for `NaN`) silently degrade to a
+ * timer that fires far more often than intended.
+ *
+ * @param {*} configured - Raw `config.updateCheckIntervalMs`
+ * @returns {{ intervalMs: number, warning: string|null }} Resolved interval, and
+ *   a reason string when the configured value was rejected (caller logs it —
+ *   this stays pure so config regeneration can call it freely).
+ */
+function resolveCheckInterval(configured) {
+  if (configured === undefined || configured === null) {
+    return { intervalMs: DEFAULT_CHECK_INTERVAL_MS, warning: null };
+  }
+  if (typeof configured !== 'number' || !Number.isFinite(configured)) {
+    return {
+      intervalMs: DEFAULT_CHECK_INTERVAL_MS,
+      warning: `updateCheckIntervalMs must be a number, got ${JSON.stringify(configured)}`
+    };
+  }
+  if (configured < MIN_CHECK_INTERVAL_MS) {
+    return {
+      intervalMs: DEFAULT_CHECK_INTERVAL_MS,
+      warning: `updateCheckIntervalMs ${configured}ms is below the ${MIN_CHECK_INTERVAL_MS}ms floor`
+    };
+  }
+  return { intervalMs: configured, warning: null };
+}
+
 /**
  * Start the periodic update checker.
- * First check runs after initialDelayMs (default 60s), then every intervalMs (default 24h).
- * @param {number} [intervalMs=86400000] - Check interval in milliseconds
+ * First check runs after initialDelayMs (default 60s), then every intervalMs
+ * (default `DEFAULT_CHECK_INTERVAL_MS`).
+ * @param {number} [intervalMs] - Check interval in ms; defaults to `DEFAULT_CHECK_INTERVAL_MS`
  * @param {number} [initialDelayMs=60000] - Delay before first check
  */
 function startChecker(intervalMs, initialDelayMs) {
   stopChecker();
-  const interval = intervalMs || 24 * 60 * 60 * 1000;
+  const interval = intervalMs || DEFAULT_CHECK_INTERVAL_MS;
   const delay = typeof initialDelayMs === 'number' ? initialDelayMs : 60000;
 
   log.debug('Starting update checker', { intervalMs: interval, initialDelayMs: delay });
@@ -296,6 +340,9 @@ module.exports = {
   compareSemver,
   parseTagsOutput,
   findLatestVersion,
+  resolveCheckInterval,
+  DEFAULT_CHECK_INTERVAL_MS,
+  MIN_CHECK_INTERVAL_MS,
   _getReleasesUrlBase,
   _parseGitHubRemote
 };

--- a/server.js
+++ b/server.js
@@ -4663,8 +4663,14 @@ if (require.main === module) {
   // Start model status monitor
   modelStatus.startMonitor(store.engines.list(), config.modelStatusIntervalMs || 120000);
 
-  // Start update checker (first check 60s after startup, then every 24h)
-  updateChecker.startChecker(config.updateCheckIntervalMs || 24 * 60 * 60 * 1000);
+  // Start update checker (first check 60s after startup, then on an interval).
+  // A rejected `updateCheckIntervalMs` is logged rather than silently swallowed —
+  // an operator who set it deserves to know it didn't take.
+  const checkInterval = updateChecker.resolveCheckInterval(config.updateCheckIntervalMs);
+  if (checkInterval.warning) {
+    log.warn(`Ignoring updateCheckIntervalMs: ${checkInterval.warning}`, { usingMs: checkInterval.intervalMs });
+  }
+  updateChecker.startChecker(checkInterval.intervalMs);
 
   // Start eval audit heartbeat watchdog
   evalAudit.startWatchdog((level, sessionId, project, message) => {

--- a/test/update-checker.test.js
+++ b/test/update-checker.test.js
@@ -200,3 +200,39 @@ describe('update-checker', () => {
     });
   });
 });
+
+describe('resolveCheckInterval (#720)', () => {
+  const uc = require('../lib/update-checker');
+
+  it('defaults to 4 hours, not the 24 it shipped with', () => {
+    assert.equal(uc.DEFAULT_CHECK_INTERVAL_MS, 4 * 60 * 60 * 1000);
+    assert.deepEqual(uc.resolveCheckInterval(undefined), { intervalMs: 4 * 60 * 60 * 1000, warning: null });
+    assert.deepEqual(uc.resolveCheckInterval(null), { intervalMs: 4 * 60 * 60 * 1000, warning: null });
+  });
+
+  it('honors a valid configured interval', () => {
+    assert.deepEqual(uc.resolveCheckInterval(7200000), { intervalMs: 7200000, warning: null });
+  });
+
+  it('rejects a non-number rather than feeding it to setInterval', () => {
+    const r = uc.resolveCheckInterval('4h');
+    assert.equal(r.intervalMs, uc.DEFAULT_CHECK_INTERVAL_MS);
+    assert.match(r.warning, /must be a number/);
+  });
+
+  it('rejects NaN and Infinity', () => {
+    for (const bad of [NaN, Infinity, -Infinity]) {
+      const r = uc.resolveCheckInterval(bad);
+      assert.equal(r.intervalMs, uc.DEFAULT_CHECK_INTERVAL_MS, `${bad} should fall back`);
+      assert.ok(r.warning);
+    }
+  });
+
+  it('rejects a value below the floor — a typo must not become a tight poll on origin', () => {
+    const r = uc.resolveCheckInterval(1000);
+    assert.equal(r.intervalMs, uc.DEFAULT_CHECK_INTERVAL_MS);
+    assert.match(r.warning, /below the .* floor/);
+    assert.deepEqual(uc.resolveCheckInterval(uc.MIN_CHECK_INTERVAL_MS),
+      { intervalMs: uc.MIN_CHECK_INTERVAL_MS, warning: null }, 'the floor itself is allowed');
+  });
+});


### PR DESCRIPTION
## What

Default update-check interval 24h → **4h**, and `updateCheckIntervalMs` becomes a documented, validated setting instead of an undocumented fallback.

Fixes #720.

## Why

24h was chosen for a quieter release cadence than this project has. A long-running server could sit through most of a release's life without noticing it, and with no manual "check now" yet (#716), the interval is currently the only lever on notification latency. One check is a single `git ls-remote` against origin — six a day instead of one costs nothing measurable. The first check still runs 60s after boot.

`updateCheckIntervalMs` was already read at `server.js` but appeared nowhere in `lib/`, `docs/`, or the live config: no documentation, no validation, no surfaced default.

## Design notes

- **A bad value is logged, not swallowed.** `resolveCheckInterval` returns the reason alongside the fallback, and boot logs it. An operator who set the key deserves to know it didn't take — silently ignoring it is how you end up debugging a setting that was never in effect.
- **60-second floor.** A units typo (seconds instead of milliseconds) would otherwise become a near-continuous poll against origin.
- **`NaN`/`Infinity` rejected explicitly**, not just non-numbers — `Number.isFinite` rather than `typeof`, since `NaN` reaching `setInterval` degrades to a far tighter timer than intended rather than erroring.
- The resolver stays pure and returns its warning rather than logging, so it is callable from any context without side effects.

## Scope

Deliberately just this. The rest of #716 — a cold cache reporting "up to date" before any check has run, on-load/on-focus checks, a manual "check now", server-side apply→restart — stays there. Worth repeating from #720: cadence is the *least* valuable third of that issue. A server restarted 30 seconds ago still reports "up to date" without having looked, at any interval.

## Test plan

- Full suite: **4783 passing, 0 failing, 1 skipped**.
- 5 new tests: the 4h default (asserted as a value, so a silent revert fails); a valid configured interval passing through; non-number rejected; `NaN`/`Infinity`/`-Infinity` rejected; sub-floor rejected while the floor itself is accepted.
- Documented in `docs/configuration-reference.md` alongside `serverPort`.