### PR TITLE
Prove break-glass by running it, and let a login-less install create one (#710 chunk 4)

### DIFF
--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -49,8 +49,10 @@ cursatory against the **hand-edited** Caddyfile, the shape only that machine has
 claims to patch without reshaping.
 
 Measured: hash moved; the real LaunchAgent restarted (PID changed, exit 0); the gate re-authenticated
-and still 401s on `/`, `/api/health` and a wrong password; config and the live file agree; a
-timestamped backup preceded the swap. The load-bearing result: the file came out **byte-identical
+and still 401s on `/` and a wrong password; config and the live file agree; a
+timestamped backup preceded the swap. (`/api/health` answered 401 too and is deliberately NOT cited:
+it is in `AUTH_BYPASS_PATHS` and exempt on a generated ingress, so the 401 is an artifact of this
+machine's hand-edited file gating it anyway.) The load-bearing result: the file came out **byte-identical
 apart from the hash**, still classifying `adoptable`/`safeToWrite: false` — so it was not silently
 re-stamped as generated, and the cutover's clobber-guard keeps protecting the operator's edits.
 

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -92,7 +92,24 @@ Also filed: **#828** (`~/.tangleclaw` derived from both `process.env.HOME` and `
 HOME override half-relocates state) and **#829** (Master control — #755/#756/#768 — the first release
 after v5, deliberately kept out of it).
 
-**Tests:** 5435 pass / 0 fail / 1 skipped.
+**Tests:** 5442 pass / 0 fail / 1 skipped. Evidence recorded against tree `52af13ab`.
+
+**Review:** one `cumulative` (3 blocking / 8 warning / 13 note, all three reviewers finding the same
+blocking defect independently) then two `verify-resolutions` passes, ending 0/0/0. Dispositions are
+prose here rather than evidence facts because `prawduct-hook` on PATH is 3.1.2 and has no
+`disposition` subcommand; stamp them if a relaunch picks up 3.2.x.
+
+- **ACCEPTED — the `--dry-run` structural test greps the script's source instead of executing the
+  branch.** Executing it in-suite needs either a `HOME` override, which half-relocates state (#828),
+  or the machine's real Caddyfile, which is the non-determinism just filed as #831. The contract is
+  covered from both sides instead: `canCreateGate`'s parity tests assert the preview and the run
+  reach the same verdict, and the branch itself was exercised live —
+  `--dry-run --create-gate --user bob` against the hand-edited Caddyfile printed
+  `would REFUSE: this Caddyfile already gates on 'jason'`, read-only. Revisit if the suite gains a
+  hermetic temp-repo helper (#831).
+- **FILED — #831** (bare `git init` in nine test files inherits the live global template dir).
+- **FILED — #828** (`~/.tangleclaw` derived from two different sources).
+- Remaining notes accepted as written; none touched behaviour.
 
 ## 2026-08-01: setup lands the operator on an address that answers (#710, chunk 3)
 

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -26,6 +26,74 @@ Tag-line conventions (ART-4K9M, ratified 2026-07-17):
 -->
 
 
+## 2026-08-01: break-glass recovery proven by running it, and a way out for an install with no login (#710, chunk 4)
+
+<!-- prawduct: type=feat | chunks=4 | scope=auth-6-secure-by-default | status= -->
+
+**Why:** v5 makes a password mandatory. The recovery path out of a lockout was **built and
+unit-tested but never executed** — `test/reset-admin.test.js` asserts the `launchctl` reload's argv
+**as data** and never runs it, so everything past "the file is patched" was inference. A mandatory
+credential whose recovery is merely believed to work strands the operator on the day it matters.
+
+**The chunk's own spec was stale in three ways, corrected before any code was written.** The
+doc/wiring contradiction it said to resolve had already been resolved on 2026-07-29; the README
+sharpening it asked for was already done; and #806 — the thing that actually needed building — was
+not in it at all. Chunk 3's lesson (a plan written before an earlier chunk landed may name
+mechanisms that chunk changed) applied again, and re-reading against the code is what caught it.
+
+**Where the run happened, and the finding that decided it.** The habitat clean room was the obvious
+safe venue and **cannot prove what this chunk exists to prove**: `deploy/cleanroom/bake.sh` is
+`FROM node:22-bookworm`, and there is no `launchctl` on Linux — a run there would cover patch →
+validate → restore and stop exactly at the reload. Only a Mac with a live gate closes it. Run on
+cursatory against the **hand-edited** Caddyfile, the shape only that machine has and the one the tool
+claims to patch without reshaping.
+
+Measured: hash moved; the real LaunchAgent restarted (PID changed, exit 0); the gate re-authenticated
+and still 401s on `/`, `/api/health` and a wrong password; config and the live file agree; a
+timestamped backup preceded the swap. The load-bearing result: the file came out **byte-identical
+apart from the hash**, still classifying `adoptable`/`safeToWrite: false` — so it was not silently
+re-stamped as generated, and the cutover's clobber-guard keeps protecting the operator's edits.
+
+**Two defects in the documented procedure that only a real run could surface.** (1) Recovery enforces
+the *current* password policy, so a credential older than the policy cannot be restored — the live
+one predated the 12-character minimum and was refused, forcing a new password to be invented seconds
+before the connection drops. The guard was documented, not weakened. (2) "Run it under tmux" was
+wrong for how an operator reaches this machine: ttyd is already tmux-backed, but its window may run
+an AI session that cannot be typed into, and `tmux new -s` fails there as a nested/duplicate session.
+
+**#806 closed.** An install that reached `setupComplete` before a credential was mandatory and then
+moved to caddy mode had no route to a login: the setup route refuses as already-complete, adoption
+runs only on a first run, and `reset-admin.js` exited 1 because it *resets* a gate and cannot
+*create* one. `--create-gate` builds one, from the same local-shell tool as recovery — a first
+credential settable over the network reopens what making the gate mandatory closed. The rebuild
+recovers its inputs from the Caddyfile rather than from config (new
+`caddy.extractGeneratedCaddyfileOptions`), so it differs from what was there by exactly the gate;
+config and the live file are known to drift. The extractor **refuses rather than defaulting**, since
+every field it reads has a default and a silent fallback would move a working port or certificate
+while reporting success. A hand-maintained file is refused, never reshaped.
+
+**One implementation of the sequence, two entry points.** Creation and change share
+`_persistGatedCaddyfile` (write → validate fail-closed → record in config → reload). The ORDER is the
+safety property, not the individual steps, and a second copy would be free to drift out of it — which
+this project has already paid for once.
+
+**Self-review caught what the tests did not.** `--dry-run --create-gate` described a rebuild the real
+run would refuse — the same "report an outcome nobody observed" class this surface exists to
+eliminate, landing on someone already locked out and checking before they commit. Extracted
+`canCreateGate` so the preview and the run ask **one** predicate, with a test asserting agreement
+rather than two independently-correct answers.
+
+**Mutation testing found two inert tests on the central claim.** The fixture for "changes nothing but
+the gate" used the default ports 8443/8080, so a rebuild that silently fell back to defaults produced
+a byte-identical file and the test could not fail. Same species as the #749 lesson. Fixture moved to
+non-default ports and the missing-field case widened to every field; all mutations now red.
+
+Also filed: **#828** (`~/.tangleclaw` derived from both `process.env.HOME` and `os.homedir()`, so a
+HOME override half-relocates state) and **#829** (Master control — #755/#756/#768 — the first release
+after v5, deliberately kept out of it).
+
+**Tests:** 5435 pass / 0 fail / 1 skipped.
+
 ## 2026-08-01: setup lands the operator on an address that answers (#710, chunk 3)
 
 <!-- prawduct: type=fix | chunks=3 | scope=auth-6-secure-by-default | status=shipped -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,11 @@ All notable changes to TangleClaw are documented in this file.
   tool promises to patch without reshaping.
 
   Measured: the hash moved; the reload restarted the real LaunchAgent (PID changed, exit 0); the gate
-  re-authenticated and still returns 401 on `/`, `/api/health` and a wrong password; config and the
-  live file agree; a timestamped backup was written before the swap. The load-bearing one — the live
+  re-authenticated and still returns 401 on `/` and on a wrong password; config and the live file
+  agree; a timestamped backup was written before the swap. (`/api/health` also returned 401 on this
+  machine, but that proves nothing portable and is not cited as evidence: the path is **exempt by
+  design** on a generated ingress, and the 401 is an artifact of this operator's hand-edited
+  Caddyfile gating it anyway.) The load-bearing one — the live
   file came out **byte-identical apart from the hash**, and still classifies
   `adoptable`/`safeToWrite: false`, so it was not silently re-stamped as generated and the cutover's
   clobber-guard keeps protecting the operator's edits.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,47 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **An install with no login can now get one, from the same terminal tool that resets one (#806,
