### PR TITLE
Send /v2/session/file as POST so wrap capture-back survives ClawBridge 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **Wrap capture-back survives ClawBridge 2.x: `/v2/session/file` now sent as `POST`.** ClawBridge
+  v2.0.0 moved consuming reads from `GET` to `POST` (a side-effecting read must not be a `GET`) and
+  answers a `GET` carrying `consume=true` with a **hard 405 — no deprecation window**. `getFile` in
+  `lib/clawbridge.js` sent `GET` with `consume:true`, and `lib/wrap-steps/ai-content.js`
+  `_runGatewayCapture` is a live caller, so every webui/gateway wrap capture-back would have started
+  failing the moment any bridge it drives crossed to 2.x — silently degrading those wraps back to
+  `mechanical-only`, the exact #334 honest-skip Slice B1 was written to close.
+
+  The call site now sends `POST` **unconditionally** rather than branching on the `consume` flag:
+  `POST` without `consume` behaves exactly like the old `GET` (200, `consumed:false`), so one method
+  covers both read paths and the flag and the method can never disagree later. Contract is otherwise
+  byte-for-byte unchanged — same path, same query params, same response keys; `content` stays raw
+  UTF-8 and an empty body stays a literal `""` rather than `null`, which `_parseFields` depends on.
+
+  **Test contract updated deliberately, not weakened:** the plain-read assertion moved `GET` → `POST`
+  because the upstream contract itself moved, and the consume test — which previously asserted only
+  the query string — now also pins the method, so the regression that broke this is covered rather
+  than merely fixed.
+
 ### Changed
 - **`PROJECT-MAP.md` no longer publishes shared-doc group membership — it reports a count and points
   at the UI.** The section used to render each group's name, shared directory, and doc names. That

