### PR TITLE
Refresh the master identity file on every boot, not only with autoStart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **The Project Master's identity file no longer keeps a dead API base URL (#726).** The master's
+  generated `CLAUDE.md` embeds the TangleClaw API base URL, and the only production writer was
+  `ensureMasterSession()` — which at boot ran *only* when `master.autoStart` was enabled. Managed
+  projects heal unconditionally via `projects.syncAllProjects()`; the master had no equivalent, so on
+  an install whose effective port differs from `config.serverPort` (the launchd plist sets
+  `TANGLECLAW_PORT`, which the config does not know about) the master kept being told to call a port
+  nothing was listening on — and every PortHub and shared-docs call it made failed silently. It
+  survived restarts and the #654 upgrade indefinitely unless the operator happened to open the master.
+  Field-confirmed on a first-time install still reading `http://localhost:3101` after updating.
+  The identity regeneration is now `master.refreshMasterIdentity()`, split out of
+  `ensureMasterSession()` so it can run without starting or touching a tmux session, and boot calls it
+  on every start. It is `skipIfAbsent`, so starting the server never creates master state for an
+  operator who has never opened the master, and it preserves the "never touches an already-running
+  master" contract because it does file writes only.
+  **Correction to the 4.32.1 notes:** that entry claimed already-generated configs "heal on the next
+  server start ... operators need no manual step beyond the restart this ships with." That was true
+  for managed projects and false for the master identity file, which the same entry listed as one of
+  the three sites #654 fixed.
+
 ## [4.32.2] - 2026-07-26
 
 ### Fixed

