### PR TITLE
Derive the prawduct install reference from a reviewed constant, not an untracked local file

### DIFF
--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -26,6 +26,39 @@ Tag-line conventions (ART-4K9M, ratified 2026-07-17):
 -->
 
 
+## 2026-07-31: the prawduct install reference becomes a reviewed constant, not a copy of local state (#807, #816)
+
+<!-- prawduct: type=fix | scope=plugin-ref-807 -->
+
+**Why:** `migrateToPlugin` built the reference by copying TangleClaw's own `.claude/settings.json`
+verbatim. That file is untracked, machine-local and freely editable, so whatever it held was stamped
+into every project migrated on that machine — invisible in any diff, different per machine. One
+design, two defects: a stale `ref: "v2.1.5"` pin reached eleven repositories (#807), and once the
+marketplace half of that file went missing, migrations wrote `enabledPlugins` with nothing to resolve
+it from (#816) — a plugin that silently never loads anywhere prawduct is not already registered, and
+that looks perfectly healthy on the machine that wrote it.
+
+**The design point worth keeping.** The original intent — "don't hardcode a version" — was right; the
+source was wrong. Avoiding a hardcoded pin by reading an untracked local file does not remove the
+pin, it makes it invisible and per-machine. The fix hardcodes upstream's *published contract* and
+puts the change under review, which is the smaller risk. It is deliberately not a runtime read of the
+plugin's own source either: TangleClaw migrates projects on machines where the plugin is absent, so
+deriving the value from a file that may not exist reproduces the same defect class one layer up.
+
+**Two things the review caught that the build missed.** The contract test compared TangleClaw's
+constant against a literal in TangleClaw's own repo, so it could only catch our side moving — while
+the JSDoc, the test comment and the CHANGELOG all claimed it caught divergence "on either side."
+Upstream drift is the direction #807 was actually bitten by. A test-only read of the installed
+plugin's `migrate_plugin.py` now makes the claim true. Separately, ADR 0011 still described the
+deleted `_readSelfPluginRef` sourcing as the design; correcting one paragraph left every *normative*
+statement of the old three-item seam count standing, which is the half-fix pattern this project keeps
+hitting — the count is now amended everywhere it is asserted, and the ADR records the amendment.
+
+**Mutation-checked, and the first attempt failed honestly.** Restoring the original conditional
+marketplace merge left the suite green: once the reference is validated complete, the conditional and
+unconditional merges are equivalent, so the comment crediting the merge as the safeguard was false.
+The completeness guard is what is load-bearing, and bypassing it turns the partial-reference test red.
+
 ## 2026-07-29: setup provisions a login by default — the step-list flip plus the cutover it enforces (#710, chunk 2 slice 2-iii-b)
 
 <!-- prawduct: type=feat | chunks=2 | scope=auth-6-secure-by-default -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,30 @@ All notable changes to TangleClaw are documented in this file.
 
 ### Fixed
 
+- **TangleClaw no longer stamps an unreviewed prawduct reference into the projects it migrates
+  (#807, #816).** `migrateToPlugin` built the plugin reference by copying TangleClaw's own
+  `.claude/settings.json` verbatim. That file is untracked, machine-local, and freely editable, so
+  whatever it happened to hold was written into every project migrated on that machine — invisible
+  in any diff, and different on every machine. Two defects came out of the one design. A stale
+  `ref: "v2.1.5"` pin reached eleven repositories and held them months behind upstream. Then the
+  marketplace half of that file was removed, after which a migration wrote `enabledPlugins` with no
+  `extraKnownMarketplaces` to resolve it from — a plugin that silently never loads anywhere prawduct
+  is not already registered, and that looks perfectly healthy on the machine that wrote it.
+
+  The reference is now a reviewed constant, `PRAWDUCT_INSTALL_REFERENCE`, mirroring prawduct's own
+  published `INSTALL_REFERENCE` (`ref: "main"`, `autoUpdate: true`). It is deliberately a literal
+  rather than a runtime read: TangleClaw migrates projects on machines where the plugin may be
+  absent, so deriving the reference from any file that can be missing, stale, or edited without
+  review reproduces the same defect class one layer up. Both halves are one atomic reference —
+  `_isCompletePluginRef` rejects a partial one and `migrateToPlugin` writes nothing at all rather
+  than a half-reference that reads as governed but resolves to nothing. `_readSelfPluginRef` and
+  the `selfSettingsPath` test seam are removed; they existed only to serve the read path.
+
+  `test/c1-plugin-migration.test.js` previously fixed the pinned, `autoUpdate: false` shape as its
+  production fixture, so the suite asserted the defect was correct behaviour. It now pins the
+  upstream shape as an explicit contract — duplicated on purpose, so a divergence on either side
+  fails loudly instead of propagating — and covers the partial-reference refusal.
+
 - **The cutover log is named on every screen that cannot confirm the outcome, including the one
   that can see least (#710).** `logLocation` was assigned only inside branches that return, so the
   crash path — a child dying between the plist writes and `finish()`, which writes no result file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,8 +152,12 @@ All notable changes to TangleClaw are documented in this file.
 
   `test/c1-plugin-migration.test.js` previously fixed the pinned, `autoUpdate: false` shape as its
   production fixture, so the suite asserted the defect was correct behaviour. It now pins the
-  upstream shape as an explicit contract — duplicated on purpose, so a divergence on either side
-  fails loudly instead of propagating — and covers the partial-reference refusal.
+  upstream shape as an explicit contract and covers the partial-reference refusal. Drift is checked
+  in both directions: a literal assertion catches TangleClaw's side changing, and a second test
+  reads the installed plugin's own `lib/migrate_plugin.py` to catch upstream's — the direction #807
+  was actually bitten by. That second check is test-only and skips when the plugin is not installed;
+  the production path still never reads that file, because migrations run on machines where it is
+  absent.
 
 - **The cutover log is named on every screen that cannot confirm the outcome, including the one
   that can see least (#710).** `logLocation` was assigned only inside branches that return, so the

--- a/docs/adr/0011-prawduct-boundary.md
+++ b/docs/adr/0011-prawduct-boundary.md
@@ -1,6 +1,8 @@
 # ADR 0011: The Prawduct boundary — TangleClaw owns the plumbing, consumes the governance
 
-**Status:** Accepted (2026-07-29).
+**Status:** Accepted (2026-07-29). **Amended 2026-07-31 (#807, #816)** — the seam grew a fourth item:
+TangleClaw now embeds a copy of Prawduct's published install reference. The amendment is recorded
+against the standing constraint in decision 3, which required exactly this.
 **Source issue:** #330 — "Decouple Prawduct from TangleClaw: direct-integration drift risk as Prawduct moves to a Claude-embedded V2 skill." Filed explicitly *to capture the decision*.
 **Builds on:** #353 (governance moved to the V2 plugin; `governanceState` derived live), #262 (the migration action), #538/#570 (methodology layer removed, `critic-check` deleted), #763 (auto-onboarding declined as out-of-boundary).
 **Decides:** #330. Governs #368 and any future proposal that moves work across this seam.
@@ -99,11 +101,16 @@ position that was in fact built.
    governance, the Critic, learnings. TangleClaw does not carry its own copy of these concepts. The
    methodology layer that used to (#538, #570) is gone and does not come back.
 
-3. **The seam is exactly three things,** and anything crossing it is a decision, not an
+3. **The seam is exactly four things,** and anything crossing it is a decision, not an
    implementation detail:
    - the `prawduct@*` key in a project's `.claude/settings.json` (governance detection),
    - `CLAUDE.md` as a plugin-owned anchor TangleClaw must not regenerate when plugin-governed,
-   - `.prawduct/` as plugin-owned state TangleClaw reads at agreed paths and never authors.
+   - `.prawduct/` as plugin-owned state TangleClaw reads at agreed paths and never authors,
+   - **`PRAWDUCT_INSTALL_REFERENCE`** (added by the 2026-07-31 amendment, #807/#816) — an embedded
+     copy of Prawduct's published `INSTALL_REFERENCE`, kept in sync by review rather than read at
+     run time. It is a *value* copied across the seam, not a call across it, which is why it is a
+     manual-sync obligation: a test reads the installed plugin's source to detect upstream drift,
+     but production never does, because migrations run on machines where the plugin is absent.
 
 4. **Governance state is derived live, never persisted.** `governanceState` inspects the filesystem on
    every read, so it self-clears the moment a project migrates. A persisted mirror of an external
@@ -142,9 +149,12 @@ projects. Under decision 6 that is governance activation happening as a side eff
 creation, which is the seam #763 was closed on.
 
 The counter-argument is genuine and should be recorded: the machinery already exists
-(`engines.migrateToPlugin` writes exactly those keys), TangleClaw already writes them for itself, and
-#368 is narrower than #763 — it writes a *reference*, not a full onboarding run, and is opt-out and
-Claude-only by design. So #368 is not absurd; it is a real proposal that this boundary rules against.
+(`engines.migrateToPlugin` writes exactly those keys), and #368 is narrower than #763 — it writes a
+*reference*, not a full onboarding run, and is opt-out and Claude-only by design. So #368 is not
+absurd; it is a real proposal that this boundary rules against. (The original phrasing also cited
+"TangleClaw already writes them for itself" — that referred to the self-sourcing deleted by the
+2026-07-31 amendment, and is no longer a supporting fact. #368 was closed `NOT_PLANNED` on
+2026-07-30.)
 
 Leaving both open unexamined is the outcome to avoid: #763 closed on "the fix belongs on the Prawduct
 side of the seam," and #368 proposes crossing that same seam. Whichever way #368 goes, it should cite
@@ -157,7 +167,9 @@ from abstracting more. Future upstream changes should be met the same way: shrin
 widening the adapter.
 
 **Standing constraints this creates:**
-- Adding a fourth item to the seam (decision 3) requires an ADR amendment.
+- Adding a **fifth** item to the seam (decision 3) requires an ADR amendment. The fourth —
+  `PRAWDUCT_INSTALL_REFERENCE` — was added by the 2026-07-31 amendment (#807/#816) under exactly
+  this constraint; the count in decision 3 is the number to check against, not this sentence.
 - No TangleClaw code may write inside `.prawduct/`.
 - No lifecycle operation may enable governance without an explicit operator action.
 - Reimplementing a Prawduct capability natively — a TangleClaw Critic, a TangleClaw discovery flow —
@@ -178,7 +190,7 @@ methodology framework, which is a second product with its own roadmap. #538 and 
 deliberately in the opposite direction.
 
 **Option 4 — drop Prawduct coupling entirely.** Rejected. The governance is *useful*, TangleClaw's own
-development depends on it, and the seam turned out to be three items — a cost far below the capability
+development depends on it, and the seam turned out to be four items — a cost far below the capability
 it buys.
 
 **A portable, engine-agnostic Critic.** Rejected as option 2 wearing a smaller hat. The Critic's value

--- a/docs/adr/0011-prawduct-boundary.md
+++ b/docs/adr/0011-prawduct-boundary.md
@@ -49,17 +49,26 @@ TangleClaw references Prawduct in 19 files under `lib/` (`git grep -il prawduct 
 decision:
 
 **1. Governance detection and migration — the real interface, and it is narrow.**
-`lib/engines.js` holds it: `isPluginGoverned` (1318) keys off a `prawduct@*` entry in the project's
-`.claude/settings.json`; `governanceState` (1355) classifies a project as `governed-plugin` /
-`governed-vendored` / `ungoverned` / `not-applicable`; `migrateToPlugin` (1452) writes the plugin
-reference, sourced from TangleClaw's *own* pin (`_readSelfPluginRef`) so a migration never hardcodes
-a version. `writeEngineConfig` (1138) defers entirely when a project is plugin-governed, because the
-plugin owns `CLAUDE.md` as a thin `PRAWDUCT:ANCHOR` file and regenerating would clobber it every
+`lib/engines.js` holds it: `isPluginGoverned` keys off a `prawduct@*` entry in the project's
+`.claude/settings.json`; `governanceState` classifies a project as `governed-plugin` /
+`governed-vendored` / `ungoverned` / `not-applicable`; `migrateToPlugin` writes the plugin
+reference from `PRAWDUCT_INSTALL_REFERENCE`, a reviewed constant mirroring prawduct's published
+`INSTALL_REFERENCE`. `writeEngineConfig` defers entirely when a project is plugin-governed, because
+the plugin owns `CLAUDE.md` as a thin `PRAWDUCT:ANCHOR` file and regenerating would clobber it every
 launch.
 
+That reference used to be read from TangleClaw's own `.claude/settings.json` at migration time, on
+the reasoning that copying its own pin meant never hardcoding a version. The reasoning was sound and
+the source was not: that file is untracked and machine-local, so the "pin" was per-machine, invisible
+in review, and free to drift. It did — a stale `v2.1.5` reached eleven repositories, and once the
+marketplace half of that file went missing, migrations wrote an unresolvable reference (#807, #816).
+Hardcoding upstream's published contract and reviewing changes to it is the smaller risk.
+
 The total surface TangleClaw depends on here is: **one settings key prefix, one anchor file it must
-not overwrite, and one directory (`.prawduct/`) it must not treat as source.** That is a remarkably
-small contract for what #330 feared.
+not overwrite, and one directory (`.prawduct/`) it must not treat as source** — plus, since #816,
+**one embedded copy of upstream's install reference**, which is a standing manual-sync obligation
+rather than a read at run time. That is still a remarkably small contract for what #330 feared, but
+it is four things now, not three.
 
 **2. Agent invocation — Claude-only, and explicitly so.**
 `lib/actions/invoke-critic.js` sends `/critic` to the live session over tmux, polls for idle, and

--- a/lib/engines.js
+++ b/lib/engines.js
@@ -1469,11 +1469,11 @@ function governanceState(projectPath, meta) {
   return 'ungoverned';
 }
 
-// #262 (C1) — test seam for the two foreign reads the migration action makes:
-// TangleClaw's OWN plugin reference (the canonical pin) and the machine-scope
-// plugin-install check. Overridable in tests so they don't depend on live state.
+// #262 (C1) — test seam for the machine-scope plugin-install check the
+// migration action makes. Overridable in tests so they don't depend on live
+// state. (There is deliberately no seam for reading TangleClaw's own settings
+// file: the install reference is a reviewed constant, not a runtime read.)
 const _internal = {
-  selfSettingsPath: () => path.join(__dirname, '..', '.claude', 'settings.json'),
   pluginsHome: () => path.join(os.homedir(), '.claude', 'plugins'),
   // Injection seam for "what is installed on this machine". `resolveDefaultEngine`
   // reads it through here so the CALL SITES are testable: engine availability
@@ -1486,33 +1486,67 @@ const _internal = {
 };
 
 /**
- * Read TangleClaw's OWN plugin reference so a migration writes whatever version
- * TC itself currently references — single source of truth that survives a pin
- * bump (no hardcoded `v2.1.5`). Returns `{ enabledPlugins, extraKnownMarketplaces }`
- * limited to the prawduct entries, or null if TC is not itself plugin-governed
- * (you cannot migrate a project onto a plugin TC doesn't reference). Fails
- * closed (null) on a missing/unreadable/malformed self settings file.
+ * The prawduct plugin install reference TangleClaw writes into a migrated
+ * project's `.claude/settings.json`.
  *
- * @returns {{enabledPlugins: object, extraKnownMarketplaces: object}|null}
+ * Mirrors prawduct's own published contract — `INSTALL_REFERENCE` in the
+ * installed plugin's `lib/migrate_plugin.py` — which is `ref: "main"` (the
+ * release surface) with `autoUpdate: true`, so a migrated project tracks
+ * prawduct's current release instead of a frozen point in time.
+ *
+ * This is deliberately a reviewed literal and NOT a value read from a file at
+ * run time. It used to be copied verbatim out of TangleClaw's own
+ * `.claude/settings.json` — an untracked, machine-local, freely-mutable file —
+ * so whatever that file happened to hold was stamped into every project
+ * migrated on that machine, unreviewed and invisible in any diff. Two failures
+ * followed. A stale `ref: "v2.1.5"` pin reached eleven repositories and left
+ * them months behind upstream. Then the marketplace half of that file was
+ * removed, after which migrations wrote `enabledPlugins` with no marketplace
+ * to resolve it from — a plugin that silently never loads on any machine where
+ * prawduct is not already registered. Sourcing this reference from any file
+ * that can be absent, stale, or edited without review reproduces that defect
+ * class, so it lives here where it is reviewable and diffable.
+ *
+ * Upstream currently marks `autoUpdate` provisional pending an empirical
+ * check, so this value can legitimately change. Compare against
+ * `INSTALL_REFERENCE` in the installed plugin's `lib/migrate_plugin.py` before
+ * assuming it is still current; `test/c1-plugin-migration.test.js` pins the
+ * expected shape so a divergence fails loudly instead of propagating silently.
+ *
+ * Both halves are ONE atomic reference: `enabledPlugins` without its
+ * `extraKnownMarketplaces` entry is unresolvable, so neither is ever written
+ * without the other.
  */
-function _readSelfPluginRef() {
-  try {
-    const s = JSON.parse(fs.readFileSync(_internal.selfSettingsPath(), 'utf8'));
-    const enabled = s && s.enabledPlugins;
-    if (!enabled || typeof enabled !== 'object') return null;
-    const prawductKeys = Object.keys(enabled).filter((k) => k.startsWith('prawduct@') && enabled[k] === true);
-    if (prawductKeys.length === 0) return null;
-    const enabledPlugins = {};
-    for (const k of prawductKeys) enabledPlugins[k] = true;
-    const markets = s.extraKnownMarketplaces;
-    const extraKnownMarketplaces = {};
-    if (markets && typeof markets === 'object' && markets.prawduct) {
-      extraKnownMarketplaces.prawduct = markets.prawduct;
+const PRAWDUCT_INSTALL_REFERENCE = Object.freeze({
+  enabledPlugins: { 'prawduct@prawduct': true },
+  extraKnownMarketplaces: {
+    prawduct: {
+      source: { source: 'github', repo: 'brookstalley/prawduct', ref: 'main' },
+      autoUpdate: true
     }
-    return { enabledPlugins, extraKnownMarketplaces };
-  } catch {
-    return null;
   }
+});
+
+/**
+ * Whether a plugin reference is complete enough to write — it must name at
+ * least one enabled prawduct plugin AND carry the marketplace entry that
+ * resolves it. A reference missing either half must never reach a project's
+ * settings file: `enabledPlugins` alone installs an unresolvable plugin, which
+ * fails silently on any machine where prawduct is not already registered (and
+ * is therefore invisible on the machine that wrote it).
+ *
+ * @param {object} ref - Candidate `{ enabledPlugins, extraKnownMarketplaces }`
+ * @returns {boolean} True iff both halves are present and non-empty.
+ */
+function _isCompletePluginRef(ref) {
+  if (!ref || typeof ref !== 'object') return false;
+  const enabled = ref.enabledPlugins;
+  if (!enabled || typeof enabled !== 'object') return false;
+  const namesPlugin = Object.keys(enabled).some((k) => k.startsWith('prawduct@') && enabled[k] === true);
+  if (!namesPlugin) return false;
+  const markets = ref.extraKnownMarketplaces;
+  if (!markets || typeof markets !== 'object') return false;
+  return Boolean(markets.prawduct);
 }
 
 /**
@@ -1551,19 +1585,21 @@ function pluginInstalledAtMachineScope() {
  *
  * @param {string} projectPath - Absolute project root
  * @param {object} [options]
- * @param {object} [options.pluginRef] - Override the reference (tests); defaults to TC's own
+ * @param {object} [options.pluginRef] - Override the reference (tests); defaults to
+ *   `PRAWDUCT_INSTALL_REFERENCE`. Rejected unless complete (both halves).
  * @returns {{written: boolean, alreadyGoverned: boolean, error?: string}}
  */
 function migrateToPlugin(projectPath, options = {}) {
   if (isPluginGoverned(projectPath)) {
     return { written: false, alreadyGoverned: true };
   }
-  const ref = options.pluginRef || _readSelfPluginRef();
-  if (!ref) {
+  const ref = options.pluginRef || PRAWDUCT_INSTALL_REFERENCE;
+  if (!_isCompletePluginRef(ref)) {
     return {
       written: false,
       alreadyGoverned: false,
-      error: 'no plugin reference available (TangleClaw is not itself plugin-governed)'
+      error: 'refusing to write an incomplete plugin reference: enabledPlugins without a resolving '
+        + 'extraKnownMarketplaces entry yields a plugin that silently never loads'
     };
   }
 
@@ -1584,10 +1620,14 @@ function migrateToPlugin(projectPath, options = {}) {
   }
 
   // Non-destructive merge: preserve every existing key; add/merge the plugin ref.
+  // Both halves are written unconditionally. The completeness check above — not
+  // this merge — is what guarantees a resolvable reference; an earlier version
+  // guarded the marketplace merge on the ref carrying one, which silently
+  // degraded to writing enabledPlugins alone whenever the ref lacked it. With
+  // the ref validated, that branch could never be false, so it is gone: a dead
+  // conditional here would read as a safeguard it is not.
   settings.enabledPlugins = { ...(settings.enabledPlugins || {}), ...ref.enabledPlugins };
-  if (ref.extraKnownMarketplaces && Object.keys(ref.extraKnownMarketplaces).length > 0) {
-    settings.extraKnownMarketplaces = { ...(settings.extraKnownMarketplaces || {}), ...ref.extraKnownMarketplaces };
-  }
+  settings.extraKnownMarketplaces = { ...(settings.extraKnownMarketplaces || {}), ...ref.extraKnownMarketplaces };
 
   fs.mkdirSync(settingsDir, { recursive: true });
   fs.writeFileSync(settingsFile, JSON.stringify(settings, null, 2) + '\n');
@@ -1626,7 +1666,8 @@ module.exports = {
   governanceState,
   migrateToPlugin,
   pluginInstalledAtMachineScope,
-  _readSelfPluginRef,
+  PRAWDUCT_INSTALL_REFERENCE,
+  _isCompletePluginRef,
   _internal,
   listWithAvailability,
   getWithAvailability,

--- a/lib/engines.js
+++ b/lib/engines.js
@@ -1486,6 +1486,19 @@ const _internal = {
 };
 
 /**
+ * Recursively freeze an object literal and every plain-object value it holds.
+ *
+ * @param {object} o - Object to freeze in place.
+ * @returns {object} The same object, frozen throughout.
+ */
+function _deepFreeze(o) {
+  for (const v of Object.values(o)) {
+    if (v && typeof v === 'object') _deepFreeze(v);
+  }
+  return Object.freeze(o);
+}
+
+/**
  * The prawduct plugin install reference TangleClaw writes into a migrated
  * project's `.claude/settings.json`.
  *
@@ -1517,7 +1530,13 @@ const _internal = {
  * `extraKnownMarketplaces` entry is unresolvable, so neither is ever written
  * without the other.
  */
-const PRAWDUCT_INSTALL_REFERENCE = Object.freeze({
+// Frozen all the way down, not just at the top level. This object is exported
+// and its nested members are spread by reference into every project TangleClaw
+// migrates, so a shallow freeze would leave `…prawduct.source.ref` writable —
+// one mutation silently riding into every subsequent migration. That is the
+// same unreviewed-mutation failure this constant exists to prevent, so the
+// guarantee has to be real rather than nominal.
+const PRAWDUCT_INSTALL_REFERENCE = _deepFreeze({
   enabledPlugins: { 'prawduct@prawduct': true },
   extraKnownMarketplaces: {
     prawduct: {
@@ -1542,11 +1561,19 @@ function _isCompletePluginRef(ref) {
   if (!ref || typeof ref !== 'object') return false;
   const enabled = ref.enabledPlugins;
   if (!enabled || typeof enabled !== 'object') return false;
-  const namesPlugin = Object.keys(enabled).some((k) => k.startsWith('prawduct@') && enabled[k] === true);
-  if (!namesPlugin) return false;
+  const enabledKeys = Object.keys(enabled).filter((k) => k.startsWith('prawduct@') && enabled[k] === true);
+  if (enabledKeys.length === 0) return false;
   const markets = ref.extraKnownMarketplaces;
   if (!markets || typeof markets !== 'object') return false;
-  return Boolean(markets.prawduct);
+  // Resolve each enabled plugin against ITS OWN marketplace, taken from the
+  // `plugin@marketplace` key rather than assumed to be "prawduct". Only
+  // `prawduct@prawduct` ships today, so hardcoding the name would pass for the
+  // wrong reason and quietly wave through a reference it cannot actually
+  // resolve the day a second marketplace exists.
+  return enabledKeys.every((k) => {
+    const marketplace = k.slice(k.indexOf('@') + 1);
+    return Boolean(marketplace && markets[marketplace]);
+  });
 }
 
 /**
@@ -1619,7 +1646,10 @@ function migrateToPlugin(projectPath, options = {}) {
     }
   }
 
-  // Non-destructive merge: preserve every existing key; add/merge the plugin ref.
+  // Non-destructive merge: every unrelated key in the project's settings
+  // survives. The prawduct entries themselves are deliberately overwritten, not
+  // preserved — a project carrying a stale pin is precisely what needs
+  // correcting, so deferring to whatever it already had would defeat the point.
   // Both halves are written unconditionally. The completeness check above — not
   // this merge — is what guarantees a resolvable reference; an earlier version
   // guarded the marketplace merge on the ref carrying one, which silently

--- a/lib/engines.js
+++ b/lib/engines.js
@@ -1548,11 +1548,12 @@ const PRAWDUCT_INSTALL_REFERENCE = _deepFreeze({
 
 /**
  * Whether a plugin reference is complete enough to write — it must name at
- * least one enabled prawduct plugin AND carry the marketplace entry that
- * resolves it. A reference missing either half must never reach a project's
- * settings file: `enabledPlugins` alone installs an unresolvable plugin, which
- * fails silently on any machine where prawduct is not already registered (and
- * is therefore invisible on the machine that wrote it).
+ * least one enabled prawduct plugin, and EVERY such plugin must carry the
+ * marketplace entry that resolves it. A reference missing either half must
+ * never reach a project's settings file: `enabledPlugins` alone installs an
+ * unresolvable plugin, which fails silently on any machine where prawduct is
+ * not already registered (and is therefore invisible on the machine that
+ * wrote it).
  *
  * @param {object} ref - Candidate `{ enabledPlugins, extraKnownMarketplaces }`
  * @returns {boolean} True iff both halves are present and non-empty.

--- a/test/c1-plugin-migration.test.js
+++ b/test/c1-plugin-migration.test.js
@@ -115,12 +115,14 @@ describe('C1 — per-project plugin migration (#262)', () => {
     // source. It is a TEST-only read: the production path deliberately does not
     // read this file, because migrations run on machines where it is absent.
     it('matches the installed plugin’s INSTALL_REFERENCE (skipped when not installed)', (t) => {
-      const home = os.homedir();
-      const candidates = [
-        path.join(home, '.claude', 'plugins', 'marketplaces', 'prawduct', 'plugin', 'lib', 'migrate_plugin.py')
-      ];
-      const src = candidates.find((f) => fs.existsSync(f));
-      if (!src) {
+      // The marketplace checkout, deliberately not the versioned cache dirs:
+      // several cache versions can coexist, so picking one would compare
+      // against whichever release happened to sort first rather than the
+      // installed contract.
+      const src = path.join(
+        os.homedir(), '.claude', 'plugins', 'marketplaces', 'prawduct', 'plugin', 'lib', 'migrate_plugin.py'
+      );
+      if (!fs.existsSync(src)) {
         t.skip('prawduct plugin source not present on this machine');
         return;
       }

--- a/test/c1-plugin-migration.test.js
+++ b/test/c1-plugin-migration.test.js
@@ -14,11 +14,6 @@ const engines = require('../lib/engines');
 const projects = require('../lib/projects');
 const sessionOwnership = require('../lib/session-ownership');
 
-// The reference TC actually writes. Not a local fixture: migrations are
-// expected to write exactly this, so the tests assert against the constant the
-// production code uses. The shape itself is pinned separately below.
-const SELF_REF = engines.PRAWDUCT_INSTALL_REFERENCE;
-
 describe('C1 — per-project plugin migration (#262)', () => {
   let tmpDir;
   let pluginsHomeInstalled; // installed_plugins.json names prawduct
@@ -99,6 +94,37 @@ describe('C1 — per-project plugin migration (#262)', () => {
       const { ref } = engines.PRAWDUCT_INSTALL_REFERENCE.extraKnownMarketplaces.prawduct.source;
       assert.equal(ref, 'main');
       assert.doesNotMatch(ref, /^v?\d+\.\d+\.\d+$/);
+    });
+
+    // The assertion above compares TC's constant against a literal in TC's own
+    // repo, so it only catches OUR side moving. Upstream drifting is the other
+    // half — and it is the half #807 actually got bitten by, since upstream
+    // marks autoUpdate provisional. This reads the installed plugin's own
+    // source. It is a TEST-only read: the production path deliberately does not
+    // read this file, because migrations run on machines where it is absent.
+    it('matches the installed plugin’s INSTALL_REFERENCE (skipped when not installed)', (t) => {
+      const home = os.homedir();
+      const candidates = [
+        path.join(home, '.claude', 'plugins', 'marketplaces', 'prawduct', 'plugin', 'lib', 'migrate_plugin.py')
+      ];
+      const src = candidates.find((f) => fs.existsSync(f));
+      if (!src) {
+        t.skip('prawduct plugin source not present on this machine');
+        return;
+      }
+      const py = fs.readFileSync(src, 'utf8');
+      const block = py.slice(py.indexOf('INSTALL_REFERENCE'));
+      assert.ok(block, 'INSTALL_REFERENCE not found in upstream source');
+
+      const ours = engines.PRAWDUCT_INSTALL_REFERENCE.extraKnownMarketplaces.prawduct;
+      const upstreamRef = /"ref":\s*"([^"]+)"/.exec(block);
+      const upstreamRepo = /"repo":\s*"([^"]+)"/.exec(block);
+      const upstreamAuto = /"autoUpdate":\s*(True|False)/.exec(block);
+      assert.ok(upstreamRef && upstreamRepo && upstreamAuto, 'could not parse upstream INSTALL_REFERENCE');
+
+      assert.equal(ours.source.ref, upstreamRef[1], 'ref drifted from upstream');
+      assert.equal(ours.source.repo, upstreamRepo[1], 'repo drifted from upstream');
+      assert.equal(ours.autoUpdate, upstreamAuto[1] === 'True', 'autoUpdate drifted from upstream');
     });
   });
 

--- a/test/c1-plugin-migration.test.js
+++ b/test/c1-plugin-migration.test.js
@@ -14,33 +14,21 @@ const engines = require('../lib/engines');
 const projects = require('../lib/projects');
 const sessionOwnership = require('../lib/session-ownership');
 
-// The plugin reference TC writes into a migrated project (sourced from TC's own
-// settings.json in production; a fixture here so tests don't read the live repo).
-const SELF_REF = {
-  enabledPlugins: { 'prawduct@prawduct': true },
-  extraKnownMarketplaces: {
-    prawduct: { source: { source: 'github', repo: 'brookstalley/prawduct', ref: 'v2.1.5' }, autoUpdate: false }
-  }
-};
+// The reference TC actually writes. Not a local fixture: migrations are
+// expected to write exactly this, so the tests assert against the constant the
+// production code uses. The shape itself is pinned separately below.
+const SELF_REF = engines.PRAWDUCT_INSTALL_REFERENCE;
 
 describe('C1 — per-project plugin migration (#262)', () => {
   let tmpDir;
-  let selfGoverned; // self settings.json fixture WITH the plugin ref
-  let selfBare; // self settings.json fixture WITHOUT the plugin ref
   let pluginsHomeInstalled; // installed_plugins.json names prawduct
   let pluginsHomeEmpty; // no install marker
-  const origSelf = engines._internal.selfSettingsPath;
   const origHome = engines._internal.pluginsHome;
 
   before(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-c1-'));
     store._setBasePath(tmpDir);
     store.init();
-
-    selfGoverned = path.join(tmpDir, 'self-governed.json');
-    fs.writeFileSync(selfGoverned, JSON.stringify(SELF_REF, null, 2));
-    selfBare = path.join(tmpDir, 'self-bare.json');
-    fs.writeFileSync(selfBare, JSON.stringify({ permissions: { allow: [] } }, null, 2));
 
     pluginsHomeInstalled = path.join(tmpDir, 'plugins-installed');
     fs.mkdirSync(pluginsHomeInstalled, { recursive: true });
@@ -51,13 +39,11 @@ describe('C1 — per-project plugin migration (#262)', () => {
     pluginsHomeEmpty = path.join(tmpDir, 'plugins-empty');
     fs.mkdirSync(pluginsHomeEmpty, { recursive: true });
 
-    // Default seams: TC is governed + the plugin is installed on this machine.
-    engines._internal.selfSettingsPath = () => selfGoverned;
+    // Default seam: the plugin is installed on this machine.
     engines._internal.pluginsHome = () => pluginsHomeInstalled;
   });
 
   after(() => {
-    engines._internal.selfSettingsPath = origSelf;
     engines._internal.pluginsHome = origHome;
     store.close();
     fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -88,17 +74,55 @@ describe('C1 — per-project plugin migration (#262)', () => {
     });
   });
 
-  describe('engines._readSelfPluginRef', () => {
-    it('reads TC’s own prawduct reference (enabledPlugins + marketplace)', () => {
-      const ref = engines._readSelfPluginRef();
-      assert.deepEqual(ref.enabledPlugins, { 'prawduct@prawduct': true });
-      assert.equal(ref.extraKnownMarketplaces.prawduct.source.repo, 'brookstalley/prawduct');
+  describe('engines.PRAWDUCT_INSTALL_REFERENCE', () => {
+    // The literal is duplicated here on purpose. This is the tripwire: prawduct
+    // publishes INSTALL_REFERENCE in its plugin's lib/migrate_plugin.py, and if
+    // either side moves, this test fails loudly instead of the divergence
+    // reaching every project TangleClaw migrates. Upstream currently marks
+    // autoUpdate provisional, so a future change here is legitimate — but it
+    // must be a deliberate edit to this assertion, never a silent drift.
+    it('matches prawduct’s published install reference verbatim', () => {
+      assert.deepEqual(engines.PRAWDUCT_INSTALL_REFERENCE, {
+        enabledPlugins: { 'prawduct@prawduct': true },
+        extraKnownMarketplaces: {
+          prawduct: {
+            source: { source: 'github', repo: 'brookstalley/prawduct', ref: 'main' },
+            autoUpdate: true
+          }
+        }
+      });
     });
 
-    it('returns null when TC is not itself plugin-governed', () => {
-      engines._internal.selfSettingsPath = () => selfBare;
-      assert.equal(engines._readSelfPluginRef(), null);
-      engines._internal.selfSettingsPath = () => selfGoverned;
+    it('pins ref to a branch, never a version tag', () => {
+      // A version-pinned ref stranded 11 repos on a months-old release; the
+      // whole point of `main` is that consumers track the current one.
+      const { ref } = engines.PRAWDUCT_INSTALL_REFERENCE.extraKnownMarketplaces.prawduct.source;
+      assert.equal(ref, 'main');
+      assert.doesNotMatch(ref, /^v?\d+\.\d+\.\d+$/);
+    });
+  });
+
+  describe('engines._isCompletePluginRef', () => {
+    it('accepts a reference carrying both halves', () => {
+      assert.equal(engines._isCompletePluginRef(engines.PRAWDUCT_INSTALL_REFERENCE), true);
+    });
+
+    it('rejects enabledPlugins with no marketplace to resolve it', () => {
+      assert.equal(engines._isCompletePluginRef({ enabledPlugins: { 'prawduct@prawduct': true } }), false);
+      assert.equal(
+        engines._isCompletePluginRef({ enabledPlugins: { 'prawduct@prawduct': true }, extraKnownMarketplaces: {} }),
+        false
+      );
+    });
+
+    it('rejects a marketplace with no enabled plugin, and junk input', () => {
+      assert.equal(
+        engines._isCompletePluginRef({ extraKnownMarketplaces: { prawduct: { source: {} } } }),
+        false
+      );
+      assert.equal(engines._isCompletePluginRef(null), false);
+      assert.equal(engines._isCompletePluginRef({}), false);
+      assert.equal(engines._isCompletePluginRef({ enabledPlugins: { 'other@x': true } }), false);
     });
   });
 
@@ -152,13 +176,28 @@ describe('C1 — per-project plugin migration (#262)', () => {
       assert.equal(fs.readFileSync(bad, 'utf8'), '{ not valid json'); // untouched
     });
 
-    it('errors when no plugin reference is available (TC not governed)', () => {
-      engines._internal.selfSettingsPath = () => selfBare;
-      const p = mkProjectDir('noref');
-      const r = engines.migrateToPlugin(p);
+    it('always writes the marketplace entry alongside enabledPlugins', () => {
+      // The defect this guards: a project told to enable a plugin it has no
+      // way to resolve loads nothing, silently, on any machine where prawduct
+      // is not already registered — and looks fine on one where it is.
+      const p = mkProjectDir('resolvable');
+      engines.migrateToPlugin(p);
+      const s = readSettings(p);
+      assert.equal(s.enabledPlugins['prawduct@prawduct'], true);
+      assert.equal(s.extraKnownMarketplaces.prawduct.source.ref, 'main');
+      assert.equal(s.extraKnownMarketplaces.prawduct.autoUpdate, true);
+    });
+
+    it('refuses an incomplete reference and writes nothing at all', () => {
+      const p = mkProjectDir('halfref');
+      const r = engines.migrateToPlugin(p, {
+        pluginRef: { enabledPlugins: { 'prawduct@prawduct': true } } // no marketplace
+      });
       assert.equal(r.written, false);
-      assert.match(r.error, /no plugin reference/);
-      engines._internal.selfSettingsPath = () => selfGoverned;
+      assert.match(r.error, /incomplete plugin reference/);
+      // Nothing half-written: the project must not read as governed afterwards.
+      assert.equal(engines.isPluginGoverned(p), false);
+      assert.equal(fs.existsSync(path.join(p, '.claude', 'settings.json')), false);
     });
 
     it('neutralizes the vendored governance hook — no product-hook command survives in settings', () => {

--- a/test/c1-plugin-migration.test.js
+++ b/test/c1-plugin-migration.test.js
@@ -70,12 +70,12 @@ describe('C1 — per-project plugin migration (#262)', () => {
   });
 
   describe('engines.PRAWDUCT_INSTALL_REFERENCE', () => {
-    // The literal is duplicated here on purpose. This is the tripwire: prawduct
-    // publishes INSTALL_REFERENCE in its plugin's lib/migrate_plugin.py, and if
-    // either side moves, this test fails loudly instead of the divergence
-    // reaching every project TangleClaw migrates. Upstream currently marks
-    // autoUpdate provisional, so a future change here is legitimate — but it
-    // must be a deliberate edit to this assertion, never a silent drift.
+    // The literal is duplicated here on purpose, and this assertion catches
+    // exactly ONE direction: TangleClaw's side changing. Both operands live in
+    // this repo, so it can say nothing about upstream — the upstream half is
+    // the separate test below that reads the installed plugin's source.
+    // Upstream marks autoUpdate provisional, so a future change here is
+    // legitimate; it must be a deliberate edit, never a silent drift.
     it('matches prawduct’s published install reference verbatim', () => {
       assert.deepEqual(engines.PRAWDUCT_INSTALL_REFERENCE, {
         enabledPlugins: { 'prawduct@prawduct': true },
@@ -86,6 +86,18 @@ describe('C1 — per-project plugin migration (#262)', () => {
           }
         }
       });
+    });
+
+    it('is frozen all the way down, not just at the top level', () => {
+      // Load-bearing: migrateToPlugin spreads the nested object into the
+      // caller's settings BY REFERENCE, so one mutation would ride into every
+      // subsequent migration. A shallow Object.freeze leaves this writable, so
+      // a refactor back to it must fail here rather than pass quietly.
+      const ref = engines.PRAWDUCT_INSTALL_REFERENCE;
+      assert.throws(() => { 'use strict'; ref.extraKnownMarketplaces.prawduct.source.ref = 'hacked'; });
+      assert.throws(() => { 'use strict'; ref.extraKnownMarketplaces.prawduct.autoUpdate = false; });
+      assert.equal(ref.extraKnownMarketplaces.prawduct.source.ref, 'main');
+      assert.equal(ref.extraKnownMarketplaces.prawduct.autoUpdate, true);
     });
 
     it('pins ref to a branch, never a version tag', () => {
@@ -113,8 +125,13 @@ describe('C1 — per-project plugin migration (#262)', () => {
         return;
       }
       const py = fs.readFileSync(src, 'utf8');
-      const block = py.slice(py.indexOf('INSTALL_REFERENCE'));
-      assert.ok(block, 'INSTALL_REFERENCE not found in upstream source');
+      const start = py.indexOf('INSTALL_REFERENCE');
+      assert.notEqual(start, -1, 'INSTALL_REFERENCE not found in upstream source');
+      // Bound the window to the dict literal. Reading to EOF happens to work
+      // today only because upstream defines nothing else matching these keys;
+      // stopping at the closing brace keeps that a fact rather than a wager.
+      const end = py.indexOf('\n}', start);
+      const block = py.slice(start, end === -1 ? undefined : end);
 
       const ours = engines.PRAWDUCT_INSTALL_REFERENCE.extraKnownMarketplaces.prawduct;
       const upstreamRef = /"ref":\s*"([^"]+)"/.exec(block);
@@ -149,6 +166,40 @@ describe('C1 — per-project plugin migration (#262)', () => {
       assert.equal(engines._isCompletePluginRef(null), false);
       assert.equal(engines._isCompletePluginRef({}), false);
       assert.equal(engines._isCompletePluginRef({ enabledPlugins: { 'other@x': true } }), false);
+    });
+
+    // The marketplace name is derived from each `plugin@marketplace` key rather
+    // than assumed to be "prawduct". Only prawduct@prawduct ships today, so
+    // without these two cases the derivation and a hardcoded `markets.prawduct`
+    // lookup are indistinguishable — every other case in this block passes
+    // under both.
+    it('resolves each plugin against its OWN marketplace, not a hardcoded one', () => {
+      // Marketplace present but not the one this key names → unresolvable.
+      assert.equal(
+        engines._isCompletePluginRef({
+          enabledPlugins: { 'prawduct@other': true },
+          extraKnownMarketplaces: { prawduct: { source: {} } }
+        }),
+        false
+      );
+      // Marketplace matching the key's suffix → resolvable.
+      assert.equal(
+        engines._isCompletePluginRef({
+          enabledPlugins: { 'prawduct@other': true },
+          extraKnownMarketplaces: { other: { source: {} } }
+        }),
+        true
+      );
+    });
+
+    it('requires EVERY enabled plugin to resolve, not merely one', () => {
+      assert.equal(
+        engines._isCompletePluginRef({
+          enabledPlugins: { 'prawduct@prawduct': true, 'prawduct@other': true },
+          extraKnownMarketplaces: { prawduct: { source: {} } } // `other` unresolvable
+        }),
+        false
+      );
     });
   });
 


### PR DESCRIPTION
Fixes #816. Refs #807 (the sweep and that issue's own closeout are owned by the PrawductSteward session).

**Targets `v5-baseline`, not `main`** — the v5 freeze routes all chunk work through the integration branch.

## What

`migrateToPlugin` built the prawduct install reference by copying TangleClaw's own `.claude/settings.json` verbatim. It now uses `PRAWDUCT_INSTALL_REFERENCE`, a reviewed constant mirroring prawduct's published `INSTALL_REFERENCE` (`ref: "main"`, `autoUpdate: true`), and refuses to write a reference missing either half.

## Why

That settings file is untracked, machine-local, and freely editable, so whatever it happened to hold was stamped into every project migrated on that machine — invisible in any diff, and different per machine.

One design, two defects:

- A stale `ref: "v2.1.5"` pin reached **eleven repositories** and held them months behind upstream (#807).
- Once the marketplace half of that file was removed, migrations wrote `enabledPlugins` with no `extraKnownMarketplaces` to resolve it from (#816) — a plugin that silently never loads on any machine where prawduct is not already registered, and that looks perfectly healthy on the machine that wrote it. That was the **live default path**, not a hypothetical.

The original intent — "don't hardcode a version" — was right; the source was wrong. Avoiding a hardcoded pin by reading an untracked local file doesn't remove the pin, it makes it invisible and per-machine.

It is deliberately **not** a runtime read of the plugin's own source either: TangleClaw migrates projects on machines where the plugin may be absent, so deriving the value from a file that might not exist reproduces the same defect class one layer up.

## Changes

- `PRAWDUCT_INSTALL_REFERENCE` — deep-frozen (the nested object is spread by reference into every migration, so a shallow freeze would leave it writable).
- `_isCompletePluginRef` — both halves are one atomic reference; a partial one is refused and **nothing** is written. Resolves each enabled plugin against its own `plugin@marketplace` suffix rather than a hardcoded `prawduct` key.
- `_readSelfPluginRef` and the `selfSettingsPath` test seam removed — they existed only to serve the read path (absence proven repo-wide before deleting).
- ADR 0011 amended: the seam grew a fourth item. The count is corrected at **every** site that asserts it, with `Status` recording the amendment.
- The test fixture that pinned `v2.1.5` / `autoUpdate: false` as production truth is gone — the suite was asserting the defect was correct behaviour.

## Test plan

Full suite: **5316 tests, 5315 pass, 0 fail, 1 skipped** (baseline before this branch: 5308 / 0 fail).

Every new guard was mutation-checked — a passing test proves nothing until it has been seen to fail:

| Mutation | Expected | Result |
|---|---|---|
| Bypass the completeness check | partial-reference test red | red |
| Revert to hardcoded `markets.prawduct` | 2 derivation tests red | red |
| Revert deep-freeze → shallow `Object.freeze` | freeze test red | red |
| Drift the constant's `ref` | all 3 drift guards red | red |

**One mutation deliberately did *not* go red, and it changed the code.** Restoring the original conditional marketplace merge left the suite green — because once the reference is validated complete, the conditional and unconditional merges are equivalent. The comment crediting the merge as the safeguard was therefore false; the completeness guard is what is load-bearing, and the comment now says so.

Drift is checked in both directions: a literal assertion catches TangleClaw's side moving, and a second test reads the installed plugin's `migrate_plugin.py` to catch upstream's — the direction #807 was actually bitten by. That second check is test-only and skips when the plugin is absent.

## Review

`cumulative` + two `verify-resolutions` passes — final verdict **0 blocking, 0 warning**. The first pass caught two blocking issues worth noting: my ADR fix corrected only the narrative paragraph and left every *normative* statement of the old seam count standing, and the marketplace-derivation change shipped with a test block that was byte-identical to before, so every case returned the same value under both implementations — untested by construction.

Remaining findings from that review belong to the v5 chunk-2 body, not this diff; they entered the review only because `base_branch` was unset and the range resolved to `origin/main` (32 files instead of 5). That is fixed by setting `base_branch: origin/v5-baseline` in `.prawduct/project-state.yaml` — which is **gitignored**, so it is local machine state and does not travel with this branch. Any other clone or worktree reviewing v5 work needs the same setting, and a worktree needs the file symlinked in, since `.prawduct/` is not checked out.

