### PR TITLE
Pin the documented install to v4.38.0 while v5 is built

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- **The README's Quick Start now installs from the `v4.38.0` tag rather than tracking `main` (#710).**
+  The install instructions were a bare `git clone` of the default branch, so a new install took
+  whatever happened to be on `main` at that moment. That is fine between releases and wrong during
+  one: the v5 Secure Baseline is being built on `main` now, and it changes how authentication and
+  network binding are configured — a half-finished version of that is exactly the thing not to hand
+  someone as their first experience. Cloning a tag gets a tree that was tested as a whole. The pin
+  moves to `v5.0.0` when it ships, and the accompanying note is removed.
+  Note this is a documentation control, not a structural one — a bare `git clone` still lands on
+  `main`, which is why the structural half is keeping in-progress v5 work off `main` entirely.
+
 ## [4.38.0] - 2026-07-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -150,10 +150,16 @@ What started as session persistence grew into a full orchestration platform — 
 ## Quick Start
 
 ```bash
-git clone https://github.com/Jason-Vaughan/TangleClaw.git
+git clone --branch v4.38.0 https://github.com/Jason-Vaughan/TangleClaw.git
 cd TangleClaw
 ./deploy/install.sh
 ```
+
+> **Install from the tag, not from `main`.** `v4.38.0` is the current supported release.
+> `main` is where the next release is built, and while a major is in progress it carries
+> partly-finished work — right now that includes changes to how authentication and network
+> binding are set up, which is not something to meet halfway through. Cloning the tag gets
+> you a version that was tested as a whole. This note goes away when the next release ships.
 
 The install script:
 1. Checks prerequisites (node 22+, ttyd, tmux)


### PR DESCRIPTION
Refs #710.

## What

`README.md` Quick Start now clones `--branch v4.38.0` instead of tracking the default branch, with a short note explaining why and when it goes away.

## Why

The install instructions were a bare `git clone` of `main`. Between releases that is harmless. During one it is not — the v5 Secure Baseline is being built on `main` and it changes how authentication and network binding are configured. A new installer following the README today would get a half-finished version of exactly that, as their first experience of the product.

Cloning a tag gets a tree that was tested as a whole.

## What this does not do

This is a **documentation control, not a structural one** — and ADR 0009 is explicit that documentation is not a control. A bare `git clone` with no `--branch` still lands on `main`. This protects everyone who follows the README; it does not protect someone who copies the repo URL.

The structural half is keeping in-progress v5 work off `main` entirely, which is a separate open decision recorded in the v5 plan.

## Reversal

The pin moves to `v5.0.0` when it ships, and the note is deleted. That is a step in the v5 release plan, not something to remember.

## Test plan

Docs-only; no code paths touched. Verified `grep -E "^## \[" CHANGELOG.md` still shows `[Unreleased]` above `[4.38.0]` after the changelog edit, and that the tag `v4.38.0` exists on origin.