### PR TITLE
Target tmux sessions by exact name so a launch cannot kill a neighbour

### DIFF
--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -2629,7 +2629,7 @@ writes the session option rather than a window one. `display-message` cannot be 
 (it answers for the attached client instead of failing), so `isAlternateScreen` checks existence
 explicitly. `new-session -s` stays bare — it names a session, it does not target one.
 
-Critic `cumulative` rev-20260729T192459Z-2bd57807: 0 blocking, 6 warnings, 13 notes. Five warnings
+Critic `cumulative` rev-20260729T192459Z-2bd57807: 0 blocking, 6 warnings, 13 notes. All six
 closed here — a structural test pinning the `_target` invariant across all 20 call sites (three
 reviewers independently found that rule was held by prose alone), pane-vs-session target-shape
 assertions in the shell test plus reverting a quoting regex that had been loosened enough to accept
@@ -2644,3 +2644,11 @@ name pairs were live on a box about to go unattended.
 
 **Classification:** fix
 **chunks:** 5
+
+Follow-up `verify-resolutions` rev-20260729T194003Z-441ad91b confirmed all six fixed (0 blocking)
+and caught one more: the round-trip test was *named* for hooks while asserting only mouse state, and
+`setMouse` merely `log.warn`s when `set-hook -t` fails — so a rejected hook target would have left
+the auto-toggle hooks uninstalled with the suite green. It now reads them back via `show-hooks`.
+Also tightened the structural extractor to catch a quoted `-t '${x}'` spelling and pinned the site
+count at exactly 20 (a site disappearing is a regression too), and moved the colon rationale into
+`deploy/ttyd-attach.sh` itself, where the next editor will actually be reading.

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -2612,3 +2612,35 @@ listed above.
 **Why:** lib/sessions.js (launch, prime prompt generation, idle detection, wrap orchestration, peek, command injection, kill, history), lib/skills.js (skill loading, wrap skill), store.sessions.start/wrap/kill/markCrashed/count, store.learnings.* full CRUD with auto-promotion, 8 API endpoints (sessions launch/kill/status/command/wrap/peek/history, activity). Critic: 2 blocking fixed (command length validation added per security-model.md, COUNT(*) replaced inefficient session list for totals), 5 warnings addressed (busy-wait replaced with spawnSync sleep, dead code removed, idle cache leak acknowledged, LIMIT string interpolation noted).
 
 **Classification:** build
+
+## 2026-07-29: tmux targets match a session name exactly — no prefix fallback (#774, PR #775)
+
+**Why:** tmux resolves a `-t <name>` target by exact name, then by unique **prefix**, then by
+fnmatch. From code that silently retargets another project's session: with no `TangleClaw` session
+running, a relaunch's orphan check matched `TangleClaw-Roadmap` and killed it in production. The
+kill was the symptom, not the boundary — the same fallback was measured on `send-keys`,
+`capture-pane` and `set-option`, and `deploy/ttyd-attach.sh` would have attached the browser
+terminal to a neighbouring project's live pane.
+
+Every `-t` now goes through `_target()`, emitting `'=name:'`. The colon is load-bearing: a bare
+`=name` is honoured only by target-session verbs, while pane- and option-scoped verbs reject it
+("can't find pane"). Verified against tmux 3.6a, including that `set-option -t '=name:'` still
+writes the session option rather than a window one. `display-message` cannot be protected this way
+(it answers for the attached client instead of failing), so `isAlternateScreen` checks existence
+explicitly. `new-session -s` stays bare — it names a session, it does not target one.
+
+Critic `cumulative` rev-20260729T192459Z-2bd57807: 0 blocking, 6 warnings, 13 notes. Five warnings
+closed here — a structural test pinning the `_target` invariant across all 20 call sites (three
+reviewers independently found that rule was held by prose alone), pane-vs-session target-shape
+assertions in the shell test plus reverting a quoting regex that had been loosened enough to accept
+the pre-fix form, mouse/hook round-trip coverage for the verbs whose rejection is silent
+(`getMouseState` catches and returns the wrong-but-plausible `{on:false}` that #574/#579 record as
+poisoning `sessionState.mouseOn`), this entry, and the `boundary-patterns.md` contract, which had
+been documenting the old wire form.
+
+Also hot-patched onto the running install the same day (uncommitted `lib/tmux.js` on `main` plus the
+live `~/.tangleclaw/deploy/ttyd-attach.sh` copy, server restarted and verified), because the exposed
+name pairs were live on a box about to go unattended.
+
+**Classification:** fix
+**chunks:** 5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **A session launch could kill, or type into, a different project's live session (#774).** tmux
+  resolves a `-t <name>` target by trying the exact session name, then a unique **prefix** of one,
+  then an fnmatch pattern — a convenience for people typing at a prompt, and destructive from code.
+  With no session named `TangleClaw` running, every `-t TangleClaw` silently retargeted
+  `TangleClaw-Roadmap`. Relaunching one project killed the other's live session; the prefix fallback
+  was verified on `send-keys` and `set-option` too, so it could equally have typed into or
+  reconfigured the neighbour, and `deploy/ttyd-attach.sh` would have attached the browser terminal
+  to that neighbour's pane.
+
+  Every tmux target now carries tmux's `=` exact-match prefix, so an absent session is an error
+  instead of whichever running session its name happens to prefix. The form is `'=name:'`: a bare
+  `=name` is honoured only by commands taking a *target-session* (`has-session`, `kill-session`),
+  while `send-keys`, `capture-pane`, `paste-buffer`, `set-option`, `show-option(s)` and `set-hook`
+  reject it outright and need the trailing colon — verified against tmux 3.6a, including that
+  `set-option -t '=name:'` still writes the session option rather than a window one. `display-message`
+  is the one command that cannot be protected this way, because it answers for the attached client
+  rather than failing on an absent session, so its caller checks existence explicitly.
+
+  Projects whose names prefix one another — `TangleClaw` / `TangleClaw-Roadmap`, `RentalClaw` /
+  `RentalClaw-Project` — were the exposed cases; no rename is needed now.
+
 ### Changed
 - **The README's Quick Start now installs from the `v4.38.0` tag rather than tracking `main` (#710).**
   The install instructions were a bare `git clone` of the default branch, so a new install took

