### PR TITLE
Parse upstream's install reference as an AST, not as scraped text

### DIFF
--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -61,17 +61,21 @@ nothing.
 Rather than tally rounds here — a count that goes stale the moment another runs — the census is
 `prawduct-hook render-dispositions --scope plugin-ref-807`.
 
-Read that with one caveat, stated because the alternative is a pointer that quietly under-reports:
-rounds on this branch were dispatched under **four different scope strings**, so a scope-filtered
-census does not reach all of them. `prawduct-hook render-dispositions` unfiltered is the whole view;
-`prawduct-hook evidence list` (no `--scope` — it takes only `--kind` and `-n`) is the raw fact log.
+**No single command shows all of it, and that is worth knowing before trusting any of them.**
+`render-dispositions` takes `[--review <id>|--scope <s>]` and has no all-scopes mode: with no
+argument it renders only the **latest** review fact, not the total. `--scope plugin-ref-807` is the
+best available census, but rounds on this branch went out under **four different scope strings**, so
+it too returns a subset. `prawduct-hook evidence list` (no `--scope` — it takes `--kind` and `-n`) is
+the unfiltered fact log.
 
-Each round's findings were fixed where a commit could fix them, and otherwise accepted with a
-recorded reason — the CI-execution gap is the standing example, since no commit can close it and only
-a runner can. Deliberately no count or all-clear here: in an append-only record, "nothing is open" is
-falsified by the next round that reads it, so the census belongs in the tool and the *why* belongs in
-prose. The findings worth carrying forward, because each is a general failure mode rather than a
-detail of this diff:
+Findings were fixed where a commit could fix them, and otherwise accepted with a recorded reason —
+the CI-execution gap is the standing example, since no commit can close it and only a runner can.
+Deliberately no count and no all-clear here: in an append-only record, any "all of them" claim is
+falsified by the next round that reads it, and a census that silently returns a subset is the same
+failure as a monitor that silently does not run — both report a number, neither reports that the
+number is partial. That is not incidental to this entry: it is the same failure the entry is about,
+and it was caught twice inside this paragraph. The findings worth carrying forward, because each is a
+general failure mode rather than a detail of this diff:
 
 - Test evidence had been recorded against the **pre-fix tree** — a green record whose
   `evidence_tree` was the review's `base_tree`, not `head_tree`. Caught on the manifest's own tree

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -45,17 +45,26 @@ reintroduce it one level up. The substring scan also matched `OLD_INSTALL_REFERE
 
 **What changed:** the module is parsed with Python's `ast` + `literal_eval` (a computed reference is
 unreadable by design rather than executed) and compared **whole** by `deepEqual`, so a key upstream
-adds or we stop writing counts as drift. Unreadable is a **finding, not a skip**: absent plugin
-source skips with a printed reason; unparseable source, a renamed symbol, or a failing `python3`
-fails. Folding "I could not read it" into "not applicable" is how a detector dies quietly while still
-reporting green.
+adds or we stop writing counts as drift. Unreadable is a **finding, not a skip**, and the skip is
+drawn as narrowly as the facts allow: only prawduct **not installed at all** skips, with a printed
+reason. Installed-but-`migrate_plugin.py`-**missing** — the module moved or was renamed — fails, as
+do an unparseable source, a renamed symbol, and a failing `python3`. "Not here" and "here, but what I
+read moved" are different facts, and only the first is a non-applicability; folding "I could not read
+it" into "not applicable" is how a detector dies quietly while still reporting green.
 
-**Test-only — no runtime path changes, so it did not gate the v5 cut.** Seven tests, each watched
-red first: swallowing reader errors turns the three `THROWS` cases red; drifting the constant to
-`ref:"v9.9.9"` turns the cross-check red; and converting the fail branch to a skip turns the
-fail-vs-skip test red. Each `THROWS` case matches its **specific** error, because a bare
-`assert.throws` accepts `python3: not found` too and would report green over a reader that parsed
-nothing.
+**Test-only — no runtime path changes, so it did not gate the v5 cut.** Eight tests, each watched
+red against the specific mutation it exists to catch: swallowing reader errors turns the three
+`THROWS` cases red; drifting the constant to `ref:"v9.9.9"` turns the cross-check red; converting
+the fail branch to a skip turns the fail-vs-skip test red; and collapsing `moved` back into
+`absent` turns the classification test red. Each `THROWS` case matches its **specific** error,
+because a bare `assert.throws` accepts `python3: not found` too and would report green over a reader
+that parsed nothing.
+
+**Known limit:** the drift comparison against the *installed* plugin runs only where prawduct is
+installed — a developer machine, never CI, which has no marketplace checkout. The reader tests do run
+on the runner, but they prove the reader raises on crafted fixtures, not that our constant still
+matches upstream's. Closing it needs a CI-side checkout or a scheduled drift job — both
+commit-shaped — tracked as #835.
 
 **Reviewed** across several rounds (`chunk`, `cumulative`, and repeated `verify-resolutions` passes).
 Rather than tally rounds here — a count that goes stale the moment another runs — the census is
@@ -68,8 +77,9 @@ best available census, but rounds on this branch went out under **four different
 it too returns a subset. `prawduct-hook evidence list` (no `--scope` — it takes `--kind` and `-n`) is
 the unfiltered fact log.
 
-Findings were fixed where a commit could fix them, and otherwise accepted with a recorded reason —
-the CI-execution gap is the standing example, since no commit can close it and only a runner can.
+Findings were fixed where fixing them belonged to this branch, and otherwise accepted with a recorded
+reason — the CI drift gap (#835) is the standing example: closable in a commit, but by touching
+`.github/workflows/`, which is a different risk surface than a test-only change.
 Deliberately no count and no all-clear here: in an append-only record, any "all of them" claim is
 falsified by the next round that reads it, and a census that silently returns a subset is the same
 failure as a monitor that silently does not run — both report a number, neither reports that the

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -63,13 +63,14 @@ Rather than tally rounds here — a count that goes stale the moment another run
 
 Read that with one caveat, stated because the alternative is a pointer that quietly under-reports:
 rounds on this branch were dispatched under **four different scope strings**, so a scope-filtered
-census does not reach all of them — including the `cumulative`, which carried the most findings.
-`prawduct-hook evidence list` (no `--scope`; it takes only `--kind` and `-n`) is the unfiltered view.
+census does not reach all of them. `prawduct-hook render-dispositions` unfiltered is the whole view;
+`prawduct-hook evidence list` (no `--scope` — it takes only `--kind` and `-n`) is the raw fact log.
 
-Findings were **fixed where fixable and accepted with a recorded reason otherwise** — no finding was
-left undispositioned. The accepts are: three notes fixed in a later commit than the round that
-raised them, and the CI-execution gap, which no commit can close because the evidence has to come
-from a runner. The ones worth carrying forward, because each is a general failure mode rather than a
+Each round's findings were fixed where a commit could fix them, and otherwise accepted with a
+recorded reason — the CI-execution gap is the standing example, since no commit can close it and only
+a runner can. Deliberately no count or all-clear here: in an append-only record, "nothing is open" is
+falsified by the next round that reads it, so the census belongs in the tool and the *why* belongs in
+prose. The findings worth carrying forward, because each is a general failure mode rather than a
 detail of this diff:
 
 - Test evidence had been recorded against the **pre-fix tree** — a green record whose

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -57,12 +57,25 @@ fail-vs-skip test red. Each `THROWS` case matches its **specific** error, becaus
 `assert.throws` accepts `python3: not found` too and would report green over a reader that parsed
 nothing.
 
-**Reviewed:** `chunk` → 1 warning (test evidence recorded against the pre-fix tree — re-run and
-re-recorded, `evidence_tree` now byte-matches `head_tree`), 1 note (CHANGELOG omitted the temp-dir
-leak fix — clause added); `verify-resolutions` → 0/0/0; `cumulative` → 0 blocking, 3 warnings,
-2 notes, all fixed rather than accepted: `python3` declared in `CONTRIBUTING.md` as a test-only
-prerequisite, matchers added to the `THROWS` cases, `encoding="utf-8"` pinned on the Python read, the
-cross-check's failure branch made reachable from a test, and this entry.
+**Reviewed** across several rounds (`chunk`, `cumulative`, and repeated `verify-resolutions` passes),
+ending with the cumulative gate `satisfied` and zero unresolved blocking findings. Rather than tally
+rounds here — a count that goes stale the moment another runs — the durable record is the evidence
+store: `prawduct-hook evidence list`, scope `plugin-ref-807`.
+
+Every finding was **fixed, none accepted**. The ones worth carrying forward, because each is a
+general failure mode rather than a detail of this diff:
+
+- Test evidence had been recorded against the **pre-fix tree** — a green record whose
+  `evidence_tree` was the review's `base_tree`, not `head_tree`. Caught on the manifest's own tree
+  pair; `test-status` exits 0 straight through it.
+- The `THROWS` matchers were **bare `assert.throws`**, then unanchored. `execFileSync` builds
+  `err.message` from the argv it ran, and that argv carries the embedded program — including its own
+  `sys.exit("INSTALL_REFERENCE not found in " + …)` source line — so the matcher matched its own
+  source text on any nonzero exit. Guards against unexamined errors were themselves tolerating one.
+- The **fail-vs-skip contract was asserted by nobody** until the comparison was factored out; the
+  block comment then justified the block in terms that invited deleting that very test.
+- The entry's own tag line was stamped `status=shipped` **on an unmerged branch**, against ART-4K9M
+  recorded in this file's header — copied from the merged precedent below without reading the token.
 
 **Adjacent, filed not fixed:** #833 — whether a managed repo's install reference should be a
 committed artifact at all, rather than untracked machine state rewritten at every session launch.

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -28,7 +28,7 @@ Tag-line conventions (ART-4K9M, ratified 2026-07-17):
 
 ## 2026-08-01: the upstream half of the install-reference check is parsed, not scraped (#807, #816)
 
-<!-- prawduct: type=fix | scope=plugin-ref-807 | status=shipped -->
+<!-- prawduct: type=fix | scope=plugin-ref-807 | status= -->
 
 **Why:** the 2026-07-31 entry below records the cross-check as shipped state, and that half of it was
 weaker than the entry implies. Entries are append-only, so this supersedes rather than edits it.

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -52,8 +52,8 @@ do an unparseable source, a renamed symbol, and a failing `python3`. "Not here" 
 read moved" are different facts, and only the first is a non-applicability; folding "I could not read
 it" into "not applicable" is how a detector dies quietly while still reporting green.
 
-**Test-only — no runtime path changes, so it did not gate the v5 cut.** Eight tests, each watched
-red against the specific mutation it exists to catch: swallowing reader errors turns the three
+**Test-only — no runtime path changes, so it did not gate the v5 cut.** Every guard added here was
+watched red against the specific mutation it exists to catch: swallowing reader errors turns the
 `THROWS` cases red; drifting the constant to `ref:"v9.9.9"` turns the cross-check red; converting
 the fail branch to a skip turns the fail-vs-skip test red; and collapsing `moved` back into
 `absent` turns the classification test red. Each `THROWS` case matches its **specific** error,

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -26,6 +26,49 @@ Tag-line conventions (ART-4K9M, ratified 2026-07-17):
 -->
 
 
+## 2026-08-01: the upstream half of the install-reference check is parsed, not scraped (#807, #816)
+
+<!-- prawduct: type=fix | scope=plugin-ref-807 | status=shipped -->
+
+**Why:** the 2026-07-31 entry below records the cross-check as shipped state, and that half of it was
+weaker than the entry implies. Entries are append-only, so this supersedes rather than edits it.
+
+`29147c7` pinned `PRAWDUCT_INSTALL_REFERENCE` against a literal in this repo — which catches only
+TangleClaw's side moving — and added a companion check reading prawduct's own `migrate_plugin.py` for
+the upstream side. That companion **scraped the module as text**, bounding the literal with
+`indexOf('\n}')`. The bound is a guess, and a guess that lands wrong does not fail: it over-extends
+on a reformat and matches `ref`/`repo` from a neighbouring literal, comparing against values that
+were never the install reference. Reading the wrong constant quietly is worse than failing to read
+one loudly — a loud failure gets fixed, a quiet wrong answer gets believed — and quiet-wrong is the
+exact failure `PRAWDUCT_INSTALL_REFERENCE` exists to end, so the check guarding it must not
+reintroduce it one level up. The substring scan also matched `OLD_INSTALL_REFERENCE`.
+
+**What changed:** the module is parsed with Python's `ast` + `literal_eval` (a computed reference is
+unreadable by design rather than executed) and compared **whole** by `deepEqual`, so a key upstream
+adds or we stop writing counts as drift. Unreadable is a **finding, not a skip**: absent plugin
+source skips with a printed reason; unparseable source, a renamed symbol, or a failing `python3`
+fails. Folding "I could not read it" into "not applicable" is how a detector dies quietly while still
+reporting green.
+
+**Test-only — no runtime path changes, so it did not gate the v5 cut.** Seven tests, each watched
+red first: swallowing reader errors turns the three `THROWS` cases red; drifting the constant to
+`ref:"v9.9.9"` turns the cross-check red; and converting the fail branch to a skip turns the
+fail-vs-skip test red. Each `THROWS` case matches its **specific** error, because a bare
+`assert.throws` accepts `python3: not found` too and would report green over a reader that parsed
+nothing.
+
+**Reviewed:** `chunk` → 1 warning (test evidence recorded against the pre-fix tree — re-run and
+re-recorded, `evidence_tree` now byte-matches `head_tree`), 1 note (CHANGELOG omitted the temp-dir
+leak fix — clause added); `verify-resolutions` → 0/0/0; `cumulative` → 0 blocking, 3 warnings,
+2 notes, all fixed rather than accepted: `python3` declared in `CONTRIBUTING.md` as a test-only
+prerequisite, matchers added to the `THROWS` cases, `encoding="utf-8"` pinned on the Python read, the
+cross-check's failure branch made reachable from a test, and this entry.
+
+**Adjacent, filed not fixed:** #833 — whether a managed repo's install reference should be a
+committed artifact at all, rather than untracked machine state rewritten at every session launch.
+`syncEngineHooks` touches only the `hooks` block, so it is not a propagation vector today; that is a
+property of current code, not a guarantee.
+
 ## 2026-08-01: break-glass recovery proven by running it, and a way out for an install with no login (#710, chunk 4)
 
 <!-- prawduct: type=feat | chunks=4 | scope=auth-6-secure-by-default | status=shipped -->

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -57,13 +57,20 @@ fail-vs-skip test red. Each `THROWS` case matches its **specific** error, becaus
 `assert.throws` accepts `python3: not found` too and would report green over a reader that parsed
 nothing.
 
-**Reviewed** across several rounds (`chunk`, `cumulative`, and repeated `verify-resolutions` passes),
-ending with the cumulative gate `satisfied` and zero unresolved blocking findings. Rather than tally
-rounds here — a count that goes stale the moment another runs — the durable record is the evidence
-store: `prawduct-hook evidence list`, scope `plugin-ref-807`.
+**Reviewed** across several rounds (`chunk`, `cumulative`, and repeated `verify-resolutions` passes).
+Rather than tally rounds here — a count that goes stale the moment another runs — the census is
+`prawduct-hook render-dispositions --scope plugin-ref-807`.
 
-Every finding was **fixed, none accepted**. The ones worth carrying forward, because each is a
-general failure mode rather than a detail of this diff:
+Read that with one caveat, stated because the alternative is a pointer that quietly under-reports:
+rounds on this branch were dispatched under **four different scope strings**, so a scope-filtered
+census does not reach all of them — including the `cumulative`, which carried the most findings.
+`prawduct-hook evidence list` (no `--scope`; it takes only `--kind` and `-n`) is the unfiltered view.
+
+Findings were **fixed where fixable and accepted with a recorded reason otherwise** — no finding was
+left undispositioned. The accepts are: three notes fixed in a later commit than the round that
+raised them, and the CI-execution gap, which no commit can close because the evidence has to come
+from a runner. The ones worth carrying forward, because each is a general failure mode rather than a
+detail of this diff:
 
 - Test evidence had been recorded against the **pre-fix tree** — a green record whose
   `evidence_tree` was the review's `base_tree`, not `head_tree`. Caught on the manifest's own tree

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -488,15 +488,27 @@ All notable changes to TangleClaw are documented in this file.
   computed reference is unreadable by design rather than executed) and compares the **whole**
   reference, so a key upstream adds or we stop writing counts as drift too.
 
-  Unreadable is a **finding, not a skip**. Absent plugin source → skip with a printed reason;
-  present but unparseable, symbol renamed, or `python3` failing → fail. Folding "I could not read it"
-  into "not applicable" is how a detector dies quietly while still reporting green — and the likeliest
-  cause of an unreadable literal is upstream restructuring it, the exact event the check exists to
-  catch. Seven tests cover the reader directly, because the cross-check reads a fixed path under
-  `$HOME`; the comparison is factored out so the fail-rather-than-skip contract is itself reachable
-  from a test, and converting that branch back to a skip turns one red. All seven were watched red
-  first. Their fixtures nest under the suite's existing temp directory rather than taking a second
-  `mkdtemp`, which was leaking one directory per run.
+  Unreadable is a **finding, not a skip**, and the skip is drawn as narrowly as the facts allow:
+  prawduct **not installed at all** skips with a printed reason, while prawduct installed with
+  `migrate_plugin.py` *missing* — the module moved or was renamed — **fails**, as do an unparseable
+  source and a failing `python3`. Those are different facts, and only the first is a
+  non-applicability; collapsing them would silence the check at the one moment it has anything to
+  say, since upstream restructuring the literal is the event it exists to catch. Folding "I could not
+  read it" into "not applicable" is how a detector dies quietly while still reporting green.
+
+  Eight tests cover the reader and the source classification directly, because the cross-check
+  resolves its own path under `$HOME` and no test can aim it at a chosen file. The comparison is
+  factored out so the fail-rather-than-skip contract is itself reachable, and each guard was watched
+  red against the specific mutation it exists to catch — converting the fail branch to a skip, and
+  collapsing "moved" back into "not installed", each turn one red. Their fixtures nest under the
+  suite's existing temp directory rather than taking a second `mkdtemp`, which was leaking one
+  directory per run.
+
+  **Known limit:** the drift comparison against the *installed* plugin only runs where prawduct is
+  installed — i.e. a developer machine, never CI, which has no marketplace checkout. The reader tests
+  do run on the runner, but they prove the reader raises on crafted fixtures, not that our constant
+  still matches upstream's. Closing that needs a CI-side checkout or a scheduled drift job, tracked
+  as #835.
 
 - **The test suite no longer restarts the developer's live Caddy (#710).** A credential change ends
   in `launchctl kickstart -k gui/<uid>/com.tangleclaw.caddy`, `execFileSync` resolves `launchctl`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -492,10 +492,11 @@ All notable changes to TangleClaw are documented in this file.
   present but unparseable, symbol renamed, or `python3` failing → fail. Folding "I could not read it"
   into "not applicable" is how a detector dies quietly while still reporting green — and the likeliest
   cause of an unreadable literal is upstream restructuring it, the exact event the check exists to
-  catch. Six tests cover the reader directly, since the cross-check reads a fixed path under `$HOME`
-  and its failure branch is otherwise unreachable from a test; all six were watched red first. Their
-  fixtures nest under the suite's existing temp directory rather than taking a second `mkdtemp`,
-  which was leaking one directory per run.
+  catch. Seven tests cover the reader directly, because the cross-check reads a fixed path under
+  `$HOME`; the comparison is factored out so the fail-rather-than-skip contract is itself reachable
+  from a test, and converting that branch back to a skip turns one red. All seven were watched red
+  first. Their fixtures nest under the suite's existing temp directory rather than taking a second
+  `mkdtemp`, which was leaking one directory per run.
 
 - **The test suite no longer restarts the developer's live Caddy (#710).** A credential change ends
   in `launchctl kickstart -k gui/<uid>/com.tangleclaw.caddy`, `execFileSync` resolves `launchctl`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -493,7 +493,9 @@ All notable changes to TangleClaw are documented in this file.
   into "not applicable" is how a detector dies quietly while still reporting green — and the likeliest
   cause of an unreadable literal is upstream restructuring it, the exact event the check exists to
   catch. Six tests cover the reader directly, since the cross-check reads a fixed path under `$HOME`
-  and its failure branch is otherwise unreachable from a test; all six were watched red first.
+  and its failure branch is otherwise unreachable from a test; all six were watched red first. Their
+  fixtures nest under the suite's existing temp directory rather than taking a second `mkdtemp`,
+  which was leaking one directory per run.
 
 - **The test suite no longer restarts the developer's live Caddy (#710).** A credential change ends
   in `launchctl kickstart -k gui/<uid>/com.tangleclaw.caddy`, `execFileSync` resolves `launchctl`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -477,6 +477,24 @@ All notable changes to TangleClaw are documented in this file.
   same text lands there.
 
 ### Internal
+- **The upstream half of the install-reference contract test is parsed, not scraped (#807, #816).**
+  `29147c7` pinned `PRAWDUCT_INSTALL_REFERENCE` against a literal in this repo, which catches only
+  TangleClaw's side moving; the companion check that reads prawduct's own `migrate_plugin.py` scraped
+  it as text, bounding the literal with `indexOf('\n}')`. That bound is a guess, and a guess that
+  lands wrong does not fail — it over-extends on a reformat and matches `ref`/`repo` from a
+  neighbouring literal, comparing against values that were never the install reference. Silently
+  reading the wrong constant outranks loudly failing to read one: a loud failure gets fixed, a quiet
+  wrong answer gets believed. It now parses the module with Python's `ast` and `literal_eval` (a
+  computed reference is unreadable by design rather than executed) and compares the **whole**
+  reference, so a key upstream adds or we stop writing counts as drift too.
+
+  Unreadable is a **finding, not a skip**. Absent plugin source → skip with a printed reason;
+  present but unparseable, symbol renamed, or `python3` failing → fail. Folding "I could not read it"
+  into "not applicable" is how a detector dies quietly while still reporting green — and the likeliest
+  cause of an unreadable literal is upstream restructuring it, the exact event the check exists to
+  catch. Six tests cover the reader directly, since the cross-check reads a fixed path under `$HOME`
+  and its failure branch is otherwise unreachable from a test; all six were watched red first.
+
 - **The test suite no longer restarts the developer's live Caddy (#710).** A credential change ends
   in `launchctl kickstart -k gui/<uid>/com.tangleclaw.caddy`, `execFileSync` resolves `launchctl`
   through PATH, and the shared test stub only stubbed `caddy` — so every full-suite run on a machine

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,12 @@ Thanks for your interest in contributing to TangleClaw! This document covers how
 - **Node.js 22+** (`node:sqlite` and `node:test` are required)
 - **ttyd** (`brew install ttyd`)
 - **tmux** (`brew install tmux`)
+- **python3** (test-only) — `test/c1-plugin-migration.test.js` parses the installed Prawduct
+  plugin's `migrate_plugin.py` with Python's `ast` to check TangleClaw's install-reference constant
+  has not drifted from upstream's. Ships with macOS; no packages needed. The check is skipped, with
+  a printed reason, when the plugin source is not present — but an unreadable source **fails**
+  rather than skipping, so a missing `python3` on a machine that does have the plugin is a test
+  failure by design, not a silent pass.
 
 ## Getting Started
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,9 +10,9 @@ Thanks for your interest in contributing to TangleClaw! This document covers how
 - **tmux** (`brew install tmux`)
 - **python3** (test-only, required) — `test/c1-plugin-migration.test.js` parses Python source with
   `ast` to check TangleClaw's install-reference constant has not drifted from the Prawduct plugin's.
-  Ships with macOS; no packages needed. **Eight of its tests spawn `python3` unconditionally**,
-  against their own fixtures, so a missing interpreter fails them whether or not the plugin is
-  installed. Only the drift comparison against the *installed* plugin is conditional, and it skips
+  Ships with macOS; no packages needed. **Seven of its eight reader tests spawn `python3`
+  unconditionally**, against their own fixtures, so a missing interpreter fails them whether or not
+  the plugin is installed. (The eighth classifies the source path and touches only the filesystem.) Only the drift comparison against the *installed* plugin is conditional, and it skips
   in exactly one case: prawduct **not installed** (no marketplace checkout). Installed-but-relocated,
   unparseable, or a failing `python3` all **fail** — "I could not read it" must never be recorded as
   "not applicable". Note this comparison therefore does not run in CI, which has no marketplace

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,12 +8,13 @@ Thanks for your interest in contributing to TangleClaw! This document covers how
 - **Node.js 22+** (`node:sqlite` and `node:test` are required)
 - **ttyd** (`brew install ttyd`)
 - **tmux** (`brew install tmux`)
-- **python3** (test-only) — `test/c1-plugin-migration.test.js` parses the installed Prawduct
-  plugin's `migrate_plugin.py` with Python's `ast` to check TangleClaw's install-reference constant
-  has not drifted from upstream's. Ships with macOS; no packages needed. The check is skipped, with
-  a printed reason, when the plugin source is not present — but an unreadable source **fails**
-  rather than skipping, so a missing `python3` on a machine that does have the plugin is a test
-  failure by design, not a silent pass.
+- **python3** (test-only, required) — `test/c1-plugin-migration.test.js` parses Python source with
+  `ast` to check TangleClaw's install-reference constant has not drifted from the Prawduct plugin's.
+  Ships with macOS; no packages needed. **Seven of its tests spawn `python3` unconditionally**,
+  against their own fixtures, so a missing interpreter fails them whether or not the plugin is
+  installed. Only the drift comparison against the *installed* plugin is conditional: absent plugin
+  source skips with a printed reason, while an unreadable source **fails** rather than skipping —
+  "I could not read it" must never be recorded as "not applicable".
 
 ## Getting Started
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,8 @@ Thanks for your interest in contributing to TangleClaw! This document covers how
   `ast` to check TangleClaw's install-reference constant has not drifted from the Prawduct plugin's.
   Ships with macOS; no packages needed. **Seven of its eight reader tests spawn `python3`
   unconditionally**, against their own fixtures, so a missing interpreter fails them whether or not
-  the plugin is installed. (The eighth classifies the source path and touches only the filesystem.) Only the drift comparison against the *installed* plugin is conditional, and it skips
+  the plugin is installed. (The eighth classifies the source path and touches only the
+  filesystem.) Only the drift comparison against the *installed* plugin is conditional, and it skips
   in exactly one case: prawduct **not installed** (no marketplace checkout). Installed-but-relocated,
   unparseable, or a failing `python3` all **fail** — "I could not read it" must never be recorded as
   "not applicable". Note this comparison therefore does not run in CI, which has no marketplace

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,11 +10,13 @@ Thanks for your interest in contributing to TangleClaw! This document covers how
 - **tmux** (`brew install tmux`)
 - **python3** (test-only, required) — `test/c1-plugin-migration.test.js` parses Python source with
   `ast` to check TangleClaw's install-reference constant has not drifted from the Prawduct plugin's.
-  Ships with macOS; no packages needed. **Seven of its tests spawn `python3` unconditionally**,
+  Ships with macOS; no packages needed. **Eight of its tests spawn `python3` unconditionally**,
   against their own fixtures, so a missing interpreter fails them whether or not the plugin is
-  installed. Only the drift comparison against the *installed* plugin is conditional: absent plugin
-  source skips with a printed reason, while an unreadable source **fails** rather than skipping —
-  "I could not read it" must never be recorded as "not applicable".
+  installed. Only the drift comparison against the *installed* plugin is conditional, and it skips
+  in exactly one case: prawduct **not installed** (no marketplace checkout). Installed-but-relocated,
+  unparseable, or a failing `python3` all **fail** — "I could not read it" must never be recorded as
+  "not applicable". Note this comparison therefore does not run in CI, which has no marketplace
+  checkout; see #835.
 
 ## Getting Started
 

--- a/test/c1-plugin-migration.test.js
+++ b/test/c1-plugin-migration.test.js
@@ -208,12 +208,14 @@ describe('C1 — per-project plugin migration (#262)', () => {
     });
   });
 
-  // The cross-check above runs against a fixed path under the real home
-  // directory, so it can only ever exercise the readable case. These aim the
-  // reader at crafted sources instead — the point is not that it parses valid
-  // Python, it is that every unreadable shape THROWS. A reader that returned a
-  // default, or an empty object, would let the cross-check pass while comparing
-  // against nothing.
+  // The cross-check above resolves its source path itself, so no test can AIM
+  // it at a chosen file. On a real machine it does take the failure branch —
+  // that is the point of it — but only when upstream actually restructures the
+  // literal, which is not something a test can arrange. These aim the reader at
+  // crafted sources instead: the point is not that it parses valid Python, it
+  // is that every unreadable shape THROWS. A reader that returned a default, or
+  // an empty object, would let the cross-check pass while comparing against
+  // nothing.
   //
   // `an unreadable source FAILS the cross-check` below covers the branch that
   // decides between failing and skipping, by calling

--- a/test/c1-plugin-migration.test.js
+++ b/test/c1-plugin-migration.test.js
@@ -54,6 +54,27 @@ function extractUpstreamInstallReference(src) {
 }
 
 /**
+ * Classify the installed plugin's source: is it absent, present, or *moved*?
+ *
+ * "Not installed" and "installed, but the module I read is gone" are different
+ * facts and only the first is a legitimate skip. A marketplace checkout that
+ * exists while `plugin/lib/migrate_plugin.py` does not means upstream
+ * relocated or renamed it — which is precisely the event this check exists to
+ * notice, so collapsing it into "not applicable" would silence the check at the
+ * only moment it was ever for. An honest skip reason in a log nobody reads is
+ * still a check that stopped checking.
+ *
+ * @param {string} marketplaceRoot - `~/.claude/plugins/marketplaces/prawduct`
+ * @returns {{state: 'absent'|'moved'|'present', src: string}}
+ */
+function classifyUpstreamSource(marketplaceRoot) {
+  const src = path.join(marketplaceRoot, 'plugin', 'lib', 'migrate_plugin.py');
+  if (!fs.existsSync(marketplaceRoot)) return { state: 'absent', src };
+  if (!fs.existsSync(src)) return { state: 'moved', src };
+  return { state: 'present', src };
+}
+
+/**
  * Assert TangleClaw's constant matches the upstream reference at `src`.
  *
  * Split out from the test that calls it with the real installed path so this
@@ -191,13 +212,19 @@ describe('C1 — per-project plugin migration (#262)', () => {
       // several cache versions can coexist, so picking one would compare
       // against whichever release happened to sort first rather than the
       // installed contract.
-      const src = path.join(
-        os.homedir(), '.claude', 'plugins', 'marketplaces', 'prawduct', 'plugin', 'lib', 'migrate_plugin.py'
-      );
-      if (!fs.existsSync(src)) {
-        t.skip('prawduct plugin source not present on this machine');
+      const root = path.join(os.homedir(), '.claude', 'plugins', 'marketplaces', 'prawduct');
+      const { state, src } = classifyUpstreamSource(root);
+      if (state === 'absent') {
+        t.skip('prawduct plugin not installed on this machine');
         return;
       }
+      // Installed, but the module is gone: upstream moved or renamed it. Only
+      // "not installed at all" earns a skip — see classifyUpstreamSource.
+      assert.notEqual(
+        state, 'moved',
+        `prawduct is installed at ${root} but ${src} is missing — the module moved or was renamed. `
+        + 'Retarget this check at its new home rather than letting it skip.'
+      );
       // Parsed as an AST, never scraped as text. A text window has to guess
       // where the literal ends, and a guess that lands wrong does not fail —
       // it silently matches keys from a NEIGHBOURING literal and compares
@@ -281,6 +308,25 @@ describe('C1 — per-project plugin migration (#262)', () => {
     it('THROWS on a syntax error rather than reporting no drift', () => {
       const f = write('broken.py', 'INSTALL_REFERENCE = {"a": \n');
       assert.throws(() => extractUpstreamInstallReference(f), /SyntaxError/);
+    });
+
+    it('distinguishes "not installed" from "installed but the module moved"', () => {
+      // The only legitimate skip is "prawduct is not here". A marketplace
+      // checkout that exists while the module does not means upstream
+      // relocated it — a finding, not a non-applicability. Collapsing the two
+      // would make this check go quiet precisely when upstream changes, which
+      // is the only time it has ever had anything to say.
+      const absent = path.join(pyDir, 'no-such-marketplace');
+      assert.equal(classifyUpstreamSource(absent).state, 'absent');
+
+      const moved = path.join(pyDir, 'installed-but-moved');
+      fs.mkdirSync(moved, { recursive: true });
+      assert.equal(classifyUpstreamSource(moved).state, 'moved');
+
+      const present = path.join(pyDir, 'installed-intact');
+      fs.mkdirSync(path.join(present, 'plugin', 'lib'), { recursive: true });
+      fs.writeFileSync(path.join(present, 'plugin', 'lib', 'migrate_plugin.py'), 'INSTALL_REFERENCE = {}\n');
+      assert.equal(classifyUpstreamSource(present).state, 'present');
     });
 
     it('an unreadable source FAILS the cross-check — it does not skip it', () => {

--- a/test/c1-plugin-migration.test.js
+++ b/test/c1-plugin-migration.test.js
@@ -50,11 +50,12 @@ function extractUpstreamInstallReference(src) {
     'else:',
     '    sys.exit("INSTALL_REFERENCE not found in " + sys.argv[1])'
   ].join('\n');
-  // Pipe stderr rather than letting it inherit: four of these tests deliberately
-  // provoke Python tracebacks, and an inherited stderr prints all four on every
-  // GREEN run. Tracebacks scrolling past a passing suite train the reader to
-  // ignore tracebacks. `err.message` still carries the child's stderr, so the
-  // matchers are unaffected.
+  // Pipe stderr rather than letting it inherit: several tests below deliberately
+  // provoke Python failures — three raise tracebacks, one exits via sys.exit
+  // with a plain message — and an inherited stderr prints every one of them on a
+  // GREEN run. Failure output scrolling past a passing suite trains the reader
+  // to ignore failure output. `err.message` still carries the child's stderr, so
+  // the matchers are unaffected.
   return execFileSync('python3', ['-c', program, src], {
     encoding: 'utf8',
     stdio: ['pipe', 'pipe', 'pipe']

--- a/test/c1-plugin-migration.test.js
+++ b/test/c1-plugin-migration.test.js
@@ -37,7 +37,11 @@ function extractUpstreamInstallReference(src) {
   // going away.
   const program = [
     'import ast, json, sys',
-    'tree = ast.parse(open(sys.argv[1]).read())',
+    // Explicit utf-8: the real migrate_plugin.py is non-ASCII from line 1, and
+    // open()'s locale default would turn a decode error under a non-UTF-8
+    // LC_CTYPE into a red "reference has drifted" — a true failure reported as
+    // the wrong failure.
+    'tree = ast.parse(open(sys.argv[1], encoding="utf-8").read())',
     'for n in ast.walk(tree):',
     '    t = n.target if isinstance(n, ast.AnnAssign) else (n.targets[0] if isinstance(n, ast.Assign) and n.targets else None)',
     '    if getattr(t, "id", "") == "INSTALL_REFERENCE":',
@@ -47,6 +51,39 @@ function extractUpstreamInstallReference(src) {
     '    sys.exit("INSTALL_REFERENCE not found in " + sys.argv[1])'
   ].join('\n');
   return execFileSync('python3', ['-c', program, src], { encoding: 'utf8' });
+}
+
+/**
+ * Assert TangleClaw's constant matches the upstream reference at `src`.
+ *
+ * Split out from the test that calls it with the real installed path so this
+ * contract — that an unreadable source **fails** rather than skipping — is
+ * itself reachable from a test. Inlined, it could only ever run against a
+ * readable file under the real `$HOME`, leaving the failure branch asserted by
+ * nobody.
+ *
+ * @param {string} src - Absolute path to the plugin's `migrate_plugin.py`
+ * @returns {void} Throws an AssertionError on unreadable source or on drift.
+ */
+function assertMatchesUpstreamReference(src) {
+  let upstream;
+  try {
+    upstream = JSON.parse(extractUpstreamInstallReference(src));
+  } catch (err) {
+    // Deliberately NOT a skip. "I could not read it" folded into "not
+    // applicable" is how a detector dies quietly and keeps reporting green —
+    // and the likeliest cause of an unreadable literal is upstream
+    // restructuring it, which is exactly the event this exists to catch.
+    assert.fail(`could not read upstream INSTALL_REFERENCE: ${err.message}`);
+  }
+  // Whole-reference comparison, not field-by-field: an upstream key we stopped
+  // writing, or one they added, is drift too, and naming three fields
+  // explicitly would wave both through.
+  assert.deepEqual(
+    engines.PRAWDUCT_INSTALL_REFERENCE,
+    upstream,
+    'TangleClaw’s install reference has drifted from the installed plugin’s INSTALL_REFERENCE'
+  );
 }
 
 describe('C1 — per-project plugin migration (#262)', () => {
@@ -167,26 +204,7 @@ describe('C1 — per-project plugin migration (#262)', () => {
       // against values that were never the install reference. Wrong-and-quiet
       // is the failure mode this whole constant exists to prevent, so the
       // check that guards it must not reintroduce it one level up.
-      let upstream;
-      try {
-        upstream = JSON.parse(extractUpstreamInstallReference(src));
-      } catch (err) {
-        // Deliberately NOT a skip. "I could not read it" folded into "not
-        // applicable" is how a detector dies quietly and keeps reporting
-        // green — and the likeliest cause of an unreadable literal is
-        // upstream restructuring it, which is exactly the event this test is
-        // here to catch.
-        assert.fail(`could not read upstream INSTALL_REFERENCE: ${err.message}`);
-      }
-
-      // Whole-reference comparison, not field-by-field: an upstream key we
-      // stopped writing, or one they added, is drift too, and naming three
-      // fields explicitly would wave both through.
-      assert.deepEqual(
-        engines.PRAWDUCT_INSTALL_REFERENCE,
-        upstream,
-        'TangleClaw’s install reference has drifted from the installed plugin’s INSTALL_REFERENCE'
-      );
+      assertMatchesUpstreamReference(src);
     });
   });
 
@@ -229,21 +247,42 @@ describe('C1 — per-project plugin migration (#262)', () => {
       assert.deepEqual(JSON.parse(extractUpstreamInstallReference(f)), { right: 2 });
     });
 
+    // Each THROWS case matches the SPECIFIC failure it is about. A bare
+    // `assert.throws(fn)` accepts any error — including `python3: not found`
+    // or a typo in the argv index — so on a machine without python3 these
+    // three would report green over a reader that parsed nothing at all.
+    // Tests whose whole subject is "unreadable must not be tolerated" are the
+    // last place to accept an unexamined error. execFileSync folds the child's
+    // stderr into err.message, so matching costs nothing.
     it('THROWS when the symbol is gone — never returns a default', () => {
       const f = write('gone.py', 'SOMETHING_ELSE = {"a": 1}\n');
-      assert.throws(() => extractUpstreamInstallReference(f));
+      assert.throws(() => extractUpstreamInstallReference(f), /INSTALL_REFERENCE not found/);
     });
 
     it('THROWS on a syntax error rather than reporting no drift', () => {
       const f = write('broken.py', 'INSTALL_REFERENCE = {"a": \n');
-      assert.throws(() => extractUpstreamInstallReference(f));
+      assert.throws(() => extractUpstreamInstallReference(f), /SyntaxError/);
+    });
+
+    it('an unreadable source FAILS the cross-check — it does not skip it', () => {
+      // The contract the whole design rests on, and until this it was asserted
+      // by nobody: the cross-check reads a fixed path under $HOME, so its
+      // failure branch is unreachable when called the way the real test calls
+      // it. Pointed at a source it cannot parse, it must raise — a skip here
+      // would mean upstream restructuring the literal reads as "not
+      // applicable" and the check goes quiet exactly when it matters.
+      const f = write('unreadable.py', 'INSTALL_REFERENCE = {"a": \n');
+      assert.throws(
+        () => assertMatchesUpstreamReference(f),
+        /could not read upstream INSTALL_REFERENCE/
+      );
     });
 
     it('THROWS rather than executing a non-literal value', () => {
       // literal_eval, not eval: a computed reference is unreadable BY DESIGN,
       // and unreadable must surface as a failure rather than run.
       const f = write('computed.py', 'import os\nINSTALL_REFERENCE = os.environ.copy()\n');
-      assert.throws(() => extractUpstreamInstallReference(f));
+      assert.throws(() => extractUpstreamInstallReference(f), /ValueError: malformed node/);
     });
   });
 

--- a/test/c1-plugin-migration.test.js
+++ b/test/c1-plugin-migration.test.js
@@ -197,8 +197,13 @@ describe('C1 — per-project plugin migration (#262)', () => {
   // returned a default, or an empty object, would let the cross-check pass
   // while comparing against nothing.
   describe('upstream INSTALL_REFERENCE reader', () => {
+    // Nested under the suite's own tmpDir so the existing teardown reclaims it;
+    // a second mkdtemp would leak a directory per run.
     let pyDir;
-    before(() => { pyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-py-')); });
+    before(() => {
+      pyDir = path.join(tmpDir, 'upstream-py');
+      fs.mkdirSync(pyDir, { recursive: true });
+    });
 
     const write = (name, body) => {
       const f = path.join(pyDir, name);

--- a/test/c1-plugin-migration.test.js
+++ b/test/c1-plugin-migration.test.js
@@ -208,12 +208,19 @@ describe('C1 — per-project plugin migration (#262)', () => {
     });
   });
 
-  // The cross-check above reads a fixed path under the real home directory, so
-  // its unreadable branch cannot be reached from a test. These exercise the
-  // reader directly against crafted sources — the point is not that it parses
-  // valid Python, it is that every unreadable shape THROWS. A reader that
-  // returned a default, or an empty object, would let the cross-check pass
-  // while comparing against nothing.
+  // The cross-check above runs against a fixed path under the real home
+  // directory, so it can only ever exercise the readable case. These aim the
+  // reader at crafted sources instead — the point is not that it parses valid
+  // Python, it is that every unreadable shape THROWS. A reader that returned a
+  // default, or an empty object, would let the cross-check pass while comparing
+  // against nothing.
+  //
+  // `an unreadable source FAILS the cross-check` below covers the branch that
+  // decides between failing and skipping, by calling
+  // `assertMatchesUpstreamReference` directly. That is the contract the whole
+  // design rests on — do not delete it as redundant with the reader tests; they
+  // prove the reader raises, and only that one proves the raise is not
+  // swallowed into a skip.
   describe('upstream INSTALL_REFERENCE reader', () => {
     // Nested under the suite's own tmpDir so the existing teardown reclaims it;
     // a second mkdtemp would leak a directory per run.
@@ -247,13 +254,13 @@ describe('C1 — per-project plugin migration (#262)', () => {
       assert.deepEqual(JSON.parse(extractUpstreamInstallReference(f)), { right: 2 });
     });
 
-    // Each THROWS case matches the SPECIFIC failure it is about. A bare
+    // Each THROWS case below matches the SPECIFIC failure it is about. A bare
     // `assert.throws(fn)` accepts any error — including `python3: not found`
-    // or a typo in the argv index — so on a machine without python3 these
-    // three would report green over a reader that parsed nothing at all.
-    // Tests whose whole subject is "unreadable must not be tolerated" are the
-    // last place to accept an unexamined error. execFileSync folds the child's
-    // stderr into err.message, so matching costs nothing.
+    // or a typo in the argv index — so unmatched, they would report green over
+    // a reader that parsed nothing at all. Tests whose whole subject is
+    // "unreadable must not be tolerated" are the last place to accept an
+    // unexamined error. execFileSync folds the child's stderr into
+    // err.message, so matching costs nothing.
     it('THROWS when the symbol is gone — never returns a default', () => {
       const f = write('gone.py', 'SOMETHING_ELSE = {"a": 1}\n');
       // Anchored on the interpolated PATH, not the bare sentence. execFileSync

--- a/test/c1-plugin-migration.test.js
+++ b/test/c1-plugin-migration.test.js
@@ -5,6 +5,7 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
+const { execFileSync } = require('node:child_process');
 const { setLevel } = require('../lib/logger');
 
 setLevel('error');
@@ -13,6 +14,40 @@ const store = require('../lib/store');
 const engines = require('../lib/engines');
 const projects = require('../lib/projects');
 const sessionOwnership = require('../lib/session-ownership');
+
+/**
+ * Read `INSTALL_REFERENCE` out of prawduct's `migrate_plugin.py` by parsing the
+ * module as Python source, and return it as JSON text.
+ *
+ * Python's own `ast` does the parsing because the literal is Python, not JSON:
+ * `True` is not `true`, and quoting/formatting are the author's to change.
+ * `ast.literal_eval` evaluates only literals, so a hostile or broken module
+ * raises rather than executes.
+ *
+ * Throws on anything short of a clean read — missing symbol, syntax error, no
+ * usable `python3`. Every caller must treat a throw as a failure, never as a
+ * skip.
+ *
+ * @param {string} src - Absolute path to the installed plugin's `migrate_plugin.py`
+ * @returns {string} The reference as a JSON string
+ */
+function extractUpstreamInstallReference(src) {
+  // Matches both `NAME: ann = {...}` and a bare `NAME = {...}`, so upstream
+  // adding or dropping the type annotation is not mistaken for the symbol
+  // going away.
+  const program = [
+    'import ast, json, sys',
+    'tree = ast.parse(open(sys.argv[1]).read())',
+    'for n in ast.walk(tree):',
+    '    t = n.target if isinstance(n, ast.AnnAssign) else (n.targets[0] if isinstance(n, ast.Assign) and n.targets else None)',
+    '    if getattr(t, "id", "") == "INSTALL_REFERENCE":',
+    '        json.dump(ast.literal_eval(n.value), sys.stdout)',
+    '        break',
+    'else:',
+    '    sys.exit("INSTALL_REFERENCE not found in " + sys.argv[1])'
+  ].join('\n');
+  return execFileSync('python3', ['-c', program, src], { encoding: 'utf8' });
+}
 
 describe('C1 — per-project plugin migration (#262)', () => {
   let tmpDir;
@@ -126,24 +161,84 @@ describe('C1 — per-project plugin migration (#262)', () => {
         t.skip('prawduct plugin source not present on this machine');
         return;
       }
-      const py = fs.readFileSync(src, 'utf8');
-      const start = py.indexOf('INSTALL_REFERENCE');
-      assert.notEqual(start, -1, 'INSTALL_REFERENCE not found in upstream source');
-      // Bound the window to the dict literal. Reading to EOF happens to work
-      // today only because upstream defines nothing else matching these keys;
-      // stopping at the closing brace keeps that a fact rather than a wager.
-      const end = py.indexOf('\n}', start);
-      const block = py.slice(start, end === -1 ? undefined : end);
+      // Parsed as an AST, never scraped as text. A text window has to guess
+      // where the literal ends, and a guess that lands wrong does not fail —
+      // it silently matches keys from a NEIGHBOURING literal and compares
+      // against values that were never the install reference. Wrong-and-quiet
+      // is the failure mode this whole constant exists to prevent, so the
+      // check that guards it must not reintroduce it one level up.
+      let upstream;
+      try {
+        upstream = JSON.parse(extractUpstreamInstallReference(src));
+      } catch (err) {
+        // Deliberately NOT a skip. "I could not read it" folded into "not
+        // applicable" is how a detector dies quietly and keeps reporting
+        // green — and the likeliest cause of an unreadable literal is
+        // upstream restructuring it, which is exactly the event this test is
+        // here to catch.
+        assert.fail(`could not read upstream INSTALL_REFERENCE: ${err.message}`);
+      }
 
-      const ours = engines.PRAWDUCT_INSTALL_REFERENCE.extraKnownMarketplaces.prawduct;
-      const upstreamRef = /"ref":\s*"([^"]+)"/.exec(block);
-      const upstreamRepo = /"repo":\s*"([^"]+)"/.exec(block);
-      const upstreamAuto = /"autoUpdate":\s*(True|False)/.exec(block);
-      assert.ok(upstreamRef && upstreamRepo && upstreamAuto, 'could not parse upstream INSTALL_REFERENCE');
+      // Whole-reference comparison, not field-by-field: an upstream key we
+      // stopped writing, or one they added, is drift too, and naming three
+      // fields explicitly would wave both through.
+      assert.deepEqual(
+        engines.PRAWDUCT_INSTALL_REFERENCE,
+        upstream,
+        'TangleClaw’s install reference has drifted from the installed plugin’s INSTALL_REFERENCE'
+      );
+    });
+  });
 
-      assert.equal(ours.source.ref, upstreamRef[1], 'ref drifted from upstream');
-      assert.equal(ours.source.repo, upstreamRepo[1], 'repo drifted from upstream');
-      assert.equal(ours.autoUpdate, upstreamAuto[1] === 'True', 'autoUpdate drifted from upstream');
+  // The cross-check above reads a fixed path under the real home directory, so
+  // its unreadable branch cannot be reached from a test. These exercise the
+  // reader directly against crafted sources — the point is not that it parses
+  // valid Python, it is that every unreadable shape THROWS. A reader that
+  // returned a default, or an empty object, would let the cross-check pass
+  // while comparing against nothing.
+  describe('upstream INSTALL_REFERENCE reader', () => {
+    let pyDir;
+    before(() => { pyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-py-')); });
+
+    const write = (name, body) => {
+      const f = path.join(pyDir, name);
+      fs.writeFileSync(f, body);
+      return f;
+    };
+
+    it('reads an annotated assignment, the shape upstream ships today', () => {
+      const f = write('ann.py', 'INSTALL_REFERENCE: dict[str, dict] = {"a": {"b": True}}\n');
+      assert.deepEqual(JSON.parse(extractUpstreamInstallReference(f)), { a: { b: true } });
+    });
+
+    it('reads a bare assignment too — dropping the annotation is not the symbol vanishing', () => {
+      const f = write('bare.py', 'INSTALL_REFERENCE = {"a": {"b": False}}\n');
+      assert.deepEqual(JSON.parse(extractUpstreamInstallReference(f)), { a: { b: false } });
+    });
+
+    it('is not fooled by a name that merely contains the symbol', () => {
+      // `py.indexOf('INSTALL_REFERENCE')` matched this; an AST target compare
+      // does not. This is the substring class of bug that made text-scraping
+      // wrong, pinned so a revert to scraping fails here.
+      const f = write('near.py', 'OLD_INSTALL_REFERENCE = {"wrong": 1}\nINSTALL_REFERENCE = {"right": 2}\n');
+      assert.deepEqual(JSON.parse(extractUpstreamInstallReference(f)), { right: 2 });
+    });
+
+    it('THROWS when the symbol is gone — never returns a default', () => {
+      const f = write('gone.py', 'SOMETHING_ELSE = {"a": 1}\n');
+      assert.throws(() => extractUpstreamInstallReference(f));
+    });
+
+    it('THROWS on a syntax error rather than reporting no drift', () => {
+      const f = write('broken.py', 'INSTALL_REFERENCE = {"a": \n');
+      assert.throws(() => extractUpstreamInstallReference(f));
+    });
+
+    it('THROWS rather than executing a non-literal value', () => {
+      // literal_eval, not eval: a computed reference is unreadable BY DESIGN,
+      // and unreadable must surface as a failure rather than run.
+      const f = write('computed.py', 'import os\nINSTALL_REFERENCE = os.environ.copy()\n');
+      assert.throws(() => extractUpstreamInstallReference(f));
     });
   });
 

--- a/test/c1-plugin-migration.test.js
+++ b/test/c1-plugin-migration.test.js
@@ -256,7 +256,17 @@ describe('C1 — per-project plugin migration (#262)', () => {
     // stderr into err.message, so matching costs nothing.
     it('THROWS when the symbol is gone — never returns a default', () => {
       const f = write('gone.py', 'SOMETHING_ELSE = {"a": 1}\n');
-      assert.throws(() => extractUpstreamInstallReference(f), /INSTALL_REFERENCE not found/);
+      // Anchored on the interpolated PATH, not the bare sentence. execFileSync
+      // builds err.message from the argv it ran, and that argv contains the
+      // embedded program — including its own `sys.exit("INSTALL_REFERENCE not
+      // found in " + …)` source line. So the unanchored form matches its own
+      // source text on ANY nonzero exit, which is the identical hole this
+      // matcher was added to close, one layer deeper. Only the interpolated
+      // filename proves the program reached that exit for this file.
+      assert.throws(
+        () => extractUpstreamInstallReference(f),
+        /INSTALL_REFERENCE not found in \S*gone\.py/
+      );
     });
 
     it('THROWS on a syntax error rather than reporting no drift', () => {

--- a/test/c1-plugin-migration.test.js
+++ b/test/c1-plugin-migration.test.js
@@ -50,7 +50,15 @@ function extractUpstreamInstallReference(src) {
     'else:',
     '    sys.exit("INSTALL_REFERENCE not found in " + sys.argv[1])'
   ].join('\n');
-  return execFileSync('python3', ['-c', program, src], { encoding: 'utf8' });
+  // Pipe stderr rather than letting it inherit: four of these tests deliberately
+  // provoke Python tracebacks, and an inherited stderr prints all four on every
+  // GREEN run. Tracebacks scrolling past a passing suite train the reader to
+  // ignore tracebacks. `err.message` still carries the child's stderr, so the
+  // matchers are unaffected.
+  return execFileSync('python3', ['-c', program, src], {
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe']
+  });
 }
 
 /**


### PR DESCRIPTION
## Status first: #807 and #816 are already fixed. This is not that fix.

`migrateToPlugin` stopped copying TangleClaw's untracked `.claude/settings.json` in **`29147c7`**
(PR #819), merged to `v5-baseline` on 2026-07-31. Both issues are code-complete.

They remain **open** because chunk PRs target `v5-baseline`, GitHub auto-closes only on merge to the
default branch, and the commit says `Refs`, not `Closes`. `main` is still pinned at v4.38.0 for the
whole of v5 — so **merged is not delivered**, and closing them now would assert a delivery that has
not happened. They close by hand at the v5 integration merge, alongside #805/#806.

Stating this at the top because two sessions independently read "open issue" as "unshipped work" and
planned a rebuild of merged code. On this repo, `git log --oneline -- <file>` is the check, not issue
state.

## What this PR actually changes

`29147c7` pinned `PRAWDUCT_INSTALL_REFERENCE` against a literal **in this repo** — which catches only
TangleClaw's side moving — and added a companion check reading prawduct's own `migrate_plugin.py` for
the upstream side. That companion **scraped the module as text**, bounding the literal with
`indexOf('\n}')`.

That bound is a guess, and a guess that lands wrong does not fail. It over-extends on a reformat and
matches `ref`/`repo` from a **neighbouring** literal, comparing against values that were never the
install reference. Reading the wrong constant quietly is worse than failing to read one loudly — a
loud failure gets fixed, a quiet wrong answer gets believed. Quiet-wrong is the exact failure
`PRAWDUCT_INSTALL_REFERENCE` exists to end, so the check guarding it must not reintroduce it one
layer up. The substring scan also matched `OLD_INSTALL_REFERENCE`.

Now: parsed with Python's `ast` + `literal_eval` (a computed reference is unreadable **by design**
rather than executed), compared **whole** by `deepEqual` so a key upstream adds or we stop writing
counts as drift, and matched on the AST target so a near-miss name does not satisfy the search.

**Unreadable is a finding, not a skip.** Absent plugin source → skip with a printed reason.
Unparseable source, renamed symbol, or a failing `python3` → **fail**. Folding "I could not read it"
into "not applicable" is how a detector dies quietly while still reporting green.

## Two writers touch `.claude/settings.json` — only one is a propagation vector

| Writer | When | Touches | Propagation vector? |
|---|---|---|---|
| `syncEngineHooks` (`lib/engines.js:1165`) | every session launch | the `hooks` block only; reads the whole object, writes it back, so the reference keys survive **by construction** | **No** |
| `migrateToPlugin` | `POST /api/projects/:name/migrate-to-plugin` only | the reference keys | Yes — this was the defect |

This matters because the file's mtime matches session start **to the second**, which reads like the
launch path propagating the reference. It does not. That is a property of what the current code
happens to touch, not a guarantee — which is why #833 asks whether the reference should be a
committed artifact at all rather than untracked machine state.

## CI caveat — stated, not discovered

**These seven `python3`-spawning tests have never run on `ubuntu-latest`.** `test.yml` triggers on
`pull_request` and pushes to `main`/`v5-baseline`; until this PR existed there was no PR and no
remote branch, so no runner had ever seen this tree. **Opening this PR is what makes them run.**
Local evidence is current and green; it is unverified on a second machine, which is different from
unverified. `python3` is now declared in `CONTRIBUTING.md` as a test-only prerequisite — this is the
first place the suite *spawns* it rather than naming it in a fixture string.

## The finding worth stealing

The three `THROWS` tests originally used bare `assert.throws(fn)`, which accepts **any** error —
including `python3: not found`. Tests whose entire subject is *"unreadable must not be tolerated"*
were themselves tolerating an unexamined error, and on a machine without python3 all three would have
reported green over a reader that parsed nothing.

Adding matchers was not enough either. `execFileSync` builds `err.message` from the argv it ran, and
that argv carries the embedded program — whose own source contains
`sys.exit("INSTALL_REFERENCE not found in " + sys.argv[1])`. So `/INSTALL_REFERENCE not found/`
matched **its own source text** on any nonzero exit: the identical hole, one layer deeper. It is now
anchored on the interpolated path, which only real stderr can produce.

Demonstrated rather than argued: break the embedded program's syntax so the reader parses nothing at
all, and the unanchored form reports **green** over it while the anchored form goes red.

## Test plan

Full suite **5448 pass / 0 fail / 1 pre-existing skip, of 5449** (+7). Evidence recorded with
`evidence_tree` byte-matching `HEAD^{tree}`.

Every new guard was **watched red first**, each against the specific mutation it exists to catch:

| Mutation | Goes red |
|---|---|
| Drift the constant to `ref:"v9.9.9"` | cross-check |
| Reader swallows errors, returns `'{}'` | the three `THROWS` cases |
| Fail branch converted to a skip | `an unreadable source FAILS the cross-check` |
| Embedded program's syntax broken | anchored matcher (unanchored stays green) |

## Review

Cumulative gate **satisfied** — 5 review facts, 0 free edges, 0 unresolved blocking. Findings were
**fixed, not accepted**, including one blocking (`status=shipped` stamped on an unmerged branch,
against ART-4K9M recorded in `.prawduct/change-log.md`'s own header).

**Test-only — no runtime path changes, so this does not gate the v5 cut.** If v5 is ready first, cut
it and land this after.

## Do not merge

Parked for the operator. Opening this PR is what runs CI; it is not a promote.

Refs #807, #816. Related: #833.
