### PR TITLE
Send the operator to an address that answers after setup (#710 chunk 3)

### DIFF
--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -80,10 +80,29 @@ correctly fell through to "unconfirmed". The fix keeps the pair together — `ef
 returns `{ origin, via }` from ONE branch, because two derivations of "is this proxied" could disagree
 with the address they describe — and the wizard probes only where a reply means something.
 
-**A test of mine could not fail, again.** `via` was added, threaded through, and asserted nowhere:
-flipping caddy's `via` to `'server'` left the whole suite green. Caught by running the mutation rather
-than by reading the test. That is three in this scope, all the same shape — an assertion that watches
-something adjacent to the thing that changed.
+**Tests of mine that could not fail — four now, and the review found what the mutations missed.**
+`via` was added, threaded through, and asserted nowhere: flipping caddy's `via` to `'server'` left the
+suite green. Then the same again one layer out — nothing pinned that the ROUTE *emits* `redirectVia`,
+so deleting the field from the response object kept every test green while a caddy-mode operator
+would be told "TangleClaw is back up" on the strength of a 502. My mutation run had stopped at the
+module boundary and never crossed the wire. And two of the six new wizard assertions were inert: one
+matched a `return;` satisfied by the function's own opening `if (!body) return;` — the exact trap the
+sibling credential test documents in a comment — and one sliced its panel with `indexOf('`,')` on the
+LAST map entry, which has no trailing delimiter, so `-1 + 2` asserted against a single character.
+
+All four are the same shape: an assertion watching something *adjacent* to what changed. The
+mechanical correction is narrower than "write better tests" — **mutate at every seam the value
+crosses, not only where it is produced**, and scope a structural assertion to the branch it names
+rather than to a span that contains it.
+
+**Filed rather than fixed: #825.** `wizardComplete` checks `ingress.protection` before
+`result.restart` and both branches return, so an install that is simultaneously "no login TangleClaw
+can confirm" and "about to restart" never reaches the overlay and lands on a Continue button that
+fetches a dying server. Reachable on a hand-maintained Caddyfile whose operator edits a cert path.
+Chunk 3 made it more visible — before, the caddy-mode redirect named a dead port, so the overlay was
+useless even when it rendered. Not fixed here because the change edits the copy of a screen whose
+whole purpose is a security warning, under chunk 2's rule that no path claims protection it did not
+observe; that compound state wants deliberate wording and its own review.
 
 **A worktree trap worth knowing.** `.prawduct/` is almost entirely gitignored here, so a new
 worktree's governance state is set up by symlinking it back to the primary checkout — but

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -69,6 +69,22 @@ endpoint regression for the reachable caddy-mode restart. Three mutations (dropp
 restoring the old inline expression, asking the provisioning arm about the pre-cutover config) each
 go red.
 
+**The review caught the consumer this change broke, which is the same shape as everything else in
+this scope.** Changing what `redirectUrl` *means* left its reader believing the old meaning: the
+restart overlay probes that address and reports "TangleClaw is back up" on any reply. That was sound
+while the address was TC's own listener. Once it is Caddy's it is not — the proxy stays up across the
+restart and answers instantly, with a 502 that an opaque `no-cors` probe cannot distinguish from
+success — so the screen would assert readiness it never observed and click the operator into an error
+page. Newly reachable, too: the old caddy-mode value named a port nothing answered on, so the overlay
+correctly fell through to "unconfirmed". The fix keeps the pair together — `effectiveOperatorFrontDoor`
+returns `{ origin, via }` from ONE branch, because two derivations of "is this proxied" could disagree
+with the address they describe — and the wizard probes only where a reply means something.
+
+**A test of mine could not fail, again.** `via` was added, threaded through, and asserted nowhere:
+flipping caddy's `via` to `'server'` left the whole suite green. Caught by running the mutation rather
+than by reading the test. That is three in this scope, all the same shape — an assertion that watches
+something adjacent to the thing that changed.
+
 **A worktree trap worth knowing.** `.prawduct/` is almost entirely gitignored here, so a new
 worktree's governance state is set up by symlinking it back to the primary checkout — but
 `change-log.md` is the one **tracked** file in that directory. Blanket-symlinking the directory's

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -26,6 +26,56 @@ Tag-line conventions (ART-4K9M, ratified 2026-07-17):
 -->
 
 
+## 2026-08-01: setup lands the operator on an address that answers (#710, chunk 3)
+
+<!-- prawduct: type=fix | chunks=3 | scope=auth-6-secure-by-default -->
+
+**Why:** the post-setup redirect answered the wrong question. "What is this server serving" and
+"where should the operator go" have different answers behind Caddy, and the redirect computed the
+first. In caddy mode TC serves plain HTTP on the loopback — Caddy terminates TLS in front — so the
+expression named `http://<host>:3102`: TC's own door, unreachable from anywhere else and **ungated**.
+It would have sent an operator past the login their setup had just installed.
+
+**The spec said to reuse the wrong pair, and that was corrected before any code.** Chunk 3's
+paragraph read "`effectiveServerPort` and `effectiveServerProtocol` already exist for this — reuse,
+do not re-derive." Those helpers' own header says they predict what *TC's listener* serves, and the
+instruction predates chunk 2 making caddy the default install path; taken literally it produces the
+exact defect the chunk exists to fix. The build plan records the correction and keeps the
+direct-mode half, where the instruction was always right.
+
+**It also collapsed a duplicate that was already there.** `POST /api/setup/complete` answered "where
+do I go now" twice, with two inline expressions: `ingress.url` on the provisioning arm (correct) and
+`redirectUrl` on the HTTPS-restart arm (wrong in caddy mode). Both now come from
+`httpsSetup.effectiveOperatorOrigin`. The provisioning arm asks about `{ ...config, ingressMode:
+'caddy' }` — the state the cutover is moving to, since `ingressMode` on disk is still whatever it was
+while the child runs. Purity is what makes that askable.
+
+**The caddy-mode case was reachable.** `shouldRestart` requires only that the HTTPS config *changed*;
+it does not consider ingress mode. A caddy-mode install whose operator edits a certificate path in
+the wizard took that path and was sent to a port nothing answers on — the same shape as the pre-#654
+dead `:3101` that read to the operator as "HTTPS setup is broken".
+
+**The Skip path is exempt, and that is a finding rather than an omission.** The standing rule from
+chunk 2 is that completion-URL logic must exist on *both* finish paths. `PATCH /api/config
+{ setupComplete: true }` can only *refuse* on the provisioning question — it never spawns a cutover —
+so finishing through Skip never moves TangleClaw and the origin the operator is on stays correct.
+Recorded because the exemption is not visible from reading that route.
+
+**Tests sweep the producer rather than sampling it**, per the rule this repo already learned: every
+mode the derivation can be asked about — caddy at a default and a custom port, caddy ignoring both
+`TANGLECLAW_PORT` and the HTTPS flags, direct with certs, direct without, `TANGLECLAW_PORT` winning
+in direct mode, a not-yet-in-force config, a missing hostname, and the bare-origin shape — plus an
+endpoint regression for the reachable caddy-mode restart. Three mutations (dropping the caddy arm,
+restoring the old inline expression, asking the provisioning arm about the pre-cutover config) each
+go red.
+
+**A worktree trap worth knowing.** `.prawduct/` is almost entirely gitignored here, so a new
+worktree's governance state is set up by symlinking it back to the primary checkout — but
+`change-log.md` is the one **tracked** file in that directory. Blanket-symlinking the directory's
+contents replaced the branch's own copy with the primary checkout's, silently, and the primary is on
+a main-based branch that has none of the v5 entries. Caught when a heading that must exist did not.
+Symlink the untracked governance files only; `change-log.md` belongs to the branch.
+
 ## 2026-08-01: the login can be changed after setup, through one guarded route (#710, #805, #806)
 
 <!-- prawduct: type=feat | chunks=3b | scope=auth-6-secure-by-default | status=shipped -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ All notable changes to TangleClaw are documented in this file.
   certificate path in the wizard took it and was sent to a port nothing answers on. That is the same
   shape as the pre-#654 dead `:3101`, which read to the operator as "HTTPS setup is broken".
 
+  **And the restart screen no longer claims a server is back when a proxy answered for it.** That
+  screen probes the address and says "TangleClaw is back up" on a reply — which proved something
+  while the address was TangleClaw's own listener, and proves nothing once it is Caddy's: the proxy
+  stays up across the restart and answers immediately, with a 502 that an opaque probe cannot tell
+  from success. The response now says who answers at that address (`redirectVia`), the probe runs
+  only where a reply means something, and behind a proxy the screen names what the operator *can*
+  check — whether it asks for their password — instead of asserting readiness nobody observed.
+
 - **The admin login can be changed from settings (#710).** Global settings gains a **Login**
   section: username, new password, confirm. It appears only when the server says this install can
   use it — `GET /api/auth/credential` answers from the same predicate the change itself uses, so the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to TangleClaw are documented in this file.
 ## [Unreleased]
 
 ### Changed
+- **Setup sends you to an address that answers, not to the one TangleClaw is bound to (#710).** The
+  two questions "what is this server serving" and "where should the operator go" have different
+  answers behind Caddy, and the redirect was computing the first. In caddy mode TangleClaw serves
+  plain HTTP on the loopback — Caddy terminates TLS in front of it — so the old expression named
+  `http://<host>:3102`: TangleClaw's own door, reachable from nowhere else, and **ungated**. It would
+  have walked an operator straight past the login their setup had just installed.
+
+  The front door is now one derivation, `httpsSetup.effectiveOperatorOrigin`, asked by both places
+  that answer "where do I go now": the post-provisioning screen and the post-restart redirect. In
+  caddy mode it is Caddy's HTTPS port — every generated site listens there and the plain-HTTP site
+  redirects to it — and outside caddy mode it is the server's own scheme and port, which is what the
+  existing helpers were always right about. The host comes from the request, never from the
+  Caddyfile, whose freshly generated local site says `localhost` — not where a remote operator is
+  standing.
+
+  The caddy-mode case was reachable, not theoretical: the restart path fires whenever the HTTPS
+  config *changed*, regardless of ingress mode, so a caddy-mode install whose operator edits a
+  certificate path in the wizard took it and was sent to a port nothing answers on. That is the same
+  shape as the pre-#654 dead `:3101`, which read to the operator as "HTTPS setup is broken".
+
 - **The admin login can be changed from settings (#710).** Global settings gains a **Login**
   section: username, new password, confirm. It appears only when the server says this install can
   use it — `GET /api/auth/credential` answers from the same predicate the change itself uses, so the

--- a/lib/https-setup.js
+++ b/lib/https-setup.js
@@ -261,6 +261,11 @@ function getRemoteTrustInstructions(carootPath) {
  * the default-true flag) injected an `https://` base URL nothing was serving —
  * every guided API call failed until the caller guessed the http fallback.
  *
+ * NOT the scheme to send an OPERATOR to (#710 chunk 3). In caddy mode this
+ * returns `http` — correctly, since that is what TC binds — while the operator's
+ * front door is Caddy's HTTPS port. `effectiveOperatorFrontDoor` answers that
+ * question and reuses this one only where the two coincide.
+ *
  * @param {object} config - Global config (`store.config.load()`).
  * @returns {'http'|'https'} Scheme for localhost API base URLs.
  */

--- a/lib/https-setup.js
+++ b/lib/https-setup.js
@@ -7,12 +7,15 @@
 // Caddy's local site). Do not delete until the Caddy cutover has soaked. See
 // lib/caddy.js and deploy/INGRESS.md.
 //
-// NOTE for whoever retires this module after the soak: `effectiveServerProtocol`
-// and `effectiveServerPort` are NOT TLS logic. They answer "what is the server
-// actually serving, and where" for every localhost API base URL TangleClaw
-// injects, and they live here only because the protocol half was born beside the
-// cert code. They must be RELOCATED (together — callers read them as a pair),
-// never dropped with the rest of the module.
+// NOTE for whoever retires this module after the soak: `effectiveServerProtocol`,
+// `effectiveServerPort`, `effectiveOperatorFrontDoor` and `effectiveOperatorOrigin`
+// are NOT TLS logic. The first two answer "what is the server actually serving,
+// and where" for every localhost API base URL TangleClaw injects; the second two
+// answer the DIFFERENT question of where an operator should knock, which behind
+// Caddy is a different address entirely. They live here only because the protocol
+// half was born beside the cert code. All four must be RELOCATED **together** —
+// callers read them as a set, and separating the two questions is what the third
+// exists to keep straight — never dropped with the rest of the module.
 
 const fs = require('node:fs');
 const path = require('node:path');
@@ -285,9 +288,13 @@ function isBindableServerPort(raw) {
  * Resolve the port the server is actually listening on — the sibling of
  * `effectiveServerProtocol` (#497 / ENG-5R2W) for the other half of every
  * localhost API base URL, and the one derivation shared by the listen call in
- * `server.js` main, engine configs via `engines._getRulesContent`, the master
- * identity file via `master.buildMasterClaudeMd`, and the post-HTTPS-restart
- * redirect.
+ * `server.js` main, engine configs via `engines._getRulesContent`, and the master
+ * identity file via `master.buildMasterClaudeMd`.
+ *
+ * NOT the post-setup redirect any more (#710 chunk 3). That asks where the
+ * OPERATOR should knock, which behind Caddy is a different address than the one
+ * this server is bound to — `effectiveOperatorFrontDoor` answers it, and reuses
+ * this function only for the direct-mode case where the two coincide.
  *
  * Deliberately NOT used by `scripts/ingress-cutover.js`: that runs
  * out-of-process, where `TANGLECLAW_PORT` describes whoever launched the shell
@@ -350,17 +357,45 @@ function effectiveServerPort(config, env) {
  *   override describing the state being moved to.
  * @param {string} hostname - Host the operator reached this server on, no port.
  * @param {object} [env] - Environment; injectable for tests, defaults to `process.env`.
- * @returns {string} Origin — scheme, host and port, no trailing slash or path.
+ * @returns {{origin: string, via: 'proxy'|'server'}} `origin` is scheme, host and
+ *   port with no trailing slash. `via` says WHO answers there: `'proxy'` when
+ *   Caddy is in front (a response from it proves nothing about the server behind
+ *   it, which is why the two travel together), `'server'` when the origin is this
+ *   server's own listener.
  */
-function effectiveOperatorOrigin(config, hostname, env) {
+function effectiveOperatorFrontDoor(config, hostname, env) {
   const host = hostname || 'localhost';
   if (config && config.ingressMode === 'caddy') {
     // The default comes from store, not a local literal: `lib/caddy.js` and the
     // cutover already carry their own `8443`, and a fourth copy is one rename
     // away from naming a port nothing listens on.
-    return `https://${host}:${config.caddyHttpsPort || store.DEFAULT_CONFIG.caddyHttpsPort}`;
+    return {
+      origin: `https://${host}:${config.caddyHttpsPort || store.DEFAULT_CONFIG.caddyHttpsPort}`,
+      via: 'proxy'
+    };
   }
-  return `${effectiveServerProtocol(config)}://${host}:${effectiveServerPort(config, env)}`;
+  return {
+    origin: `${effectiveServerProtocol(config)}://${host}:${effectiveServerPort(config, env)}`,
+    via: 'server'
+  };
+}
+
+/**
+ * The front door as a bare origin string, for callers that need only the address.
+ *
+ * `via` and `origin` come out of one conditional deliberately. A caller that
+ * probes the origin to decide whether TangleClaw is back needs to know whether a
+ * response proves anything — behind a proxy it does not, because the proxy stays
+ * up and answers while the server behind it restarts — and two separate
+ * derivations of "is this proxied" would be free to disagree with the address
+ * they describe.
+ * @param {object} config - Global config, or a shallow override.
+ * @param {string} hostname - Host the operator reached this server on, no port.
+ * @param {object} [env] - Environment; injectable for tests.
+ * @returns {string} Origin — scheme, host and port, no trailing slash or path.
+ */
+function effectiveOperatorOrigin(config, hostname, env) {
+  return effectiveOperatorFrontDoor(config, hostname, env).origin;
 }
 
 /**
@@ -387,6 +422,7 @@ module.exports = {
   getCertsDir,
   effectiveServerProtocol,
   effectiveServerPort,
+  effectiveOperatorFrontDoor,
   effectiveOperatorOrigin,
   isBindableServerPort
 };

--- a/lib/https-setup.js
+++ b/lib/https-setup.js
@@ -319,6 +319,51 @@ function effectiveServerPort(config, env) {
 }
 
 /**
+ * The origin an OPERATOR should open — the front door, which is not always the
+ * door this server is listening on.
+ *
+ * This is a different question from `effectiveServerProtocol` /
+ * `effectiveServerPort`, and conflating the two is the defect it exists to fix.
+ * Those two predict what **TC's own listener** serves. In caddy mode that is
+ * plain HTTP on the loopback, because Caddy terminates TLS and proxies inward —
+ * so composing them there yields `http://host:3102`, TC's loopback-only and
+ * **ungated** door. Sending an operator to it walks them straight past the login
+ * gate, and from any other device it is simply dead. The pre-#654 wizard's dead
+ * `:3101` redirect, which read as "HTTPS setup is broken", is the same failure
+ * from the other direction.
+ *
+ * In caddy mode the front door is Caddy's HTTPS listener: `buildCaddyfileContent`
+ * puts every site on `httpsPort` and gives the plain-HTTP site a `redir` to it,
+ * so HTTPS on that port is the one address that always answers. Outside caddy
+ * mode the two helpers above ARE the front door, and are reused rather than
+ * re-derived.
+ *
+ * `hostname` must come from the request's `Host` header, never from the
+ * Caddyfile: a freshly generated local site says `localhost`, which is not where
+ * a remote operator is standing.
+ *
+ * Pure, so a caller can ask about a config that is not in force yet — the setup
+ * route asks about `{ ...config, ingressMode: 'caddy' }` while a cutover is still
+ * running, which is precisely "where will they go once this lands".
+ *
+ * @param {object} config - Global config (`store.config.load()`), or a shallow
+ *   override describing the state being moved to.
+ * @param {string} hostname - Host the operator reached this server on, no port.
+ * @param {object} [env] - Environment; injectable for tests, defaults to `process.env`.
+ * @returns {string} Origin — scheme, host and port, no trailing slash or path.
+ */
+function effectiveOperatorOrigin(config, hostname, env) {
+  const host = hostname || 'localhost';
+  if (config && config.ingressMode === 'caddy') {
+    // The default comes from store, not a local literal: `lib/caddy.js` and the
+    // cutover already carry their own `8443`, and a fourth copy is one rename
+    // away from naming a port nothing listens on.
+    return `https://${host}:${config.caddyHttpsPort || store.DEFAULT_CONFIG.caddyHttpsPort}`;
+  }
+  return `${effectiveServerProtocol(config)}://${host}:${effectiveServerPort(config, env)}`;
+}
+
+/**
  * Attempt to read a certificate's "valid to" timestamp. Returns null on failure.
  * @param {string} certPath
  * @returns {string|null}
@@ -342,5 +387,6 @@ module.exports = {
   getCertsDir,
   effectiveServerProtocol,
   effectiveServerPort,
+  effectiveOperatorOrigin,
   isBindableServerPort
 };

--- a/public/setup.js
+++ b/public/setup.js
@@ -1136,7 +1136,8 @@ async function wizardComplete() {
     // to the current origin so the overlay still shows while the server
     // cycles — otherwise the normal dismiss flow would run fetches against
     // a process that's exiting.
-    _showRestartOverlay(result.redirectUrl || (window.location && window.location.origin) || '/', carried);
+    _showRestartOverlay(result.redirectUrl || (window.location && window.location.origin) || '/',
+      carried, result.redirectVia);
     return;
   }
 
@@ -1542,7 +1543,7 @@ function _httpsSummaryLabel() {
  * @param {string[]} [warnings] - Server warnings to restate here, since this screen
  *   replaces the body that reported them.
  */
-function _showRestartOverlay(redirectUrl, warnings) {
+function _showRestartOverlay(redirectUrl, warnings, via) {
   _clearOverlayError();
   // Every terminal screen owes the same three things, and this one was outside all
   // of them: claim the view (the ingress probe re-renders asynchronously and would
@@ -1552,7 +1553,17 @@ function _showRestartOverlay(redirectUrl, warnings) {
   wizard.view = 'restarting';
   const body = document.getElementById('setupBody');
   if (!body) return;
-  _renderRestartOverlay(redirectUrl, warnings, 'waiting');
+  _renderRestartOverlay(redirectUrl, warnings, 'waiting', via);
+  // Only probe when a response from that address would MEAN anything. Behind
+  // Caddy it does not: the proxy stays up across TangleClaw's restart and answers
+  // straight away — with a 502, which an opaque `no-cors` probe cannot tell from
+  // success. Probing there would paint "TangleClaw is back up" over a server that
+  // is still down, and send the operator into an error page. Not observing is the
+  // honest state, and this screen already has words for it.
+  if (via === 'proxy') {
+    _renderRestartOverlay(redirectUrl, warnings, 'behind-proxy', via);
+    return;
+  }
   _pollRestartReady(redirectUrl, warnings);
 }
 
@@ -1562,9 +1573,11 @@ function _showRestartOverlay(redirectUrl, warnings) {
  * Navigation is ALWAYS the button, never this function — see `_pollRestartReady`.
  * @param {string} redirectUrl - Where TangleClaw will be reachable.
  * @param {string[]} [warnings] - Server warnings to restate.
- * @param {'waiting'|'ready'|'unconfirmed'} state - What the probe has observed.
+ * @param {'waiting'|'ready'|'unconfirmed'|'behind-proxy'} state - What the probe
+ *   has observed, or `behind-proxy` where no probe can observe anything.
+ * @param {string} [via] - `'proxy'` when the address is fronted by Caddy.
  */
-function _renderRestartOverlay(redirectUrl, warnings, state) {
+function _renderRestartOverlay(redirectUrl, warnings, state, via) {
   const body = document.getElementById('setupBody');
   if (!body) return;
   const go = `<button class="btn btn-primary setup-btn" onclick="window.location.href='${esc(redirectUrl)}'">Open ${esc(redirectUrl)}</button>`;
@@ -1578,7 +1591,14 @@ function _renderRestartOverlay(redirectUrl, warnings, state) {
         <p class="setup-text-muted">This address will not work any more.</p>`,
     unconfirmed: `
         <p class="setup-text">The server was restarting, and this page has not seen it come back at <code>${esc(redirectUrl)}</code>.</p>
-        <p class="setup-text-muted">That may just mean this page cannot reach the new address — try opening it. If nothing loads, check <code>~/.tangleclaw/logs/</code>.</p>`
+        <p class="setup-text-muted">That may just mean this page cannot reach the new address — try opening it. If nothing loads, check <code>~/.tangleclaw/logs/</code>.</p>`,
+    // Deliberately claims nothing about readiness. Caddy answers at this address
+    // whether or not TangleClaw is back, so there is nothing this page could
+    // check that would mean anything — and saying "it is back up" on the strength
+    // of the proxy replying is a report of something never observed.
+    'behind-proxy': `
+        <p class="setup-text">TangleClaw is restarting behind your login at <code>${esc(redirectUrl)}</code>.</p>
+        <p class="setup-text-muted">Give it a moment, then open it. <strong>If it asks for your username and password, it is back.</strong> If you get an error page, it is still starting — wait and reload.</p>`
   }[state];
   // The heading names the operation and stays put across all three states; the
   // panel below carries what has been observed. A heading that changes underneath

--- a/server.js
+++ b/server.js
@@ -1685,7 +1685,11 @@ route('POST', '/api/setup/complete', (req, res, _params, body) => {
       // below, so the two answers to "where do I go now" cannot drift.
       ingress.url = httpsSetup.effectiveOperatorOrigin(
         { ...config, ingressMode: 'caddy' }, requestHostname);
-      log.info('Setup started the ingress cutover', { pid: started.pid, host: requestHostname });
+      // The whole address, not just the host: scheme and port are the two halves
+      // this derivation exists to get right, and the operator is almost never at
+      // this machine to read the browser that was told them.
+      log.info('Setup started the ingress cutover',
+        { pid: started.pid, host: requestHostname, operatorUrl: ingress.url });
     } else {
       // The credential is stored and nothing enforces it. Say so — this is the
       // one outcome this path exists to make impossible to mistake for success.
@@ -1825,6 +1829,7 @@ route('POST', '/api/setup/complete', (req, res, _params, body) => {
     && httpsChanged && (willServeHttps || prevWillServeHttps);
 
   let redirectUrl = null;
+  let redirectVia = null;
   if (shouldRestart) {
     // The same derivation the provisioning arm uses. It used to compose the
     // scheme from `willServeHttps` and the port from TC's own listener, which is
@@ -1833,7 +1838,15 @@ route('POST', '/api/setup/complete', (req, res, _params, body) => {
     // reachable: a caddy-mode install whose operator changes a cert path in the
     // wizard satisfies `shouldRestart`, and the old expression sent them to a
     // port nothing answers on.
-    redirectUrl = httpsSetup.effectiveOperatorOrigin(config, requestHostname);
+    const frontDoor = httpsSetup.effectiveOperatorFrontDoor(config, requestHostname);
+    redirectUrl = frontDoor.origin;
+    // Who answers there, so the wizard does not read a response as proof the
+    // server is back. Behind Caddy it is not: Caddy stays up across TC's restart
+    // and answers immediately — with a 502, which an opaque `no-cors` probe
+    // cannot tell from success.
+    redirectVia = frontDoor.via;
+    log.info('Setup will restart; operator front door computed',
+      { redirectUrl, via: redirectVia });
     _scheduleRestart();
   }
 
@@ -1851,6 +1864,7 @@ route('POST', '/api/setup/complete', (req, res, _params, body) => {
     warnings,
     restart: shouldRestart,
     redirectUrl,
+    redirectVia,
     ingress
   });
 });

--- a/server.js
+++ b/server.js
@@ -1678,10 +1678,13 @@ route('POST', '/api/setup/complete', (req, res, _params, body) => {
       ingress.provisioning = true;
       ingress.protection = 'pending';
       ingress.user = config.basicAuthUser || null;
-      // Where the gate is about to listen. Built from the host the operator
-      // actually used, because a fresh Caddyfile's local site says `localhost`
-      // and that is not where a remote operator is standing.
-      ingress.url = `https://${requestHostname}:${config.caddyHttpsPort || 8443}`;
+      // Where the gate is about to listen. Asked of the config this cutover is
+      // MOVING to, not the one on disk — `ingressMode` is still whatever it was
+      // until the cutover writes it, and the question here is where the operator
+      // goes once this lands. One derivation, shared with the restart redirect
+      // below, so the two answers to "where do I go now" cannot drift.
+      ingress.url = httpsSetup.effectiveOperatorOrigin(
+        { ...config, ingressMode: 'caddy' }, requestHostname);
       log.info('Setup started the ingress cutover', { pid: started.pid, host: requestHostname });
     } else {
       // The credential is stored and nothing enforces it. Say so — this is the
@@ -1823,9 +1826,14 @@ route('POST', '/api/setup/complete', (req, res, _params, body) => {
 
   let redirectUrl = null;
   if (shouldRestart) {
-    const port = httpsSetup.effectiveServerPort(config);
-    const protocol = willServeHttps ? 'https' : 'http';
-    redirectUrl = `${protocol}://${requestHostname}:${port}`;
+    // The same derivation the provisioning arm uses. It used to compose the
+    // scheme from `willServeHttps` and the port from TC's own listener, which is
+    // right in direct mode and wrong in caddy mode — where TC serves plain HTTP
+    // on the loopback and the front door is Caddy's HTTPS port. That case is
+    // reachable: a caddy-mode install whose operator changes a cert path in the
+    // wizard satisfies `shouldRestart`, and the old expression sent them to a
+    // port nothing answers on.
+    redirectUrl = httpsSetup.effectiveOperatorOrigin(config, requestHostname);
     _scheduleRestart();
   }
 

--- a/test/api-setup-https.test.js
+++ b/test/api-setup-https.test.js
@@ -288,6 +288,8 @@ describe('HTTPS Setup API', () => {
         assert.equal(status, 200);
         assert.equal(data.restart, true);
         assert.match(data.redirectUrl, /^https:\/\/[^:/]+:3102$/);
+        assert.equal(data.redirectVia, 'server',
+          'in direct mode the address IS the server, so a reply there does mean it is back');
         assert.ok(
           !data.redirectUrl.endsWith(':3101'),
           'must not redirect to the config port when the environment overrides it'
@@ -334,6 +336,9 @@ describe('HTTPS Setup API', () => {
         assert.equal(status, 200);
         assert.match(data.redirectUrl, /^https:\/\/[^:/]+:8443$/,
           'the front door in caddy mode is Caddy, on its own port');
+        assert.equal(data.redirectVia, 'proxy',
+          'and the client must be TOLD a proxy answers there — it cannot tell from the URL, '
+          + 'and probing a proxy proves nothing about the server behind it');
         assert.ok(!/:3101$|:3102$/.test(data.redirectUrl),
           'never TC\'s own listener — behind Caddy that is the ungated loopback door');
       } finally {

--- a/test/api-setup-https.test.js
+++ b/test/api-setup-https.test.js
@@ -298,6 +298,51 @@ describe('HTTPS Setup API', () => {
       }
     });
 
+    it('sends a caddy-mode operator to Caddy, not to the port TC re-binds', async (t) => {
+      if (!hasOpenssl) return t.skip('openssl not available');
+
+      // The reachable version of the bug this chunk exists for. `shouldRestart`
+      // only needs the HTTPS config to have CHANGED — it does not care about
+      // ingress mode — so a caddy-mode install whose operator edits a cert path
+      // in the wizard takes this path. The old expression built the scheme from
+      // `willServeHttps` and the port from TC's own listener, which behind Caddy
+      // is plain HTTP on the loopback: it named a port nothing answers on, and
+      // an ungated one at that.
+      await request(server, 'PATCH', '/api/config', {
+        httpsEnabled: false, httpsCertPath: '', httpsKeyPath: ''
+      });
+      // A credential is required to finish setup in caddy mode (chunk 2's
+      // ADMIN_REQUIRED), so the fixture carries one — this test is about where
+      // the operator is SENT, on an install that legitimately completes.
+      store.config.save(Object.assign(store.config.load(), {
+        ingressMode: 'caddy',
+        caddyHttpsPort: 8443,
+        serverPort: 3101,
+        authEnabled: true,
+        basicAuthUser: 'jason',
+        basicAuthHash: '$2a$14$' + 'o'.repeat(53)
+      }));
+      restartCalls = 0;
+
+      try {
+        const { status, data } = await request(server, 'POST', '/api/setup/complete', {
+          httpsEnabled: true,
+          httpsCertPath: fixture.certPath,
+          httpsKeyPath: fixture.keyPath
+        });
+
+        assert.equal(status, 200);
+        assert.match(data.redirectUrl, /^https:\/\/[^:/]+:8443$/,
+          'the front door in caddy mode is Caddy, on its own port');
+        assert.ok(!/:3101$|:3102$/.test(data.redirectUrl),
+          'never TC\'s own listener — behind Caddy that is the ungated loopback door');
+      } finally {
+        store.config.save(Object.assign(store.config.load(), {
+          ingressMode: 'direct', authEnabled: false, basicAuthUser: null, basicAuthHash: null
+        }));
+      }
+    });
+
     it('returns 400 when cert files are invalid', async () => {
       restartCalls = 0;
       const badCert = path.join(tmpDir, 'bad-cert.pem');

--- a/test/https-setup.test.js
+++ b/test/https-setup.test.js
@@ -318,6 +318,41 @@ describe('https-setup', () => {
       }
     });
 
+    it('says WHO answers at that origin, not only where it is', () => {
+      // `via` is what stops a caller reading a response as proof the server is
+      // back. Behind Caddy it is not: the proxy stays up across TangleClaw's
+      // restart and answers immediately, so the wizard must not probe there.
+      assert.deepEqual(
+        httpsSetup.effectiveOperatorFrontDoor({ ingressMode: 'caddy' }, 'box', {}),
+        { origin: 'https://box:8443', via: 'proxy' }
+      );
+      assert.deepEqual(
+        httpsSetup.effectiveOperatorFrontDoor({ ingressMode: 'direct', serverPort: 3101 }, 'box', {}),
+        { origin: 'http://box:3101', via: 'server' }
+      );
+    });
+
+    it('derives the address and who answers it from ONE branch', () => {
+      // Two derivations of "is this proxied" would be free to disagree with the
+      // address they describe — a screen probing a proxy while calling it the
+      // server is exactly the defect this pair exists to prevent.
+      for (const config of [
+        { ingressMode: 'caddy' },
+        { ingressMode: 'caddy', caddyHttpsPort: 9443 },
+        { ingressMode: 'direct', serverPort: 3101 },
+        { ingressMode: 'direct', httpsEnabled: true, httpsCertPath: '/c', httpsKeyPath: '/k' },
+        {}
+      ]) {
+        const door = httpsSetup.effectiveOperatorFrontDoor(config, 'box', {});
+        const proxied = config.ingressMode === 'caddy';
+        assert.equal(door.via, proxied ? 'proxy' : 'server');
+        assert.equal(door.origin.startsWith('https://box:8443') || door.origin.startsWith('https://box:9443'),
+          proxied, `${JSON.stringify(config)} — the port must agree with who answers`);
+        assert.equal(httpsSetup.effectiveOperatorOrigin(config, 'box', {}), door.origin,
+          'the string form must be the same derivation, not a second one');
+      }
+    });
+
     it('emits an origin with no trailing slash or path', () => {
       // Callers append nothing and the wizard renders it verbatim in a button.
       for (const config of [{ ingressMode: 'caddy' }, { ingressMode: 'direct', serverPort: 3101 }]) {

--- a/test/https-setup.test.js
+++ b/test/https-setup.test.js
@@ -228,6 +228,105 @@ describe('https-setup', () => {
     });
   });
 
+  describe('effectiveOperatorOrigin (#710)', () => {
+    // The producer is swept, not sampled: every mode this function can be asked
+    // about appears below. A guard for a class that exercises one member is the
+    // defect this repo already learned once.
+
+    it('sends a caddy-mode operator to CADDY, not to the server behind it', () => {
+      // The whole reason this function exists. In caddy mode the server itself
+      // serves plain HTTP on the loopback — `effectiveServerProtocol` says so —
+      // so composing the two "what is TC serving" helpers yields
+      // http://host:3102, which is TC's loopback-only and UNGATED door. Sending
+      // an operator there walks them past the login gate setup just installed,
+      // and from another device it is dead.
+      assert.equal(
+        httpsSetup.effectiveOperatorOrigin({ ingressMode: 'caddy' }, 'box.tail123.ts.net', {}),
+        'https://box.tail123.ts.net:8443'
+      );
+    });
+
+    it('honours a custom caddy HTTPS port', () => {
+      assert.equal(
+        httpsSetup.effectiveOperatorOrigin(
+          { ingressMode: 'caddy', caddyHttpsPort: 9443 }, 'box', {}),
+        'https://box:9443'
+      );
+    });
+
+    it('ignores TC\'s own port and scheme entirely in caddy mode', () => {
+      // Caddy terminates TLS and listens on its own port; nothing about TC's
+      // listener changes where the operator knocks. TANGLECLAW_PORT is the
+      // sharpest version of this — it is what the installed plist sets, so a
+      // derivation that leaked it would be wrong on every standard install.
+      assert.equal(
+        httpsSetup.effectiveOperatorOrigin(
+          { ingressMode: 'caddy', serverPort: 3101, httpsEnabled: false },
+          'box',
+          { TANGLECLAW_PORT: '3102' }
+        ),
+        'https://box:8443'
+      );
+    });
+
+    it('is the server\'s own origin in direct mode with certs', () => {
+      assert.equal(
+        httpsSetup.effectiveOperatorOrigin({
+          ingressMode: 'direct', httpsEnabled: true, httpsCertPath: '/c', httpsKeyPath: '/k', serverPort: 3101
+        }, 'box', {}),
+        'https://box:3101'
+      );
+    });
+
+    it('is http in direct mode when the certs are missing, since that is what binds', () => {
+      // `httpsEnabled` defaults to true, so a no-cert install still serves HTTP
+      // via createServer's fallback — the ENG-5R2W defect was trusting the flag.
+      assert.equal(
+        httpsSetup.effectiveOperatorOrigin(
+          { ingressMode: 'direct', httpsEnabled: true, serverPort: 3101 }, 'box', {}),
+        'http://box:3101'
+      );
+    });
+
+    it('follows TANGLECLAW_PORT in direct mode, where it IS the front door', () => {
+      assert.equal(
+        httpsSetup.effectiveOperatorOrigin(
+          { ingressMode: 'direct', serverPort: 3101 }, 'box', { TANGLECLAW_PORT: '3102' }),
+        'http://box:3102'
+      );
+    });
+
+    it('answers about a config that is not in force yet', () => {
+      // The setup route asks while a cutover is still running: `ingressMode` on
+      // disk is whatever it was, and the question is where the operator goes
+      // once it lands. Purity is what makes that askable.
+      const onDisk = { ingressMode: 'direct', serverPort: 3101, caddyHttpsPort: 8443 };
+      assert.equal(
+        httpsSetup.effectiveOperatorOrigin({ ...onDisk, ingressMode: 'caddy' }, 'box', {}),
+        'https://box:8443'
+      );
+      assert.equal(httpsSetup.effectiveOperatorOrigin(onDisk, 'box', {}), 'http://box:3101',
+        'and the on-disk config still answers for itself');
+    });
+
+    it('falls back to localhost rather than emitting a hostless origin', () => {
+      for (const host of ['', null, undefined]) {
+        assert.equal(
+          httpsSetup.effectiveOperatorOrigin({ ingressMode: 'caddy' }, host, {}),
+          'https://localhost:8443'
+        );
+      }
+    });
+
+    it('emits an origin with no trailing slash or path', () => {
+      // Callers append nothing and the wizard renders it verbatim in a button.
+      for (const config of [{ ingressMode: 'caddy' }, { ingressMode: 'direct', serverPort: 3101 }]) {
+        const origin = httpsSetup.effectiveOperatorOrigin(config, 'box', {});
+        assert.match(origin, /^https?:\/\/[^/]+$/, `${origin} must be a bare origin`);
+      }
+    });
+  });
+
   describe('detectMkcert', () => {
     it('reports available: true when mkcert stub is on PATH', (t) => {
       if (!hasOpenssl) return t.skip('openssl not available');

--- a/test/setup-wizard-https.test.js
+++ b/test/setup-wizard-https.test.js
@@ -549,8 +549,12 @@ describe('the restart overlay behind a proxy (#710 chunk 3)', () => {
     // the LAST entry and has none, so `indexOf` returned -1 and the old slice
     // asserted against a single character. It could not have failed.
     const start = render.indexOf("'behind-proxy'");
-    const panel = render.slice(start, render.indexOf('}[state];', start));
-    assert.ok(panel.length > 200, 'the panel body must actually be in the slice');
+    const end = render.indexOf('}[state];', start);
+    // Relational, not a magic length: this catches the slice collapsing (what the
+    // old `indexOf('`,')` bound did) without pretending to know how long the copy
+    // should be, and it fails in both directions if the terminator moves.
+    assert.ok(start > -1 && end > start, 'the behind-proxy panel must be locatable and non-empty');
+    const panel = render.slice(start, end);
     assert.doesNotMatch(panel, /is back up/,
       'no readiness claim on the branch where readiness is unobservable');
     assert.match(panel, /asks for your username and password/,

--- a/test/setup-wizard-https.test.js
+++ b/test/setup-wizard-https.test.js
@@ -532,14 +532,26 @@ describe('the restart overlay behind a proxy (#710 chunk 3)', () => {
     // an error page.
     assert.match(show, /via === 'proxy'/,
       'the proxied case must be recognised before any probe');
-    const beforePoll = show.slice(0, show.indexOf('_pollRestartReady'));
-    assert.match(beforePoll, /return;/,
-      'and must return, so the probe never runs for it');
+    // Scoped to the proxy BRANCH, not to everything before the probe: the
+    // function opens with `if (!body) return;`, so a bare /return;/ over that
+    // span passes with the proxy branch's own return deleted. The sibling test
+    // for the credential section carries this same warning; I reproduced the
+    // defect it documents.
+    const branch = show.slice(show.indexOf("via === 'proxy'"), show.indexOf('_pollRestartReady'));
+    assert.match(branch, /_renderRestartOverlay\([^)]*'behind-proxy'/,
+      'the proxied case paints its own panel');
+    assert.match(branch, /\breturn;/,
+      'and returns, so the probe never runs for it');
   });
 
   it('claims nothing it cannot observe, and names what the operator CAN check', () => {
-    const panel = render.slice(render.indexOf("'behind-proxy'"));
-    assert.doesNotMatch(panel.slice(0, panel.indexOf('`,') + 2 || undefined), /is back up/,
+    // Bounded by the end of the map, not by a trailing '`,' — 'behind-proxy' is
+    // the LAST entry and has none, so `indexOf` returned -1 and the old slice
+    // asserted against a single character. It could not have failed.
+    const start = render.indexOf("'behind-proxy'");
+    const panel = render.slice(start, render.indexOf('}[state];', start));
+    assert.ok(panel.length > 200, 'the panel body must actually be in the slice');
+    assert.doesNotMatch(panel, /is back up/,
       'no readiness claim on the branch where readiness is unobservable');
     assert.match(panel, /asks for your username and password/,
       'the password prompt is the one thing the operator can actually verify');

--- a/test/setup-wizard-https.test.js
+++ b/test/setup-wizard-https.test.js
@@ -512,3 +512,48 @@ describe('Setup wizard — HTTPS step (frontend)', () => {
     });
   });
 });
+
+describe('the restart overlay behind a proxy (#710 chunk 3)', () => {
+  // Structural, matching how this repo pins setup.js elsewhere: the file renders
+  // via innerHTML strings and cannot be imported.
+  const src = fs.readFileSync(path.join(__dirname, '..', 'public', 'setup.js'), 'utf8');
+  const strip = (t) => t.split('\n').filter((l) => !l.trim().startsWith('//')).join('\n');
+  const show = strip(src.slice(src.indexOf('function _showRestartOverlay'),
+    src.indexOf('function _renderRestartOverlay')));
+  const render = strip(src.slice(src.indexOf('function _renderRestartOverlay'),
+    src.indexOf('async function _pollRestartReady')));
+
+  it('does not probe an address a proxy answers for', () => {
+    // The defect this pins. `redirectUrl` used to be TangleClaw's own listener,
+    // so a response proved it was back. In caddy mode it is Caddy's port, and
+    // Caddy stays up across TangleClaw's restart and answers instantly — with a
+    // 502, which an opaque `no-cors` fetch cannot distinguish from success. The
+    // screen would assert readiness it never observed and send the operator into
+    // an error page.
+    assert.match(show, /via === 'proxy'/,
+      'the proxied case must be recognised before any probe');
+    const beforePoll = show.slice(0, show.indexOf('_pollRestartReady'));
+    assert.match(beforePoll, /return;/,
+      'and must return, so the probe never runs for it');
+  });
+
+  it('claims nothing it cannot observe, and names what the operator CAN check', () => {
+    const panel = render.slice(render.indexOf("'behind-proxy'"));
+    assert.doesNotMatch(panel.slice(0, panel.indexOf('`,') + 2 || undefined), /is back up/,
+      'no readiness claim on the branch where readiness is unobservable');
+    assert.match(panel, /asks for your username and password/,
+      'the password prompt is the one thing the operator can actually verify');
+  });
+
+  it('still offers the front door as the destination', () => {
+    // Not probing it is not the same as not linking it — the address is still
+    // where they are going.
+    assert.match(render, /window\.location\.href='\$\{esc\(redirectUrl\)\}'/);
+  });
+
+  it('carries `via` from the server rather than guessing at it', () => {
+    // The client cannot tell a proxy from a server by looking at a URL; the
+    // server derives both halves from one place and says which it is.
+    assert.match(src, /result\.redirectVia/);
+  });
+});


### PR DESCRIPTION
## What

After setup, TangleClaw sends the operator to an address that **answers** — which behind a reverse
proxy is not the address this server is bound to.

One derivation now answers "where do I go now": `httpsSetup.effectiveOperatorFrontDoor`, returning
`{ origin, via }`. In caddy mode the origin is Caddy's HTTPS port (every generated site listens
there, and the plain-HTTP site redirects to it); otherwise it is the server's own scheme and port.
The host always comes from the request, never from the Caddyfile — a freshly generated local site
says `localhost`, which is not where a remote operator is standing.

## Why

**The old expression named an ungated door.** In caddy mode TangleClaw serves plain HTTP on the
loopback — Caddy terminates TLS in front of it — so the redirect resolved to `http://<host>:3102`:
TangleClaw's own listener, reachable from nowhere else, and **not behind the login gate**. It would
have walked an operator straight past the password their setup had just installed.

**It was reachable, not theoretical.** `shouldRestart` fires whenever the HTTPS config *changed*,
regardless of ingress mode, so a caddy-mode install whose operator edits a certificate path in the
wizard took that path and was sent to a port nothing answers on. Same shape as the pre-#654 dead
`:3101`, which read to the operator as "HTTPS setup is broken".

**And it collapsed a duplicate that was already there.** `POST /api/setup/complete` answered this
question twice with two inline expressions — `ingress.url` on the provisioning arm and `redirectUrl`
on the restart arm — which disagreed in caddy mode. The provisioning arm asks about
`{ ...config, ingressMode: 'caddy' }`, the state the cutover is *moving to*, since `ingressMode` on
disk is still the old value while the child runs.

## The spec was wrong, and that is recorded

Chunk 3's paragraph said: *"`effectiveServerPort` and `effectiveServerProtocol` already exist for
this — reuse, do not re-derive."* Those helpers' own header says they predict what **TC's listener**
serves, and the instruction predates chunk 2 making Caddy the default install path — so taken
literally it produces the exact defect the chunk exists to fix. The build plan now carries the
correction in place, and keeps the direct-mode half, where the instruction was always right.

"What is this server serving" and "where should the operator go" are two questions. Behind a proxy
they have different answers, and conflating them is the bug.

## The consumer this broke, caught in review

The restart overlay probes `redirectUrl` and reports **"TangleClaw is back up"** on any reply. Sound
while that address was TangleClaw's own listener; meaningless once it is Caddy's — the proxy stays up
across the restart and answers immediately, with a **502** that an opaque `no-cors` probe cannot
distinguish from success. The screen would assert readiness it never observed and click the operator
into an error page. *Newly* reachable, too: the old caddy-mode value named a port nothing answered
on, so the overlay correctly fell through to "unconfirmed".

The response now carries `redirectVia` — a client cannot tell a proxy from a server by looking at a
URL — and it comes out of the **same branch** as the origin, because two derivations of "is this
proxied" could disagree with the address they describe. The wizard probes only where a reply means
something; behind a proxy it names what the operator *can* check: whether the address asks for their
password.

## Also in here

- `POST /api/setup/complete` logs the computed front door on both arms. It was derived and handed to
  a browser the (almost always remote) operator may have closed, leaving no server-side record.
- `lib/https-setup.js`'s header and `effectiveServerPort`'s JSDoc were still describing a module
  with two non-TLS helpers and naming the redirect as a caller — an invitation to reuse them for
  exactly the question the correction forbids.
- `api-contracts.md` for this route was three response fields stale and omitted the HTTPS and admin
  request fields entirely.

## Test plan

- `node --test 'test/*.test.js'` — **5410 tests, 0 fail, 1 skip.**
- The derivation is **swept, not sampled**: caddy at a default and a custom port, caddy ignoring both
  `TANGLECLAW_PORT` and the HTTPS flags, direct with certs, direct without, `TANGLECLAW_PORT` winning
  in direct mode, a config not yet in force, a missing hostname, the bare-origin shape, and that
  `origin` and `via` come from one branch for every input.
- Endpoint regressions for the reachable caddy-mode restart **and** the direct-mode one, each pinning
  `redirectVia` at the wire.
- Wizard pins that the proxied case never probes, claims no readiness, still offers the front door,
  and takes `via` from the server rather than guessing.
- **Nine mutations across the review rounds; every one goes red.**
- Not verified against a live cutover: this clone is the live install and the operator's remote
  access depends on a hand-edited Caddyfile. The clean-room VRF is where that gets exercised.

## Review

Cumulative Critic `rev-20260801T051617Z-9012c0e7`: 0 blocking, 5 warnings, 9 notes. Then two
`verify-resolutions` rounds — the first returned a **blocking** finding worth naming: `redirectVia`
was pinned where it was *produced* and where the client *mentions* it, but nothing pinned that the
route *emits* it, so deleting the field from the response left the whole suite green while a
caddy-mode operator would be told the server was back on the strength of a 502. Two further
assertions of mine were inert — one satisfied by an unrelated `return;` earlier in the same function,
one slicing on a delimiter the last map entry does not have. All closed and mutation-verified.

**Filed rather than fixed: #825.** `wizardComplete` returns on `ingress.protection` before it checks
`result.restart`, so an install that is simultaneously "no login TangleClaw can confirm" and "about to
restart" never reaches the overlay and lands on a Continue button that fetches a dying server.
Reachable on a hand-maintained Caddyfile. Not fixed here because it edits the copy of a
security-warning screen, under chunk 2's rule that no path claims protection it did not observe —
that compound state wants deliberate wording and its own review.