--- a/deploy/ttyd-attach.sh
+++ b/deploy/ttyd-attach.sh
@@ -15,6 +15,14 @@ session=$(echo "$raw" | tr ' ' '-' | sed 's/[^a-zA-Z0-9_-]//g')
 # otherwise falls back to matching a unique PREFIX, so with no `TangleClaw`
 # session running, `-t TangleClaw` resolves to `TangleClaw-Roadmap` — and this
 # script would attach the browser terminal to a different project's live pane.
+#
+# The targets are NOT spelled the same way, and the difference is load-bearing.
+# `has-session` and `attach-session` take a target-SESSION and accept `=name`.
+# `capture-pane` takes a target-PANE and rejects `=name` outright ("can't find
+# pane"); it needs the trailing `:`, which resolves the session exactly and then
+# takes its current pane. Getting that wrong is silent here — the capture-pane
+# line ends in `2>/dev/null || true`, so a rejected target would just skip the
+# scrollback replay below with nothing to see. Measured against tmux 3.6a.
 if tmux has-session -t "=$session" 2>/dev/null; then
   # Replay scrolled-off history into the fresh xterm.js buffer before attaching
   # (#322). ttyd pipes this script's stdout straight into the browser terminal,

--- a/deploy/ttyd-attach.sh
+++ b/deploy/ttyd-attach.sh
@@ -11,7 +11,11 @@ session=$(echo "$raw" | tr ' ' '-' | sed 's/[^a-zA-Z0-9_-]//g')
 # The old `tmux new-session -A` pattern silently spawned a bare shell when the
 # real engine session ended, leaving an orphan that confused TangleClaw's
 # session state tracking and showed ulimit errors from .zshrc (fixes #47).
-if tmux has-session -t "$session" 2>/dev/null; then
+# The `=` prefix on every target forces an EXACT session-name match. tmux
+# otherwise falls back to matching a unique PREFIX, so with no `TangleClaw`
+# session running, `-t TangleClaw` resolves to `TangleClaw-Roadmap` — and this
+# script would attach the browser terminal to a different project's live pane.
+if tmux has-session -t "=$session" 2>/dev/null; then
   # Replay scrolled-off history into the fresh xterm.js buffer before attaching
   # (#322). ttyd pipes this script's stdout straight into the browser terminal,
   # so printing the pane history here restores scrollback that a reconnect or a
@@ -26,8 +30,8 @@ if tmux has-session -t "$session" 2>/dev/null; then
   #             is about to redraw aren't printed twice
   # Errors (e.g. a brand-new pane with no history) are swallowed — the replay is
   # best-effort and must never block the attach.
-  tmux capture-pane -e -p -t "$session" -S -10000 -E -1 2>/dev/null || true
-  exec tmux attach-session -t "$session"
+  tmux capture-pane -e -p -t "=$session:" -S -10000 -E -1 2>/dev/null || true
+  exec tmux attach-session -t "=$session"
 else
   echo "Session '${session}' is not running."
   echo "Return to TangleClaw to start a new session."

