### PR TITLE
Merge hooks into .claude/settings.json instead of replacing them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to TangleClaw are documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- **TangleClaw no longer deletes the hooks you wrote in `.claude/settings.json` (#752).**
+  `syncEngineHooks` assigned `settings.hooks` wholesale from its own baseline, which emits exactly one
+  entry — TangleClaw's `SessionStart` prime. Every other hook in the file was discarded. That file is
+  the **shareable, committable** hooks location the Claude Code docs point operators at, and the sync
+  runs on **every session launch**, so a `PreToolUse` guard or `PostToolUse` formatter vanished
+  silently and repeatedly; on a committed file, TangleClaw also dirtied the working tree each launch.
+  The same defect sat in the non-claude branch, which cleared stale hooks with `delete existing.hooks`
+  and took the operator's with them.
+
+  Both branches now reconcile only the entries TangleClaw itself emits. Ownership is decided by hook
+  script name rather than by the resolved install path, so a clone the operator has since **moved**
+  still recognizes its own old entries instead of leaving a duplicate beside them, and shapes this code
+  does not model are passed through untouched rather than normalized away.
+
+  **One rule was deliberately narrowed to make this possible, and it is worth stating.** #538/#570
+  retired the vendored governance layer, and part of the wholesale write's purpose was clearing a
+  leftover `Stop` hook so the retired gate could not fire alongside the plugin's. That cleanup was
+  unconditional — *any* `Stop` hook — which cannot tell a retired gate from something the operator
+  wrote. It is now scoped to the vendored script the V1 layer actually emitted
+  (`tools/product-hook`), which is the same marker `governanceState` already uses to classify a
+  project as `governed-vendored`. A leftover gate is still cleared; an operator's own `Stop` hook is
+  not. The pre-existing tests that asserted the unconditional rule used fixtures indistinguishable
+  from an operator's hook (`echo governance-gate`, a bare `Old` event), so they were standing in for
+  "TangleClaw's entry" with something that isn't one; they now use the real emitted shape, and a
+  companion case pins that an operator `Stop` hook survives.
+
+  **Tests:** new `test/engine-hooks-merge.test.js` (17) — ownership across both current scripts and a
+  relocated install, refusal to claim an operator hook that merely references the TangleClaw
+  directory, a foreign event preserved, a foreign entry preserved *inside* an event TangleClaw also
+  writes, no duplication across five repeated syncs, unmodelled shapes passed through, and the
+  non-claude branch not rewriting a file when it has nothing of its own to clear. Verified by reverting
+  each of the three changes and confirming the suite goes red.
+
 - **A session launch could kill, or type into, a different project's live session (#774).** tmux
   resolves a `-t <name>` target by trying the exact session name, then a unique **prefix** of one,
   then an fnmatch pattern — a convenience for people typing at a prompt, and destructive from code.

--- a/lib/engines.js
+++ b/lib/engines.js
@@ -1008,6 +1008,90 @@ function _resolveHooksObject(hooks) {
   return resolved;
 }
 
+// Basenames of every hook script TangleClaw emits into a project's
+// .claude/settings.json. Ownership is decided by these rather than by the resolved
+// install path, so an install the operator has since MOVED still recognises its own
+// old entries and reconciles them instead of orphaning a duplicate beside them.
+const TC_HOOK_SCRIPTS = ['sessionstart-prime.sh', 'sessionstart-rules.sh'];
+
+// Hooks TangleClaw wrote in the PRE-PLUGIN era and is still responsible for
+// removing. The V1 methodology layer emitted `python3 "$CLAUDE_PROJECT_DIR/tools/
+// product-hook" <phase>` entries; #538/#570 deleted that layer, and a leftover Stop
+// entry must be cleared or it fires the retired vendored gate alongside the plugin's.
+//
+// Scoped to the vendored script by NAME, which is the same marker `governanceState`
+// already uses for `governed-vendored` (see `tools/product-hook` below). The old code
+// achieved this cleanup by clearing the ENTIRE hooks block, which is what made it
+// destroy operator hooks (#752) — an unconditional "drop any Stop hook" rule cannot
+// tell a retired gate from a formatter the operator wrote.
+const TC_LEGACY_HOOK_MARKERS = ['tools/product-hook'];
+
+/**
+ * Whether a hooks-array entry is one TangleClaw emitted.
+ *
+ * `.claude/settings.json` is the SHAREABLE, committable hooks location — where the
+ * Claude Code docs tell an operator to put a project-wide hook. TangleClaw owns only
+ * the entries it writes and must be able to name them exactly, because the
+ * alternative (replacing the whole block) silently discarded every hook the operator
+ * put there, on every session launch (#752).
+ * @param {*} entry - One element of a `hooks[<Event>]` array.
+ * @returns {boolean}
+ */
+function _isTangleClawHookEntry(entry) {
+  if (!entry || !Array.isArray(entry.hooks)) return false;
+  return entry.hooks.some((h) => {
+    if (!h || typeof h.command !== 'string') return false;
+    if (TC_HOOK_SCRIPTS.some((script) => h.command.includes(`data/hooks/${script}`))) return true;
+    // Ours historically, and still ours to retire.
+    return TC_LEGACY_HOOK_MARKERS.some((marker) => h.command.includes(marker));
+  });
+}
+
+/**
+ * Reconcile TangleClaw's baseline hooks into an existing hooks object.
+ *
+ * Merges rather than replaces: TangleClaw's own previous entries are dropped and its
+ * current ones added, while every foreign event and every foreign entry within a
+ * shared event survives verbatim — including shapes this function does not
+ * understand, which are passed through untouched rather than normalized away.
+ *
+ * An event left with no entries is removed, so TangleClaw retiring a hook does not
+ * leave an empty array behind; an event that still holds foreign entries is kept even
+ * when TangleClaw no longer emits into it.
+ * @param {object|undefined} existingHooks - The on-disk `hooks` object, if any.
+ * @param {object} baselineHooks - TangleClaw's current emission (already resolved).
+ * @returns {{ hooks: object, preservedForeign: number, replacedOwn: number }}
+ */
+function _mergeBaselineHooks(existingHooks, baselineHooks) {
+  const isPlainObject = (v) => !!v && typeof v === 'object' && !Array.isArray(v);
+  const existing = isPlainObject(existingHooks) ? existingHooks : {};
+  const merged = {};
+  let preservedForeign = 0;
+  let replacedOwn = 0;
+
+  for (const [event, entries] of Object.entries(existing)) {
+    if (!Array.isArray(entries)) {
+      // Not a shape this function models. Preserving it verbatim is strictly safer
+      // than dropping something an operator or a future Claude Code version wrote.
+      merged[event] = entries;
+      continue;
+    }
+    const foreign = entries.filter((entry) => {
+      if (_isTangleClawHookEntry(entry)) { replacedOwn += 1; return false; }
+      return true;
+    });
+    preservedForeign += foreign.length;
+    if (foreign.length > 0) merged[event] = foreign;
+  }
+
+  for (const [event, entries] of Object.entries(baselineHooks || {})) {
+    if (!Array.isArray(entries)) continue;
+    merged[event] = Array.isArray(merged[event]) ? merged[event].concat(entries) : entries.slice();
+  }
+
+  return { hooks: merged, preservedForeign, replacedOwn };
+}
+
 /**
  * Build engine-level baseline hooks based on per-project config and engine
  * capability. syncEngineHooks writes these as the project's hooks block.
@@ -1223,12 +1307,21 @@ function syncEngineHooks(projectPath, engineIdOverride) {
       try {
         const existing = JSON.parse(fs.readFileSync(settingsFile, 'utf8'));
         if (existing && existing.hooks) {
-          delete existing.hooks;
-          fs.writeFileSync(settingsFile, JSON.stringify(existing, null, 2) + '\n');
-          log.info('Cleared stale .claude/settings.json hooks for non-claude engine', {
-            projectPath,
-            engine: engineId
-          });
+          // Same rule as the claude branch, and the same defect it had: clearing
+          // TangleClaw's stale entries must not clear the operator's. `delete
+          // existing.hooks` took every hook in the file with it.
+          const { hooks: kept, preservedForeign, replacedOwn } = _mergeBaselineHooks(existing.hooks, {});
+          if (replacedOwn > 0 || Object.keys(kept).length !== Object.keys(existing.hooks).length) {
+            if (Object.keys(kept).length > 0) existing.hooks = kept;
+            else delete existing.hooks;
+            fs.writeFileSync(settingsFile, JSON.stringify(existing, null, 2) + '\n');
+            log.info('Cleared stale TangleClaw hooks for non-claude engine', {
+              projectPath,
+              engine: engineId,
+              preservedForeign,
+              replacedOwn
+            });
+          }
         }
       } catch (err) {
         log.warn('Failed to clear stale .claude/settings.json hooks', { projectPath, error: err.message });
@@ -1278,8 +1371,17 @@ function syncEngineHooks(projectPath, engineIdOverride) {
   }
   const baselineHooks = _buildBaselineHooks(projConfig, engineProfile, ruleShardCount);
 
-  if (Object.keys(baselineHooks).length > 0) {
-    settings.hooks = _resolveHooksObject(baselineHooks);
+  // Merge, never replace. `settings.hooks` may hold hooks the OPERATOR wrote —
+  // .claude/settings.json is the committable, shareable location the Claude Code
+  // docs point them at — and this function runs on every session launch, so a
+  // wholesale assignment discarded them silently and repeatedly (#752). Only the
+  // entries TangleClaw itself emits are reconciled.
+  const { hooks: mergedHooks, preservedForeign, replacedOwn } = _mergeBaselineHooks(
+    settings.hooks,
+    _resolveHooksObject(baselineHooks)
+  );
+  if (Object.keys(mergedHooks).length > 0) {
+    settings.hooks = mergedHooks;
   } else {
     delete settings.hooks;
   }
@@ -1292,7 +1394,10 @@ function syncEngineHooks(projectPath, engineIdOverride) {
   log.info('Synced engine hooks', {
     projectPath,
     engine: engineId,
-    hasBaselineHooks: Object.keys(baselineHooks).length > 0
+    hasBaselineHooks: Object.keys(baselineHooks).length > 0,
+    // Counted so a regression shows up in the log rather than only in a lost hook.
+    preservedForeign,
+    replacedOwn
   });
 }
 
@@ -1508,6 +1613,10 @@ function migrateToPlugin(projectPath, options = {}) {
 }
 
 module.exports = {
+  _mergeBaselineHooks,
+  _isTangleClawHookEntry,
+  TC_HOOK_SCRIPTS,
+  TC_LEGACY_HOOK_MARKERS,
   detect,
   detectEngine,
   resolveDefaultEngine,

--- a/test/engine-hooks-merge.test.js
+++ b/test/engine-hooks-merge.test.js
@@ -1,0 +1,222 @@
+'use strict';
+
+// `.claude/settings.json` hooks are MERGED, not replaced (#752).
+//
+// The defect: `syncEngineHooks` assigned `settings.hooks` wholesale from
+// `_buildBaselineHooks`, which emits exactly one entry — TangleClaw's own
+// SessionStart prime. Every other hook in the file was discarded. That file is the
+// shareable, committable hooks location the Claude Code docs point operators at, and
+// this function runs on every session launch, so an operator's PreToolUse guard or
+// PostToolUse formatter vanished silently and repeatedly — and if the file was
+// committed, TangleClaw dirtied the working tree on every launch too.
+//
+// The property under test is therefore not "our hook is present" but "everything
+// that is not ours is still there", including in shapes this code does not model.
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { setLevel } = require('../lib/logger');
+const store = require('../lib/store');
+const engines = require('../lib/engines');
+
+setLevel('error');
+
+/** A hook entry TangleClaw emits, as it appears on disk after placeholder resolution. */
+function tcEntry(script = 'sessionstart-prime.sh', arg = '') {
+  return {
+    matcher: 'startup',
+    hooks: [{
+      type: 'command',
+      command: `"/Users/someone/Projects/TangleClaw/data/hooks/${script}"${arg}`,
+      statusMessage: 'Loading session prime...'
+    }]
+  };
+}
+
+/** A hook entry the OPERATOR wrote — the thing that used to be destroyed. */
+function operatorEntry(command = 'npm run lint') {
+  return { matcher: 'Bash', hooks: [{ type: 'command', command }] };
+}
+
+describe('_isTangleClawHookEntry', () => {
+  it('recognizes both scripts TangleClaw emits', () => {
+    for (const script of engines.TC_HOOK_SCRIPTS) {
+      assert.equal(engines._isTangleClawHookEntry(tcEntry(script)), true, script);
+    }
+  });
+
+  it('recognizes its own entry after the install has been MOVED', () => {
+    // Ownership keys off the script path, not the resolved install directory: an
+    // operator who relocates the clone must not end up with a duplicate prime hook
+    // beside an unrecognized old one.
+    const moved = {
+      matcher: 'startup',
+      hooks: [{ type: 'command', command: '"/opt/tc/data/hooks/sessionstart-prime.sh"' }]
+    };
+    assert.equal(engines._isTangleClawHookEntry(moved), true);
+  });
+
+  it('does not claim an operator hook, however it is shaped', () => {
+    for (const entry of [
+      operatorEntry(),
+      operatorEntry('/Users/someone/data/hooks/my-own-script.sh'),
+      { matcher: 'Bash', hooks: [] },
+      { hooks: [{ type: 'command' }] },
+      {}, null, undefined, 'nonsense', 42
+    ]) {
+      assert.equal(engines._isTangleClawHookEntry(entry), false, JSON.stringify(entry));
+    }
+  });
+
+  it('does not claim a hook merely because it mentions the TangleClaw directory', () => {
+    // An operator hook that happens to reference the install (a wrap helper, a log
+    // tail) is still theirs.
+    const referencing = {
+      hooks: [{ type: 'command', command: 'tail -f /Users/someone/Projects/TangleClaw/logs/server.log' }]
+    };
+    assert.equal(engines._isTangleClawHookEntry(referencing), false);
+  });
+});
+
+describe('_mergeBaselineHooks', () => {
+  it('keeps a foreign EVENT untouched', () => {
+    const existing = { PreToolUse: [operatorEntry()] };
+    const { hooks, preservedForeign } = engines._mergeBaselineHooks(existing, { SessionStart: [tcEntry()] });
+    assert.deepEqual(hooks.PreToolUse, [operatorEntry()]);
+    assert.equal(hooks.SessionStart.length, 1);
+    assert.equal(preservedForeign, 1);
+  });
+
+  it('keeps a foreign ENTRY inside an event TangleClaw also writes', () => {
+    // The harder half: SessionStart shared between an operator hook and ours.
+    const existing = { SessionStart: [operatorEntry('echo hi'), tcEntry()] };
+    const { hooks, replacedOwn } = engines._mergeBaselineHooks(existing, { SessionStart: [tcEntry()] });
+    assert.equal(replacedOwn, 1, 'our previous entry is reconciled, not duplicated');
+    assert.equal(hooks.SessionStart.length, 2);
+    assert.deepEqual(hooks.SessionStart[0], operatorEntry('echo hi'), 'the operator entry survives');
+    assert.equal(engines._isTangleClawHookEntry(hooks.SessionStart[1]), true);
+  });
+
+  it('does not duplicate our own entry across repeated syncs', () => {
+    // syncEngineHooks runs on EVERY session launch, so a merge that appended
+    // without reconciling would grow the file without bound.
+    let hooks = { SessionStart: [tcEntry()] };
+    for (let i = 0; i < 5; i += 1) {
+      hooks = engines._mergeBaselineHooks(hooks, { SessionStart: [tcEntry()] }).hooks;
+    }
+    assert.equal(hooks.SessionStart.length, 1);
+  });
+
+  it('drops an event that held only our entries once we stop emitting it', () => {
+    const { hooks } = engines._mergeBaselineHooks({ SessionStart: [tcEntry()] }, {});
+    assert.equal('SessionStart' in hooks, false);
+  });
+
+  it('keeps an event that still holds foreign entries once we stop emitting it', () => {
+    const { hooks } = engines._mergeBaselineHooks(
+      { SessionStart: [operatorEntry('echo hi'), tcEntry()] }, {});
+    assert.equal(hooks.SessionStart.length, 1);
+    assert.deepEqual(hooks.SessionStart[0], operatorEntry('echo hi'));
+  });
+
+  it('passes through a shape it does not model rather than normalizing it away', () => {
+    // A future Claude Code version, or an operator's hand-edit, may use a shape this
+    // function has never seen. Dropping it would be the same class of loss as #752.
+    const existing = { Stop: { legacy: 'object-not-array' }, PreToolUse: 'string' };
+    const { hooks } = engines._mergeBaselineHooks(existing, {});
+    assert.deepEqual(hooks.Stop, { legacy: 'object-not-array' });
+    assert.equal(hooks.PreToolUse, 'string');
+  });
+
+  it('handles an absent or malformed existing hooks object', () => {
+    for (const input of [undefined, null, 'x', 42, []]) {
+      const { hooks } = engines._mergeBaselineHooks(input, { SessionStart: [tcEntry()] });
+      assert.equal(hooks.SessionStart.length, 1, JSON.stringify(input));
+    }
+  });
+
+  it('does not mutate the inputs', () => {
+    const existing = { SessionStart: [operatorEntry()] };
+    const baseline = { SessionStart: [tcEntry()] };
+    const before = JSON.stringify([existing, baseline]);
+    engines._mergeBaselineHooks(existing, baseline);
+    assert.equal(JSON.stringify([existing, baseline]), before);
+  });
+});
+
+describe('syncEngineHooks preserves operator hooks end to end', () => {
+  let tmpDir;
+  let projectPath;
+
+  before(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-hookmerge-'));
+    store._setBasePath(path.join(tmpDir, 'home'));
+    store.init();
+    projectPath = path.join(tmpDir, 'project');
+    fs.mkdirSync(path.join(projectPath, '.claude'), { recursive: true });
+  });
+
+  after(() => {
+    store.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  /** Write a settings.json and return its parsed content after a sync. */
+  function syncWith(settings, projConfig) {
+    fs.writeFileSync(path.join(projectPath, '.claude', 'settings.json'),
+      JSON.stringify(settings, null, 2) + '\n');
+    const cfg = { ...store.DEFAULT_PROJECT_CONFIG, ...(projConfig || {}) };
+    store.projectConfig.save(projectPath, cfg);
+    engines.syncEngineHooks(projectPath, cfg.engine || 'claude');
+    return JSON.parse(fs.readFileSync(path.join(projectPath, '.claude', 'settings.json'), 'utf8'));
+  }
+
+  it('leaves an operator PreToolUse guard in place after a claude sync', () => {
+    const after = syncWith({
+      enabledPlugins: { 'prawduct@prawduct': true },
+      hooks: { PreToolUse: [operatorEntry()] }
+    }, { engine: 'claude', silentPrime: true });
+
+    assert.deepEqual(after.hooks.PreToolUse, [operatorEntry()],
+      'the operator guard was discarded — this is #752');
+    assert.deepEqual(after.enabledPlugins, { 'prawduct@prawduct': true },
+      'non-hook keys must still survive');
+  });
+
+  it('leaves an operator hook in place when the engine is NOT claude', () => {
+    // The non-claude branch deleted the whole hooks object, so it had the same
+    // defect as the claude branch and needed the same fix.
+    const after = syncWith({ hooks: { PreToolUse: [operatorEntry()] } }, { engine: 'codex' });
+    assert.deepEqual(after.hooks.PreToolUse, [operatorEntry()]);
+  });
+
+  it('still clears OUR stale entry when the engine is not claude', () => {
+    const after = syncWith({
+      hooks: { SessionStart: [tcEntry()], PreToolUse: [operatorEntry()] }
+    }, { engine: 'codex' });
+    assert.equal('SessionStart' in (after.hooks || {}), false, 'our stale entry must go');
+    assert.deepEqual(after.hooks.PreToolUse, [operatorEntry()], 'theirs must stay');
+  });
+
+  it('removes the hooks key entirely when nothing is left to hold', () => {
+    const after = syncWith({ hooks: { SessionStart: [tcEntry()] } }, { engine: 'codex' });
+    assert.equal('hooks' in after, false);
+  });
+
+  it('does not rewrite the file when there is nothing of ours to clear', () => {
+    // Avoids dirtying a committed settings.json on every launch for a non-claude
+    // project that has only operator hooks.
+    const settingsFile = path.join(projectPath, '.claude', 'settings.json');
+    fs.writeFileSync(settingsFile, JSON.stringify({ hooks: { PreToolUse: [operatorEntry()] } }, null, 2) + '\n');
+    const cfg = { ...store.DEFAULT_PROJECT_CONFIG, engine: 'codex' };
+    store.projectConfig.save(projectPath, cfg);
+    const before = fs.statSync(settingsFile).mtimeMs;
+    const raw = fs.readFileSync(settingsFile, 'utf8');
+    engines.syncEngineHooks(projectPath, 'codex');
+    assert.equal(fs.readFileSync(settingsFile, 'utf8'), raw, 'file content changed');
+    assert.equal(fs.statSync(settingsFile).mtimeMs, before, 'file was rewritten unnecessarily');
+  });
+});

--- a/test/engines.test.js
+++ b/test/engines.test.js
@@ -1285,6 +1285,16 @@ describe('engines', () => {
       });
     });
 