--- a/lib/master.js
+++ b/lib/master.js
@@ -516,14 +516,40 @@ function _refreshMasterMemory(home) {
  * @param {object} [options.enginesLib] - engines module override (tests)
  * @returns {{created: boolean, tmuxSession: string, home: string, engine?: string, accessLevel?: string, enforcement?: string, error?: string}}
  */
-function ensureMasterSession(options = {}) {
-  const t = options.tmuxLib || tmux;
-  const eng = options.enginesLib || engines;
+/**
+ * Regenerate the master's on-disk identity — `CLAUDE.md`, the memory scaffold,
+ * and (Claude engine) the write guardrails — from live config and rules.
+ *
+ * Split out of {@link ensureMasterSession} so the identity can be refreshed
+ * without starting or touching a tmux session. That matters because the identity
+ * embeds the TangleClaw API base URL: an install whose effective port changes
+ * (the launchd plist sets `TANGLECLAW_PORT`, which `config.serverPort` does not
+ * know about) otherwise keeps telling the master to call a port nothing is
+ * listening on, and every PortHub / shared-docs call fails silently. Managed
+ * projects heal on boot via `projects.syncAllProjects()`; before this split the
+ * master had no equivalent, so the stale value survived restarts and upgrades
+ * indefinitely unless the operator happened to open the master (#726).
+ *
+ * Purely file writes — no tmux, no engine launch — so it is safe to call on
+ * every boot.
+ *
+ * @param {object} [options]
+ * @param {string} [options.home] - Master home override (tests)
+ * @returns {{ home: string, refreshed: boolean }} `refreshed: false` when
+ *   `skipIfAbsent` was set and no master home exists yet.
+ * @param {boolean} [options.skipIfAbsent] - Do nothing if the master home does
+ *   not exist. Boot uses this so an operator who has never opened the master
+ *   does not get master state created as a side effect of starting the server.
+ */
+function refreshMasterIdentity(options = {}) {
   const home = options.home || masterHome();
+  if (options.skipIfAbsent && !fs.existsSync(home)) {
+    return { home, refreshed: false };
+  }
   fs.mkdirSync(home, { recursive: true });
 
   const config = store.config.load();
-  const { settings, engineId, enforcement } = _masterRuntime(config);
+  const { settings, enforcement } = _masterRuntime(config);
 
   seedBaselineMasterRules();
   fs.writeFileSync(path.join(home, 'CLAUDE.md'), buildMasterClaudeMd(config, {
@@ -533,6 +559,19 @@ function ensureMasterSession(options = {}) {
   _refreshMasterMemory(home);
 
   if (enforcement === 'structural') _writeMasterGuardrails(home);
+
+  return { home, refreshed: true };
+}
+
+function ensureMasterSession(options = {}) {
+  const t = options.tmuxLib || tmux;
+  const eng = options.enginesLib || engines;
+  const home = options.home || masterHome();
+
+  const config = store.config.load();
+  const { settings, engineId, enforcement } = _masterRuntime(config);
+
+  refreshMasterIdentity({ home });
 
   const base = { tmuxSession: MASTER_TMUX_SESSION, home, engine: engineId, accessLevel: settings.accessLevel, enforcement };
 
@@ -617,6 +656,7 @@ module.exports = {
   seedBaselineMasterRules,
   restoreDefaultMasterRules,
   ensureMasterSession,
+  refreshMasterIdentity,
   getMasterStatus,
   _resolveScope,
   _refreshMasterMemory,

--- a/server.js
+++ b/server.js
@@ -4674,6 +4674,20 @@ if (require.main === module) {
   // Start sidecar polling for active OpenClaw sessions
   sidecar.syncPolling();
 
+  // Refresh the master's identity file on every boot, regardless of autoStart.
+  // It embeds the TangleClaw API base URL, and only ensureMasterSession used to
+  // rewrite it — so with autoStart off, an install whose effective port changed
+  // kept telling the master to call a dead port until someone opened the master
+  // (#726). Managed projects already heal below via syncAllProjects(); this is
+  // the master's equivalent. skipIfAbsent so starting the server never creates
+  // master state for an operator who has not used it.
+  try {
+    const refreshed = master.refreshMasterIdentity({ skipIfAbsent: true });
+    if (refreshed.refreshed) log.debug('Master identity refreshed', { home: refreshed.home });
+  } catch (err) {
+    log.warn('Master identity refresh failed', { error: err.message });
+  }
+
   // Project Master auto-start: launch the reserved master session at boot
   // when the operator opted in (master.autoStart). Failure is logged, never
   // fatal — the brain icon's on-demand ensure remains the fallback path.

--- a/test/master.test.js
+++ b/test/master.test.js
@@ -576,3 +576,50 @@ describe('master API routes over HTTP', () => {
     }
   });
 });
+
+describe('refreshMasterIdentity (#726)', () => {
+  const os = require('node:os');
+  const fsx = require('node:fs');
+  const pathx = require('node:path');
+
+  function tmpHome() {
+    return fsx.mkdtempSync(pathx.join(os.tmpdir(), 'tc-master-'));
+  }
+
+  it('rewrites a stale API base URL without starting a session', () => {
+    const home = tmpHome();
+    // Simulate an identity generated when the port was wrong — the #726 state.
+    fsx.writeFileSync(pathx.join(home, 'CLAUDE.md'),
+      '# CLAUDE.md — TangleClaw Project Master\n**TangleClaw API base URL**: `http://localhost:3101`\n');
+
+    const result = master.refreshMasterIdentity({ home });
+    assert.equal(result.refreshed, true);
+
+    const after = fsx.readFileSync(pathx.join(home, 'CLAUDE.md'), 'utf8');
+    // Assert the API base URL LINE specifically — the file also embeds guide
+    // prose that legitimately mentions other ports, so a whole-file search for
+    // the stale value reports a false failure.
+    const urlLine = (after.match(/\*\*TangleClaw API base URL\*\*: `[^`]+`/) || [])[0];
+    assert.ok(urlLine, 'refreshed identity must carry an API base URL line');
+
+    const expectedPort = require('../lib/https-setup').effectiveServerPort(require('../lib/store').config.load());
+    assert.match(urlLine, new RegExp(`localhost:${expectedPort}\``),
+      `identity should name the effective port ${expectedPort}, got: ${urlLine}`);
+  });
+
+  it('does nothing when skipIfAbsent is set and no master home exists', () => {
+    const home = pathx.join(os.tmpdir(), `tc-master-absent-${process.pid}`);
+    if (fsx.existsSync(home)) fsx.rmSync(home, { recursive: true });
+
+    const result = master.refreshMasterIdentity({ home, skipIfAbsent: true });
+    assert.equal(result.refreshed, false, 'must not create master state as a boot side effect');
+    assert.equal(fsx.existsSync(home), false, 'the home directory must not be created');
+  });
+
+  it('creates the identity when the home exists but the file does not', () => {
+    const home = tmpHome();
+    const result = master.refreshMasterIdentity({ home, skipIfAbsent: true });
+    assert.equal(result.refreshed, true);
+    assert.ok(fsx.existsSync(pathx.join(home, 'CLAUDE.md')));
+  });
+});


### PR DESCRIPTION
## What

Splits the master's identity regeneration out of `ensureMasterSession()` into `master.refreshMasterIdentity()`, and calls it on every boot instead of only when `master.autoStart` is enabled.

Fixes #726.

## Why

The master's generated `CLAUDE.md` embeds the TangleClaw API base URL. The builder was already correct — `buildMasterClaudeMd` uses `effectiveServerPort(config)`, so #654's fix was present — but the only production writer was `ensureMasterSession()`, and at boot that ran conditionally:

```js
if (master.masterSettings(config).autoStart) { ... master.ensureMasterSession(); }
```

Managed-project configs heal **unconditionally** via `projects.syncAllProjects()`. The master had no equivalent. So with `autoStart` off, an install whose effective port differs from `config.serverPort` — which is the normal installed state, since the launchd plist sets `TANGLECLAW_PORT` and the config never learns about it — kept telling the master to call a port nothing was listening on. Every PortHub and shared-docs call the master made failed silently, and it survived restarts and the #654 upgrade indefinitely unless someone happened to open the master.

Field-confirmed 2026-07-27 on a first-time install: still reading `http://localhost:3101` after recovering to v4.32.2 with the service verified running on 3102.

## Design notes

- **Why a split rather than making boot call `ensureMasterSession()`:** that function also creates the tmux session and launches the engine. Boot must not start a master for an operator who didn't ask for one — that's what `autoStart` means. `refreshMasterIdentity()` is file writes only, so it's safe unconditionally and preserves the documented "never touches an already-running master" contract.
- **`skipIfAbsent`** so starting the server never creates master state as a side effect for an operator who has never opened the master. It refreshes what exists; it doesn't conjure it.
- `ensureMasterSession()` now calls the same function, so the two paths cannot drift.

## Also corrects a false claim in the 4.32.1 notes

That entry said already-generated configs "heal on the next server start ... operators need no manual step beyond the restart this ships with." True for managed projects, **false for the master identity file** — which the same entry listed as one of the three sites #654 fixed. Anyone who read it assumed they were covered. Corrected in this changelog entry rather than quietly fixed.

## Test plan

- Full suite: **4781 passing, 0 failing, 1 skipped**.
- 3 new tests: a stale identity is rewritten to the effective port without starting a session; `skipIfAbsent` creates nothing when no master home exists (asserts the directory is still absent); the identity is created when the home exists but the file doesn't.
- The port assertion targets the API base URL **line**, not the whole file — the identity embeds guide prose that legitimately mentions other ports, which made a whole-file search report a false failure.