--- a/lib/clawbridge.js
+++ b/lib/clawbridge.js
@@ -29,7 +29,13 @@
  *   - ClawBridge v1.6.0 — `permissionMode` field added (PR ClawBridge#3)
  *   - ClawBridge v1.7.0 — `attachIfExists` field added (PR ClawBridge#5)
  *   - ClawBridge v1.7.1 — full PTY-broker contract (`send`/`output`/`status`/`transcript`)
- *   - ClawBridge v1.9.1 — `GET /v2/session/file` capture-back endpoint (ClawBridge#18)
+ *   - ClawBridge v1.9.1 — `/v2/session/file` capture-back endpoint (ClawBridge#18)
+ *   - ClawBridge v2.0.0 — BREAKING: consuming reads moved `GET` → `POST` on
+ *     `/v2/session/file` (a side-effecting read must not be a GET). `GET` with
+ *     `consume=true` is now a hard 405 with no deprecation window, so this call
+ *     site sends `POST` unconditionally — `POST` without `consume` behaves
+ *     exactly like the old `GET` (200, `consumed:false`), which keeps the method
+ *     and the flag from ever disagreeing.
  *   - TC #210 Phase 1 (PR #249) — engine-profile scaffold
  *   - TC reference: `~/.claude/projects/.../memory/reference_clawbridge_architecture.md`
  */
@@ -332,8 +338,9 @@ async function getStatus(opts) {
 }
 
 /**
- * GET `/v2/session/file` — read a session-relative file's raw bytes over the
- * bridge (ClawBridge #18, shipped v1.9.1). The bridge resolves `path` against
+ * POST `/v2/session/file` — read a session-relative file's raw bytes over the
+ * bridge (ClawBridge #18, shipped v1.9.1; method moved GET → POST in v2.0.0
+ * because a consuming read has a side effect). The bridge resolves `path` against
  * the session cwd (`<projectsDir>/<project>`), so it is the SAME
  * project-relative `captureFile` the local/tmux `ai-content` contract already
  * uses — no path translation needed. The body's `content` is raw UTF-8,
@@ -370,7 +377,7 @@ async function getFile(opts) {
   // truthiness check); anything else is omitted so the file is preserved.
   const qs = _queryString({ project, path: filePath, consume: consume ? 'true' : undefined });
   const r = await _requestJson({
-    localPort, token, method: 'GET', path: `/v2/session/file?${qs}`, timeoutMs
+    localPort, token, method: 'POST', path: `/v2/session/file?${qs}`, timeoutMs
   });
   const p = r.parsed || {};
   if (r.ok2xx) {

--- a/test/clawbridge.test.js
+++ b/test/clawbridge.test.js
@@ -380,7 +380,7 @@ describe('clawbridge.getStatus', () => {
 // ── CC-7 Slice B1: getFile (ClawBridge #18 / v1.9.1 capture-back) ──
 
 describe('clawbridge.getFile', () => {
-  it('GETs /v2/session/file with project + path and returns raw content verbatim', async () => {
+  it('POSTs /v2/session/file with project + path and returns raw content verbatim', async () => {
     let req = null;
     const raw = '## Next action\nship it — `##` and\nnewlines preserved\n';
     const stub = await startStubBridge((r) => {
@@ -396,7 +396,10 @@ describe('clawbridge.getFile', () => {
       assert.equal(result.bytes, Buffer.byteLength(raw));
       assert.equal(result.consumed, false);
       assert.equal(result.path, '.wrap-capture.md');
-      assert.equal(req.method, 'GET');
+      // ClawBridge v2.0.0 moved consuming reads GET → POST; this call site sends
+      // POST unconditionally, so a plain read must be POST too (200,
+      // consumed:false). A GET carrying consume=true is a hard 405 on 2.x.
+      assert.equal(req.method, 'POST');
       assert.equal(req.auth, 'Bearer tok');
       // No consume param when not requested.
       assert.match(req.path, /^\/v2\/session\/file\?project=demo&path=\.wrap-capture\.md$/);
@@ -405,10 +408,12 @@ describe('clawbridge.getFile', () => {
     }
   });
 
-  it('sends consume=true (literal string) only when consume is truthy', async () => {
+  it('sends consume=true (literal string) over POST, never GET', async () => {
     let path = null;
+    let method = null;
     const stub = await startStubBridge((r) => {
       path = r.url;
+      method = r.method;
       return { status: 200, body: { ok: true, content: 'x', bytes: 1, consumed: true } };
     });
     try {
@@ -416,6 +421,9 @@ describe('clawbridge.getFile', () => {
       assert.equal(result.ok, true);
       assert.equal(result.consumed, true);
       assert.match(path, /[?&]consume=true(&|$)/, 'consume must be the literal string "true"');
+      // The regression this pins: ClawBridge 2.x answers a consuming GET with a
+      // hard 405 (no deprecation window), which silently broke wrap capture-back.
+      assert.equal(method, 'POST', 'a consuming read must never go over GET');
     } finally {
       await stub.close();
     }


### PR DESCRIPTION
## What

`getFile` in `lib/clawbridge.js` now sends `POST /v2/session/file` instead of `GET`.

## Why

ClawBridge v2.0.0 moved consuming reads from `GET` to `POST` and answers a `GET` carrying `consume=true` with a **hard 405 — no deprecation window**. `lib/wrap-steps/ai-content.js:778` (`_runGatewayCapture`) is a live caller with `consume: true`, so webui/gateway wrap capture-back would break against any 2.x bridge, degrading those wraps to `mechanical-only`.

Found while bumping RentalClaw's clawbridge pin `^1.5.0` → `^2.0.0` to close two unauthenticated single-request process kills live in 1.9.1 (what habitat serves). Because the 405 is immediate, this had to land **before** the habitat bridge restart.

`POST` is sent unconditionally rather than branching on `consume` — `POST` without `consume` behaves exactly like the old `GET` (200, `consumed:false`), so the flag and the method cannot disagree later. Contract otherwise byte-for-byte identical; verified against the published 2.0.1 tarball by the ClawBridge session, including the empty-body case (`""`, not `null`) that `_parseFields` depends on.

## Test plan

- `node --test test/clawbridge.test.js` — **26/26 pass**
- `node --test test/wrap-step-ai-content.test.js` — **62/62 pass**

Test contract updated deliberately: the plain-read assertion moved `GET` → `POST` because the upstream contract moved. The consume test previously asserted only the query string and now also pins the method, so the regression is covered rather than merely fixed.

Fixes #855