+    // A hook as TangleClaw actually emits it. Fixtures that used `echo stale` or a
+    // bare `Old` event were standing in for "TangleClaw's own entry" with something
+    // indistinguishable from an operator's hook — so once hooks are MERGED rather
+    // than replaced (#752) they no longer discriminate anything. Ownership is the
+    // whole question now, so the fixture has to carry it.
+    const tcOwnedHook = (script = 'sessionstart-prime.sh') => ({
+      matcher: 'startup',
+      hooks: [{ type: 'command', command: `"/Users/x/TangleClaw/data/hooks/${script}"` }]
+    });
+
     describe('syncEngineHooks defers GOVERNANCE but keeps TC L1 prime (#330)', () => {
       const staleGovHook = { Stop: [{ matcher: '', hooks: [{ type: 'command', command: 'python3 "$CLAUDE_PROJECT_DIR/tools/product-hook" stop' }] }] };
 
@@ -1336,7 +1346,15 @@ describe('engines', () => {
         // not the plugin is enabled. Ungoverned is the case that would regress
         // silently if this became conditional again, since that project has no
         // plugin to own the gate in TC's place.
-        const legacy = { Stop: [{ matcher: '', hooks: [{ type: 'command', command: 'echo governance-gate' }] }] };
+        // NARROWED by #752, deliberately: the rule is no longer "drop any Stop hook"
+        // but "drop the retired VENDORED gate", identified by the `tools/product-hook`
+        // script the V1 methodology layer emitted — the same marker `governanceState`
+        // uses for `governed-vendored`. The unconditional version could not tell that
+        // gate from a Stop hook the operator wrote in the committable settings file,
+        // and destroyed both on every session launch.
+        const legacy = {
+          Stop: [{ matcher: '', hooks: [{ type: 'command', command: 'python3 "$CLAUDE_PROJECT_DIR/tools/product-hook" stop' }] }]
+        };
 
         for (const [label, settings] of [
           ['ungoverned', {}],
@@ -1347,6 +1365,17 @@ describe('engines', () => {
           const written = JSON.parse(fs.readFileSync(path.join(p, '.claude', 'settings.json'), 'utf8'));
           assert.equal(written.hooks, undefined, `${label}: the legacy governance Stop hook must be cleared`);
         }
+      });
+
+      it('does NOT clear a Stop hook the operator wrote (#752)', () => {
+        // The other half of the narrowing above, and the reason for it. A Stop hook
+        // that is not the retired vendored gate belongs to whoever put it in the
+        // committable settings file, and this function runs on every session launch.
+        const own = { Stop: [{ matcher: '', hooks: [{ type: 'command', command: 'make verify' }] }] };
+        const p = mkProject({ hooks: own }, { engine: 'claude', silentPrime: false });
+        engines.syncEngineHooks(p);
+        const written = JSON.parse(fs.readFileSync(path.join(p, '.claude', 'settings.json'), 'utf8'));
+        assert.deepEqual(written.hooks.Stop, own.Stop, 'an operator Stop hook was destroyed');
       });
     });
 
@@ -1361,7 +1390,7 @@ describe('engines', () => {
         // L1 SessionStart baseline hook; resolved-as-codex takes the cleanup
         // branch and removes the hooks block entirely.
         const p = mkProject(
-          { hooks: { SessionStart: [{ matcher: '', hooks: [{ type: 'command', command: 'echo stale' }] }] } },
+          { hooks: { SessionStart: [tcOwnedHook()] } },
           { methodology: 'minimal', silentPrime: true } // no engine key
         );
         store.projects.create({ name: `db-hooks-${path.basename(p)}`, path: p, engine: 'codex' });
@@ -1375,7 +1404,7 @@ describe('engines', () => {
 
       it('unregistered path still falls back to projConfig.engine', () => {
         const p = mkProject(
-          { hooks: { Stop: [{ matcher: '', hooks: [{ type: 'command', command: 'echo stale' }] }] } },
+          { hooks: { SessionStart: [tcOwnedHook()] } },
           { engine: 'codex', methodology: 'minimal', silentPrime: false }
         );
         engines.syncEngineHooks(p);
@@ -1799,13 +1828,18 @@ describe('engines', () => {
         'resolved command should carry a real path');
     });
 
-    it('preserves existing non-hook settings and replaces the hooks block wholesale', () => {
+    it('preserves existing non-hook settings AND foreign hooks, reconciling only its own', () => {
+      // Was "replaces the hooks block wholesale". That is the #752 defect stated as a
+      // contract: `.claude/settings.json` is the committable, shareable hooks location,
+      // and a wholesale replacement discarded whatever the operator put there on every
+      // session launch. TangleClaw reconciles only the entries it emits.
       const claudeDir = path.join(projectDir, '.claude');
       fs.mkdirSync(claudeDir, { recursive: true });
+      const operatorHook = { matcher: 'Bash', hooks: [{ type: 'command', command: 'npm run lint' }] };
       fs.writeFileSync(path.join(claudeDir, 'settings.json'), JSON.stringify({
         permissions: { allow: ['Bash(git status:*)'] },
         companyAnnouncements: ['Test announcement'],
-        hooks: { Old: [{ matcher: '', hooks: [] }] }
+        hooks: { PreToolUse: [operatorHook] }
       }, null, 2));
 
       engines.syncEngineHooks(projectDir);
@@ -1813,16 +1847,20 @@ describe('engines', () => {
       const settings = readSettings();
       assert.deepStrictEqual(settings.permissions, { allow: ['Bash(git status:*)'] });
       assert.deepStrictEqual(settings.companyAnnouncements, ['Test announcement']);
-      assert.ok(!settings.hooks.Old, 'old hooks should be replaced, not merged');
+      assert.deepStrictEqual(settings.hooks.PreToolUse, [operatorHook],
+        'a foreign hook event must survive TangleClaw\'s sync');
       assert.ok(settings.hooks.SessionStart, 'new hooks should be present');
     });
 
-    it('removes the hooks block when there are no hooks to write', () => {
+    it('removes the hooks block when nothing of its own is left to hold', () => {
+      // The fixture has to be a hook TangleClaw OWNS. It used to be a bare `Stop`
+      // entry, which under merge semantics (#752) is a hook belonging to whoever put
+      // it in the committable settings file — preserved, so the key correctly stays.
       const claudeDir = path.join(projectDir, '.claude');
       fs.mkdirSync(claudeDir, { recursive: true });
       fs.writeFileSync(path.join(claudeDir, 'settings.json'), JSON.stringify({
         permissions: { allow: [] },
-        hooks: { Stop: [{ matcher: '', hooks: [] }] }
+        hooks: { SessionStart: [{ matcher: 'startup', hooks: [{ type: 'command', command: '"/Users/x/TangleClaw/data/hooks/sessionstart-prime.sh"' }] }] }
       }, null, 2));
       fs.writeFileSync(path.join(projectDir, '.tangleclaw', 'project.json'), JSON.stringify({
         engine: 'claude',


### PR DESCRIPTION
Fixes #752

## What

`syncEngineHooks` reconciles only the hook entries TangleClaw itself emits, instead of assigning `settings.hooks` wholesale. The non-claude branch gets the same treatment — it cleared stale hooks with `delete existing.hooks`, which took the operator's with them.

Ownership keys off hook **script name**, not the resolved install path, so a clone the operator has since moved still recognizes its own old entries rather than leaving a duplicate beside them. Shapes this code doesn't model are passed through untouched rather than normalized away.

## Why

`.claude/settings.json` is the shareable, committable hooks location the Claude Code docs point operators at, and `syncEngineHooks` runs on **every session launch**. Since `_buildBaselineHooks` emits exactly one entry, everything else in the file was discarded — silently, repeatedly, and on a committed file it dirtied the working tree each launch too.

## The one judgement call — a narrowed contract, flagged deliberately

Part of the wholesale write's purpose was legitimate: #538/#570 retired the vendored governance layer, and a leftover `Stop` hook must be cleared so the retired gate can't fire alongside the plugin's. But that cleanup was **unconditional** — *any* `Stop` hook — and that cannot distinguish a retired gate from something the operator wrote.

It is now scoped to `tools/product-hook`, the script the V1 layer actually emitted, which is already the marker `governanceState` uses to classify a project `governed-vendored`. **A leftover gate is still cleared; an operator's own `Stop` hook is not.** If you'd rather keep the unconditional sweep, say so and I'll invert it — but as written the two behaviours were in direct conflict.

Three pre-existing tests asserted the old contract using fixtures indistinguishable from an operator's hook (`echo governance-gate`, `echo stale`, a bare `Old` event) — they were standing in for "TangleClaw's own entry" with something that isn't one, and stopped discriminating anything once hooks are merged. They now use the real emitted shape, and a companion case pins that an operator `Stop` hook survives.

## Test plan

- New `test/engine-hooks-merge.test.js` (17 cases): ownership across both emitted scripts and a **relocated** install; refusal to claim an operator hook that merely references the TangleClaw directory; a foreign *event* preserved; a foreign *entry* preserved inside an event TangleClaw also writes; no duplication across five repeated syncs; unmodelled shapes passed through; the hooks key removed only when nothing of TangleClaw's is left; and the non-claude branch not rewriting a file it has nothing to clear in.
- **Mutation-verified rather than assumed**: reverting the claude-branch merge, the non-claude-branch merge, and the legacy-marker recognition each makes the suite go red.
- Full suite: **5127 passed, 0 failed, 1 skipped.**

## Note for the reviewer

`prawduct-hook verify-chunk-refs` exits 1 in symlinked worktrees for an unrelated reason (it resolves plan refs through the symlink realpath) — filed as `PRW-6T2M`. Not related to this change.