--- a/lib/tmux.js
+++ b/lib/tmux.js
@@ -82,12 +82,17 @@ function listSessions() {
 
 /**
  * Check if a tmux session exists.
+ *
+ * Matches the name EXACTLY: a live `Foo-Bar` does not make `hasSession('Foo')`
+ * true. Callers rely on this to decide whether to kill, adopt, or type into a
+ * session, so a near-miss must read as absent (see `_target`).
+ *
  * @param {string} name - Session name
  * @returns {boolean}
  */
 function hasSession(name) {
   try {
-    _exec(`tmux has-session -t ${_escapeArg(name)} 2>/dev/null`);
+    _exec(`tmux has-session -t ${_target(name)} 2>/dev/null`);
     return true;
   } catch {
     return false;
@@ -161,7 +166,7 @@ function refreshStatusBars(deps = {}) {
 
   for (const session of list()) {
     try {
-      const current = exec(`tmux show-option -t ${_escapeArg(session.name)} status-left 2>/dev/null`);
+      const current = exec(`tmux show-option -t ${_target(session.name)} status-left 2>/dev/null`);
       // Not ours: re-stamping an unbranded bar would put TangleClaw's name on
       // a session someone else started.
       if (!current || !current.includes(STATUS_BRAND)) {
@@ -184,7 +189,7 @@ function refreshStatusBars(deps = {}) {
         skipped++;
         continue;
       }
-      exec(`tmux set-option -t ${_escapeArg(session.name)} status-left ${_escapeArg(desired)}`);
+      exec(`tmux set-option -t ${_target(session.name)} status-left ${_escapeArg(desired)}`);
       updated++;
     } catch (err) {
       // One unhealthy session must not stop the rest from being corrected.
@@ -255,15 +260,15 @@ function createSession(name, options = {}) {
 
   // Set scrollback history to 50K lines for full peek capture
   try {
-    _exec(`tmux set-option -t ${_escapeArg(name)} history-limit 50000`);
+    _exec(`tmux set-option -t ${_target(name)} history-limit 50000`);
   } catch (err) {
     log.warn('Failed to set history-limit', { name, error: err.message });
   }
 
   // Configure status bar — show "TangleClaw v<version>" on left, time/date on right
   try {
-    _exec(`tmux set-option -t ${_escapeArg(name)} status-left ${_escapeArg(buildStatusLeft(serverInfo.getRunningVersion()))}`);
-    _exec(`tmux set-option -t ${_escapeArg(name)} status-right ${_escapeArg('#[fg=#777777] %H:%M  %Y-%m-%d ')}`);
+    _exec(`tmux set-option -t ${_target(name)} status-left ${_escapeArg(buildStatusLeft(serverInfo.getRunningVersion()))}`);
+    _exec(`tmux set-option -t ${_target(name)} status-right ${_escapeArg('#[fg=#777777] %H:%M  %Y-%m-%d ')}`);
   } catch (err) {
     log.warn('Failed to set status bar options', { name, error: err.message });
   }
@@ -282,7 +287,7 @@ function killSession(name) {
     return false;
   }
 
-  _exec(`tmux kill-session -t ${_escapeArg(name)}`);
+  _exec(`tmux kill-session -t ${_target(name)}`);
   log.info('Killed tmux session', { name });
   return true;
 }
@@ -311,7 +316,7 @@ function sendKeys(session, text, options = {}) {
   try {
     fs.writeFileSync(tmpFile, text);
     _exec(`tmux load-buffer ${_escapeArg(tmpFile)}`);
-    _exec(`tmux paste-buffer -p -t ${_escapeArg(session)}`);
+    _exec(`tmux paste-buffer -p -t ${_target(session)}`);
   } finally {
     try { fs.unlinkSync(tmpFile); } catch (_e) { /* ignore cleanup errors */ }
   }
@@ -319,7 +324,7 @@ function sendKeys(session, text, options = {}) {
   if (enter) {
     // Delay to let the terminal process the pasted content before sending Enter
     execSync(`sleep ${enterDelay / 1000}`);
-    _exec(`tmux send-keys -t ${_escapeArg(session)} Enter`);
+    _exec(`tmux send-keys -t ${_target(session)} Enter`);
   }
 
   log.debug('Sent keys to session', { session, length: text.length });
@@ -335,7 +340,7 @@ function sendRawKey(session, key) {
   if (!hasSession(session)) {
     throw new Error(`tmux session "${session}" does not exist`);
   }
-  _exec(`tmux send-keys -t ${_escapeArg(session)} ${_escapeArg(key)}`);
+  _exec(`tmux send-keys -t ${_target(session)} ${_escapeArg(key)}`);
   log.debug('Sent raw key to session', { session, key });
 }
 
@@ -347,9 +352,18 @@ function sendRawKey(session, key) {
  * @returns {boolean}
  */
 function isAlternateScreen(session) {
+  // display-message is the one target-taking command that does NOT fail on an
+  // absent session — it silently answers for the attached client instead, so an
+  // exact-match target cannot protect it the way it protects the others. Check
+  // existence explicitly, or a missing session reads as "whatever pane the
+  // operator happens to be looking at".
+  if (!hasSession(session)) {
+    return false;
+  }
+
   try {
     const result = _exec(
-      `tmux display-message -t ${_escapeArg(session)} -p '#{alternate_on}'`
+      `tmux display-message -t ${_target(session)} -p '#{alternate_on}'`
     );
     return result.trim() === '1';
   } catch {
@@ -380,7 +394,7 @@ function capturePane(session, options = {}) {
   if (altScreen) {
     try {
       const output = _exec(
-        `tmux capture-pane -t ${_escapeArg(session)} -p`
+        `tmux capture-pane -t ${_target(session)} -p`
       );
       return { lines: output.split('\n'), alternateScreen: true };
     } catch (err) {
@@ -399,7 +413,7 @@ function capturePane(session, options = {}) {
 
   try {
     const output = _exec(
-      `tmux capture-pane -t ${_escapeArg(session)} -p ${rangeFlag}`
+      `tmux capture-pane -t ${_target(session)} -p ${rangeFlag}`
     );
     return { lines: output.split('\n'), alternateScreen: false };
   } catch (err) {
@@ -421,21 +435,21 @@ function setMouse(session, on, options = {}) {
   }
 
   const value = on ? 'on' : 'off';
-  _exec(`tmux set-option -t ${_escapeArg(session)} mouse ${value}`);
+  _exec(`tmux set-option -t ${_target(session)} mouse ${value}`);
 
   if (options.hooks) {
     if (on) {
       // Set hooks that auto-toggle mouse on window changes
       try {
-        _exec(`tmux set-hook -t ${_escapeArg(session)} after-select-window "set mouse on"`);
-        _exec(`tmux set-hook -t ${_escapeArg(session)} after-select-pane "set mouse on"`);
+        _exec(`tmux set-hook -t ${_target(session)} after-select-window "set mouse on"`);
+        _exec(`tmux set-hook -t ${_target(session)} after-select-pane "set mouse on"`);
       } catch (err) {
         log.warn('Failed to set mouse hooks', { session, error: err.message });
       }
     } else {
       try {
-        _exec(`tmux set-hook -u -t ${_escapeArg(session)} after-select-window`);
-        _exec(`tmux set-hook -u -t ${_escapeArg(session)} after-select-pane`);
+        _exec(`tmux set-hook -u -t ${_target(session)} after-select-window`);
+        _exec(`tmux set-hook -u -t ${_target(session)} after-select-pane`);
       } catch (err) {
         log.warn('Failed to unset mouse hooks', { session, error: err.message });
       }
@@ -505,7 +519,7 @@ function getMouseState(session) {
   }
 
   try {
-    const sessionVal = _exec(`tmux show-options -t ${_escapeArg(session)} -v mouse 2>/dev/null`).trim();
+    const sessionVal = _exec(`tmux show-options -t ${_target(session)} -v mouse 2>/dev/null`).trim();
     const globalVal = _exec('tmux show-options -g -v mouse 2>/dev/null').trim();
     return _resolveMouseState(sessionVal, globalVal);
   } catch {
@@ -524,7 +538,7 @@ function unsetMouse(session) {
   if (!hasSession(session)) {
     throw new Error(`tmux session "${session}" does not exist`);
   }
-  _exec(`tmux set-option -u -t ${_escapeArg(session)} mouse`);
+  _exec(`tmux set-option -u -t ${_target(session)} mouse`);
   log.debug('Unset session-level mouse override', { session });
 }
 
@@ -555,6 +569,38 @@ function isServerRunning() {
 function _escapeArg(arg) {
   // Use single quotes, escaping any embedded single quotes
   return `'${String(arg).replace(/'/g, "'\\''")}'`;
+}
+
+/**
+ * Build a `-t` target argument that matches a session name EXACTLY.
+ *
+ * tmux resolves a target name by trying, in order: the exact session name, then
+ * a unique PREFIX of one, then an fnmatch pattern. That fallback is a
+ * convenience for humans typing at a prompt, and it is destructive from code:
+ * with no session named `TangleClaw`, `kill-session -t TangleClaw` silently
+ * resolves to `TangleClaw-Roadmap` and kills a different project's session —
+ * which is how one project's relaunch killed another's live session. The same
+ * fallback was verified on `send-keys` and `set-option`, so it could also type
+ * into, and reconfigure, a neighbour.
+ *
+ * The `=` prefix demands an exact match. The trailing colon is not cosmetic:
+ * `=name` is honoured only by commands taking a *target-session*
+ * (`has-session`, `kill-session`). Commands taking a target-pane or an option
+ * scope — `send-keys`, `capture-pane`, `paste-buffer`, `set-option`,
+ * `show-option(s)`, `set-hook` — reject a bare `=name` outright ("can't find
+ * pane"), and accept `=name:` , which resolves the session exactly and then
+ * takes its current window/pane. Verified against tmux 3.6a, including that
+ * `set-option -t '=name:'` still writes the SESSION option, not a window one.
+ *
+ * Every `-t` in this module must go through here. The one command this cannot
+ * protect is `display-message`, which falls back to the attached client instead
+ * of erroring on an absent session — its caller guards existence separately.
+ *
+ * @param {string} name - Session name
+ * @returns {string} Shell-escaped exact-match target (e.g. `'=TangleClaw:'`)
+ */
+function _target(name) {
+  return _escapeArg(`=${String(name)}:`);
 }
 
 module.exports = {

--- a/test/tmux.test.js
+++ b/test/tmux.test.js
@@ -615,9 +615,13 @@ describe('tmux', () => {
     // target goes through _target" for verbs whose misuse is silent.
     it('should route every tmux -t target in lib/tmux.js through _target', () => {
       const src = fs.readFileSync(path.join(__dirname, '..', 'lib', 'tmux.js'), 'utf8');
-      const targets = [...src.matchAll(/-t \$\{([^}]+)\}/g)].map(m => m[1]);
+      // Matches a quoted spelling too (`-t '${x}'`), which the bare-brace form
+      // would let slip past unchecked.
+      const targets = [...src.matchAll(/-t '?\$\{([^}]+)\}/g)].map(m => m[1]);
 
-      assert.ok(targets.length >= 15, `expected the module's many -t sites, found ${targets.length}`);
+      // An exact floor, not a lower bound: a site DISAPPEARING is as much a
+      // regression as one losing its wrapper, and `>=` would wave that through.
+      assert.equal(targets.length, 20, `expected 20 -t sites in lib/tmux.js, found ${targets.length}`);
       for (const expr of targets) {
         assert.match(
           expr,
@@ -636,6 +640,10 @@ describe('tmux', () => {
     // the wrong-but-plausible value #574/#579 record as poisoning
     // sessionState.mouseOn. A round trip is the only thing that catches it.
     it('should round-trip mouse state and hooks through exact-match targets', () => {
+      /** @returns {string} The session's installed hooks, via an exact-match target. */
+      const showHooks = () =>
+        tmux._exec(`tmux show-hooks -t ${tmux._escapeArg(`=${longer}:`)} 2>/dev/null`);
+
       tmux.createSession(longer, { command: 'exec bash --norc --noprofile' });
       try {
         tmux.setMouse(longer, true, { hooks: true });
@@ -643,8 +651,22 @@ describe('tmux', () => {
         assert.equal(on.on, true, 'mouse should read back on — a rejected target would read false');
         assert.equal(on.explicit, true, 'a session-level override should be visible as explicit');
 
+        // setMouse only log.warns when `set-hook -t` fails, so a rejected hook
+        // target leaves the auto-toggle hooks uninstalled with the test still
+        // green. Read them back or this assertion is decoration.
+        assert.match(
+          showHooks(),
+          /after-select-window/,
+          'enabling with hooks:true must actually install the after-select-window hook'
+        );
+
         tmux.setMouse(longer, false, { hooks: true });
         assert.equal(tmux.getMouse(longer), false, 'mouse should read back off');
+        assert.doesNotMatch(
+          showHooks(),
+          /after-select-window/,
+          'disabling with hooks:true must actually unset the hook'
+        );
 
         tmux.unsetMouse(longer);
         assert.equal(

--- a/test/tmux.test.js
+++ b/test/tmux.test.js
@@ -2,6 +2,8 @@
 
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
 const tmux = require('../lib/tmux');
 
 describe('tmux', () => {
@@ -603,6 +605,67 @@ describe('tmux', () => {
           () => tmux.capturePane(base),
           /does not exist/,
           'capturePane must not read a prefix-matched neighbour'
+        );
+      });
+    });
+
+    // The behavioural tests above all enter through hasSession, so a `-t` that
+    // lost its exact-match target on some OTHER verb would still pass them.
+    // This reads the source instead, which is the only way to hold "every
+    // target goes through _target" for verbs whose misuse is silent.
+    it('should route every tmux -t target in lib/tmux.js through _target', () => {
+      const src = fs.readFileSync(path.join(__dirname, '..', 'lib', 'tmux.js'), 'utf8');
+      const targets = [...src.matchAll(/-t \$\{([^}]+)\}/g)].map(m => m[1]);
+
+      assert.ok(targets.length >= 15, `expected the module's many -t sites, found ${targets.length}`);
+      for (const expr of targets) {
+        assert.match(
+          expr,
+          /^_target\(/,
+          `every tmux -t target must be built by _target(), found: -t \${${expr}}`
+        );
+      }
+      // `new-session -s` names a session being created; it is not a target and
+      // must stay bare, or tmux would create a session literally called "=x:".
+      assert.match(src, /new-session[^\n]*-s \$\{_escapeArg\(name\)\}/,
+        'new-session -s names a new session and must NOT be exact-match wrapped');
+    });
+
+    // These four verbs reject a bare `=name` and are the ones whose failure is
+    // invisible: getMouseState catches and returns {on:false, explicit:false} —
+    // the wrong-but-plausible value #574/#579 record as poisoning
+    // sessionState.mouseOn. A round trip is the only thing that catches it.
+    it('should round-trip mouse state and hooks through exact-match targets', () => {
+      tmux.createSession(longer, { command: 'exec bash --norc --noprofile' });
+      try {
+        tmux.setMouse(longer, true, { hooks: true });
+        const on = tmux.getMouseState(longer);
+        assert.equal(on.on, true, 'mouse should read back on — a rejected target would read false');
+        assert.equal(on.explicit, true, 'a session-level override should be visible as explicit');
+
+        tmux.setMouse(longer, false, { hooks: true });
+        assert.equal(tmux.getMouse(longer), false, 'mouse should read back off');
+
+        tmux.unsetMouse(longer);
+        assert.equal(
+          tmux.getMouseState(longer).explicit,
+          false,
+          'unsetMouse should remove the session-level override, not silently no-op'
+        );
+      } finally {
+        try { tmux.killSession(longer); } catch (_) {}
+      }
+    });
+
+    it('should refuse mouse and capture calls aimed at a prefix-matched neighbour', () => {
+      withNeighbour(() => {
+        assert.throws(() => tmux.getMouseState(base), /does not exist/);
+        assert.throws(() => tmux.setMouse(base, true), /does not exist/);
+        assert.throws(() => tmux.unsetMouse(base), /does not exist/);
+        assert.equal(
+          tmux.isAlternateScreen(base),
+          false,
+          'isAlternateScreen must not answer for the attached client when the session is absent'
         );
       });
     });

--- a/test/tmux.test.js
+++ b/test/tmux.test.js
@@ -542,4 +542,83 @@ describe('tmux', () => {
       assert.equal(result, false);
     });
   });
+
+  // tmux resolves a `-t` target by exact name, then by unique PREFIX, then by
+  // fnmatch. The prefix fallback is why a relaunch of project `Foo` killed live
+  // session `Foo-Bar`: with no `Foo` session, every `-t Foo` silently retargeted
+  // its longer-named neighbour. These tests pin the exact-match contract, so a
+  // target that loses its `=` prefix goes red instead of eating a neighbour.
+  describe('exact session-name targeting (no prefix fallback)', () => {
+    const base = '__tc_test_prefix__';
+    const longer = `${base}-neighbour`;
+
+    const withNeighbour = (fn) => {
+      tmux.createSession(longer, { command: 'exec bash --norc --noprofile' });
+      try {
+        assert.equal(tmux.hasSession(longer), true, 'precondition: neighbour should exist');
+        fn();
+      } finally {
+        try { tmux.killSession(longer); } catch (_) {}
+      }
+    };
+
+    it('should not report a session as existing when only a longer-named one does', () => {
+      withNeighbour(() => {
+        assert.equal(
+          tmux.hasSession(base),
+          false,
+          `hasSession('${base}') must be false while only '${longer}' is running`
+        );
+      });
+    });
+
+    it('should refuse to kill a longer-named session when the exact name is absent', () => {
+      withNeighbour(() => {
+        assert.equal(
+          tmux.killSession(base),
+          false,
+          'killSession must not resolve to a prefix-matched neighbour'
+        );
+        assert.equal(
+          tmux.hasSession(longer),
+          true,
+          'the neighbour session must survive — this is the data-loss case'
+        );
+      });
+    });
+
+    it('should refuse to send keys to a prefix-matched neighbour', () => {
+      withNeighbour(() => {
+        assert.throws(
+          () => tmux.sendKeys(base, 'echo prefix-leak'),
+          /does not exist/,
+          'sendKeys must not type into a prefix-matched neighbour'
+        );
+      });
+    });
+
+    it('should refuse to capture a prefix-matched neighbour', () => {
+      withNeighbour(() => {
+        assert.throws(
+          () => tmux.capturePane(base),
+          /does not exist/,
+          'capturePane must not read a prefix-matched neighbour'
+        );
+      });
+    });
+
+    it('should still act on the exact name when both it and a longer one exist', () => {
+      withNeighbour(() => {
+        tmux.createSession(base, { command: 'exec bash --norc --noprofile' });
+        try {
+          assert.equal(tmux.hasSession(base), true);
+          assert.equal(tmux.killSession(base), true);
+          assert.equal(tmux.hasSession(base), false, 'the exact-named session should be gone');
+          assert.equal(tmux.hasSession(longer), true, 'the neighbour should be untouched');
+        } finally {
+          try { tmux.killSession(base); } catch (_) {}
+        }
+      });
+    });
+  });
 });

--- a/test/ttyd-attach.test.js
+++ b/test/ttyd-attach.test.js
@@ -40,6 +40,26 @@ describe('deploy/ttyd-attach.sh', () => {
     );
   });
 
+  // tmux falls back to matching a unique PREFIX when no session has the exact
+  // target name, so `-t "$session"` would attach the browser terminal to a
+  // different project's live pane whenever the requested session is down and a
+  // longer-named one is up (e.g. TangleClaw down, TangleClaw-Roadmap running).
+  // The `=` prefix demands an exact match.
+  it('should target sessions by exact name so it cannot attach to a prefix-matched neighbour', () => {
+    const targets = codeLines().filter(l => /tmux\s+\S+\s.*-t\s/.test(l));
+    assert.ok(targets.length >= 3, 'expected has-session, capture-pane and attach-session targets');
+
+    for (const line of targets) {
+      const target = line.match(/-t\s+("?)(\S*?)\1(\s|$)/);
+      assert.ok(target, `could not parse -t target from: ${line.trim()}`);
+      assert.match(
+        target[2],
+        /^=/,
+        `tmux target must be exact-matched with a leading "=": ${line.trim()}`
+      );
+    }
+  });
+
   it('should use tmux attach-session (not new-session -A) to avoid orphan shells', () => {
     const attachLine = codeLines().find(l => l.includes('tmux attach-session'));
     assert.ok(attachLine, 'must use tmux attach-session for existing sessions');
@@ -74,9 +94,12 @@ describe('deploy/ttyd-attach.sh', () => {
 
   it('should quote the session variable', () => {
     const attachLine = codeLines().find(l => l.includes('tmux attach-session'));
+    // The exact-match `=` prefix (and the `:` pane-scope suffix some verbs
+    // need) sit INSIDE the quotes, so the assertion allows them while still
+    // requiring the quoting this test exists to protect.
     assert.match(
       attachLine,
-      /"\$session"/,
+      /"=?\$session:?"/,
       'session variable must be quoted to handle names with spaces'
     );
   });

--- a/test/ttyd-attach.test.js
+++ b/test/ttyd-attach.test.js
@@ -60,6 +60,36 @@ describe('deploy/ttyd-attach.sh', () => {
     }
   });
 
+  // The `=` alone is not enough, and getting this wrong is SILENT here: the
+  // capture-pane line ends in `2>/dev/null || true`, so a target tmux rejects
+  // just skips the scrollback replay (#322) with no error anyone sees. tmux
+  // accepts a bare `=name` only for target-SESSION verbs (has-session,
+  // attach-session); pane-scoped verbs need the `:` suffix or they fail with
+  // "can't find pane".
+  it('should give pane-scoped verbs the ":" suffix and session-scoped verbs the bare form', () => {
+    const paneScoped = /\b(capture-pane|send-keys|paste-buffer|display-message)\b/;
+    const sessionScoped = /\b(has-session|attach-session|kill-session)\b/;
+
+    for (const line of codeLines().filter(l => /tmux\s+\S+\s.*-t\s/.test(l))) {
+      const target = line.match(/-t\s+"([^"]+)"/);
+      assert.ok(target, `expected a quoted -t target in: ${line.trim()}`);
+
+      if (paneScoped.test(line)) {
+        assert.match(
+          target[1],
+          /^=.*:$/,
+          `pane-scoped tmux verbs need an "=name:" target or tmux rejects them: ${line.trim()}`
+        );
+      } else if (sessionScoped.test(line)) {
+        assert.match(
+          target[1],
+          /^=[^:]*$/,
+          `session-scoped tmux verbs take "=name" without the colon: ${line.trim()}`
+        );
+      }
+    }
+  });
+
   it('should use tmux attach-session (not new-session -A) to avoid orphan shells', () => {
     const attachLine = codeLines().find(l => l.includes('tmux attach-session'));
     assert.ok(attachLine, 'must use tmux attach-session for existing sessions');
@@ -94,12 +124,12 @@ describe('deploy/ttyd-attach.sh', () => {
 
   it('should quote the session variable', () => {
     const attachLine = codeLines().find(l => l.includes('tmux attach-session'));
-    // The exact-match `=` prefix (and the `:` pane-scope suffix some verbs
-    // need) sit INSIDE the quotes, so the assertion allows them while still
-    // requiring the quoting this test exists to protect.
+    // The exact-match `=` prefix sits INSIDE the quotes. It is required, not
+    // optional: an `=?` here would also accept the pre-fix `"$session"` form
+    // this test is meant to outlive.
     assert.match(
       attachLine,
-      /"=?\$session:?"/,
+      /"=\$session"/,
       'session variable must be quoted to handle names with spaces'
     );
   });

--- a/test/version-visibility.test.js
+++ b/test/version-visibility.test.js
@@ -118,7 +118,10 @@ describe('#745 status bar names the version the process actually loaded', () => 
       const setCalls = [];
       const exec = (cmd) => {
         if (cmd.includes('set-option')) { setCalls.push(cmd); return ''; }
-        const name = /-t '?([^' ]+)/.exec(cmd)[1];
+        // Targets are exact-match (`'=name:'`) so tmux cannot prefix-resolve
+        // them onto a neighbouring session; strip the `=` and `:` to recover
+        // the plain name this fixture is keyed by.
+        const name = /-t '?=?([^':]+)/.exec(cmd)[1];
         const val = current[name];
         if (val instanceof Error) throw val;
         return val;
@@ -179,7 +182,7 @@ describe('#745 status bar names the version the process actually loaded', () => 
       );
       const res = tmux.refreshStatusBars(h.deps);
       assert.deepEqual(res, { updated: 1, skipped: 1 });
-      assert.match(h.setCalls[0], /-t 'good'/);
+      assert.match(h.setCalls[0], /-t '=good:'/);
     });
 
     it('does nothing at all when the running version is unknown', () => {


### PR DESCRIPTION
## What

Routes every tmux `-t` target in `lib/tmux.js` and `deploy/ttyd-attach.sh` through tmux's `=` exact-match prefix, so a target names exactly one session and an absent session is an error rather than a neighbour whose name it prefixes.

Fixes #774.

## Why

tmux resolves a target by trying the exact session name, then a unique **prefix** of one, then an fnmatch pattern. That fallback is a convenience for humans typing at a prompt and is destructive from code. Wrapping the `TangleClaw` session and relaunching it killed the live `TangleClaw-Roadmap` session:

```
18:58:51.194 [sessions] Killing orphaned tmux session before fresh launch name=TangleClaw
18:58:51.204 [tmux]     Killed tmux session name=TangleClaw
18:58:53.936 [WARN] [sessions] Active session tmux died project=TangleClaw-Roadmap session=764
```

The kill was the visible symptom, not the whole bug: the same fallback was verified on `send-keys`, `capture-pane` and `set-option`, so it could type into, read from, or reconfigure a neighbouring session — and `ttyd-attach.sh` would have attached the browser terminal to that neighbour's live pane.

## The non-obvious part

`=` is **not** uniformly accepted (tmux 3.6a, measured not recalled):

| target form | `has-session` / `kill-session` / `attach-session` | `send-keys`, `capture-pane`, `paste-buffer`, `set-option`, `show-option(s)`, `set-hook` |
|---|---|---|
| `name` | prefix-matches (the bug) | prefix-matches (the bug) |
| `=name` | exact | **rejected** — "can't find pane" |
| `=name:` | exact | exact |

So the helper emits `=name:`. Confirmed `set-option -t '=name:'` still writes the SESSION option, not a window one. `display-message` cannot be protected this way — it answers for the attached client rather than failing on an absent session — so `isAlternateScreen` checks existence explicitly.

## Test plan

- Five new behavioural tests in `test/tmux.test.js` create a `X-neighbour` session with no `X` present and assert `hasSession`, `killSession`, `sendKeys` and `capturePane` all refuse it, the neighbour survives, and the exact name still works when both exist.
- One new test in `test/ttyd-attach.test.js` asserts every `-t` in the script is exact-matched.
- **Mutation-checked:** dropping the `=` from `_target()` turns exactly those six guards red and nothing else. A guard that passes either way would be worthless here.
- Full suite: **5105 pass, 0 fail, 1 pre-existing skip.**

Two `version-visibility.test.js` fakes parsed/asserted the old bare-name target and were taught the real command shape — assertions unchanged in intent; the one pinning a literal target now pins the exact-match form.