+  #710).** A machine that reached `setupComplete` before a credential was mandatory and then moved
+  to caddy mode had no way forward: the setup route answers `409 SETUP_ALREADY_COMPLETE`, the adopt
+  path only runs on a first run, and `reset-admin.js` exited 1 because it *resets* a gate and could
+  not *create* one. Closing #805 removed the unauthenticated `PATCH /api/config` escape that had
+  been masking it. `node scripts/reset-admin.js --create-gate --user <name>` builds the gate.
+
+  It stays the terminal tool deliberately. The alternative — letting an unauthenticated route set
+  the first credential — reopens exactly the hole that making the gate mandatory closed, and a
+  recovery path reachable over the network is not a recovery path for someone the network is
+  refusing.
+
+  **The rebuild reads its inputs back out of the file, not out of `config`.** New
+  `caddy.extractGeneratedCaddyfileOptions` recovers the ports, upstream and certificate a generated
+  Caddyfile was emitted from, so the result differs from what was there by exactly the gate.
+  Rebuilding from config instead would fold in every field that has since drifted — and config and
+  the live Caddyfile are known to drift; that is the state ADR 0009's amendment describes. Every
+  field involved has a default in `buildCaddyfileContent`, so the extractor **refuses rather than
+  defaulting**: a silent fallback would emit a plausible file that moves a working port or
+  certificate while reporting success.
+
+  A hand-maintained Caddyfile is **refused, not reshaped** — adding a gate means placing directives
+  inside site blocks this code did not write, and guessing wrong either drops the operator's
+  configuration or leaves an opening that looks closed. The refusal an operator hits on the reset
+  path now names the create command, but only when the file is one the tool could actually build in,
+  so it never advertises a command that would refuse them.
+
+  Creation and change share one implementation of the sequence that matters
+  (`_persistGatedCaddyfile`: write, validate fail-closed, only then record in config, then reload).
+  The order is the safety property rather than the individual steps, and a second copy would be free
+  to drift out of it — which this project has already paid for once.
+
+- **A setup guide for someone who has never heard of a reverse proxy (`docs/setup-guide.md`).**
+  `deploy/INGRESS.md` documents the same machinery for a reader who already knows what it is; this
+  one explains what the login protects (a browser that can run commands as you), what Caddy is and
+  why the password check happens before anything reaches TangleClaw, how to verify from a second
+  device that the gate is actually in force rather than trusting the dashboard, and what to do when
+  locked out — including that the reload restarts Caddy and will drop the connection you are reading
+  it through, so run it under `tmux`.
+
 ### Changed
 - **Setup sends you to an address that answers, not to the one TangleClaw is bound to (#710).** The
   two questions "what is this server serving" and "where should the operator go" have different

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,40 +4,6 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
-### Security
-- **Break-glass recovery is proven by execution, not by reading the code (#710).** The
-  no-permanent-lockout guarantee rested on a tool whose reload had never run: `test/reset-admin.test.js`
-  asserts the `launchctl` argv **as data** and never executes it, so every claim past "the file is
-  patched" was inference. Run on 2026-08-01 against a live, **hand-edited** Caddyfile — the shape the
-  tool promises to patch without reshaping.
-
-  Measured: the hash moved; the reload restarted the real LaunchAgent (PID changed, exit 0); the gate
-  re-authenticated and still returns 401 on `/` and on a wrong password; config and the live file
-  agree; a timestamped backup was written before the swap. (`/api/health` also returned 401 on this
-  machine, but that proves nothing portable and is not cited as evidence: the path is **exempt by
-  design** on a generated ingress, and the 401 is an artifact of this operator's hand-edited
-  Caddyfile gating it anyway.) The load-bearing one — the live
-  file came out **byte-identical apart from the hash**, and still classifies
-  `adoptable`/`safeToWrite: false`, so it was not silently re-stamped as generated and the cutover's
-  clobber-guard keeps protecting the operator's edits.
-
-  **Two defects in the documented procedure that only a real run could surface**, both now fixed in
-  `docs/setup-guide.md` and `deploy/INGRESS.md`:
-
-  - **Recovery enforces the current password policy, so a credential older than the policy cannot be
-    restored.** The live credential predated the 12-character minimum and was refused. The refusal is
-    right — recovery that installs a weak credential undermines a mandatory gate — but an operator
-    reaching for break-glass to reinstate a password they *know* is forced to invent one at the worst
-    moment, with the disconnect seconds away. Documented rather than relaxed: the guard is not
-    weakened to fit a legacy credential.
-  - **"Run it under tmux" was wrong for how an operator actually reaches the machine.** They arrive
-    through a browser terminal that is already tmux-backed — but whose window may be running an AI
-    session that cannot be typed into, and where `tmux new -s` fails as a nested/duplicate session.
-    The instruction is now to open a second window in the session they are already in.
-
-  `security-model.md` §2 records the run. Its "built, not yet proven" line is resolved the way it
-  demanded — by running the tool, not by editing the sentence a third time.
-
 ### Added
 - **An install with no login can now get one, from the same terminal tool that resets one (#806,
   #710).** A machine that reached `setupComplete` before a credential was mandatory and then moved
@@ -426,6 +392,40 @@ All notable changes to TangleClaw are documented in this file.
   `RentalClaw-Project` — were the exposed cases; no rename is needed now.
 
 ### Security
+
+- **Break-glass recovery is proven by execution, not by reading the code (#710).** The
+  no-permanent-lockout guarantee rested on a tool whose reload had never run: `test/reset-admin.test.js`
+  asserts the `launchctl` argv **as data** and never executes it, so every claim past "the file is
+  patched" was inference. Run on 2026-08-01 against a live, **hand-edited** Caddyfile — the shape the
+  tool promises to patch without reshaping.
+
+  Measured: the hash moved; the reload restarted the real LaunchAgent (PID changed, exit 0); the gate
+  re-authenticated and still returns 401 on `/` and on a wrong password; config and the live file
+  agree; a timestamped backup was written before the swap. (`/api/health` also returned 401 on this
+  machine, but that proves nothing portable and is not cited as evidence: the path is **exempt by
+  design** on a generated ingress, and the 401 is an artifact of this operator's hand-edited
+  Caddyfile gating it anyway.) The load-bearing one — the live
+  file came out **byte-identical apart from the hash**, and still classifies
+  `adoptable`/`safeToWrite: false`, so it was not silently re-stamped as generated and the cutover's
+  clobber-guard keeps protecting the operator's edits.
+
+  **Two defects in the documented procedure that only a real run could surface**, both now fixed in
+  `docs/setup-guide.md` and `deploy/INGRESS.md`:
+
+  - **Recovery enforces the current password policy, so a credential older than the policy cannot be
+    restored.** The live credential predated the 12-character minimum and was refused. The refusal is
+    right — recovery that installs a weak credential undermines a mandatory gate — but an operator
+    reaching for break-glass to reinstate a password they *know* is forced to invent one at the worst
+    moment, with the disconnect seconds away. Documented rather than relaxed: the guard is not
+    weakened to fit a legacy credential.
+  - **"Run it under tmux" was wrong for how an operator actually reaches the machine.** They arrive
+    through a browser terminal that is already tmux-backed — but whose window may be running an AI
+    session that cannot be typed into, and where `tmux new -s` fails as a nested/duplicate session.
+    The instruction is now to open a second window in the session they are already in.
+
+  `security-model.md` §2 records the run. Its "built, not yet proven" line is resolved the way it
+  demanded — by running the tool, not by editing the sentence a third time.
+
 - **Changing the login is refused on any connection that did not arrive over loopback (#710, #822).**
   In caddy mode TangleClaw binds loopback only, so Caddy is the only way in — but that binding is
   chosen when the server starts listening, while `ingressMode` is read per request. An install still

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,13 @@ All notable changes to TangleClaw are documented in this file.
   why the password check happens before anything reaches TangleClaw, how to verify from a second
   device that the gate is actually in force rather than trusting the dashboard, and what to do when
   locked out — including that the reload restarts Caddy and will drop the connection you are reading
-  it through, so run it under `tmux`.
+  it through, and how to get a shell that survives that (a second window in the session you are
+  already in, per the Security entry above — not a fresh `tmux new -s`).
+
+  It also names the three paths that are **exempt** from the gate — `/api/health`,
+  `/openclaw-direct/*`, `/manifest.json` — because "check a second URL to confirm the gate is on" is
+  useless advice if the reader picks `/api/health`, which is the obvious choice and answers without
+  a password by design.
 
 ### Changed
 - **Setup sends you to an address that answers, not to the one TangleClaw is bound to (#710).** The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Security
+- **Break-glass recovery is proven by execution, not by reading the code (#710).** The
+  no-permanent-lockout guarantee rested on a tool whose reload had never run: `test/reset-admin.test.js`
+  asserts the `launchctl` argv **as data** and never executes it, so every claim past "the file is
+  patched" was inference. Run on 2026-08-01 against a live, **hand-edited** Caddyfile — the shape the
+  tool promises to patch without reshaping.
+
+  Measured: the hash moved; the reload restarted the real LaunchAgent (PID changed, exit 0); the gate
+  re-authenticated and still returns 401 on `/`, `/api/health` and a wrong password; config and the
+  live file agree; a timestamped backup was written before the swap. The load-bearing one — the live
+  file came out **byte-identical apart from the hash**, and still classifies
+  `adoptable`/`safeToWrite: false`, so it was not silently re-stamped as generated and the cutover's
+  clobber-guard keeps protecting the operator's edits.
+
+  **Two defects in the documented procedure that only a real run could surface**, both now fixed in
+  `docs/setup-guide.md` and `deploy/INGRESS.md`:
+
+  - **Recovery enforces the current password policy, so a credential older than the policy cannot be
+    restored.** The live credential predated the 12-character minimum and was refused. The refusal is
+    right — recovery that installs a weak credential undermines a mandatory gate — but an operator
+    reaching for break-glass to reinstate a password they *know* is forced to invent one at the worst
+    moment, with the disconnect seconds away. Documented rather than relaxed: the guard is not
+    weakened to fit a legacy credential.
+  - **"Run it under tmux" was wrong for how an operator actually reaches the machine.** They arrive
+    through a browser terminal that is already tmux-backed — but whose window may be running an AI
+    session that cannot be typed into, and where `tmux new -s` fails as a nested/duplicate session.
+    The instruction is now to open a second window in the session they are already in.
+
+  `security-model.md` §2 records the run. Its "built, not yet proven" line is resolved the way it
+  demanded — by running the tool, not by editing the sentence a third time.
+
 ### Added
 - **An install with no login can now get one, from the same terminal tool that resets one (#806,
   #710).** A machine that reached `setupComplete` before a credential was mandatory and then moved

--- a/README.md
+++ b/README.md
@@ -205,9 +205,11 @@ Quick answers, with links into the full docs:
 | Cut a release, or work out why one never reached installs | [Release Process](docs/release-process.md) |
 | Change any config setting | [Configuration Reference](docs/configuration-reference.md) |
 | Fix something that's broken | [User Guide — Troubleshooting](docs/user-guide.md#troubleshooting), or [Service Management](#service-management) below |
+| Set it up safely, or get back in when locked out | [Setup Guide](docs/setup-guide.md) |
 
 ## Documentation
 
+- **[Setup Guide](docs/setup-guide.md)** — setting up safely with no prior background: what the login protects, reaching it from another device, checking it worked, getting back in if you are locked out
 - **[User Guide](docs/user-guide.md)** — getting started, full UI walkthrough, sessions, groups, mobile setup, troubleshooting
 - **[Ingress Guide](deploy/INGRESS.md)** — Caddy reverse proxy, TLS, password gate, break-glass reset, public domains
 - **[Session Rules & Self-Improvement](docs/session-rules-self-improvement.md)** — durable session directives, the Critic gate, version history

--- a/deploy/INGRESS.md
+++ b/deploy/INGRESS.md
@@ -195,6 +195,18 @@ Run `--dry-run --create-gate --user <name>` first: the preview asks the identica
 predicate, so it reports the refusal you would actually get rather than describing a
 rebuild that will not happen.
 
+**Undoing a gate created with the wrong username.** There is no rename path — the
+ordinary reset refuses one (`rename-unsupported`, because the underlying replace
+writes back the *matched* username, so a "successful" rename would leave the gate on
+the old name while config recorded the new one), and a second `--create-gate` refuses
+with `gate-exists`. Restore the timestamped backup the run printed, then create again:
+
+```bash
+cp ~/.tangleclaw/Caddyfile.<stamp>.credential.bak ~/.tangleclaw/Caddyfile
+caddy validate --config ~/.tangleclaw/Caddyfile --adapter caddyfile
+node scripts/reset-admin.js --create-gate --user <correct-name>
+```
+
 ## Public domain on 443/80 (root LaunchDaemon)
 
 Real Let's Encrypt issuance needs a public domain with ports 80/443 reachable

--- a/deploy/INGRESS.md
+++ b/deploy/INGRESS.md
@@ -178,11 +178,22 @@ This rebuilds the Caddyfile **from its own current settings** — ports, upstrea
 certificate are read back out of the file rather than out of `config`, so the result
 differs from what was there by exactly the gate, and config drift cannot ride along.
 
-It applies only to a TangleClaw-generated Caddyfile. A hand-maintained one is
-**refused, not reshaped**: adding a gate means placing directives inside site blocks
-this code did not write, and guessing wrong either drops the operator's configuration
-or leaves an opening that looks closed. Add the `basic_auth` block by hand, then use
-the ordinary reset above.
+It refuses far more than it accepts, and each refusal names its own remedy:
+
+| Refusal | Meaning | What to do |
+|---|---|---|
+| `not-caddy-mode` | The install is not in caddy ingress mode, so nothing would enforce a gate written into this file. A Caddyfile left behind by `--to direct` is a file, not a live gate. | `ingress-cutover.js --to caddy` first |
+| `gate-exists` | A credential is already present. | Use the ordinary reset above |
+| `not-generated` | The Caddyfile is hand-maintained. **Refused, not reshaped** — adding a gate means placing directives inside site blocks this code did not write, and guessing wrong either drops your configuration or leaves an opening that looks closed. | Add the `basic_auth` block by hand, then reset |
+| `unrecognized-shape` | The file is TangleClaw-generated but the ungated rebuild does not reproduce it byte-for-byte, so something in it would be silently dropped. **A `publicDomain` ACME site is the common case** — see the section below. | `ingress-cutover.js`, which builds from your full config |
+
+The last one exists because rebuilding from a handful of recovered fields can only
+preserve what those fields model. The check is a round-trip rather than a field list,
+so it also covers whatever option the generator gains next.
+
+Run `--dry-run --create-gate --user <name>` first: the preview asks the identical
+predicate, so it reports the refusal you would actually get rather than describing a
+rebuild that will not happen.
 
 ## Public domain on 443/80 (root LaunchDaemon)
 

--- a/deploy/INGRESS.md
+++ b/deploy/INGRESS.md
@@ -136,6 +136,34 @@ so a later cutover stays consistent. New passwords must be ≥12 chars, not a co
 weak password, and must not contain the username. The machine-local
 `~/.tangleclaw/EMERGENCY-RECOVERY.md` carries the full runbook + a manual fallback.
 
+**The reload is a restart, and it drops connections.** `admin off` is set in both
+the generated and the hand-edited Caddyfile, so Caddy's `localhost:2019` admin API
+is unavailable and the graceful `caddy reload` path does not exist here — the reload
+is `launchctl kickstart -k`. Anything arriving through Caddy (the dashboard, the
+browser terminal, a proxied OpenClaw UI) is interrupted while it comes back. Run the
+tool under `tmux`/`screen` when your terminal itself arrives through Caddy, so the
+sequence completes even if the connection carrying it does not.
+
+### Creating a gate where there is none
+
+An install that reached `setupComplete` before a credential was mandatory and then
+moved to caddy mode has no `basic_auth` line to patch, and every other route out of
+that state refuses it. `reset-admin.js` builds one:
+
+```bash
+node scripts/reset-admin.js --create-gate --user <name>
+```
+
+This rebuilds the Caddyfile **from its own current settings** — ports, upstream and
+certificate are read back out of the file rather than out of `config`, so the result
+differs from what was there by exactly the gate, and config drift cannot ride along.
+
+It applies only to a TangleClaw-generated Caddyfile. A hand-maintained one is
+**refused, not reshaped**: adding a gate means placing directives inside site blocks
+this code did not write, and guessing wrong either drops the operator's configuration
+or leaves an opening that looks closed. Add the `basic_auth` block by hand, then use
+the ordinary reset above.
+
 ## Public domain on 443/80 (root LaunchDaemon)
 
 Real Let's Encrypt issuance needs a public domain with ports 80/443 reachable

--- a/deploy/INGRESS.md
+++ b/deploy/INGRESS.md
@@ -140,9 +140,29 @@ weak password, and must not contain the username. The machine-local
 the generated and the hand-edited Caddyfile, so Caddy's `localhost:2019` admin API
 is unavailable and the graceful `caddy reload` path does not exist here — the reload
 is `launchctl kickstart -k`. Anything arriving through Caddy (the dashboard, the
-browser terminal, a proxied OpenClaw UI) is interrupted while it comes back. Run the
-tool under `tmux`/`screen` when your terminal itself arrives through Caddy, so the
-sequence completes even if the connection carrying it does not.
+browser terminal, a proxied OpenClaw UI) is interrupted while it comes back.
+
+**Verified live on 2026-08-01** against this machine's hand-edited Caddyfile, which is
+what moved break-glass from "built and unit-tested" to proven: the reload executed on
+the real LaunchAgent (PID changed, exit 0), the gate re-authenticated on the new
+credential, config and the live file stayed in agreement, and the file came out
+**byte-identical apart from the hash** — still classified `adoptable`/`safeToWrite:
+false`, so the cutover's clobber-guard keeps protecting it. Two operational facts came
+out of that run and are worth knowing before you need this tool:
+
+- **It enforces the CURRENT password policy, so a credential predating the policy
+  cannot be restored as-is.** The rules (≥12 chars, not a common password, must not
+  contain the username) apply to whatever you type, including the password already in
+  force. An operator reaching for break-glass intending to reinstate a password they
+  know may be refused and forced to choose a new one mid-incident. Correct behaviour —
+  a recovery path that installs a weak credential undermines the mandatory gate — but
+  decide and record the new password *before* starting, because the disconnect follows
+  within seconds.
+- **"Run it under tmux" is not sufficient guidance when the operator arrives through
+  ttyd.** That terminal is already tmux-backed (so the process does survive the drop),
+  but its window may be running an AI session rather than a shell. Open a second window
+  (`Ctrl-b c`) and run it there; `tmux new -s <name>` from inside fails as a nested or
+  duplicate session.
 
 ### Creating a gate where there is none
 

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -1,0 +1,190 @@
+# Setting up TangleClaw safely
+
+This guide is for setting up TangleClaw for the first time, or for checking that an
+existing install is set up the way you think it is. It assumes no background in web
+servers, TLS, or reverse proxies — where a term matters, it is explained where it
+first appears.
+
+If you already know what a reverse proxy is and want flags, tables and rollback
+commands, read [deploy/INGRESS.md](../deploy/INGRESS.md) instead. This guide and that
+one describe the same machinery for different readers.
+
+---
+
+## The one thing to understand first
+
+TangleClaw gives a web browser the ability to run terminal commands on your computer.
+That is the whole point of it — and it means **anyone who can open the dashboard can
+run commands as you**. Not "see your data". Run commands.
+
+So the only question that really matters during setup is: *who can reach the
+dashboard?* Everything below is about answering that deliberately instead of by
+accident.
+
+---
+
+## What a fresh install does on its own
+
+A newly installed TangleClaw listens on `127.0.0.1` — an address that means "this
+computer only". Other machines on your network cannot reach it, even if they know
+your IP address. This is the default and it needs no decision from you.
+
+During setup the wizard asks you to create a **login** — a username and a password.
+There is no default password to change later; you either set one or setup does not
+finish. It then puts that login in front of everything TangleClaw serves.
+
+That is the finished, intended state: reachable from this computer, and from
+elsewhere only with a password.
+
+---
+
+## Reaching it from your phone or another computer
+
+To open the dashboard from somewhere other than the machine it runs on, something has
+to accept connections from the outside. TangleClaw uses **Caddy** for this.
+
+**What Caddy is, in one paragraph.** Caddy is a small, separate program that sits in
+front of TangleClaw and answers the network on its behalf. Requests arrive at Caddy;
+Caddy checks the password, and only then passes the request along to TangleClaw,
+which is still listening only to `127.0.0.1`. That arrangement — one program
+answering the outside world and forwarding to another — is what "reverse proxy"
+means. Caddy also handles **TLS**, which is what makes the address start with
+`https://` and stops other people on the network from reading the traffic.
+
+The advantage of doing it this way is that the password check happens *before*
+anything reaches TangleClaw. There is one door, and it is locked.
+
+Setup installs and configures this for you. You do not need to write any Caddy
+configuration by hand.
+
+### If setup could not do it
+
+Setup skips the Caddy step in two situations, and says so rather than pretending:
+
+- **Caddy is not installed.** Install it with `brew install caddy` and re-run setup,
+  or use the manual path below.
+- **There is already a Caddy configuration that TangleClaw did not write.** It will
+  not overwrite a file you or another tool maintains. This is deliberate: silently
+  replacing it could take down something else you are running.
+
+In both cases the install finishes **with no login**, and TangleClaw tells you so on
+the dashboard rather than implying you are protected. Loopback-only is still in force,
+so it is not exposed — it just cannot be reached remotely yet.
+
+To set it up afterwards:
+
+```sh
+brew install caddy
+node scripts/ingress-cutover.js --to caddy --dry-run   # preview, changes nothing
+node scripts/ingress-cutover.js --to caddy
+```
+
+---
+
+## Checking it actually worked
+
+Do not take the dashboard's word for it. Two checks, from a *different* device than
+the one TangleClaw runs on:
+
+1. **Open the dashboard address.** A password prompt should appear before you see
+   anything. If you see the dashboard with no prompt, the gate is not in force —
+   stop and fix that before going further.
+2. **Check a URL that is not the dashboard**, for example `/api/config`. It should
+   also ask for the password. The gate covers everything, not just the front page.
+
+If you have a Tailscale or WireGuard tunnel, use the tunnel address for both checks —
+that is the perimeter you actually rely on.
+
+---
+
+## If you are locked out
+
+There is always a way back in, and it deliberately requires **physical access to the
+machine** rather than a second way in over the network. A "reset my password" link
+that worked remotely would be exactly the door the password exists to close.
+
+Open a terminal on the computer TangleClaw runs on and:
+
+```sh
+cd /path/to/TangleClaw
+node scripts/reset-admin.js
+```
+
+It asks for a new password twice, then updates the gate and restarts Caddy.
+
+**Your connection will drop for a few seconds.** That is expected: Caddy is the thing
+being restarted, so anything arriving through it — the dashboard, the browser
+terminal — is interrupted while it comes back. Reconnect afterwards with the new
+password.
+
+Two things worth knowing before you run it:
+
+- **Run it inside `tmux` or `screen`** if you are connected over SSH or through
+  TangleClaw's own browser terminal. The restart drops your connection, and you want
+  the reset to finish even if your terminal does not survive it.
+- **It takes a backup first.** If the new configuration is invalid for any reason,
+  the original is put back and your existing password keeps working. It will not
+  leave you worse off than when you started.
+
+To see what it would do without changing anything:
+
+```sh
+node scripts/reset-admin.js --dry-run
+```
+
+### If there is no login to reset
+
+An install that finished setup before a login was required — and later moved to Caddy
+— can end up with no password at all and no obvious way to add one. If
+`reset-admin.js` says there is nothing to reset, create the login instead:
+
+```sh
+node scripts/reset-admin.js --create-gate --user <name>
+```
+
+This only works on a Caddy configuration TangleClaw generated. If you maintain that
+file yourself, the tool will refuse rather than rewrite your work — add a
+`basic_auth` block to it by hand, then use the ordinary reset above.
+
+---
+
+## Where you should and should not run this
+
+**Supported:** on the machine itself; over a private tunnel such as Tailscale or
+WireGuard; on a network you fully control, behind the login.
+
+**Not supported:** exposed to the open internet. This is not a strong recommendation,
+it is a boundary. The login is a single shared username and password with no rate
+limiting, no lockout after repeated guesses, no second factor and no way to revoke a
+session — sitting in front of something that runs commands on your computer. Put it
+behind a tunnel instead; the reasoning is written up in
+[ADR 0009](adr/0009-secure-by-default.md).
+
+---
+
+## Upgrading an older install
+
+If you installed TangleClaw before it defaulted to loopback, your existing network
+binding is **left exactly as it was**. Narrowing it automatically would take away
+remote access you might be depending on, possibly while you are away from the
+machine, and before there is a password to replace it with.
+
+TangleClaw will keep telling you about it — on every start and on the dashboard —
+until you resolve it one of two ways:
+
+- **Set up the login** (recommended): you keep remote access, now with a password in
+  front of it.
+- **Close it**: set `"bindAllInterfaces": false` in `~/.tangleclaw/config.json` and
+  restart. Loopback only, no remote access.
+
+Either is a real answer. Leaving it as it is — reachable from the network with no
+password — is the one option that is not.
+
+---
+
+## Related documents
+
+- [Ingress Guide](../deploy/INGRESS.md) — the same subject with the flags, tables and rollback commands
+- [User Guide](user-guide.md) — using TangleClaw once it is running
+- [Configuration Reference](configuration-reference.md) — every config field
+- [ADR 0009](adr/0009-secure-by-default.md) — why the posture is what it is

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -117,11 +117,20 @@ being restarted, so anything arriving through it — the dashboard, the browser
 terminal — is interrupted while it comes back. Reconnect afterwards with the new
 password.
 
-Two things worth knowing before you run it:
+Three things worth knowing before you run it — all of them learned by actually doing it:
 
-- **Run it inside `tmux` or `screen`** if you are connected over SSH or through
-  TangleClaw's own browser terminal. The restart drops your connection, and you want
-  the reset to finish even if your terminal does not survive it.
+- **It has to be a genuinely new password, even if you still know the old one.** The tool enforces
+  today's rules on whatever you type: at least 12 characters, not a common password, and it must not
+  contain your username. A credential set before those rules existed will be **refused**, so if you
+  came here intending to reinstate a password you already have, you may not be able to. Decide the
+  new one and save it somewhere *before* you start — your connection drops seconds after you confirm
+  it, and the very next thing that happens is being asked for it.
+- **Get a shell that survives the restart, and notice where you are typing.** If you reach this
+  machine through TangleClaw's own browser terminal you are already inside a persistent `tmux`
+  session, so anything you run there survives the drop with no extra work. But that session's window
+  may be running an AI session rather than a shell, in which case open a second window with
+  `Ctrl-b` then `c` and work there. Running `tmux new -s <name>` from inside it does not help — that
+  nests one session in another, and fails outright if the name is already taken.
 - **It takes a backup first.** If the new configuration is invalid for any reason,
   the original is put back and your existing password keeps working. It will not
   leave you worse off than when you started.

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -90,7 +90,13 @@ the one TangleClaw runs on:
    anything. If you see the dashboard with no prompt, the gate is not in force —
    stop and fix that before going further.
 2. **Check a URL that is not the dashboard**, for example `/api/config`. It should
-   also ask for the password. The gate covers everything, not just the front page.
+   also ask for the password — the gate is not just on the front page.
+
+   Pick that URL deliberately. Three paths are **exempt by design** and will answer
+   without a password: `/api/health` (so an uptime monitor can check liveness without
+   a credential), `/openclaw-direct/*` (the OpenClaw gateway does its own token
+   authentication) and `/manifest.json` (browsers fetch PWA manifests anonymously).
+   Testing one of those and seeing a reply proves nothing about your gate.
 
 If you have a Tailscale or WireGuard tunnel, use the tunnel address for both checks —
 that is the perimeter you actually rely on.
@@ -131,9 +137,14 @@ Three things worth knowing before you run it — all of them learned by actually
   may be running an AI session rather than a shell, in which case open a second window with
   `Ctrl-b` then `c` and work there. Running `tmux new -s <name>` from inside it does not help — that
   nests one session in another, and fails outright if the name is already taken.
-- **It takes a backup first.** If the new configuration is invalid for any reason,
-  the original is put back and your existing password keeps working. It will not
-  leave you worse off than when you started.
+- **It takes a backup first, and tells you the truth about what happened.** In the
+  ordinary failure — the new configuration does not validate — the original is put
+  back and your existing password keeps working. Two rarer failures cannot promise
+  that, and the tool says so plainly rather than reassuring you: if the disk fails
+  midway it may report that the gate could not be written *or* restored (fix that by
+  hand from the backup path it prints, before restarting Caddy), or that the new
+  password is in force and could not be rolled back. Read the last thing it prints;
+  it distinguishes these deliberately, because they send you to different places.
 
 To see what it would do without changing anything:
 

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -166,6 +166,11 @@ This only works on a Caddy configuration TangleClaw generated. If you maintain t
 file yourself, the tool will refuse rather than rewrite your work — add a
 `basic_auth` block to it by hand, then use the ordinary reset above.
 
+**If you typed the username wrong**, you cannot rename it: the ordinary reset changes
+a password, not a name, and running `--create-gate` a second time refuses because a
+login now exists. Restore the backup the run printed — its path is in the output —
+and create it again with the right name.
+
 ---
 
 ## Where you should and should not run this

--- a/lib/admin-credential.js
+++ b/lib/admin-credential.js
@@ -595,6 +595,63 @@ function _persistGatedCaddyfile(opts) {
 }
 
 /**
+ * Whether a gate can be built in this Caddyfile — the pure predicate behind
+ * {@link createGate}.
+ *
+ * Separate from the write so a `--dry-run` can answer the same question the real
+ * run will. A preview that promised a rebuild the real path then refuses is the
+ * failure this whole surface exists to avoid, and it would land on someone
+ * already locked out, checking before they commit. Same reason
+ * `canChangeCredential` is separate from `applyCredentialChange`.
+ *
+ * @param {string} content - Caddyfile text.
+ * @param {string} [user] - Proposed username.
+ * @returns {{allowed: boolean, code: string, reason: (string|null)}}
+ */
+function canCreateGate(content, user) {
+  if (!user) {
+    return {
+      allowed: false,
+      code: CREDENTIAL_CODES.NO_CREDENTIAL,
+      reason: 'a username is required to create a gate (there is no existing one to read it from)'
+    };
+  }
+  const state = caddy.classifyCaddyfileContent(content);
+  // Asked BEFORE the generated check so a hand-edited file that already has a
+  // login is told it has one, rather than being told it is the wrong shape to
+  // build one in. Same refusal either way; only one of them is the truth.
+  if (state.users.length > 0) {
+    return {
+      allowed: false,
+      code: CREDENTIAL_CODES.GATE_EXISTS,
+      reason: `this Caddyfile already gates on '${state.users.join("', '")}'`
+    };
+  }
+  if (!state.safeToWrite) {
+    return {
+      allowed: false,
+      code: CREDENTIAL_CODES.NOT_GENERATED,
+      reason: 'this Caddyfile is hand-maintained and carries no login. Adding one means editing '
+        + 'blocks this tool did not write, so it will not guess at them'
+    };
+  }
+  // Forward-looking rather than reachable today: a body edit breaks the sha256
+  // header before it can produce a generated-but-unreadable file, so current
+  // shapes all land on the refusal above. This answers a LATER generator emitting
+  // a shape this extractor cannot read back — at which point defaulting the
+  // missing fields would quietly move a working port or certificate.
+  if (!caddy.extractGeneratedCaddyfileOptions(content)) {
+    return {
+      allowed: false,
+      code: CREDENTIAL_CODES.UNRECOGNIZED_SHAPE,
+      reason: 'this Caddyfile is stamped as generated but its ports, upstream or certificate '
+        + 'could not be read back, so regenerating it could move settings that are working'
+    };
+  }
+  return { allowed: true, code: CREDENTIAL_CODES.OK, reason: null };
+}
+
+/**
  * Build a basic_auth gate on an install that completed setup without one.
  *
  * A machine can reach `setupComplete` in caddy mode carrying no credential — an
@@ -642,11 +699,6 @@ function createGate(opts) {
     reloaded: false, reloadPending: false, reloadCommand, replaced: 0, user: null
   });
 
-  if (!user) {
-    return refuse(CREDENTIAL_CODES.NO_CREDENTIAL,
-      'a username is required to create a gate (there is no existing one to read it from)');
-  }
-
   let original;
   try {
     original = fs.readFileSync(caddyfilePath, 'utf8');
@@ -657,34 +709,13 @@ function createGate(opts) {
     return refuse(CREDENTIAL_CODES.UNREADABLE, err.message);
   }
 
-  const state = caddy.classifyCaddyfileContent(original);
-  // Asked BEFORE the generated check so a hand-edited file that already has a
-  // login is told it has one, rather than being told it is the wrong shape to
-  // build one in. Same refusal either way; only one of them is the truth.
-  if (state.users.length > 0) {
-    return refuse(CREDENTIAL_CODES.GATE_EXISTS,
-      `this Caddyfile already gates on '${state.users.join("', '")}'`);
-  }
-  if (!state.safeToWrite) {
-    return refuse(CREDENTIAL_CODES.NOT_GENERATED,
-      'this Caddyfile is hand-maintained and carries no login. Adding one means editing '
-      + 'blocks this tool did not write, so it will not guess at them');
-  }
-
-  // Forward-looking rather than reachable today: a body edit breaks the sha256
-  // header before it can produce a generated-but-unreadable file, so current
-  // shapes all land on the refusal above. This answers a LATER generator emitting
-  // a shape this extractor cannot read back — at which point defaulting the
-  // missing fields would quietly move a working port or certificate.
-  const derived = caddy.extractGeneratedCaddyfileOptions(original);
-  if (!derived) {
-    return refuse(CREDENTIAL_CODES.UNRECOGNIZED_SHAPE,
-      'this Caddyfile is stamped as generated but its ports, upstream or certificate '
-      + 'could not be read back, so regenerating it could move settings that are working');
-  }
+  // One predicate, asked here and by `--dry-run`, so a preview cannot promise a
+  // rebuild this refuses.
+  const verdict = canCreateGate(original, user);
+  if (!verdict.allowed) return refuse(verdict.code, verdict.reason);
 
   const newContent = caddy.buildCaddyfileContent({
-    ...derived,
+    ...caddy.extractGeneratedCaddyfileOptions(original),
     basicAuthUser: user,
     basicAuthHash: hash
   });
@@ -713,6 +744,7 @@ module.exports = {
   pruneCaddyfileBackups,
   writeValidatedCaddyfile,
   canChangeCredential,
+  canCreateGate,
   applyCredentialChange,
   createGate
 };

--- a/lib/admin-credential.js
+++ b/lib/admin-credential.js
@@ -708,12 +708,19 @@ function canCreateGate(config, content, user) {
  * as recovery: the alternative — letting an unauthenticated route set the first
  * credential — reopens the hole that making the gate mandatory closed.
  *
- * Only a TangleClaw-GENERATED file is rebuilt. An ungated file a human maintains
- * is refused rather than reshaped: adding a gate means placing directives inside
- * site blocks this code did not write, and guessing wrong either drops the
- * operator's configuration or leaves an opening it appears to have closed. The
- * regenerated content is derived from the ORIGINAL FILE, not from config, so it
- * differs from what was there by exactly the gate.
+ * Refuses unless ALL of: the install is in caddy mode (read from config here — a
+ * Caddyfile left behind by a `--to direct` cutover is a file, not a live gate, and
+ * gating it would record protection nothing enforces), a username is supplied, the
+ * file carries no credential already, and the file is TangleClaw-GENERATED. An
+ * ungated file a human maintains is refused rather than reshaped: adding a gate
+ * means placing directives inside site blocks this code did not write, and guessing
+ * wrong either drops the operator's configuration or leaves an opening it appears to
+ * have closed. See {@link canCreateGate}, which both this and `--dry-run` ask.
+ *
+ * Where it does proceed, the rebuild is derived from the ORIGINAL FILE rather than
+ * from config and is proven byte-for-byte reproducible first, so it differs from what
+ * was there by exactly the gate. A file that cannot be reproduced is refused, not
+ * approximated.
  *
  * @param {object} opts
  * @param {string} opts.caddyfilePath - Live Caddyfile.

--- a/lib/admin-credential.js
+++ b/lib/admin-credential.js
@@ -52,7 +52,13 @@ const CREDENTIAL_CODES = Object.freeze({
   DIVERGED: 'diverged',
   GATE_BROKEN: 'gate-broken',
   WRITE_FAILED: 'write-failed',
-  REMOTE_CONNECTION: 'remote-connection'
+  REMOTE_CONNECTION: 'remote-connection',
+  // Gate CREATION refusals. Distinct from NO_GATE, which means "there is no gate
+  // to change" — these say why one cannot be built, and each sends the operator
+  // somewhere different.
+  GATE_EXISTS: 'gate-exists',
+  NOT_GENERATED: 'not-generated',
+  UNRECOGNIZED_SHAPE: 'unrecognized-shape'
 });
 
 /**
@@ -441,7 +447,49 @@ function applyCredentialChange(opts) {
   }
 
   const patched = caddy.replaceBasicAuthCredential(original, { hash, user });
-  const written = writeValidatedCaddyfile(caddyfilePath, patched.content, validateFn, stamp);
+  return _persistGatedCaddyfile({
+    caddyfilePath,
+    newContent: patched.content,
+    user: patched.user,
+    hash,
+    replaced: patched.replaced,
+    uid, stamp, reload, execFn, validateFn, reloadCommand
+  });
+}
+
+/**
+ * Write a new Caddyfile fail-closed, record the credential it carries, and
+ * reload — the half of a credential change that is identical whether the gate
+ * was re-hashed in place or built for the first time.
+ *
+ * Shared rather than duplicated because the ORDER is the safety property, not
+ * the individual steps: the file is written and validated before config moves,
+ * so a failure leaves the live gate and the recorded credential agreeing. A
+ * second copy of this sequence would be free to drift out of that order, and
+ * this project has already paid for exactly that once.
+ *
+ * @param {object} opts
+ * @param {string} opts.caddyfilePath - Live Caddyfile.
+ * @param {string} opts.newContent - Full replacement content, already gated.
+ * @param {string} opts.user - Username the new content's gate carries.
+ * @param {string} opts.hash - Bcrypt hash to record in config.
+ * @param {number} opts.replaced - Credential lines changed, for reporting.
+ * @param {number} opts.uid - Numeric uid for the launchctl target.
+ * @param {string} opts.stamp - Filename-safe timestamp for the backup.
+ * @param {boolean} opts.reload - Reload inline, or leave pending for the caller.
+ * @param {Function} opts.execFn - Injected `execFileSync` (tests).
+ * @param {Function} opts.validateFn - Injected validator (tests).
+ * @param {string} opts.reloadCommand - Pre-rendered manual reload command.
+ * @returns {{ok: boolean, code: string, backup: (string|null), error: (string|null),
+ *   reloaded: boolean, reloadPending: boolean, reloadCommand: string,
+ *   replaced: number, user: (string|null)}}
+ */
+function _persistGatedCaddyfile(opts) {
+  const {
+    caddyfilePath, newContent, user, hash, replaced,
+    uid, stamp, reload, execFn, validateFn, reloadCommand
+  } = opts;
+  const written = writeValidatedCaddyfile(caddyfilePath, newContent, validateFn, stamp);
 
   if (!written.ok) {
     return {
@@ -462,7 +510,7 @@ function applyCredentialChange(opts) {
       reloadPending: false,
       reloadCommand,
       replaced: 0,
-      user: patched.user
+      user: user
     };
   }
 
@@ -478,7 +526,7 @@ function applyCredentialChange(opts) {
   try {
     const config = store.config.load();
     config.authEnabled = true;
-    config.basicAuthUser = patched.user;
+    config.basicAuthUser = user;
     config.basicAuthHash = hash;
     store.config.save(config);
   } catch (err) {
@@ -501,8 +549,8 @@ function applyCredentialChange(opts) {
         reloaded: false,
         reloadPending: false,
         reloadCommand,
-        replaced: patched.replaced,
-        user: patched.user
+        replaced: replaced,
+        user: user
       };
     }
     return {
@@ -514,7 +562,7 @@ function applyCredentialChange(opts) {
       reloadPending: false,
       reloadCommand,
       replaced: 0,
-      user: patched.user
+      user: user
     };
   }
 
@@ -541,9 +589,117 @@ function applyCredentialChange(opts) {
     reloaded,
     reloadPending: !reload,
     reloadCommand,
-    replaced: patched.replaced,
-    user: patched.user
+    replaced: replaced,
+    user: user
   };
+}
+
+/**
+ * Build a basic_auth gate on an install that completed setup without one.
+ *
+ * A machine can reach `setupComplete` in caddy mode carrying no credential — an
+ * install that finished before the credential became mandatory and then moved to
+ * caddy ingress. Every other way in refuses it: the setup route is already
+ * complete, the adopt path only runs on a first run, and changing a credential
+ * needs one to change. Nothing was left that could put a login on it, which is a
+ * strange place for a product whose posture is secure-by-default to strand
+ * someone. This is the way out, and it is deliberately the same local-shell tool
+ * as recovery: the alternative — letting an unauthenticated route set the first
+ * credential — reopens the hole that making the gate mandatory closed.
+ *
+ * Only a TangleClaw-GENERATED file is rebuilt. An ungated file a human maintains
+ * is refused rather than reshaped: adding a gate means placing directives inside
+ * site blocks this code did not write, and guessing wrong either drops the
+ * operator's configuration or leaves an opening it appears to have closed. The
+ * regenerated content is derived from the ORIGINAL FILE, not from config, so it
+ * differs from what was there by exactly the gate.
+ *
+ * @param {object} opts
+ * @param {string} opts.caddyfilePath - Live Caddyfile.
+ * @param {string} opts.user - Username for the new gate. Required — unlike a
+ *   change, there is no existing line to read one from.
+ * @param {string} opts.hash - New bcrypt hash.
+ * @param {number} opts.uid - Numeric uid for the launchctl target.
+ * @param {string} opts.stamp - Filename-safe timestamp for the backup.
+ * @param {boolean} [opts.reload] - Reload Caddy inline.
+ * @param {Function} [opts.execFn] - Injected `execFileSync` (tests).
+ * @param {Function} [opts.validateFn] - Injected validator (tests).
+ * @returns {{ok: boolean, code: string, backup: (string|null), error: (string|null),
+ *   reloaded: boolean, reloadPending: boolean, reloadCommand: string,
+ *   replaced: number, user: (string|null)}}
+ */
+function createGate(opts) {
+  const {
+    caddyfilePath, user, hash, uid, stamp,
+    reload = true,
+    execFn = execFileSync,
+    validateFn = caddy.validateCaddyfile
+  } = opts;
+
+  const reloadCommand = `launchctl ${reloadCaddyArgs(uid).join(' ')}`;
+  const refuse = (code, error) => ({
+    ok: false, code, backup: null, error,
+    reloaded: false, reloadPending: false, reloadCommand, replaced: 0, user: null
+  });
+
+  if (!user) {
+    return refuse(CREDENTIAL_CODES.NO_CREDENTIAL,
+      'a username is required to create a gate (there is no existing one to read it from)');
+  }
+
+  let original;
+  try {
+    original = fs.readFileSync(caddyfilePath, 'utf8');
+  } catch (err) {
+    // Includes ENOENT. Creating a Caddyfile from nothing is provisioning, not
+    // recovery — it needs certificates and LaunchAgents this tool does not
+    // manage — so a missing file is a refusal here rather than a blank canvas.
+    return refuse(CREDENTIAL_CODES.UNREADABLE, err.message);
+  }
+
+  const state = caddy.classifyCaddyfileContent(original);
+  // Asked BEFORE the generated check so a hand-edited file that already has a
+  // login is told it has one, rather than being told it is the wrong shape to
+  // build one in. Same refusal either way; only one of them is the truth.
+  if (state.users.length > 0) {
+    return refuse(CREDENTIAL_CODES.GATE_EXISTS,
+      `this Caddyfile already gates on '${state.users.join("', '")}'`);
+  }
+  if (!state.safeToWrite) {
+    return refuse(CREDENTIAL_CODES.NOT_GENERATED,
+      'this Caddyfile is hand-maintained and carries no login. Adding one means editing '
+      + 'blocks this tool did not write, so it will not guess at them');
+  }
+
+  // Forward-looking rather than reachable today: a body edit breaks the sha256
+  // header before it can produce a generated-but-unreadable file, so current
+  // shapes all land on the refusal above. This answers a LATER generator emitting
+  // a shape this extractor cannot read back — at which point defaulting the
+  // missing fields would quietly move a working port or certificate.
+  const derived = caddy.extractGeneratedCaddyfileOptions(original);
+  if (!derived) {
+    return refuse(CREDENTIAL_CODES.UNRECOGNIZED_SHAPE,
+      'this Caddyfile is stamped as generated but its ports, upstream or certificate '
+      + 'could not be read back, so regenerating it could move settings that are working');
+  }
+
+  const newContent = caddy.buildCaddyfileContent({
+    ...derived,
+    basicAuthUser: user,
+    basicAuthHash: hash
+  });
+
+  return _persistGatedCaddyfile({
+    caddyfilePath,
+    newContent,
+    user,
+    hash,
+    // Counted from the built content rather than assumed to be 1: the generator
+    // emits the credential once per gated site, and the operator is told how
+    // many lines changed.
+    replaced: newContent.split(hash).length - 1,
+    uid, stamp, reload, execFn, validateFn, reloadCommand
+  });
 }
 
 module.exports = {
@@ -557,5 +713,6 @@ module.exports = {
   pruneCaddyfileBackups,
   writeValidatedCaddyfile,
   canChangeCredential,
-  applyCredentialChange
+  applyCredentialChange,
+  createGate
 };

--- a/lib/admin-credential.js
+++ b/lib/admin-credential.js
@@ -604,11 +604,25 @@ function _persistGatedCaddyfile(opts) {
  * already locked out, checking before they commit. Same reason
  * `canChangeCredential` is separate from `applyCredentialChange`.
  *
+ * @param {object} config - Loaded config; `ingressMode` decides whether a gate in
+ *   this file would be enforced by anything.
  * @param {string} content - Caddyfile text.
  * @param {string} [user] - Proposed username.
  * @returns {{allowed: boolean, code: string, reason: (string|null)}}
  */
-function canCreateGate(content, user) {
+function canCreateGate(config, content, user) {
+  // Config is REQUIRED rather than optional. An ingress check that a caller may
+  // omit is one forgetful call site away from writing `authEnabled: true` onto a
+  // machine nothing is gating, and the sibling predicate would have refused it.
+  if (!config || config.ingressMode !== 'caddy') {
+    return {
+      allowed: false,
+      code: CREDENTIAL_CODES.NOT_CADDY_MODE,
+      reason: 'this install is not in caddy ingress mode, so nothing would enforce a gate written '
+        + 'into this file. A leftover Caddyfile from a previous cutover is not a live gate — '
+        + 'run `ingress-cutover.js --to caddy` first'
+    };
+  }
   if (!user) {
     return {
       allowed: false,
@@ -635,12 +649,8 @@ function canCreateGate(content, user) {
         + 'blocks this tool did not write, so it will not guess at them'
     };
   }
-  // Forward-looking rather than reachable today: a body edit breaks the sha256
-  // header before it can produce a generated-but-unreadable file, so current
-  // shapes all land on the refusal above. This answers a LATER generator emitting
-  // a shape this extractor cannot read back — at which point defaulting the
-  // missing fields would quietly move a working port or certificate.
-  if (!caddy.extractGeneratedCaddyfileOptions(content)) {
+  const derived = caddy.extractGeneratedCaddyfileOptions(content);
+  if (!derived) {
     return {
       allowed: false,
       code: CREDENTIAL_CODES.UNRECOGNIZED_SHAPE,
@@ -648,6 +658,40 @@ function canCreateGate(content, user) {
         + 'could not be read back, so regenerating it could move settings that are working'
     };
   }
+
+  // PROVE the recovery is total, rather than trusting the field list.
+  //
+  // Rebuilding from a handful of extracted fields silently drops anything the
+  // extractor does not model. That is not hypothetical: `buildCaddyfileContent`
+  // also takes `publicDomain`, the cutover passes it whether or not a gate is
+  // configured, and an ungated file carrying a public ACME site is exactly the
+  // population this function serves. Such a file extracts CLEANLY — the public
+  // block repeats the same upstream and emits no `tls` line, so both unanimity
+  // checks still hold — and the rebuild then omits the block, validates, and
+  // restarts Caddy while reporting success. The operator loses their public site
+  // with no error, on the one surface built to never report an unobserved outcome.
+  //
+  // So the ungated rebuild must reproduce the original byte for byte. The header
+  // is a sha256 of the body, which makes this an exact round-trip and turns "we
+  // extracted the right fields" from a claim into a check — one that covers
+  // `publicDomain`, `localSite`, and whatever option the generator gains next.
+  let roundTrip;
+  try {
+    roundTrip = caddy.buildCaddyfileContent(derived);
+  } catch (err) {
+    return { allowed: false, code: CREDENTIAL_CODES.UNRECOGNIZED_SHAPE, reason: err.message };
+  }
+  if (roundTrip !== content) {
+    return {
+      allowed: false,
+      code: CREDENTIAL_CODES.UNRECOGNIZED_SHAPE,
+      reason: 'this Caddyfile carries settings this tool cannot reproduce — a public-domain site, '
+        + 'or an option added since it was written. Rebuilding it would drop them silently, so it '
+        + 'will not rebuild. Add the credential with `ingress-cutover.js` instead, which builds from '
+        + 'your full config'
+    };
+  }
+
   return { allowed: true, code: CREDENTIAL_CODES.OK, reason: null };
 }
 
@@ -711,7 +755,7 @@ function createGate(opts) {
 
   // One predicate, asked here and by `--dry-run`, so a preview cannot promise a
   // rebuild this refuses.
-  const verdict = canCreateGate(original, user);
+  const verdict = canCreateGate(store.config.load(), original, user);
   if (!verdict.allowed) return refuse(verdict.code, verdict.reason);
 
   const newContent = caddy.buildCaddyfileContent({

--- a/lib/caddy.js
+++ b/lib/caddy.js
@@ -868,6 +868,55 @@ function extractTailnetHost(content) {
 }
 
 /**
+ * Recover the `buildCaddyfileContent` inputs that a GENERATED Caddyfile was
+ * emitted from, by reading the file itself.
+ *
+ * Exists so a gate can be added to an install that completed setup without one
+ * while changing NOTHING else. Rebuilding from `config` instead would fold in
+ * every field that has since drifted from the file — cert paths, ports, a
+ * tailnet host the file never carried — and the operator asked for a login, not
+ * a reshaped ingress. Reading the parameters back out of the file means the
+ * regenerated content can differ from the original by exactly the gate.
+ *
+ * Only ever call this on content that {@link classifyCaddyfileContent} reports
+ * as `generated`. A hand-edited file may express the same settings in shapes
+ * this does not read, and a partial recovery would regenerate a file that drops
+ * the operator's edits — the one thing the credential tooling must never do.
+ *
+ * Deliberately returns null rather than defaulting a missing field. Every value
+ * here already has a default in `buildCaddyfileContent`, so a silent fallback
+ * would emit a plausible file that quietly moves a port or a certificate. Not
+ * being able to reproduce the file is a refusal, not a value to guess.
+ *
+ * @param {string} content - Caddyfile text, expected to be TangleClaw-generated.
+ * @returns {{ serverPort: number, certPath: string, keyPath: string,
+ *   httpsPort: number, httpPort: number }|null} null when any field is absent
+ *   or carries more than one distinct value.
+ */
+function extractGeneratedCaddyfileOptions(content) {
+  if (typeof content !== 'string') return null;
+  const stripped = content.split('\n').map((l) => l.replace(/#.*$/, '')).join('\n');
+
+  // Each field is matched globally and required to be UNANIMOUS. A generated
+  // file states the upstream once per site block, so several sites agreeing is
+  // normal and two sites disagreeing means this is not a shape we emitted —
+  // which is a refusal, not a case for taking the first hit.
+  const sole = (re, map) => {
+    const seen = new Set([...stripped.matchAll(re)].map((m) => map(m)));
+    return seen.size === 1 ? [...seen][0] : null;
+  };
+
+  const tls = sole(/^[ \t]*tls[ \t]+(\S+)[ \t]+(\S+)[ \t]*$/gm, (m) => `${m[1]}\t${m[2]}`);
+  const serverPort = sole(/^[ \t]*reverse_proxy[ \t]+127\.0\.0\.1:(\d+)/gm, (m) => Number(m[1]));
+  const httpsPort = sole(/^[ \t]*https_port[ \t]+(\d+)[ \t]*$/gm, (m) => Number(m[1]));
+  const httpPort = sole(/^[ \t]*http_port[ \t]+(\d+)[ \t]*$/gm, (m) => Number(m[1]));
+  if (tls === null || serverPort === null || httpsPort === null || httpPort === null) return null;
+
+  const [certPath, keyPath] = tls.split('\t');
+  return { serverPort, certPath, keyPath, httpsPort, httpPort };
+}
+
+/**
  * Compute Caddyfile→config adoption on an IN-MEMORY config — the shared pure
  * core of `adoptCredentialIntoConfig` (real path: loads, persists, logs) and
  * the cutover script's `applyDryRunAdoptionPreview` (dry-run path: previews
@@ -1089,6 +1138,7 @@ module.exports = {
   listBasicAuthUsers,
   extractBasicAuthCredential,
   hasRemoteHttpCatchAll,
+  extractGeneratedCaddyfileOptions,
   caddyCanonicalPath,
   isCaddyAuthBypassPath,
   extractTailnetHost,

--- a/scripts/reset-admin.js
+++ b/scripts/reset-admin.js
@@ -14,6 +14,9 @@
 //   node scripts/reset-admin.js --user jason      disambiguate when >1 user exists
 //   node scripts/reset-admin.js --password-stdin  read the new password from stdin (piped)
 //   node scripts/reset-admin.js --dry-run         show what would change, touch nothing
+//   node scripts/reset-admin.js --create-gate --user jason
+//                                                 put a FIRST login on an install that
+//                                                 completed setup without one
 //
 // Fail-closed: the patched Caddyfile is `caddy validate`d BEFORE the reload, and
 // the prior file is restored from a timestamped backup if validation fails — a
@@ -33,7 +36,9 @@ const adminCredential = require(path.join(REPO_DIR, 'lib', 'admin-credential'));
 const { reloadCaddyArgs, writeValidatedCaddyfile } = adminCredential;
 const USAGE =
   'Usage: node scripts/reset-admin.js [--user <name>] [--password-stdin] [--dry-run]\n' +
-  '  Resets the Caddy basic_auth admin password (break-glass recovery).\n' +
+  '       node scripts/reset-admin.js --create-gate --user <name>\n' +
+  '  Resets the Caddy basic_auth admin password (break-glass recovery), or with\n' +
+  '  --create-gate puts a first login on an install that completed setup without one.\n' +
   '  Run this at a terminal ON the TangleClaw host.\n';
 
 /**
@@ -46,14 +51,16 @@ function parseArgs(argv) {
   let dryRun = false;
   let passwordStdin = false;
   let help = false;
+  let createGate = false;
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === '--user') { user = argv[++i] || null; }
     else if (a === '--dry-run') { dryRun = true; }
     else if (a === '--password-stdin') { passwordStdin = true; }
+    else if (a === '--create-gate') { createGate = true; }
     else if (a === '--help' || a === '-h') { help = true; }
   }
-  return { user, dryRun, passwordStdin, help };
+  return { user, dryRun, passwordStdin, help, createGate };
 }
 
 /**
@@ -159,7 +166,7 @@ async function acquirePassword({ passwordStdin, user }) {
 }
 
 async function main() {
-  const { user, dryRun, passwordStdin, help } = parseArgs(process.argv.slice(2));
+  const { user, dryRun, passwordStdin, help, createGate } = parseArgs(process.argv.slice(2));
   if (help) {
     process.stdout.write(USAGE);
     return;
@@ -176,21 +183,45 @@ async function main() {
   }
   const original = fs.readFileSync(caddyfilePath, 'utf8');
 
+  const existingUsers = caddy.listBasicAuthUsers(original);
+
   let targetUser;
-  try {
-    targetUser = resolveTargetUser(caddy.listBasicAuthUsers(original), user);
-  } catch (err) {
-    process.stderr.write(`ERROR: ${err.message}\n`);
-    store.close();
-    process.exit(1);
+  if (createGate) {
+    // No existing line to read a username from, so one must be supplied.
+    if (!user) {
+      process.stderr.write('ERROR: --create-gate needs a username\n'
+        + '  node scripts/reset-admin.js --create-gate --user <name>\n');
+      store.close();
+      process.exit(1);
+    }
+    targetUser = user;
+  } else {
+    try {
+      targetUser = resolveTargetUser(existingUsers, user);
+    } catch (err) {
+      process.stderr.write(`ERROR: ${err.message}\n`);
+      // An install with no gate used to stop here, which is where #806 stranded
+      // people: the message was true and led nowhere. Only offered when this file
+      // is one the tool can actually build in, so it never advertises a command
+      // that will refuse.
+      if (existingUsers.length === 0 && caddy.classifyCaddyfileContent(original).safeToWrite) {
+        process.stderr.write('\n  This install has no login yet. Create one with:\n'
+          + '    node scripts/reset-admin.js --create-gate --user <name>\n');
+      }
+      store.close();
+      process.exit(1);
+    }
   }
 
   if (dryRun) {
     const uid = process.getuid();
-    process.stdout.write(`\n[dry-run] reset admin credential\n`);
+    process.stdout.write(`\n[dry-run] ${createGate ? 'create admin gate' : 'reset admin credential'}\n`);
     process.stdout.write(`  caddyfile:    ${caddyfilePath}\n`);
     process.stdout.write(`  admin user:   ${targetUser}\n`);
-    process.stdout.write(`  would: prompt new password → caddy hash-password → patch credential line(s)\n`);
+    process.stdout.write(createGate
+      ? '  would: prompt new password → caddy hash-password → rebuild this generated Caddyfile\n'
+        + '         from its own settings, adding the gate and changing nothing else\n'
+      : '  would: prompt new password → caddy hash-password → patch credential line(s)\n');
     process.stdout.write(`         → backup + caddy validate (restore on failure) → sync config → launchctl ${reloadCaddyArgs(uid).join(' ')}\n\n`);
     store.close();
     return;
@@ -212,13 +243,16 @@ async function main() {
   // the settings surface performs the identical one, so it is called rather than
   // repeated: two copies of a sequence that rewrites the live gate is the drift
   // the CAD-7X4V precedent already paid for once.
-  const result = adminCredential.applyCredentialChange({
+  const applyOpts = {
     caddyfilePath,
     user: targetUser,
     hash,
     uid: process.getuid(),
     stamp: new Date().toISOString().replace(/[:.]/g, '-')
-  });
+  };
+  const result = createGate
+    ? adminCredential.createGate(applyOpts)
+    : adminCredential.applyCredentialChange(applyOpts);
 
   if (!result.ok) {
     // Redacted for the same reason the HTTP path redacts it: `caddy validate`
@@ -256,7 +290,9 @@ async function main() {
     process.stderr.write(`WARNING: could not reload Caddy automatically.\n  Run: ${result.reloadCommand}\n`);
   }
 
-  process.stdout.write(`\nAdmin credential reset for '${result.user}' (${result.replaced} line(s) updated).\n`);
+  process.stdout.write(createGate
+    ? `\nAdmin login created for '${result.user}' (${result.replaced} gate line(s) written).\n`
+    : `\nAdmin credential reset for '${result.user}' (${result.replaced} line(s) updated).\n`);
   process.stdout.write(`  Caddyfile: ${caddyfilePath}\n  Backup:    ${result.backup}\n`);
   if (result.reloaded) process.stdout.write('  ✓ Caddy reloaded — log in with the new password.\n\n');
   store.close();

--- a/scripts/reset-admin.js
+++ b/scripts/reset-admin.js
@@ -222,7 +222,7 @@ async function main() {
     // locked out. It asks the SAME predicate the real run will, so it can never
     // describe a rebuild that would then be refused.
     const verdict = createGate
-      ? adminCredential.canCreateGate(original, targetUser)
+      ? adminCredential.canCreateGate(store.config.load(), original, targetUser)
       : { allowed: true, reason: null };
     if (!verdict.allowed) {
       process.stdout.write(`  would REFUSE: ${verdict.reason}\n\n`);

--- a/scripts/reset-admin.js
+++ b/scripts/reset-admin.js
@@ -218,6 +218,17 @@ async function main() {
     process.stdout.write(`\n[dry-run] ${createGate ? 'create admin gate' : 'reset admin credential'}\n`);
     process.stdout.write(`  caddyfile:    ${caddyfilePath}\n`);
     process.stdout.write(`  admin user:   ${targetUser}\n`);
+    // A preview is read by someone deciding whether to commit, often already
+    // locked out. It asks the SAME predicate the real run will, so it can never
+    // describe a rebuild that would then be refused.
+    const verdict = createGate
+      ? adminCredential.canCreateGate(original, targetUser)
+      : { allowed: true, reason: null };
+    if (!verdict.allowed) {
+      process.stdout.write(`  would REFUSE: ${verdict.reason}\n\n`);
+      store.close();
+      return;
+    }
     process.stdout.write(createGate
       ? '  would: prompt new password → caddy hash-password → rebuild this generated Caddyfile\n'
         + '         from its own settings, adding the gate and changing nothing else\n'

--- a/scripts/reset-admin.js
+++ b/scripts/reset-admin.js
@@ -44,7 +44,8 @@ const USAGE =
 /**
  * Parse CLI args. Pure — no I/O — so it is unit-testable.
  * @param {string[]} argv - process.argv.slice(2)
- * @returns {{ user: string|null, dryRun: boolean, passwordStdin: boolean, help: boolean }}
+ * @returns {{ user: string|null, dryRun: boolean, passwordStdin: boolean, help: boolean,
+ *   createGate: boolean }}
  */
 function parseArgs(argv) {
   let user = null;

--- a/test/admin-credential.test.js
+++ b/test/admin-credential.test.js
@@ -13,6 +13,8 @@ const os = require('node:os');
 const store = require('../lib/store');
 const cred = require('../lib/admin-credential');
 
+const CADDY_CFG = Object.freeze({ ingressMode: 'caddy' });
+
 const HASH_OLD = '$2a$14$' + 'o'.repeat(53);
 const HASH_NEW = '$2b$12$' + 'n'.repeat(53);
 
@@ -821,6 +823,11 @@ describe('canCreateGate — the preview and the real run answer the same questio
     tmpBase = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-cangate-'));
     store._setBasePath(tmpBase);
     store.init();
+    // createGate reads config to confirm something is actually gating this
+    // file; without it the subject refuses as not-caddy-mode.
+    const cfg = store.config.load();
+    cfg.ingressMode = 'caddy';
+    store.config.save(cfg);
     certPath = path.join(tmpBase, 'cert.pem');
     keyPath = path.join(tmpBase, 'key.pem');
     caddyfilePath = path.join(tmpBase, 'Caddyfile');
@@ -846,7 +853,7 @@ describe('canCreateGate — the preview and the real run answer the same questio
     it(`agrees with createGate on ${label}`, () => {
       const content = build();
       fs.writeFileSync(caddyfilePath, content);
-      const predicted = cred.canCreateGate(content, user);
+      const predicted = cred.canCreateGate(CADDY_CFG, content, user);
       assert.equal(predicted.allowed, expected, `predicate said ${predicted.allowed}`);
 
       const actual = cred.createGate({
@@ -862,4 +869,122 @@ describe('canCreateGate — the preview and the real run answer the same questio
       }
     });
   }
+});
+
+describe('createGate refuses a file it cannot reproduce', () => {
+  // The Critic caught this, and it is the exact failure this surface exists to
+  // prevent: a rebuild that drops something, validates, restarts Caddy, and
+  // reports success. Rebuilding from an enumerated field list can only preserve
+  // what the list models; `buildCaddyfileContent` also takes `publicDomain`, and
+  // `scripts/ingress-cutover.js` passes it whether or not a gate is configured —
+  // so an ungated file with a public ACME site is squarely the population
+  // --create-gate serves. `tailnetHost` and `remoteHttpCatchAll` cannot appear
+  // (the generator throws for either without a gate); publicDomain has no such
+  // guard.
+  const caddy = require('../lib/caddy');
+  let tmpBase; let prevBase; let caddyfilePath; let certPath; let keyPath;
+
+  before(() => {
+    prevBase = store._getBasePath();
+    tmpBase = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-roundtrip-'));
+    store._setBasePath(tmpBase);
+    store.init();
+    // createGate reads config to confirm something is actually gating this
+    // file; without it the subject refuses as not-caddy-mode.
+    const cfg = store.config.load();
+    cfg.ingressMode = 'caddy';
+    store.config.save(cfg);
+    certPath = path.join(tmpBase, 'cert.pem');
+    keyPath = path.join(tmpBase, 'key.pem');
+    caddyfilePath = path.join(tmpBase, 'Caddyfile');
+  });
+
+  after(() => {
+    store._setBasePath(prevBase);
+    fs.rmSync(tmpBase, { recursive: true, force: true });
+  });
+
+  it('extracts cleanly from a publicDomain file — which is why a field list is not enough', () => {
+    // Pinning WHY the round-trip check is required rather than belt-and-braces:
+    // neither unanimity check notices the public block. It repeats the same
+    // upstream, and it carries no `tls` line at all (Caddy provisions ACME).
+    const withPublic = caddy.buildCaddyfileContent({
+      serverPort: 3102, certPath, keyPath, publicDomain: 'tc.example.com'
+    });
+    assert.ok(caddy.extractGeneratedCaddyfileOptions(withPublic),
+      'the extractor succeeds here — it cannot see a block it never modelled');
+    assert.match(withPublic, /tc\.example\.com/);
+  });
+
+  it('REFUSES rather than silently dropping a public-domain site', () => {
+    const withPublic = caddy.buildCaddyfileContent({
+      serverPort: 3102, certPath, keyPath, publicDomain: 'tc.example.com'
+    });
+    fs.writeFileSync(caddyfilePath, withPublic);
+
+    const r = cred.createGate({
+      caddyfilePath, user: 'jason', hash: HASH_NEW, uid: 501, stamp: 'STAMP',
+      execFn: () => { throw new Error('Caddy must not be restarted'); },
+      validateFn: () => ({ ok: true })
+    });
+
+    assert.equal(r.ok, false);
+    assert.equal(r.code, 'unrecognized-shape');
+    assert.equal(fs.readFileSync(caddyfilePath, 'utf8'), withPublic, 'the file must be untouched');
+    assert.match(r.error, /public-domain site|cannot reproduce/,
+      'and it must say what it could not reproduce');
+  });
+
+  it('the preview refuses it too, for the same reason', () => {
+    const withPublic = caddy.buildCaddyfileContent({
+      serverPort: 3102, certPath, keyPath, publicDomain: 'tc.example.com'
+    });
+    const v = cred.canCreateGate(CADDY_CFG, withPublic, 'jason');
+    assert.equal(v.allowed, false);
+    assert.equal(v.code, 'unrecognized-shape');
+  });
+
+  it('still allows the plain ungated file, so the check is not just refusing everything', () => {
+    // A guard that refused every input would pass the three tests above.
+    const plain = caddy.buildCaddyfileContent({
+      serverPort: 3102, certPath, keyPath, httpsPort: 9443, httpPort: 9080
+    });
+    assert.equal(cred.canCreateGate(CADDY_CFG, plain, 'jason').allowed, true);
+  });
+});
+
+describe('createGate will not gate an install nothing is gating', () => {
+  // A Caddyfile left behind by a previous `--to direct` cutover is a file, not a
+  // live gate. Writing a credential into it and recording authEnabled: true would
+  // make config claim a protection no running process enforces — the same false
+  // report as the dropped public-domain block, arrived at from the other side.
+  // The HTTP sibling `canChangeCredential` already refuses this; creation must too.
+  const caddy = require('../lib/caddy');
+
+  it('refuses when ingressMode is not caddy, and says a leftover file is not a gate', () => {
+    const content = caddy.buildCaddyfileContent({
+      serverPort: 3102, certPath: '/c/cert.pem', keyPath: '/c/key.pem'
+    });
+    const r = cred.canCreateGate({ ingressMode: 'direct' }, content, 'jason');
+    assert.equal(r.allowed, false);
+    assert.equal(r.code, 'not-caddy-mode');
+    assert.match(r.reason, /not a live gate|ingress-cutover/);
+  });
+
+  it('refuses a missing config rather than treating it as permission', () => {
+    const content = caddy.buildCaddyfileContent({
+      serverPort: 3102, certPath: '/c/cert.pem', keyPath: '/c/key.pem'
+    });
+    assert.equal(cred.canCreateGate(null, content, 'jason').allowed, false);
+    assert.equal(cred.canCreateGate(undefined, content, 'jason').code, 'not-caddy-mode');
+  });
+
+  it('asks about the ingress BEFORE anything about the file', () => {
+    // Order matters for the same reason it does on the HTTP path: the other
+    // refusals describe the machine's Caddyfile, and there is no reason to
+    // report its shape when the answer is "nothing here is gating anything".
+    const gated = gatedCaddyfile('alice');
+    assert.equal(cred.canCreateGate({ ingressMode: 'direct' }, gated, 'jason').code,
+      'not-caddy-mode', 'not gate-exists');
+  });
 });

--- a/test/admin-credential.test.js
+++ b/test/admin-credential.test.js
@@ -625,3 +625,185 @@ describe('one implementation, not two', () => {
     assert.equal(resetAdmin.writeValidatedCaddyfile, cred.writeValidatedCaddyfile);
   });
 });
+
+describe('createGate — an install that completed setup with no login', () => {
+  // The #806 state: `setupComplete` reached in caddy mode carrying no credential.
+  // Every other route out refuses it, so this is the only way to put a login on
+  // such a machine — and it must do that without reshaping anything else.
+  const caddy = require('../lib/caddy');
+  let tmpBase; let prevBase; let caddyfilePath; let certPath; let keyPath;
+
+  /**
+   * An UNGATED Caddyfile in exactly the shape the generator emits.
+   *
+   * Deliberately on NON-DEFAULT ports. With 8443/8080 a rebuild that silently
+   * fell back to `buildCaddyfileContent`'s defaults would produce a
+   * byte-identical file, so the test that exists to catch exactly that drift
+   * could not fail. The fixture has to carry the values that distinguish
+   * "recovered from the file" from "guessed".
+   */
+  function ungenerated() {
+    return caddy.buildCaddyfileContent({
+      serverPort: 3102, certPath, keyPath, httpsPort: 9443, httpPort: 9080
+    });
+  }
+
+  before(() => {
+    prevBase = store._getBasePath();
+    tmpBase = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-creategate-'));
+    store._setBasePath(tmpBase);
+    store.init();
+    certPath = path.join(tmpBase, 'cert.pem');
+    keyPath = path.join(tmpBase, 'key.pem');
+  });
+
+  after(() => {
+    store._setBasePath(prevBase);
+    fs.rmSync(tmpBase, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    caddyfilePath = path.join(tmpBase, 'Caddyfile');
+    fs.writeFileSync(caddyfilePath, ungenerated(), { mode: 0o600 });
+    const config = store.config.load();
+    config.ingressMode = 'caddy';
+    config.authEnabled = false;
+    config.basicAuthUser = null;
+    config.basicAuthHash = null;
+    store.config.save(config);
+  });
+
+  it('puts a working gate on the file and records it', () => {
+    const calls = [];
+    const r = cred.createGate({
+      caddyfilePath, user: 'jason', hash: HASH_NEW, uid: 501, stamp: 'STAMP',
+      execFn: (cmd, argv) => { calls.push({ cmd, argv }); },
+      validateFn: () => ({ ok: true })
+    });
+
+    assert.equal(r.ok, true, r.error || '');
+    assert.equal(r.user, 'jason');
+    assert.ok(r.replaced >= 1, 'at least one credential line must have been written');
+    const live = fs.readFileSync(caddyfilePath, 'utf8');
+    assert.deepEqual(caddy.listBasicAuthUsers(live), ['jason'],
+      'the LIVE file is the gate — config alone is not a login');
+    const config = store.config.load();
+    assert.equal(config.authEnabled, true);
+    assert.equal(config.basicAuthUser, 'jason');
+    assert.equal(config.basicAuthHash, HASH_NEW);
+    assert.deepEqual(calls[0].argv, ['kickstart', '-k', 'gui/501/com.tangleclaw.caddy']);
+  });
+
+  it('changes NOTHING but the gate', () => {
+    // The promise this tool makes. Rebuilding from `config` instead of from the
+    // file would fold in every field that has since drifted — a moved port, a
+    // different certificate, a tailnet site the file never carried — and the
+    // operator asked for a login, not a reshaped ingress. Compared line-wise so
+    // a regression names the setting it moved.
+    const before = fs.readFileSync(caddyfilePath, 'utf8');
+    cred.createGate({
+      caddyfilePath, user: 'jason', hash: HASH_NEW, uid: 501, stamp: 'STAMP',
+      execFn: () => {}, validateFn: () => ({ ok: true })
+    });
+    const after = fs.readFileSync(caddyfilePath, 'utf8');
+
+    // The stamped header vouches for the body, so it legitimately differs; every
+    // other removed or altered line is a setting that moved.
+    const body = (s) => s.split('\n').slice(1);
+    // One line legitimately changes shape rather than surviving verbatim: gating
+    // turns `reverse_proxy <upstream>` into `reverse_proxy <upstream> {` so the
+    // authenticated username can be forwarded to TangleClaw. That is part of the
+    // gate. Anything else that disappears is a setting this rebuild dropped.
+    const survives = (l, out) => out.includes(l) || out.includes(`${l} {`);
+    const gone = body(before).filter((l) => !survives(l, body(after)));
+    assert.deepEqual(gone, [], `these settings were dropped or altered: ${JSON.stringify(gone)}`);
+
+    // Same transformation seen from the other side: the opened `reverse_proxy`
+    // line is not new content, it is a surviving line that grew a brace.
+    const opened = new Set(body(before).map((l) => `${l} {`));
+    const added = body(after).filter((l) => !body(before).includes(l) && !opened.has(l));
+    assert.ok(added.length > 0, 'a gate must actually have been added');
+    assert.ok(added.every((l) => /basic_auth|@protected|X-Auth-User|^\s*[}{]\s*$|jason/.test(l)),
+      `only gate lines may be added, got: ${JSON.stringify(added)}`);
+  });
+
+  it('stays fail-closed: a rejected file leaves no gate and no recorded credential', () => {
+    const r = cred.createGate({
+      caddyfilePath, user: 'jason', hash: HASH_NEW, uid: 501, stamp: 'STAMP',
+      execFn: () => { throw new Error('reload must not be reached'); },
+      validateFn: () => ({ ok: false, error: 'bad directive' })
+    });
+
+    assert.equal(r.ok, false);
+    assert.equal(r.code, 'validate-failed');
+    assert.deepEqual(caddy.listBasicAuthUsers(fs.readFileSync(caddyfilePath, 'utf8')), [],
+      'the original ungated file must be restored');
+    const config = store.config.load();
+    assert.equal(config.basicAuthHash, null, 'config must not claim a credential the gate lacks');
+    assert.notEqual(config.authEnabled, true);
+  });
+
+  it('refuses a file that already has a login, naming who holds it', () => {
+    fs.writeFileSync(caddyfilePath, gatedCaddyfile('alice'));
+    const r = cred.createGate({
+      caddyfilePath, user: 'jason', hash: HASH_NEW, uid: 501, stamp: 'STAMP',
+      execFn: () => {}, validateFn: () => ({ ok: true })
+    });
+    assert.equal(r.ok, false);
+    assert.equal(r.code, 'gate-exists');
+    assert.match(r.error, /alice/);
+  });
+
+  it('refuses to reshape a hand-maintained file rather than guessing where a gate goes', () => {
+    // The invariant the whole credential surface rests on: a file a human
+    // maintains is never rewritten by this code. Guessing wrong either drops
+    // their configuration or leaves an opening that looks closed.
+    const handEdited = ungenerated().split('\n').slice(1).join('\n') + '\n# operator note\n';
+    fs.writeFileSync(caddyfilePath, handEdited);
+    const r = cred.createGate({
+      caddyfilePath, user: 'jason', hash: HASH_NEW, uid: 501, stamp: 'STAMP',
+      execFn: () => {}, validateFn: () => ({ ok: true })
+    });
+    assert.equal(r.ok, false);
+    assert.equal(r.code, 'not-generated');
+    assert.equal(fs.readFileSync(caddyfilePath, 'utf8'), handEdited, 'the file must be byte-identical');
+  });
+
+  it('requires a username, because there is no existing line to read one from', () => {
+    const r = cred.createGate({
+      caddyfilePath, hash: HASH_NEW, uid: 501, stamp: 'STAMP',
+      execFn: () => {}, validateFn: () => ({ ok: true })
+    });
+    assert.equal(r.ok, false);
+    assert.equal(r.code, 'no-credential');
+  });
+
+  it('refuses a missing file instead of provisioning one from nothing', () => {
+    fs.rmSync(caddyfilePath);
+    const r = cred.createGate({
+      caddyfilePath, user: 'jason', hash: HASH_NEW, uid: 501, stamp: 'STAMP',
+      execFn: () => {}, validateFn: () => ({ ok: true })
+    });
+    assert.equal(r.ok, false);
+    assert.equal(r.code, 'unreadable');
+  });
+
+  it('treats a body edit as hand-maintained, because editing breaks the stamp first', () => {
+    // Worth pinning as its own fact: removing a setting from a generated file
+    // cannot produce a "generated but unreadable" file, because the sha256 header
+    // stops matching the moment the body changes. The unrecognized-shape guard is
+    // therefore forward-looking — it answers a FUTURE generator emitting a shape
+    // this extractor cannot read back — and today every edited file lands on the
+    // hand-maintained refusal instead. Both refuse without writing, which is the
+    // property that matters.
+    const noTls = ungenerated().split('\n').filter((l) => !/^\s*tls\s/.test(l)).join('\n');
+    fs.writeFileSync(caddyfilePath, noTls);
+    const r = cred.createGate({
+      caddyfilePath, user: 'jason', hash: HASH_NEW, uid: 501, stamp: 'STAMP',
+      execFn: () => {}, validateFn: () => ({ ok: true })
+    });
+    assert.equal(r.ok, false);
+    assert.equal(r.code, 'not-generated');
+    assert.equal(fs.readFileSync(caddyfilePath, 'utf8'), noTls, 'nothing may be written');
+  });
+});

--- a/test/admin-credential.test.js
+++ b/test/admin-credential.test.js
@@ -807,3 +807,59 @@ describe('createGate — an install that completed setup with no login', () => {
     assert.equal(fs.readFileSync(caddyfilePath, 'utf8'), noTls, 'nothing may be written');
   });
 });
+
+describe('canCreateGate — the preview and the real run answer the same question', () => {
+  // A --dry-run is read by someone deciding whether to commit, often already
+  // locked out. If it could describe a rebuild that the real run then refuses, it
+  // would be reporting an outcome nobody observed — on the one surface where that
+  // is least affordable.
+  const caddy = require('../lib/caddy');
+  let tmpBase; let prevBase; let caddyfilePath; let certPath; let keyPath;
+
+  before(() => {
+    prevBase = store._getBasePath();
+    tmpBase = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-cangate-'));
+    store._setBasePath(tmpBase);
+    store.init();
+    certPath = path.join(tmpBase, 'cert.pem');
+    keyPath = path.join(tmpBase, 'key.pem');
+    caddyfilePath = path.join(tmpBase, 'Caddyfile');
+  });
+
+  after(() => {
+    store._setBasePath(prevBase);
+    fs.rmSync(tmpBase, { recursive: true, force: true });
+  });
+
+  const generatedUngated = () => caddy.buildCaddyfileContent({
+    serverPort: 3102, certPath, keyPath, httpsPort: 9443, httpPort: 9080
+  });
+
+  const cases = [
+    ['a generated ungated file, with a username', () => generatedUngated(), 'jason', true],
+    ['no username', () => generatedUngated(), undefined, false],
+    ['a file that already has a login', () => gatedCaddyfile('alice'), 'jason', false],
+    ['a hand-maintained ungated file', () => generatedUngated().split('\n').slice(1).join('\n'), 'jason', false]
+  ];
+
+  for (const [label, build, user, expected] of cases) {
+    it(`agrees with createGate on ${label}`, () => {
+      const content = build();
+      fs.writeFileSync(caddyfilePath, content);
+      const predicted = cred.canCreateGate(content, user);
+      assert.equal(predicted.allowed, expected, `predicate said ${predicted.allowed}`);
+
+      const actual = cred.createGate({
+        caddyfilePath, user, hash: HASH_NEW, uid: 501, stamp: 'STAMP',
+        execFn: () => {}, validateFn: () => ({ ok: true })
+      });
+      // The property is agreement, not two independently-correct answers: a
+      // preview that is right by coincidence drifts the moment either side moves.
+      assert.equal(actual.ok, predicted.allowed,
+        'the real run must reach the same verdict the preview showed');
+      if (!predicted.allowed) {
+        assert.equal(actual.code, predicted.code, 'and the same reason code');
+      }
+    });
+  }
+});

--- a/test/auth-credential-durability.test.js
+++ b/test/auth-credential-durability.test.js
@@ -603,3 +603,70 @@ describe('auth credential durability (#397 / 2026-07-03 lockout)', () => {
     });
   });
 });
+
+describe('extractGeneratedCaddyfileOptions — reading a generated file back into its own inputs', () => {
+  // Adding a first login to an install that completed setup without one rebuilds
+  // the Caddyfile. Rebuilding from `config` would fold in every field that has
+  // since drifted from the file, so the inputs are recovered from the file
+  // itself. That only works if the recovery is exact, which is what this pins.
+
+  it('round-trips the ungated shape an install with no login actually has', () => {
+    const opts = buildOpts({ httpsPort: 9443, httpPort: 9080 });
+    const content = caddy.buildCaddyfileContent(opts);
+    assert.deepEqual(caddy.extractGeneratedCaddyfileOptions(content), {
+      serverPort: 3102,
+      certPath: '/c/cert.pem',
+      keyPath: '/c/key.pem',
+      httpsPort: 9443,
+      httpPort: 9080
+    });
+  });
+
+  it('round-trips a multi-site file, where every site states the same upstream', () => {
+    // Several sites agreeing is the normal case, not ambiguity — the unanimity
+    // rule must not mistake repetition for conflict.
+    const content = caddy.buildCaddyfileContent(buildOpts({
+      basicAuthUser: 'jason', basicAuthHash: HASH_A,
+      tailnetHost: TAILNET_HOST, remoteHttpCatchAll: true
+    }));
+    const got = caddy.extractGeneratedCaddyfileOptions(content);
+    assert.equal(got.serverPort, 3102);
+    assert.equal(got.certPath, '/c/cert.pem');
+    assert.equal(got.httpsPort, 8443);
+  });
+
+  it('refuses rather than defaulting when ANY field is missing', () => {
+    // Every field here has a default in buildCaddyfileContent, so guessing would
+    // emit a plausible file that silently moves a working certificate or port.
+    // Each field is dropped in turn: a guard that covered only the certificate
+    // would still let a missing port fall back to 8443 on a machine serving 9443.
+    const content = caddy.buildCaddyfileContent(buildOpts({ httpsPort: 9443, httpPort: 9080 }));
+    const drop = (re) => content.split('\n').filter((l) => !re.test(l)).join('\n');
+    for (const [field, re] of [
+      ['tls', /^\s*tls\s/],
+      ['https_port', /^\s*https_port\s/],
+      ['http_port', /^\s*http_port\s/],
+      ['reverse_proxy', /^\s*reverse_proxy\s/]
+    ]) {
+      assert.equal(caddy.extractGeneratedCaddyfileOptions(drop(re)), null,
+        `a file with no ${field} must be refused, not defaulted`);
+    }
+  });
+
+  it('refuses when two sites disagree about the upstream', () => {
+    const content = caddy.buildCaddyfileContent(buildOpts({
+      basicAuthUser: 'jason', basicAuthHash: HASH_A, tailnetHost: TAILNET_HOST
+    })).replace('reverse_proxy 127.0.0.1:3102', 'reverse_proxy 127.0.0.1:3999');
+    assert.equal(caddy.extractGeneratedCaddyfileOptions(content), null);
+  });
+
+  it('does not read settings out of comments', () => {
+    const content = caddy.buildCaddyfileContent(buildOpts())
+      .replace('\tadmin off', '\tadmin off\n\t# https_port 1234');
+    assert.equal(caddy.extractGeneratedCaddyfileOptions(content).httpsPort, 8443);
+  });
+
+  it('returns null for a non-string', () => {
+    assert.equal(caddy.extractGeneratedCaddyfileOptions(null), null);
+  });
+});

--- a/test/reset-admin.test.js
+++ b/test/reset-admin.test.js
@@ -177,3 +177,40 @@ describe('the dead end #806 left, and the signpost that replaces it', () => {
       'the default path must remain the credential change');
   });
 });
+
+describe('the preview cannot promise what the run refuses', () => {
+  // --dry-run exists so someone deciding whether to commit can look first, and on
+  // this tool that someone is often already locked out. Describing a rebuild the
+  // real path would refuse is the same false-report class the credential surface
+  // was built to eliminate — so the preview asks the SAME predicate, rather than
+  // a second one that happens to agree today.
+  const src = fs.readFileSync(path.join(__dirname, '..', 'scripts', 'reset-admin.js'), 'utf8');
+  const code = src.split('\n').filter((l) => !l.trim().startsWith('//')).join('\n');
+  // The end delimiter is searched FROM the start offset, not from zero:
+  // `let password;` also occurs earlier inside acquirePassword, and anchoring on
+  // the first hit sliced backwards to an empty string that satisfied nothing.
+  const dryRunStart = code.indexOf('if (dryRun) {');
+  const dryRun = code.slice(dryRunStart, code.indexOf('let password;', dryRunStart));
+
+  it('the slice actually covers the dry-run branch', () => {
+    // Guards the two assertions below from silently measuring an empty string.
+    assert.ok(dryRunStart > -1, 'the dry-run branch must be findable');
+    assert.ok(dryRun.length > 200, `slice looks wrong (${dryRun.length} chars)`);
+    assert.match(dryRun, /\[dry-run\]/);
+  });
+
+  it('consults canCreateGate inside the dry-run branch', () => {
+    assert.match(dryRun, /adminCredential\.canCreateGate\(/,
+      'the preview must ask the shared predicate, not assume success');
+  });
+
+  it('reports the refusal and stops, instead of describing the steps anyway', () => {
+    const refusalAt = dryRun.indexOf('would REFUSE');
+    const stepsAt = dryRun.indexOf('would: prompt new password');
+    assert.ok(refusalAt > -1, 'a refused preview must say so');
+    assert.ok(refusalAt < stepsAt,
+      'the refusal must be handled before the would-do description is printed');
+    assert.match(dryRun.slice(refusalAt, stepsAt), /return;/,
+      'and it must stop, not fall through into describing a rebuild that will not happen');
+  });
+});

--- a/test/reset-admin.test.js
+++ b/test/reset-admin.test.js
@@ -11,7 +11,15 @@ const { parseArgs, resolveTargetUser, reloadCaddyArgs, writeValidatedCaddyfile }
 describe('reset-admin', () => {
   describe('parseArgs', () => {
     it('defaults: no user, no flags', () => {
-      assert.deepEqual(parseArgs([]), { user: null, dryRun: false, passwordStdin: false, help: false });
+      assert.deepEqual(parseArgs([]),
+        { user: null, dryRun: false, passwordStdin: false, help: false, createGate: false });
+    });
+
+    it('parses --create-gate, which is off unless asked for', () => {
+      // Opt-in on purpose. Creating a gate rewrites the whole Caddyfile, so it is
+      // never something a plain password reset falls into by accident.
+      assert.equal(parseArgs(['--create-gate']).createGate, true);
+      assert.equal(parseArgs(['--user', 'jason']).createGate, false);
     });
 
     it('parses --user <name>', () => {
@@ -136,5 +144,36 @@ describe('what the operator is told when it fails', () => {
       'the arm for an unrestorable write must not say the original was restored');
     assert.match(gateBrokenArm, /may now be broken/,
       'it must say what is actually true of the machine');
+  });
+});
+
+describe('the dead end #806 left, and the signpost that replaces it', () => {
+  // An install that completed setup in caddy mode with no credential used to hit
+  // `nothing to reset` and stop. The message was true and led nowhere, which is
+  // how that state stranded people. It must now name the way out — but only when
+  // this file is one the tool can actually build a gate in, or it would advertise
+  // a command that refuses.
+  const src = fs.readFileSync(path.join(__dirname, '..', 'scripts', 'reset-admin.js'), 'utf8');
+  const code = src.split('\n').filter((l) => !l.trim().startsWith('//')).join('\n');
+
+  it('offers --create-gate on the no-gate path', () => {
+    assert.match(code, /--create-gate --user/,
+      'the no-gate refusal must name the command that resolves it');
+  });
+
+  it('gates that offer on the file being one it can write, not merely on there being no user', () => {
+    // `safeToWrite` is the single field the classifier exposes for this decision.
+    // Offering on the absence of a credential alone would send an operator with a
+    // hand-maintained Caddyfile to a command that refuses them.
+    const offer = code.slice(code.indexOf('existingUsers.length === 0'));
+    assert.match(offer.slice(0, 200), /safeToWrite/,
+      'the offer must be conditioned on the file being safe to rewrite');
+  });
+
+  it('routes --create-gate to createGate and everything else to applyCredentialChange', () => {
+    assert.match(code, /createGate\s*\n?\s*\?\s*adminCredential\.createGate/,
+      'the create path must call createGate, not the change path');
+    assert.match(code, /:\s*adminCredential\.applyCredentialChange/,
+      'the default path must remain the credential change');
   });
 });


### PR DESCRIPTION
The last unshipped chunk of the v5 secure baseline. Based on **`v5-baseline`, not `main`** — the whole v5 release is being assembled there under the install freeze.

## What

**1. Break-glass recovery is proven by execution.** The no-permanent-lockout guarantee rested on a tool whose reload had never run: `test/reset-admin.test.js` asserts the `launchctl` argv **as data** and never executes it, so everything past "the file is patched" was inference. Run on 2026-08-01 against the operator's **live, hand-edited** Caddyfile — the shape the tool promises to patch without reshaping, and the one only that machine has.

| Claim | Evidence |
|---|---|
| The credential changes | `$2a$14$iTSJI…` → `$2a$14$UdZRP…` |
| **An operator-owned file is never reshaped** | live file **byte-identical apart from the hash** |
| A hand-edited file is not silently made clobberable | still `adoptable` / `safeToWrite: false` |
| The reload actually reloads | `com.tangleclaw.caddy` PID 28797 → 36189, exit 0 |
| The gate is shut afterwards | 401 on `/` and on a wrong password |
| Config never claims what the gate lacks | user and hash both match the live file |
| A failed change is recoverable | timestamped `.credential.bak` written before the swap |

**2. `--create-gate` closes #806.** An install that reached `setupComplete` before a credential was mandatory and then moved to caddy mode had no route to a login at all — the setup route refuses as already-complete, adoption runs only on a first run, and `reset-admin.js` exited 1 because it *resets* a gate and cannot *create* one. Closing #805 removed the unauthenticated `PATCH /api/config` escape that was masking it.

**3. Docs.** New `docs/setup-guide.md` for a reader with no reverse-proxy background; `deploy/INGRESS.md` gains the create path, its four refusals, and the undo.

## Why these decisions

- **Creation stays a local-shell tool.** A first credential settable over the network reopens exactly what making the gate mandatory closed, and a recovery path reachable over the network is no recovery for someone the network is refusing.
- **The rebuild reads its inputs back out of the file, not out of config** (`caddy.extractGeneratedCaddyfileOptions`), because config and the live Caddyfile are known to drift.
- **A hand-maintained file is refused, never reshaped.**
- **One sequence, four writers.** Creation and change share `_persistGatedCaddyfile` (write → validate fail-closed → record in config → reload). The order is the safety property, and a second copy would be free to drift out of it.

## The blocking finding, worth reading

All three Critic reviewers independently found that rebuilding from an enumerated field list silently drops anything the extractor does not model. `buildCaddyfileContent` also takes `publicDomain`; the cutover passes it whether or not a gate is configured; an ungated file with a public ACME site is exactly this feature's population. Such a file extracts *cleanly* — the public block repeats the same upstream and emits no `tls` line, so both unanimity checks hold — and the rebuild dropped it, validated, restarted Caddy, and printed "Admin login created". Reproduced before fixing.

Fixed generically rather than by adding a field: **the ungated rebuild must reproduce the original byte-for-byte** before any gate is added. The sha256 header makes that an exact round-trip, so the promise is checked rather than asserted and it covers whatever option the generator gains next.

## Two procedural defects only a real run could surface

- **Recovery enforces the *current* password policy**, so a credential older than the policy cannot be restored — the live one predated the 12-character minimum and was refused, forcing a new password to be chosen seconds before the connection drops. Documented, not weakened.
- **"Run it under tmux" was wrong** for how an operator reaches this machine: ttyd is already tmux-backed, but its window may run an AI session that cannot be typed into, and `tmux new -s` fails there as nested/duplicate.

## Test plan

Full suite **5442 pass / 0 fail / 1 skipped**, evidence recorded against the shippable tree. New guards mutation-tested: removing the round-trip check → 3 red; removing the ingress-mode check → 4 red.

## Review

One `cumulative` (3 blocking / 8 warning / 13 note) → fixes → two `verify-resolutions` passes ending **0/0/0**. PR reviewer: **0 blocking**, 1 warning + 2 notes, all three fixed in `7b2d117`.

## Deferred, filed not fixed

- **#828** — `~/.tangleclaw` is derived from both `process.env.HOME` and `os.homedir()`, so a `HOME` override half-relocates state.
- **#831** — nine test files run bare `git init` and inherit the live global template dir, making the suite non-deterministic on any machine running TangleClaw.

## Note on issue closing

`Closes #806` is deliberately **omitted**: GitHub auto-closes only on merges into the default branch, and `main` still has the hole. #805 and #806 are closed by hand at the v5 integration merge.