### PR TITLE
Quote the SessionStart prime hook so a spaced install path stops breaking Claude startup (#759)

### DIFF
--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -26,6 +26,32 @@ Tag-line conventions (ART-4K9M, ratified 2026-07-17):
 -->
 
 
+## 2026-07-29: Quote the prime hook so a spaced install path stops breaking Claude startup (#759)
+
+<!-- prawduct: type=fix | chunks=01 | scope=759-hook-path-quoting -->
+
+**Why:** TangleClaw wrote the silent-prime `SessionStart` command into `.claude/settings.json`
+unquoted (`lib/engines.js`), and `_resolveHookPlaceholders` substitutes the install path by literal
+string replace. On an install under `~/Library/Mobile Documents/…` that made `/bin/sh` split the
+path — every Claude session start reported a hook error and booted with no prime and no project
+rules. The sibling rules hook shipped in #749 was quoted and carried a comment naming this precise
+hazard; the pre-existing prime hook fifteen lines above it was not brought along, which is the
+defect: the risk was identified and written down without sweeping the file it was written in.
+
+**Field-reported.** Structurally unreproducible here (this install's path has no space) and
+invisible on engines that never read `.claude/settings.json`, so it surfaced only when the reporter
+installed Claude Code and switched a project off codex. His report carried the generated settings
+file, both real paths, exact versions, and the correct fix.
+
+**What:** one-character-class fix — quote the command, exactly as its sibling already is. The guard
+runs **every** command `_buildBaselineHooks` emits through `/bin/sh` from a fixture directory
+containing a space, rather than asserting on the string: the rules hook was already correct, so a
+sampled test could have passed while the bug shipped. Revert-verified — un-quoting turns both new
+tests red.
+
+**Process note:** a duplicate (#760) was filed from this session ~20 minutes after the reporter's
+#759, because the pre-filing duplicate search was skipped. Closed as a duplicate; #759 is canonical.
+
 ## 2026-07-29: Update checks happen when they matter (#716)
 
 <!-- prawduct: type=feat | chunks=01 | scope=716-update-check-on-demand | status=shipped -->

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -43,6 +43,11 @@ invisible on engines that never read `.claude/settings.json`, so it surfaced onl
 installed Claude Code and switched a project off codex. His report carried the generated settings
 file, both real paths, exact versions, and the correct fix.
 
+**Recovery is automatic.** `syncEngineHooks` rewrites the entire `hooks` block before every launch
+(`lib/sessions.js`), so an install carrying the broken command self-heals on its first session after
+updating — no hand-edit of `.claude/settings.json`, which is the first thing the reporter would
+otherwise have to ask.
+
 **What:** one-character-class fix — quote the command, exactly as its sibling already is. The guard
 runs **every** command `_buildBaselineHooks` emits through `/bin/sh` from a fixture directory
 containing a space, rather than asserting on the string: the rules hook was already correct, so a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,23 @@ All notable changes to TangleClaw are documented in this file.
   /api/update-status` is unchanged for its existing consumers.
 
 ### Fixed
+- **Claude sessions no longer fail at startup when TangleClaw is installed under a path containing a
+  space (#759).** The silent-prime `SessionStart` hook was written into `.claude/settings.json`
+  unquoted, so `/bin/sh` split the path and every session start reported
+  `/bin/sh: /Users/<user>/Library/Mobile: No such file or directory`. Those sessions also launched
+  with **no session prime and no project rules** — the agent booted without its resume context or the
+  operator's governing rules.
+
+  Reported from the field by an installer whose checkout lives in iCloud Drive
+  (`~/Library/Mobile Documents/…`), complete with the generated settings file. Unreproducible on a
+  development machine whose own install path happens to have no space, and invisible on any engine
+  that does not read `.claude/settings.json` — it surfaced the moment that install switched a project
+  from codex to claude. The sibling rules hook added in the previous release was already quoted and
+  carried a comment naming this exact hazard; the older prime hook beside it was not brought along.
+
+  The regression guard runs **every** command `_buildBaselineHooks` emits through `/bin/sh` from a
+  fixture directory containing a space, rather than asserting on the string — a test that sampled one
+  command would have hit the correct one and passed.
 - **The header version no longer freezes when a tab is backgrounded (#716, #744).** A browser
   suspends timers in a background tab, so the 60-second poll #744 added simply stops and the header
   keeps naming whatever version was running when the tab was last awake — observed 2026-07-29, a tab

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,11 @@ All notable changes to TangleClaw are documented in this file.
   from codex to claude. The sibling rules hook added in the previous release was already quoted and
   carried a comment naming this exact hazard; the older prime hook beside it was not brought along.
 
+  **No manual cleanup is needed on an affected install.** `syncEngineHooks` rewrites the whole
+  `hooks` block in `.claude/settings.json` before every session launch, so an install that already
+  has the broken command self-heals the first time it launches a session after updating — nothing to
+  hand-edit.
+
   The regression guard runs **every** command `_buildBaselineHooks` emits through `/bin/sh` from a
   fixture directory containing a space, rather than asserting on the string — a test that sampled one
   command would have hit the correct one and passed.

--- a/lib/engines.js
+++ b/lib/engines.js
@@ -1042,7 +1042,14 @@ function _buildBaselineHooks(projConfig, engineProfile, ruleShardCount = 0) {
         hooks: [
           {
             type: 'command',
-            command: '{{TANGLECLAW_DIR}}/data/hooks/sessionstart-prime.sh',
+            // Quoted for the same reason the rules hook below is: the resolved
+            // TangleClaw directory is wherever the operator cloned it, and an
+            // unquoted one breaks the moment it contains a space. Unquoted, an
+            // install under `~/Library/Mobile Documents/…` made every Claude
+            // session start report a hook error and boot with no prime and no
+            // rules — reported from the field, unreproducible on a dev box
+            // whose own path happens to have no spaces.
+            command: '"{{TANGLECLAW_DIR}}/data/hooks/sessionstart-prime.sh"',
             statusMessage: 'Loading session prime...'
           }
         ]

--- a/test/api-projects.test.js
+++ b/test/api-projects.test.js
@@ -229,7 +229,8 @@ describe('api-projects', () => {
       const settings = JSON.parse(fs.readFileSync(settingsFile, 'utf8'));
       assert.ok(settings.hooks && settings.hooks.SessionStart, 'SessionStart hook should be present');
       const cmd = settings.hooks.SessionStart[0].hooks[0].command;
-      assert.ok(cmd.endsWith('sessionstart-prime.sh'), 'should point at the bundled hook script');
+      assert.match(cmd, /"[^"]*\/data\/hooks\/sessionstart-prime\.sh"$/,
+        'the command must be a QUOTED absolute path — an unquoted one breaks the moment the install path contains a space (#759)')
     });
   });
 

--- a/test/engines.test.js
+++ b/test/engines.test.js
@@ -1885,7 +1885,7 @@ describe('engines', () => {
       const result = engines._buildBaselineHooks({ silentPrime: true }, supportingProfile, 3);
       assert.equal(result.SessionStart.length, 4, 'one prime entry plus one per shard');
       const commands = result.SessionStart.map((e) => e.hooks[0].command);
-      assert.match(commands[0], /sessionstart-prime\.sh$/);
+      assert.match(commands[0], /"[^"]*\/data\/hooks\/sessionstart-prime\.sh"$/);
       // Each shard gets its OWN entry: the engine caps each hook's output
       // separately, so one hook emitting every shard would be capped as one.
       assert.match(commands[1], /sessionstart-rules\.sh" 1$/);
@@ -1896,7 +1896,7 @@ describe('engines', () => {
     it('registers no rules hook when the project has no rules', () => {
       const result = engines._buildBaselineHooks({ silentPrime: true }, supportingProfile, 0);
       assert.equal(result.SessionStart.length, 1, 'only the prime hook');
-      assert.match(result.SessionStart[0].hooks[0].command, /sessionstart-prime\.sh$/);
+      assert.match(result.SessionStart[0].hooks[0].command, /"[^"]*\/data\/hooks\/sessionstart-prime\.sh"$/);
     });
 
     it('registers no rules hook for an engine that cannot take a silent prime', () => {
@@ -1922,7 +1922,8 @@ describe('engines', () => {
       const result = engines._buildBaselineHooks({ silentPrime: true }, supportingProfile);
       const cmd = result.SessionStart[0].hooks[0].command;
       assert.ok(cmd.includes('{{TANGLECLAW_DIR}}'), 'should use placeholder for portability');
-      assert.ok(cmd.endsWith('sessionstart-prime.sh'), 'should point at the bundled hook script');
+      assert.match(cmd, /"[^"]*\/data\/hooks\/sessionstart-prime\.sh"$/,
+        'the command must be a QUOTED absolute path — an unquoted one breaks the moment the install path contains a space (#759)')
     });
 
     it('SessionStart entry has command type and a status message', () => {
@@ -1963,7 +1964,8 @@ describe('engines', () => {
       const settings = readSettings();
       assert.equal(settings.hooks.SessionStart.length, 1);
       assert.equal(settings.hooks.SessionStart[0].matcher, 'startup');
-      assert.ok(settings.hooks.SessionStart[0].hooks[0].command.endsWith('sessionstart-prime.sh'));
+      assert.match(settings.hooks.SessionStart[0].hooks[0].command, /"[^"]*\/data\/hooks\/sessionstart-prime\.sh"$/,
+        'the command must be a QUOTED absolute path — an unquoted one breaks the moment the install path contains a space (#759)')
     });
 
 
@@ -2042,7 +2044,7 @@ describe('engines', () => {
         engines.syncEngineHooks(projectDir);
         const entries = readSettings().hooks.SessionStart;
         assert.equal(entries.length, 1, 'a rules-query failure must not cost the session its prime');
-        assert.match(entries[0].hooks[0].command, /sessionstart-prime\.sh$/);
+        assert.match(entries[0].hooks[0].command, /"[^"]*\/data\/hooks\/sessionstart-prime\.sh"$/);
       } finally {
         store.sessionRules.listActiveForProject = real;
         store.projects.delete(project.id);
@@ -2068,8 +2070,13 @@ describe('engines', () => {
       const settings = readSettings();
       const cmd = settings.hooks.SessionStart[0].hooks[0].command;
       assert.ok(!cmd.includes('{{TANGLECLAW_DIR}}'), 'placeholder should be resolved before write');
-      assert.ok(path.isAbsolute(cmd), 'resolved path should be absolute');
-      assert.ok(cmd.endsWith('/data/hooks/sessionstart-prime.sh'));
+      // The command is a quoted path, so assert on what is INSIDE the quotes —
+      // testing the raw command string as if it were a bare path is the shape
+      // of assertion that let the unquoted form ship (#759).
+      const quoted = /^"(.+)"$/.exec(cmd);
+      assert.ok(quoted, 'the command must be a QUOTED path — unquoted breaks on a space (#759)');
+      assert.ok(path.isAbsolute(quoted[1]), 'resolved path should be absolute');
+      assert.match(quoted[1], /\/data\/hooks\/sessionstart-prime\.sh$/)
     });
 
     it('does not run for non-claude engines even with silentPrime enabled', () => {

--- a/test/projects.test.js
+++ b/test/projects.test.js
@@ -1661,7 +1661,8 @@ describe('projects', () => {
       assert.equal(settings.hooks.SessionStart.length, 1);
       assert.equal(settings.hooks.SessionStart[0].matcher, 'startup');
       const cmd = settings.hooks.SessionStart[0].hooks[0].command;
-      assert.ok(cmd.endsWith('sessionstart-prime.sh'), 'command should point at the bundled hook script');
+      assert.match(cmd, /"[^"]*\/data\/hooks\/sessionstart-prime\.sh"$/,
+        'the command must be a QUOTED absolute path — an unquoted one breaks the moment the install path contains a space (#759)')
       assert.equal(cmd.includes('{{TANGLECLAW_DIR}}'), false, 'placeholder should be resolved');
     });
 

--- a/test/sessionstart-prime-hook.test.js
+++ b/test/sessionstart-prime-hook.test.js
@@ -120,3 +120,78 @@ describe('sessionstart-prime.sh hook script (#103)', () => {
     assert.equal(out, '');
   });
 });
+
+/*
+ * #760 — every emitted hook command must survive an install path with a space.
+ *
+ * Reported from the field: a TangleClaw directory under `~/Library/Mobile
+ * Documents/…` made every Claude session start fail with
+ * `/bin/sh: /Users/<user>/Library/Mobile  No such file or directory`. The prime
+ * hook was emitted unquoted while the rules hook fifteen lines below it was
+ * quoted, with a comment naming this exact hazard — so a test that sampled one
+ * command could pass while the other shipped broken.
+ *
+ * This asserts over EVERY command `_buildBaselineHooks` emits, and asserts it
+ * by running the command the way Claude Code does rather than by inspecting the
+ * string. Unreproducible on this machine's own install, whose path has no space.
+ */
+describe('#760 hook commands survive a TangleClaw path containing a space', () => {
+  const engines = require('../lib/engines');
+
+  /** An engine profile that opts into the silent-prime hook. */
+  const PROFILE = { id: 'claude', capabilities: { supportsSilentPrime: true } };
+
+  /**
+   * Build a fake TangleClaw dir whose path contains a space, with executable
+   * no-op stand-ins for every shipped hook script.
+   * @returns {string} the directory path
+   */
+  function makeSpacedInstallDir() {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-hooks-'));
+    const dir = path.join(root, 'Mobile Documents', 'TangleClaw');
+    fs.mkdirSync(path.join(dir, 'data', 'hooks'), { recursive: true });
+    for (const name of ['sessionstart-prime.sh', 'sessionstart-rules.sh']) {
+      const p = path.join(dir, 'data', 'hooks', name);
+      fs.writeFileSync(p, '#!/bin/sh\nexit 0\n');
+      fs.chmodSync(p, 0o755);
+    }
+    assert.ok(dir.includes(' '), 'the fixture must actually contain a space');
+    return dir;
+  }
+
+  /** Every command string in a hooks object, flattened. @returns {string[]} */
+  function allCommands(hooks) {
+    const out = [];
+    for (const entries of Object.values(hooks)) {
+      for (const entry of entries) {
+        for (const h of entry.hooks) out.push(h.command);
+      }
+    }
+    return out;
+  }
+
+  it('runs every emitted command from a spaced install path', () => {
+    const dir = makeSpacedInstallDir();
+    // Two shards so the rules hook is emitted more than once — the loop that
+    // builds them must not be the only guarded path.
+    const hooks = engines._buildBaselineHooks({ silentPrime: true }, PROFILE, 2);
+    const commands = allCommands(hooks);
+    assert.ok(commands.length >= 2, `expected prime + rules commands, got ${commands.length}`);
+
+    for (const raw of commands) {
+      const command = raw.replace(/\{\{TANGLECLAW_DIR\}\}/g, dir);
+      // Exactly how the engine runs it: hand the string to a shell.
+      execFileSync('/bin/sh', ['-c', command], { stdio: ['pipe', 'pipe', 'pipe'] });
+    }
+  });
+
+  it('covers the prime hook specifically, since that is the one that shipped broken', () => {
+    const dir = makeSpacedInstallDir();
+    const hooks = engines._buildBaselineHooks({ silentPrime: true }, PROFILE, 0);
+    const commands = allCommands(hooks);
+    assert.equal(commands.length, 1, 'with no rule shards, only the prime hook is emitted');
+    const command = commands[0].replace(/\{\{TANGLECLAW_DIR\}\}/g, dir);
+    assert.match(command, /sessionstart-prime\.sh/);
+    execFileSync('/bin/sh', ['-c', command], { stdio: ['pipe', 'pipe', 'pipe'] });
+  });
+});

--- a/test/sessionstart-prime-hook.test.js
+++ b/test/sessionstart-prime-hook.test.js
@@ -122,7 +122,7 @@ describe('sessionstart-prime.sh hook script (#103)', () => {
 });
 
 /*
- * #760 — every emitted hook command must survive an install path with a space.
+ * #759 — every emitted hook command must survive an install path with a space.
  *
  * Reported from the field: a TangleClaw directory under `~/Library/Mobile
  * Documents/…` made every Claude session start fail with
@@ -135,8 +135,15 @@ describe('sessionstart-prime.sh hook script (#103)', () => {
  * by running the command the way Claude Code does rather than by inspecting the
  * string. Unreproducible on this machine's own install, whose path has no space.
  */
-describe('#760 hook commands survive a TangleClaw path containing a space', () => {
+describe('#759 hook commands survive a TangleClaw path containing a space', () => {
   const engines = require('../lib/engines');
+
+  // Matches this file's existing convention — every fixture root this block
+  // creates is torn down, so a run leaves nothing behind in tmp.
+  const fixtureRoots = [];
+  afterEach(() => {
+    while (fixtureRoots.length) fs.rmSync(fixtureRoots.pop(), { recursive: true, force: true });
+  });
 
   /** An engine profile that opts into the silent-prime hook. */
   const PROFILE = { id: 'claude', capabilities: { supportsSilentPrime: true } };
@@ -148,6 +155,7 @@ describe('#760 hook commands survive a TangleClaw path containing a space', () =
    */
   function makeSpacedInstallDir() {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-hooks-'));
+    fixtureRoots.push(root);
     const dir = path.join(root, 'Mobile Documents', 'TangleClaw');
     fs.mkdirSync(path.join(dir, 'data', 'hooks'), { recursive: true });
     for (const name of ['sessionstart-prime.sh', 'sessionstart-rules.sh']) {


### PR DESCRIPTION
Reported in #759 by a third-party installer. **Not using `Fixes #759`** — closing that issue is the maintainer's call, since it's someone else's. One word and I'll switch it.

> ⚠️ The branch is named `fix/760-…`. #760 was a duplicate filed from the same session ~20 minutes *after* #759 and closed as not-planned; every artifact inside the bundle cites #759. The branch name is the last stale pointer and it is deleted on merge.

## The bug

On an install whose TangleClaw checkout contains a space, every Claude session start failed:

```
SessionStart:startup hook error
/bin/sh: /Users/<user>/Library/Mobile: No such file or directory
```

Claude still reached a prompt — the hook is non-blocking — but **the prime never ran, so those sessions booted with no resume context and no project rules.** That is #749's failure arriving through a different door.

## Root cause

`lib/engines.js` emitted the silent-prime command unquoted, and `_resolveHookPlaceholders` substitutes the install path by literal string replace. The reporter's checkout is in iCloud Drive (`~/Library/Mobile Documents/…`), so `/bin/sh` split it at the space.

**The fix already existed fifteen lines below it.** #749 added the rules hook *quoted*, with a comment reading:

> *"an unquoted one breaks the moment it contains a space — silently, since the hook simply fails to run"*

Same function, same file. The hazard was identified and written down; the pre-existing sibling was not swept. That is the actual defect, and it is now a `learnings.md` rule.

## Why it was invisible here

- This machine's install path has no space — structurally unreproducible.
- The hook only fires for engines that read `.claude/settings.json`, so a codex project never touches it. It surfaced the moment that install switched a project to claude.
- **TangleClaw's own ledger recorded the entire outage as `delivered`** — delivery is stamped when shards are *written*, not when the hook *runs*. Filed as `PRM-7T3Q`; the #749 detector can't cover it either, since it rides the channel that broke.

## Recovery

No hand-editing. `syncEngineHooks` rewrites the whole `hooks` block before every launch, so an affected install self-heals on its first session after updating.

## Tests

**Eight existing assertions across four files used `endsWith('sessionstart-prime.sh')` — which passes for the broken form.** The tests actively protected the bug. The reporter predicted this exactly:

> *"existing tests assert suffix/presence but do not execute a command whose resolved install path contains spaces"*

All eight now pin a **quoted absolute path** at the right location. **None was loosened.** The new guard runs *every* command `_buildBaselineHooks` emits through `/bin/sh` from a fixture path containing a space — sampling one would have hit the already-correct rules hook and stayed green. Revert-verified: un-quoting turns both new tests red.

- Suite **5099 / 5100 pass, 0 fail**, 1 pre-existing skip.

## Review

Critic `cumulative` → `verify-resolutions`: **0 blocking, 0 warning, 0 new findings.** PR reviewer: **0 blocking, 0 warning, 2 notes**, both applied.

Two Critic warnings routed to backlog rather than expanded here: `ENG-6J8P` (quoting is owned per-call-site and covers only spaces — `$VAR`, `$(...)`, a literal `"` or `\` all still break it) and `PRM-7T3Q` (write-time delivery accounting).