### PR TITLE
Require a served Host, so a rebound name cannot satisfy the cross-site guards

### DIFF
--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -3303,25 +3303,51 @@ an attacker controlling DNS satisfies them without forging anything — the brow
 `same-origin` for `evil.example` pointed at `127.0.0.1`. The payoff is the ungated loopback listener
 and a `--writable` ttyd.
 
-**What:** `servedHostAllowlist` derives the names the install already serves (mkcert defaults, mDNS
-name, `publicDomain`, `caddyTailnetHost`); both guards check `Host` against it. Scoped to
-state-changing requests and WS upgrades so a mis-derived list refuses writes rather than removing
-the dashboard. Startup logs the computed list.
+**What:** `servedHostAllowlist` derives the names this install serves and both guards check `Host`
+against it. Scoped to browser-shaped state-changing requests and WS upgrades, so a mis-derived list
+refuses writes rather than removing the dashboard, and header-less consumers keep working. Startup
+logs the computed list.
 
-**Two decisions the build turned up, neither in the issue:**
+**CORRECTION — this entry previously claimed `certHostUnion` does not exist. It does**, at
+`scripts/ingress-cutover.js`, exported and tested (#863). The claim came from grepping only `lib/`
+and `server.js` and reading that bounded window as absence — the exact failure the
+prove-absence-before-deleting rule names — and it was then recorded here as a *verified finding*,
+which made a confident falsehood look like diligence. The Critic caught it; all three reviewers
+found it independently.
 
-1. The issue's suggested fix cited `certHostUnion` as an existing helper to reuse. **There is no
-   such function** — the real pieces are `mdnsHostFor` and `MKCERT_HOSTS_DEFAULT`. Verifying before
-   building is what caught it; a filed diagnosis is a hypothesis.
-2. An existing test (`[fd7a:115c::1]` tailnet upgrade) went red and was right to. Enumerating the
+It was also a real defect, not just a bad record: the parallel union built here was a fourth copy
+and the only one omitting `certSanHosts`. An install whose cert carries an operator-added name
+(`POST /api/setup/generate-cert` takes a hosts array that lands in no config field, and the cert is
+its own only record) would have loaded the dashboard over a valid cert, served reads, then refused
+every write and destroyed every terminal upgrade. `certHostUnion` now lives in `lib/https-setup.js`
+beside the inputs it reads, the script delegates to it, and `servedHostAllowlist` derives FROM it —
+so "the names we serve cannot drift from the names the cert carries" is now true by construction
+rather than asserted.
+
+**The blocking finding, and why the first fix was wrong.** The first-run carve-out exempted
+`/api/setup/*` while `setupComplete === false`, justified as "a fresh install is unprotected
+anyway". That premise is false for the default population: `bindAllInterfaces: false` +
+`ingressMode: 'direct'` binds loopback only, so **no remote operator can reach the wizard**, and the
+only request that could arrive there under an unserved `Host` was the rebound one — on the route
+that sets the admin credential. The carve-out now also requires the install to actually be reachable
+(`describeBindState(config).wide` or caddy mode), so it applies exactly where the flow it protects
+can happen. It also covers `PATCH /api/config`, the wizard's OTHER terminator (ADR 0009 point 2) —
+guarding Finish but not Skip is the half-swept-family defect again.
+
+**Two more the build turned up:**
+
+1. An existing test (`[fd7a:115c::1]` tailnet upgrade) went red and was right to. Enumerating the
    machine's interface addresses would have fixed it but bound the allowlist to a network that
    changes. **Bare IPs are allowed outright instead**: rebinding needs a NAME, and a cross-address
-   page yields `Origin` ≠ `Host`, already refused. Simpler and machine-independent.
+   page yields `Origin` != `Host`, already refused.
+2. Two integration tests proved `POST /api/setup/complete` legitimately arrives under a host the
+   allowlist cannot know — including one named "keeps a legitimate hostname, so a remote operator
+   gets their own address". That is what forced the carve-out into the open.
 
-**And one the tests forced into the open:** `POST /api/setup/complete` legitimately arrives under a
-host the allowlist cannot know, because setup is what configures it. Two integration tests went red
-— including one named "keeps a legitimate hostname, so a remote operator gets their own address".
-Carve-out is the smallest that works: `/api/setup/*` only, and only while `setupComplete` is false.
-Operator chose that over exempting all pre-setup writes.
+**And the carve-out tests did not test the carve-out.** The first version posted only to
+`/api/config` and `/api/setupsomething` — neither is a `/api/setup/*` path, so no axis was pinned,
+including the one that makes it close. Rewritten against a real store: reachable-and-first-run is
+exempt, the loopback default is not, it closes on `setupComplete`, and Skip is covered. Each is
+mutation-verified, including reverting to the exact two-axis form that was the blocking defect.
 
 **Classification:** fix

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -802,6 +802,13 @@ concludes "up to date", and (given the same commit's hide-on-real-answer branch)
 down while old code is still serving. Pointed at `getRunningVersion()` with the disk read kept
 as the fallback, so all three consumers now derive it from one place.
 
+**Also:** the allowlist is memoized on the configured names, the hostname, and the certificate's
+mtime/size. That is not only a cost fix — computing it read and X.509-parsed the cert on every
+guarded write and upgrade, and on an install with no cert yet emitted a warning about *regeneration*
+per request, loudest during the setup wizard. The warning now reports a change of state. Each key
+term is mutation-pinned, because the first two were added without one and the certificate term is
+load-bearing: a SAN from `generate-cert` lives in no config field.
+
 **Classification:** fix
 
 ## 2026-07-28: Bind loopback unless something is guarding the door (#710, chunk 1)
@@ -3329,9 +3336,12 @@ rather than asserted.
 anyway". That premise is false for the default population: `bindAllInterfaces: false` +
 `ingressMode: 'direct'` binds loopback only, so **no remote operator can reach the wizard**, and the
 only request that could arrive there under an unserved `Host` was the rebound one — on the route
-that sets the admin credential. The carve-out now also requires the install to actually be reachable
-(`describeBindState(config).wide` or caddy mode), so it applies exactly where the flow it protects
-can happen. It also covers `PATCH /api/config`, the wizard's OTHER terminator (ADR 0009 point 2) —
+that sets the admin credential. The carve-out now also requires the install to actually be reachable —
+`describeBindState(config).wide`, and *only* that. Caddy mode looks like a second way to qualify and
+is not: `bindPolicy` refuses the wide opt-in there, so the listener is loopback-only behind Caddy, a
+remote operator arrives THROUGH Caddy under an allowlisted name, and a rebound page reaches
+127.0.0.1 without traversing Caddy at all. Accepting it would have exempted only the attack — the
+same defect in the other arm, and it was caught only because the Critic noticed the arm had no test. It also covers `PATCH /api/config`, the wizard's OTHER terminator (ADR 0009 point 2) —
 guarding Finish but not Skip is the half-swept-family defect again.
 
 **Two more the build turned up:**

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -809,7 +809,7 @@ per request, loudest during the setup wizard. The warning now reports a change o
 `publicDomain`, `caddyTailnetHost`, the hostname, and the certificate's mtime/size — are
 mutation-pinned. They were not at first, and the record claimed otherwise before the tests existed,
 which is worse than the gap: the certificate term is load-bearing (a SAN from `generate-cert` lives
-in no config field), and the config terms are PATCHable on a running server.
+in no config field), and the config terms are both written on a RUNNING server — `publicDomain` via `PATCH /api/config`, `caddyTailnetHost` by the Caddyfile-adoption path.
 
 **Classification:** fix
 

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -805,9 +805,11 @@ as the fallback, so all three consumers now derive it from one place.
 **Also:** the allowlist is memoized on the configured names, the hostname, and the certificate's
 mtime/size. That is not only a cost fix — computing it read and X.509-parsed the cert on every
 guarded write and upgrade, and on an install with no cert yet emitted a warning about *regeneration*
-per request, loudest during the setup wizard. The warning now reports a change of state. Each key
-term is mutation-pinned, because the first two were added without one and the certificate term is
-load-bearing: a SAN from `generate-cert` lives in no config field.
+per request, loudest during the setup wizard. The warning now reports a change of state. All four key terms —
+`publicDomain`, `caddyTailnetHost`, the hostname, and the certificate's mtime/size — are
+mutation-pinned. They were not at first, and the record claimed otherwise before the tests existed,
+which is worse than the gap: the certificate term is load-bearing (a SAN from `generate-cert` lives
+in no config field), and the config terms are PATCHable on a running server.
 
 **Classification:** fix
 

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -3293,3 +3293,35 @@ that resolves itself. Both fixed; cross-file tests now pin the two predicates to
 and go red when either drifts.
 
 **Classification:** fix
+
+## 2026-08-04: A rebound name no longer satisfies the cross-site guards (#864)
+
+<!-- prawduct: type=fix | scope=auth-6-secure-by-default | status=shipped -->
+
+**Why:** both v5 cross-site guards decide "is this cross-site?" relative to the request itself, so
+an attacker controlling DNS satisfies them without forging anything — the browser honestly reports
+`same-origin` for `evil.example` pointed at `127.0.0.1`. The payoff is the ungated loopback listener
+and a `--writable` ttyd.
+
+**What:** `servedHostAllowlist` derives the names the install already serves (mkcert defaults, mDNS
+name, `publicDomain`, `caddyTailnetHost`); both guards check `Host` against it. Scoped to
+state-changing requests and WS upgrades so a mis-derived list refuses writes rather than removing
+the dashboard. Startup logs the computed list.
+
+**Two decisions the build turned up, neither in the issue:**
+
+1. The issue's suggested fix cited `certHostUnion` as an existing helper to reuse. **There is no
+   such function** — the real pieces are `mdnsHostFor` and `MKCERT_HOSTS_DEFAULT`. Verifying before
+   building is what caught it; a filed diagnosis is a hypothesis.
+2. An existing test (`[fd7a:115c::1]` tailnet upgrade) went red and was right to. Enumerating the
+   machine's interface addresses would have fixed it but bound the allowlist to a network that
+   changes. **Bare IPs are allowed outright instead**: rebinding needs a NAME, and a cross-address
+   page yields `Origin` ≠ `Host`, already refused. Simpler and machine-independent.
+
+**And one the tests forced into the open:** `POST /api/setup/complete` legitimately arrives under a
+host the allowlist cannot know, because setup is what configures it. Two integration tests went red
+— including one named "keeps a legitimate hostname, so a remote operator gets their own address".
+Carve-out is the smallest that works: `/api/setup/*` only, and only while `setupComplete` is false.
+Operator chose that over exempting all pre-setup writes.
+
+**Classification:** fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -823,8 +823,11 @@ All notable changes to TangleClaw are documented in this file.
   `ingressMode: 'direct'` — loopback only — so **no remote operator can reach the wizard at all**,
   and the only request that could arrive there under an unserved `Host` was the rebound one, on the
   route that sets the admin credential. The carve-out therefore also requires the install to be
-  genuinely reachable (a wide socket, or Caddy in front), so it applies exactly where the flow it
-  protects can occur and nowhere else. It covers `PATCH /api/config` as well as `/api/setup/*`,
+  genuinely reachable — a wide socket, and *only* that. Caddy mode looks like it qualifies and does
+  not: `bindPolicy` refuses the wide opt-in there, so the listener is loopback-only behind Caddy. A
+  remote operator arrives *through* Caddy under a name this list already holds, while a rebound page
+  reaches `127.0.0.1` without traversing Caddy at all — so accepting caddy mode would have exempted
+  only the attack, the same defect in the other arm. It covers `PATCH /api/config` as well as `/api/setup/*`,
   because the wizard has two terminators — Finish and Skip — and guarding one is guarding neither.
 
 - **BREAKING: cross-site requests can no longer change server state (#860).** A page on another

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -813,6 +813,15 @@ All notable changes to TangleClaw are documented in this file.
   field. The startup line now logs the computed list for the same reason: a wrong derivation should
   be a diff against reality, not a mystery.
 
+  The list is memoized on the configured names, the machine's hostname, and the certificate's mtime
+  and size — which changes what you *see*, not only what it costs. Computing it reads and parses the
+  certificate, so an uncached version did that on every guarded write and every terminal upgrade,
+  and on an install with no certificate yet it logged a warning about certificate *regeneration* on
+  each one — loudest during the setup wizard, about an operation the request path is not performing.
+  That warning now fires once per change of state, which is what it was written to report. A
+  regenerated certificate invalidates the memo by itself, which matters because the names
+  `generate-cert` adds live nowhere else.
+
   **First-run setup is exempt on three axes, and the third is the one that matters.** Setup is what
   *configures* the public names, so on an install a remote operator can reach, first run is the one
   moment the allowlist cannot contain the address they arrived by — the `Host` header is how the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -773,6 +773,47 @@ All notable changes to TangleClaw are documented in this file.
 
 ### Security
 
+- **A state-changing request or terminal socket must now arrive under a name this install
+  actually serves — closing the DNS-rebinding path around both v5 cross-site guards (#864).**
+  Those guards decide "is this cross-site?" *relative to the request itself*: `Sec-Fetch-Site` is
+  what the browser computed from the page's own origin, and the upgrade check compares `Origin`
+  against the request's own `Host`. An attacker controlling DNS satisfies both without forging
+  anything — point `evil.example` at `127.0.0.1`, get the operator to load it, and the browser
+  honestly reports `same-origin`, because as far as it knows it is. `Origin` and `Host` agree, on a
+  lie. The request then reaches the ungated loopback listener that exists in caddy mode, where
+  `/terminal/*` proxies to a `--writable` ttyd.
+
+  The guards now check that agreement against an independent fact: `servedHostAllowlist` derives
+  the names this install is *already configured to serve* — the mkcert defaults, the mDNS name that
+  goes in the certificate, and `publicDomain` / `caddyTailnetHost`. Nothing new to maintain, and it
+  cannot drift from the certificate, because it is built from the same inputs.
+
+  **Bare IP addresses are allowed outright, and that is the shape of the attack rather than a
+  loophole.** Rebinding needs a *name* — the trick is making a name the browser already trusts
+  resolve elsewhere, and `Host` then carries that name. A request that reaches us same-origin as
+  `192.168.1.50` or a Tailscale `[fd7a:115c::1]` means the browser really is talking to that
+  address; a page at a *different* address posting here yields `Origin` ≠ `Host`, which the existing
+  guards already refuse. This also keeps the allowlist free of interface addresses that would
+  change with the network.
+
+  **Scoped to state-changing requests and WebSocket upgrades, deliberately — not to every
+  request.** This list is derived, and a derivation that misses a legitimate address (a proxy that
+  rewrites `Host`, a container name) then refuses writes from it. That degrades to "reads still
+  work, writes return a named `HOST_NOT_SERVED`" instead of taking the dashboard away from a remote
+  operator entirely — the silent-failure mode this release spent its cycle eliminating. Tightening
+  to an outright refusal is a separate decision, once the derivation has proven itself in the
+  field. The startup line now logs the computed list for the same reason: a wrong derivation should
+  be a diff against reality, not a mystery.
+
+  **First-run setup is exempt, on two axes at once.** Setup is what *configures* the public names,
+  so during first run the install genuinely does not know the address a remote operator reached it
+  by — the `Host` header is how it learns it, and the wizard names that address back. The carve-out
+  is therefore only `/api/setup/*`, and only while `setupComplete` is `false`; every other
+  state-changing route is guarded even before setup, and the setup routes rejoin the guard the
+  moment it flips. The window is real and bounded: a fresh install has no credential and no gate
+  yet — it is unprotected by construction until setup runs — so the guard begins protecting at
+  exactly the point there is something to protect.
+
 - **BREAKING: cross-site requests can no longer change server state (#860).** A page on another
   site could change the TangleClaw admin credential. Several routes authorize on "this request
   arrived over loopback" — most sharply `POST /api/auth/credential`, which treats loopback as proof

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -784,9 +784,14 @@ All notable changes to TangleClaw are documented in this file.
   `/terminal/*` proxies to a `--writable` ttyd.
 
   The guards now check that agreement against an independent fact: `servedHostAllowlist` derives
-  the names this install is *already configured to serve* — the mkcert defaults, the mDNS name that
-  goes in the certificate, and `publicDomain` / `caddyTailnetHost`. Nothing new to maintain, and it
-  cannot drift from the certificate, because it is built from the same inputs.
+  the names this install is *already configured to serve*. It does not assemble that set itself — it
+  derives from `certHostUnion`, the function the cert paths already share, which is why it cannot
+  drift from the certificate. That matters more than it sounds: `POST /api/setup/generate-cert`
+  accepts a caller-supplied host list that lands in **no config field**, so the certificate is the
+  only record those names have. A list built from config alone would have loaded the dashboard over
+  a valid certificate, served reads, then refused every write and destroyed every terminal upgrade
+  on exactly the installs an operator had customised. `certHostUnion` moved to `lib/https-setup.js`
+  beside the inputs it reads; the cutover script delegates to it.
 
   **Bare IP addresses are allowed outright, and that is the shape of the attack rather than a
   loophole.** Rebinding needs a *name* — the trick is making a name the browser already trusts
@@ -796,8 +801,11 @@ All notable changes to TangleClaw are documented in this file.
   guards already refuse. This also keeps the allowlist free of interface addresses that would
   change with the network.
 
-  **Scoped to state-changing requests and WebSocket upgrades, deliberately — not to every
-  request.** This list is derived, and a derivation that misses a legitimate address (a proxy that
+  **Scoped to browser-shaped state-changing requests and WebSocket upgrades, deliberately — not to
+  every request.** `curl`, scripts and the agent-facing API send neither `Sec-Fetch-Site` nor
+  `Origin`, are not a cross-site vector, and keep working under any `Host` — the same exemption both
+  sibling guards already state. It costs the guard nothing, because a rebound page *is* a browser
+  and cannot suppress `Sec-Fetch-Site` from script. This list is derived, and a derivation that misses a legitimate address (a proxy that
   rewrites `Host`, a container name) then refuses writes from it. That degrades to "reads still
   work, writes return a named `HOST_NOT_SERVED`" instead of taking the dashboard away from a remote
   operator entirely — the silent-failure mode this release spent its cycle eliminating. Tightening
@@ -805,14 +813,19 @@ All notable changes to TangleClaw are documented in this file.
   field. The startup line now logs the computed list for the same reason: a wrong derivation should
   be a diff against reality, not a mystery.
 
-  **First-run setup is exempt, on two axes at once.** Setup is what *configures* the public names,
-  so during first run the install genuinely does not know the address a remote operator reached it
-  by — the `Host` header is how it learns it, and the wizard names that address back. The carve-out
-  is therefore only `/api/setup/*`, and only while `setupComplete` is `false`; every other
-  state-changing route is guarded even before setup, and the setup routes rejoin the guard the
-  moment it flips. The window is real and bounded: a fresh install has no credential and no gate
-  yet — it is unprotected by construction until setup runs — so the guard begins protecting at
-  exactly the point there is something to protect.
+  **First-run setup is exempt on three axes, and the third is the one that matters.** Setup is what
+  *configures* the public names, so on an install a remote operator can reach, first run is the one
+  moment the allowlist cannot contain the address they arrived by — the `Host` header is how the
+  install learns it, and the wizard names that address back.
+
+  An exemption keyed only on "a setup route, before `setupComplete`" would have been wrong, and
+  wrong in the dangerous direction. The default install is `bindAllInterfaces: false` with
+  `ingressMode: 'direct'` — loopback only — so **no remote operator can reach the wizard at all**,
+  and the only request that could arrive there under an unserved `Host` was the rebound one, on the
+  route that sets the admin credential. The carve-out therefore also requires the install to be
+  genuinely reachable (a wide socket, or Caddy in front), so it applies exactly where the flow it
+  protects can occur and nowhere else. It covers `PATCH /api/config` as well as `/api/setup/*`,
+  because the wizard has two terminators — Finish and Skip — and guarding one is guarding neither.
 
 - **BREAKING: cross-site requests can no longer change server state (#860).** A page on another
   site could change the TangleClaw admin credential. Several routes authorize on "this request

--- a/lib/https-setup.js
+++ b/lib/https-setup.js
@@ -50,6 +50,43 @@ function mdnsHostFor(hostname) {
 }
 
 /**
+ * Every host name a regenerated certificate must carry.
+ *
+ * Regeneration must never SHRINK the SAN list: a cert minted with a tailnet
+ * FQDN, regenerated from the defaults alone, silently stops covering the name
+ * the tailnet HTTPS site reuses it for. Measured on a clean-room install, so
+ * this is not a theoretical hazard. Every path that generates or previews a
+ * cert calls THIS, because two paths drifted once already — the union was added
+ * to one and the other silently kept dropping names (#863).
+ *
+ * Lives here rather than in `scripts/ingress-cutover.js` because every input it
+ * reads is defined in this module, and it now has a second consumer:
+ * `servedHostAllowlist` derives from it, so "the names we serve" cannot drift
+ * from "the names the certificate carries" (#864). The script re-exports it.
+ *
+ * @param {string|null} certPath - Existing cert to carry names forward from.
+ * @param {object} config - Loaded TangleClaw config.
+ * @returns {string[]} Deduplicated host list for mkcert.
+ */
+function certHostUnion(certPath, config) {
+  // Read the standard cert location as well as whatever the caller resolved.
+  // The "no valid cert configured" branch calls this BEFORE its certPath is
+  // assigned — still null — and that is precisely the branch that regenerates,
+  // so reading only the argument carried nothing forward and dropped every
+  // name. Verified by running it: a cert holding a tailnet FQDN still came out
+  // with only the defaults until this fallback existed.
+  const candidates = [certPath, path.join(getCertsDir(), 'cert.pem')].filter(Boolean);
+  const carried = candidates.flatMap((p) => certSanHosts(p));
+  return [...new Set([
+    ...carried,
+    ...MKCERT_HOSTS_DEFAULT,
+    mdnsHostFor(os.hostname()),
+    (config && config.caddyTailnetHost) || null,
+    (config && config.publicDomain) || null
+  ].filter(Boolean))];
+}
+
+/**
  * The host names this install legitimately answers to.
  *
  * Both cross-site guards decide "is this cross-site?" *relative to the request
@@ -61,11 +98,20 @@ function mdnsHostFor(hostname) {
  * request to vouch for itself. This list is the independent answer they check
  * against (#864).
  *
- * Deliberately built from what the install is *already configured to serve*,
- * not from a new setting nobody will maintain: the mkcert defaults, the mDNS
- * name that goes in the certificate, and the two configured public names. A
- * name that is not in a certificate and not in the config is not a name this
- * machine is reachable by on purpose.
+ * **Derived from `certHostUnion`, not assembled alongside it.** The names this
+ * install serves and the names its certificate carries are the same question
+ * asked twice, and the union had already drifted between two call sites once
+ * (#863). Building a parallel copy here would have made a third, and it would
+ * have been the only one missing `certSanHosts` — so an install whose cert
+ * carries an operator-added name (added via `POST /api/setup/generate-cert`,
+ * which lands in no config field) would load the dashboard over a valid
+ * certificate, serve reads, then refuse every write and destroy every terminal
+ * upgrade. The cert is the only record of those names, which is exactly why
+ * this reads them from it.
+ *
+ * The one addition is the bare machine name: `studio` alongside `studio.local`.
+ * A certificate has no reason to carry it, but a browser sends whatever the
+ * operator typed, and on many LANs the short form resolves.
  *
  * IPv6 literals are stored unbracketed, matching what `new URL().hostname`
  * yields for a bracketed `Host` — the caller compares against that, never
@@ -75,11 +121,20 @@ function mdnsHostFor(hostname) {
  *   `caddyTailnetHost` are read when present.
  * @param {object} [options]
  * @param {string} [options.hostname] - Override for `os.hostname()` (tests).
+ * @param {string[]} [options.certHosts] - Override for the `certHostUnion`
+ *   result (tests), so a case can pin behaviour without minting a certificate.
  * @param {string[]} [options.extraHosts] - Additional names to trust.
  * @returns {Set<string>} Lower-cased names, safe to test membership against.
  */
 function servedHostAllowlist(config, options = {}) {
-  const allowed = new Set(MKCERT_HOSTS_DEFAULT.map((h) => h.toLowerCase()));
+  const fromCert = Object.prototype.hasOwnProperty.call(options, 'certHosts')
+    ? (options.certHosts || [])
+    : certHostUnion(null, config);
+
+  const allowed = new Set();
+  for (const name of fromCert) {
+    if (typeof name === 'string' && name.trim()) allowed.add(name.trim().toLowerCase());
+  }
 
   const rawHostname = Object.prototype.hasOwnProperty.call(options, 'hostname')
     ? options.hostname
@@ -87,13 +142,7 @@ function servedHostAllowlist(config, options = {}) {
   const mdnsHost = mdnsHostFor(rawHostname);
   if (mdnsHost) {
     allowed.add(mdnsHost.toLowerCase());
-    // The bare machine name resolves on many LANs without the suffix, and a
-    // browser sends whatever the operator typed.
     allowed.add(mdnsHost.toLowerCase().replace(/\.local$/, ''));
-  }
-
-  for (const name of [config && config.publicDomain, config && config.caddyTailnetHost]) {
-    if (typeof name === 'string' && name.trim()) allowed.add(name.trim().toLowerCase());
   }
 
   // NOTE: bare IP addresses are deliberately NOT enumerated here. The caller
@@ -574,6 +623,7 @@ function _readCertExpiry(certPath) {
 module.exports = {
   MKCERT_HOSTS_DEFAULT,
   mdnsHostFor,
+  certHostUnion,
   servedHostAllowlist,
   certCoversHost,
   certSanHosts,

--- a/lib/https-setup.js
+++ b/lib/https-setup.js
@@ -50,6 +50,67 @@ function mdnsHostFor(hostname) {
 }
 
 /**
+ * The host names this install legitimately answers to.
+ *
+ * Both cross-site guards decide "is this cross-site?" *relative to the request
+ * itself* — `Sec-Fetch-Site` is computed by the browser from the page's own
+ * origin, and the upgrade guard compares `Origin` against the request's own
+ * `Host`. An attacker who controls DNS satisfies both: point `evil.example` at
+ * `127.0.0.1`, get the operator to load it, and the browser reports
+ * `same-origin` because as far as it knows, it is. The guards are asking the
+ * request to vouch for itself. This list is the independent answer they check
+ * against (#864).
+ *
+ * Deliberately built from what the install is *already configured to serve*,
+ * not from a new setting nobody will maintain: the mkcert defaults, the mDNS
+ * name that goes in the certificate, and the two configured public names. A
+ * name that is not in a certificate and not in the config is not a name this
+ * machine is reachable by on purpose.
+ *
+ * IPv6 literals are stored unbracketed, matching what `new URL().hostname`
+ * yields for a bracketed `Host` — the caller compares against that, never
+ * against the raw header (see `_hostIsAllowed` in `server.js`).
+ *
+ * @param {object|null} config - Store config; `publicDomain` and
+ *   `caddyTailnetHost` are read when present.
+ * @param {object} [options]
+ * @param {string} [options.hostname] - Override for `os.hostname()` (tests).
+ * @param {string[]} [options.extraHosts] - Additional names to trust.
+ * @returns {Set<string>} Lower-cased names, safe to test membership against.
+ */
+function servedHostAllowlist(config, options = {}) {
+  const allowed = new Set(MKCERT_HOSTS_DEFAULT.map((h) => h.toLowerCase()));
+
+  const rawHostname = Object.prototype.hasOwnProperty.call(options, 'hostname')
+    ? options.hostname
+    : os.hostname();
+  const mdnsHost = mdnsHostFor(rawHostname);
+  if (mdnsHost) {
+    allowed.add(mdnsHost.toLowerCase());
+    // The bare machine name resolves on many LANs without the suffix, and a
+    // browser sends whatever the operator typed.
+    allowed.add(mdnsHost.toLowerCase().replace(/\.local$/, ''));
+  }
+
+  for (const name of [config && config.publicDomain, config && config.caddyTailnetHost]) {
+    if (typeof name === 'string' && name.trim()) allowed.add(name.trim().toLowerCase());
+  }
+
+  // NOTE: bare IP addresses are deliberately NOT enumerated here. The caller
+  // (`_hostIsAllowed` in `server.js`) accepts any IP-literal `Host` outright,
+  // because an IP cannot be rebound — see the reasoning there. Listing this
+  // machine's interface addresses would add a machine-dependent set that
+  // changes with the network, to answer a question already answered.
+
+  for (const name of options.extraHosts || []) {
+    if (typeof name === 'string' && name.trim()) allowed.add(name.trim().toLowerCase());
+  }
+
+  allowed.delete('');
+  return allowed;
+}
+
+/**
  * Every host name and IP already carried in a certificate's subjectAltName.
  *
  * Regenerating a certificate is DESTRUCTIVE to names nobody recorded anywhere
@@ -513,6 +574,7 @@ function _readCertExpiry(certPath) {
 module.exports = {
   MKCERT_HOSTS_DEFAULT,
   mdnsHostFor,
+  servedHostAllowlist,
   certCoversHost,
   certSanHosts,
   detectMkcert,

--- a/scripts/ingress-cutover.js
+++ b/scripts/ingress-cutover.js
@@ -54,36 +54,19 @@ const CADDY_LABEL = caddy.CADDY_LABEL;
 /**
  * Every hostname a regenerated certificate must carry.
  *
- * Regenerating is destructive to names nothing else records: no config field
- * stores the host list a cert was minted with, so generating from the defaults
- * discards a tailnet FQDN supplied through `POST /api/setup/generate-cert` — and
- * the tailnet HTTPS site reuses this very cert. Measured on a clean-room
- * install, so this is not a theoretical hazard. Both generation paths and the
- * dry-run preview call THIS, because the two paths drifted once already: the
- * union was added to one of them and the other silently kept dropping names.
+ * Delegates to `lib/https-setup.js`, which is where the implementation now
+ * lives: every input it reads is defined there, and `servedHostAllowlist`
+ * derives from it so the names this install SERVES cannot drift from the names
+ * its certificate CARRIES (#864). Kept exported under this name because both
+ * generation paths and the dry-run preview call it, and the #863 regression
+ * tests pin it here.
  *
  * @param {string|null} certPath - Existing cert to carry names forward from.
  * @param {object} config - Loaded TangleClaw config.
  * @returns {string[]} Deduplicated host list for mkcert.
  */
 function certHostUnion(certPath, config) {
-  const httpsSetup = httpsSetupModule();
-  // Read from the standard cert location as well as whatever the caller has
-  // resolved so far. The "no valid cert configured" branch calls this BEFORE
-  // ctx.certPath is assigned — it is still null there — and that is precisely
-  // the branch that regenerates, so reading only the argument carried nothing
-  // forward and dropped every name anyway. Verified by running it: a cert
-  // holding a tailnet FQDN still came out with only the defaults until this
-  // fallback existed.
-  const candidates = [certPath, path.join(httpsSetup.getCertsDir(), 'cert.pem')].filter(Boolean);
-  const carried = candidates.flatMap((p) => httpsSetup.certSanHosts(p));
-  return [...new Set([
-    ...carried,
-    ...httpsSetup.MKCERT_HOSTS_DEFAULT,
-    httpsSetup.mdnsHostFor(require('node:os').hostname()),
-    (config && config.caddyTailnetHost) || null,
-    (config && config.publicDomain) || null
-  ].filter(Boolean))];
+  return httpsSetupModule().certHostUnion(certPath, config);
 }
 
 /** @returns {object} lib/https-setup, resolved lazily (REPO_DIR-relative like the others). */

--- a/server.js
+++ b/server.js
@@ -77,70 +77,56 @@ function _loadConfigOrNull() {
   try { return store.config.load(); } catch { return null; }
 }
 
+let _servedHostsCache = null;
+
 /**
  * The served-name allowlist, or an empty set if it cannot be computed.
  *
- * `servedHostAllowlist` reads the certificate to carry its names forward, so an
- * unreadable or malformed cert must not take a request down with it. Empty
- * fails closed for NAMES; an IP-literal `Host` still passes inside
- * `_hostIsAllowed` on its own reasoning, which does not depend on this list.
+ * **Cached, because computing it reads and X.509-parses the certificate.** This
+ * runs on every guarded write and every WebSocket upgrade, and an uncached
+ * version did a synchronous file read plus a certificate parse per request —
+ * and, on an install with no certificate yet, emitted a warning about
+ * regeneration on each one, loudest during the setup wizard, about an operation
+ * the request path is not performing. Caching removes the per-request cost and
+ * reduces that warning to once per change of state, which is what it was
+ * written to report.
+ *
+ * The key is what the answer actually depends on: the two configured names, and
+ * the certificate's own mtime and size. A regenerated cert therefore invalidates
+ * this without anyone having to remember to, which matters because
+ * `POST /api/setup/generate-cert` can add names that live nowhere else.
+ *
+ * An unreadable or malformed cert must not take a request down with it, so
+ * failure yields an empty set: names all refused, while an IP-literal `Host`
+ * still passes inside `_hostIsAllowed` on reasoning that does not consult this
+ * list at all.
  *
  * @param {object} config - Loaded config.
  * @returns {Set<string>}
  */
 function _servedHostsOrEmpty(config) {
+  let certStamp = 'none';
   try {
-    return httpsSetup.servedHostAllowlist(config);
+    const st = fs.statSync(path.join(httpsSetup.getCertsDir(), 'cert.pem'));
+    certStamp = `${st.mtimeMs}:${st.size}`;
+  } catch { /* no cert yet — a real state, and a stable cache key for it */ }
+
+  const key = `${config.publicDomain || ''}|${config.caddyTailnetHost || ''}|${certStamp}`;
+  if (_servedHostsCache && _servedHostsCache.key === key) return _servedHostsCache.value;
+
+  let value;
+  try {
+    value = httpsSetup.servedHostAllowlist(config);
   } catch (err) {
     log.warn('Could not compute the served-host allowlist; refusing named hosts', {
       error: err.message
     });
-    return new Set();
+    value = new Set();
   }
+  _servedHostsCache = { key, value };
+  return value;
 }
 
-function _setupRouteNeedingHostExemption(pathname, config) {
-  // `/api/config` is here because the wizard has TWO terminators: Finish posts
-  // `/api/setup/complete`, and Skip sends `PATCH /api/config { setupComplete:
-  // true }` (ADR 0009 point 2). Guarding one and not the other is the
-  // half-swept-family defect this repo keeps re-learning — remote Skip would
-  // 403 while remote Finish worked.
-  //
-  // Including a general settings route looks wide until you note WHERE this can
-  // apply: an install that is pre-setup and remotely reachable has no credential
-  // and no gate, so anyone who can reach it can already PATCH config directly.
-  // Rebinding buys an attacker nothing there that direct access does not. That
-  // is precisely why the three-axis form is safe and the two-axis one was not.
-  const isSetupSurface = pathname.startsWith('/api/setup/') || pathname === '/api/config';
-  if (!isSetupSurface) return false;
-  // A config that could not be read is not a reason to open the carve-out.
-  if (!config || config.setupComplete !== false) return false;
-  // Reachable from another machine at all? If not, there is no remote first run.
-  return bindPolicy.describeBindState(config).wide === true || config.ingressMode === 'caddy';
-}
-
-/**
- * Is `Host` a name this install actually serves?
- *
- * The cross-site guards ask the request to vouch for itself: `Sec-Fetch-Site`
- * is what the browser computed from the page's own origin, and the upgrade
- * guard compares `Origin` to the request's own `Host`. Both are satisfied by an
- * attacker who controls DNS — `evil.example` pointed at `127.0.0.1` is
- * `same-origin` as far as the browser knows, and reaches the ungated loopback
- * listener. This is the independent check (#864).
- *
- * Parsed via `URL`, never split on `':'`: a bracketed IPv6 `Host`
- * (`[fd7a:115c::1]:3102`) splits into `'['`, and Tailscale gives every node an
- * `fd7a:115c::/48` address, so splitting would refuse a normal way to reach
- * this product. Same reasoning as `_isSameOriginUpgrade`.
- *
- * A missing `Host` is refused: HTTP/1.1 requires it, and the callers only
- * consult this for state-changing requests and upgrades.
- *
- * @param {string|undefined} host - The `Host` header.
- * @param {Set<string>} [allowlist] - Override (tests); defaults to the live config.
- * @returns {boolean}
- */
 /**
  * Is this a first-run setup request the Host allowlist genuinely cannot cover?
  *
@@ -165,7 +151,62 @@ function _setupRouteNeedingHostExemption(pathname, config) {
  * no exemption, because it has no remote first run to protect.
  *
  * @param {string} pathname - Request path.
- * @param {object} [config] - Loaded config; read from the store when omitted.
+ * @param {object|null} config - Loaded config, or `null` when it could not be
+ *   read. `null` denies the exemption — it is never re-read here, because the
+ *   caller loads it once and shares it with the allowlist check.
+ * @returns {boolean}
+ */
+function _setupRouteNeedingHostExemption(pathname, config) {
+  // `/api/config` is here because the wizard has TWO terminators: Finish posts
+  // `/api/setup/complete`, and Skip sends `PATCH /api/config { setupComplete:
+  // true }` (ADR 0009 point 2). Guarding one and not the other is the
+  // half-swept-family defect this repo keeps re-learning — remote Skip would
+  // 403 while remote Finish worked.
+  //
+  // Including a general settings route looks wide until you note WHERE this can
+  // apply: an install that is pre-setup and remotely reachable has no credential
+  // and no gate, so anyone who can reach it can already PATCH config directly.
+  // Rebinding buys an attacker nothing there that direct access does not. That
+  // is precisely why the three-axis form is safe and the two-axis one was not.
+  const isSetupSurface = pathname.startsWith('/api/setup/') || pathname === '/api/config';
+  if (!isSetupSurface) return false;
+  // A config that could not be read is not a reason to open the carve-out.
+  if (!config || config.setupComplete !== false) return false;
+  // Is this socket reachable from another machine at all? If not, there is no
+  // remote first run, and the only request that can arrive here under an
+  // unserved Host is the rebound one.
+  //
+  // Caddy mode is deliberately NOT a second way to qualify, though it looks like
+  // one. `bindPolicy` refuses the wide opt-in in caddy mode, so the listener is
+  // loopback-only there too — Caddy holds the gate in front of it. A remote
+  // operator therefore reaches the wizard THROUGH Caddy, under the site name
+  // Caddy serves, which this allowlist already contains; while a rebound page
+  // reaches 127.0.0.1 directly, without traversing Caddy at all. Adding caddy
+  // mode would have exempted only the attack — the same defect as keying on
+  // `setupComplete` alone, in the other arm.
+  return bindPolicy.describeBindState(config).wide === true;
+}
+
+/**
+ * Is `Host` a name this install actually serves?
+ *
+ * The cross-site guards ask the request to vouch for itself: `Sec-Fetch-Site`
+ * is what the browser computed from the page's own origin, and the upgrade
+ * guard compares `Origin` to the request's own `Host`. Both are satisfied by an
+ * attacker who controls DNS — `evil.example` pointed at `127.0.0.1` is
+ * `same-origin` as far as the browser knows, and reaches the ungated loopback
+ * listener. This is the independent check (#864).
+ *
+ * Parsed via `URL`, never split on `':'`: a bracketed IPv6 `Host`
+ * (`[fd7a:115c::1]:3102`) splits into `'['`, and Tailscale gives every node an
+ * `fd7a:115c::/48` address, so splitting would refuse a normal way to reach
+ * this product. Same reasoning as `_isSameOriginUpgrade`.
+ *
+ * A missing `Host` is refused: HTTP/1.1 requires it, and the callers only
+ * consult this for state-changing requests and upgrades.
+ *
+ * @param {string|undefined} host - The `Host` header.
+ * @param {Set<string>} [allowlist] - Override (tests); defaults to the live config.
  * @returns {boolean}
  */
 function _hostIsAllowed(host, allowlist) {
@@ -6056,9 +6097,11 @@ if (require.main === module) {
       pid: process.pid,
       https: servingHttps,
       // #864 — the names state-changing requests and WebSocket upgrades are
-      // accepted under. Logged because this list is DERIVED (mkcert defaults +
-      // mDNS name + the two configured public names), and a derivation that
-      // misses a legitimate address refuses writes from it. That reads as "the
+      // accepted under. Logged because this list is DERIVED (from
+      // `certHostUnion` — the certificate's own names, the mkcert defaults, the
+      // mDNS name and the two configured public names — plus the bare machine
+      // name), and a derivation that misses a legitimate address refuses writes
+      // from it. That reads as "the
       // dashboard is broken" unless the operator can see what the server
       // believes it serves. Printing it costs one line and turns a silent
       // refusal into a diff against reality.

--- a/server.js
+++ b/server.js
@@ -158,8 +158,9 @@ function _servedHostsOrEmpty(config) {
  * the route that sets the admin credential.
  *
  * So the carve-out applies only where the flow it exists for is possible: the
- * socket is actually wide, or Caddy is in front. A loopback-only install gets
- * no exemption, because it has no remote first run to protect.
+ * socket is actually wide. A loopback-only install gets no exemption, because it
+ * has no remote first run to protect — and neither does caddy mode, which reads
+ * like a second qualifier and is not (see the reasoning at the return below).
  *
  * @param {string} pathname - Request path.
  * @param {object|null} config - Loaded config, or `null` when it could not be

--- a/server.js
+++ b/server.js
@@ -91,10 +91,20 @@ let _servedHostsCache = null;
  * reduces that warning to once per change of state, which is what it was
  * written to report.
  *
- * The key is what the answer actually depends on: the two configured names, and
- * the certificate's own mtime and size. A regenerated cert therefore invalidates
- * this without anyone having to remember to, which matters because
- * `POST /api/setup/generate-cert` can add names that live nowhere else.
+ * The key is every input the answer depends on: the two configured names, the
+ * machine's hostname, and the certificate's own mtime and size.
+ *
+ * The certificate term is the load-bearing one. `POST /api/setup/generate-cert`
+ * accepts a host list that lands in no config field, so the cert is those names'
+ * only record — key on the config alone and a freshly added SAN never enters the
+ * allowlist for the life of the process, producing exactly the "loads over a
+ * valid certificate, serves reads, refuses every write, kills every terminal
+ * upgrade" failure this list exists to prevent. A test rewrites the cert between
+ * two guarded requests to hold that.
+ *
+ * `os.hostname()` is in the key because both `certHostUnion` and
+ * `servedHostAllowlist` derive names from it; without it a machine renamed
+ * mid-run keeps answering to its old `.local` name until something else moves.
  *
  * An unreadable or malformed cert must not take a request down with it, so
  * failure yields an empty set: names all refused, while an IP-literal `Host`
@@ -111,7 +121,8 @@ function _servedHostsOrEmpty(config) {
     certStamp = `${st.mtimeMs}:${st.size}`;
   } catch { /* no cert yet — a real state, and a stable cache key for it */ }
 
-  const key = `${config.publicDomain || ''}|${config.caddyTailnetHost || ''}|${certStamp}`;
+  const key = `${config.publicDomain || ''}|${config.caddyTailnetHost || ''}`
+    + `|${os.hostname()}|${certStamp}`;
   if (_servedHostsCache && _servedHostsCache.key === key) return _servedHostsCache.value;
 
   let value;
@@ -6177,4 +6188,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { createServer, serverProtocol, warnUnbindablePortEnv, handleRequest, handleUpgrade, route, matchRoute, jsonResponse, errorResponse, parseBody, parseQuery, reqUrl, MAX_BODY_SIZE, _setRestartScheduler, _setCutoverSpawner, _openclawProxyHeaders, _openclawWsRequestLines, _hostIsAllowed };
+module.exports = { createServer, serverProtocol, warnUnbindablePortEnv, handleRequest, handleUpgrade, route, matchRoute, jsonResponse, errorResponse, parseBody, parseQuery, reqUrl, MAX_BODY_SIZE, _setRestartScheduler, _setCutoverSpawner, _openclawProxyHeaders, _openclawWsRequestLines, _hostIsAllowed, _servedHostsOrEmpty };

--- a/server.js
+++ b/server.js
@@ -44,6 +44,7 @@ const sidecar = require('./lib/sidecar');
 const openclawVersion = require('./lib/openclaw-version');
 const openclawDetect = require('./lib/openclaw-detect');
 const tunnelMonitor = require('./lib/tunnel-monitor');
+const net = require('node:net');
 const httpsSetup = require('./lib/https-setup');
 const caddy = require('./lib/caddy');
 const ingressProvision = require('./lib/ingress-provision');
@@ -66,6 +67,93 @@ const MAX_BODY_SIZE = 10 * 1024; // 10 KB
 // issues while merely navigating; any route that mutates behind a GET is a bug
 // in that route, not something to paper over here.
 const CSRF_UNSAFE_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+
+/**
+ * Is `Host` a name this install actually serves?
+ *
+ * The cross-site guards ask the request to vouch for itself: `Sec-Fetch-Site`
+ * is what the browser computed from the page's own origin, and the upgrade
+ * guard compares `Origin` to the request's own `Host`. Both are satisfied by an
+ * attacker who controls DNS — `evil.example` pointed at `127.0.0.1` is
+ * `same-origin` as far as the browser knows, and reaches the ungated loopback
+ * listener. This is the independent check (#864).
+ *
+ * Parsed via `URL`, never split on `':'`: a bracketed IPv6 `Host`
+ * (`[fd7a:115c::1]:3102`) splits into `'['`, and Tailscale gives every node an
+ * `fd7a:115c::/48` address, so splitting would refuse a normal way to reach
+ * this product. Same reasoning as `_isSameOriginUpgrade`.
+ *
+ * A missing `Host` is refused: HTTP/1.1 requires it, and the callers only
+ * consult this for state-changing requests and upgrades.
+ *
+ * @param {string|undefined} host - The `Host` header.
+ * @param {Set<string>} [allowlist] - Override (tests); defaults to the live config.
+ * @returns {boolean}
+ */
+/**
+ * Is this the first-run setup flow, which the Host allowlist cannot yet cover?
+ *
+ * Setup is what *configures* `publicDomain` / `caddyTailnetHost`, so during
+ * first run the install genuinely does not know the name a remote operator
+ * reached it by — the `Host` header is how it learns it, and the wizard names
+ * that address back so the operator knows where the gate will appear. Enforcing
+ * the allowlist here would 403 the documented remote first-run flow, which is
+ * the "reachable from another device" case this release exists to deliver.
+ *
+ * Deliberately the SMALLEST carve-out that works, on two axes at once: only the
+ * setup routes, and only while setup is unfinished. Every other state-changing
+ * route is guarded even before setup, and these routes rejoin the guard the
+ * moment `setupComplete` flips.
+ *
+ * The window it opens is real and bounded: on a fresh, network-reachable
+ * install an attacker who can rebind DNS *and* get the operator to load their
+ * page could complete setup with a credential of their choosing. That install
+ * has no credential and no gate yet — it is unprotected by construction until
+ * setup runs — so the guard begins protecting at exactly the point there is
+ * something to protect. Narrowing it further means giving the wizard another
+ * way to learn its own address (#864).
+ *
+ * @param {string} pathname - Request path.
+ * @returns {boolean}
+ */
+function _setupRouteBeforeSetupComplete(pathname) {
+  if (!pathname.startsWith('/api/setup/')) return false;
+  try {
+    return store.config.load().setupComplete === false;
+  } catch {
+    // An unreadable config is not a reason to open the carve-out.
+    return false;
+  }
+}
+
+function _hostIsAllowed(host, allowlist) {
+  if (!host) return false;
+  let name;
+  try {
+    name = new URL(`http://${host}`).hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+  // `URL` keeps IPv6 literals bracketed; unwrap before testing either branch.
+  if (name.startsWith('[') && name.endsWith(']')) name = name.slice(1, -1);
+
+  // An IP literal is always allowed, and this is the whole shape of the attack.
+  // Rebinding needs a NAME: the trick is to make a name the browser already
+  // trusts resolve somewhere else, and `Host` then carries that name. There is
+  // no DNS step for a literal — a request that reaches us same-origin as
+  // `192.168.1.50` or `[fd7a:115c::1]` means the browser really is talking to
+  // that address. A page hosted at a DIFFERENT address posting here yields
+  // `Origin` ≠ `Host`, which the two guards above already refuse.
+  //
+  // This also keeps the allowlist free of the machine's own interface
+  // addresses, which would otherwise have to be enumerated and would change
+  // with the network — a Tailscale node's `fd7a:115c::/48` address is a normal
+  // way to reach this product and appears in no config field.
+  if (net.isIP(name)) return true;
+
+  const allowed = allowlist || httpsSetup.servedHostAllowlist(store.config.load());
+  return allowed.has(name);
+}
 const CONTENT_TYPES = {
   '.html': 'text/html; charset=utf-8',
   '.css': 'text/css; charset=utf-8',
@@ -4492,6 +4580,24 @@ function handleUpgrade(req, socket, head) {
     return;
   }
 
+  // #864 — the check above only proves Origin and Host AGREE, which they do
+  // under DNS rebinding: both read `evil.example`, and the handshake proceeds
+  // to a `--writable` ttyd. Requiring the name to be one this install serves is
+  // what makes them agree on something true.
+  //
+  // Gated on `origin` for the same reason the check above is: a browser always
+  // sends it, a non-browser client (the OpenClaw CLI, scripts) does not and is
+  // not a cross-site vector. Without that gate this would refuse every
+  // headless consumer that reaches the socket by an address the allowlist has
+  // no way to know about.
+  if (origin && !_hostIsAllowed(req.headers.host)) {
+    log.warn('Refused WebSocket upgrade for an unserved Host', {
+      path: urlObj.pathname, origin, host: req.headers.host
+    });
+    socket.destroy();
+    return;
+  }
+
   // OpenClaw direct WebSocket proxy — /openclaw-direct/:connId/*
   if (urlObj.pathname.startsWith('/openclaw-direct/')) {
     const parts = urlObj.pathname.split('/'); // ['', 'openclaw-direct', connId, ...rest]
@@ -4720,6 +4826,26 @@ async function handleRequest(req, res) {
     log.warn('Refused cross-site state-changing request', { method, path: pathname });
     return errorResponse(res, 403,
       'Cross-site requests may not change server state.', 'CROSS_SITE_FORBIDDEN');
+  }
+
+  // #864 — the check above trusts the browser's own same-origin verdict, which
+  // an attacker controlling DNS can manufacture. Refuse a state-changing
+  // request that arrives under a name this install does not serve.
+  //
+  // Scoped to the unsafe methods ON PURPOSE, not applied to every request: an
+  // allowlist derived wrongly (a reverse proxy that rewrites Host, a container
+  // name, a LAN address nobody registered) then degrades to "reads still work,
+  // writes are refused with a named error" instead of taking the dashboard away
+  // from a remote operator entirely. Tightening to an outright refusal is a
+  // separate decision, to be made once the derivation has proven itself.
+  if (CSRF_UNSAFE_METHODS.has(method)
+      && !_setupRouteBeforeSetupComplete(pathname)
+      && !_hostIsAllowed(req.headers.host)) {
+    log.warn('Refused state-changing request for an unserved Host', {
+      method, path: pathname, host: req.headers.host
+    });
+    return errorResponse(res, 403,
+      'This server does not answer to that host name.', 'HOST_NOT_SERVED');
   }
 
   // API routes
@@ -5862,6 +5988,14 @@ if (require.main === module) {
       node: process.version,
       pid: process.pid,
       https: servingHttps,
+      // #864 — the names state-changing requests and WebSocket upgrades are
+      // accepted under. Logged because this list is DERIVED (mkcert defaults +
+      // mDNS name + the two configured public names), and a derivation that
+      // misses a legitimate address refuses writes from it. That reads as "the
+      // dashboard is broken" unless the operator can see what the server
+      // believes it serves. Printing it costs one line and turns a silent
+      // refusal into a diff against reality.
+      servedHosts: [...httpsSetup.servedHostAllowlist(config)].sort().join(', '),
       // Surfaced only when intent and reality diverge, so the listen line
       // points back at the fallback WARN logged during construction rather
       // than leaving the operator to notice the mismatch themselves.
@@ -5933,4 +6067,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { createServer, serverProtocol, warnUnbindablePortEnv, handleRequest, handleUpgrade, route, matchRoute, jsonResponse, errorResponse, parseBody, parseQuery, reqUrl, MAX_BODY_SIZE, _setRestartScheduler, _setCutoverSpawner, _openclawProxyHeaders, _openclawWsRequestLines };
+module.exports = { createServer, serverProtocol, warnUnbindablePortEnv, handleRequest, handleUpgrade, route, matchRoute, jsonResponse, errorResponse, parseBody, parseQuery, reqUrl, MAX_BODY_SIZE, _setRestartScheduler, _setCutoverSpawner, _openclawProxyHeaders, _openclawWsRequestLines, _hostIsAllowed };

--- a/server.js
+++ b/server.js
@@ -69,6 +69,57 @@ const MAX_BODY_SIZE = 10 * 1024; // 10 KB
 const CSRF_UNSAFE_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
 
 /**
+ * Load config, or `null` if it cannot be read. Both Host-guard callers fail
+ * closed on `null` rather than letting a corrupt config throw out of a request.
+ * @returns {object|null}
+ */
+function _loadConfigOrNull() {
+  try { return store.config.load(); } catch { return null; }
+}
+
+/**
+ * The served-name allowlist, or an empty set if it cannot be computed.
+ *
+ * `servedHostAllowlist` reads the certificate to carry its names forward, so an
+ * unreadable or malformed cert must not take a request down with it. Empty
+ * fails closed for NAMES; an IP-literal `Host` still passes inside
+ * `_hostIsAllowed` on its own reasoning, which does not depend on this list.
+ *
+ * @param {object} config - Loaded config.
+ * @returns {Set<string>}
+ */
+function _servedHostsOrEmpty(config) {
+  try {
+    return httpsSetup.servedHostAllowlist(config);
+  } catch (err) {
+    log.warn('Could not compute the served-host allowlist; refusing named hosts', {
+      error: err.message
+    });
+    return new Set();
+  }
+}
+
+function _setupRouteNeedingHostExemption(pathname, config) {
+  // `/api/config` is here because the wizard has TWO terminators: Finish posts
+  // `/api/setup/complete`, and Skip sends `PATCH /api/config { setupComplete:
+  // true }` (ADR 0009 point 2). Guarding one and not the other is the
+  // half-swept-family defect this repo keeps re-learning — remote Skip would
+  // 403 while remote Finish worked.
+  //
+  // Including a general settings route looks wide until you note WHERE this can
+  // apply: an install that is pre-setup and remotely reachable has no credential
+  // and no gate, so anyone who can reach it can already PATCH config directly.
+  // Rebinding buys an attacker nothing there that direct access does not. That
+  // is precisely why the three-axis form is safe and the two-axis one was not.
+  const isSetupSurface = pathname.startsWith('/api/setup/') || pathname === '/api/config';
+  if (!isSetupSurface) return false;
+  // A config that could not be read is not a reason to open the carve-out.
+  if (!config || config.setupComplete !== false) return false;
+  // Reachable from another machine at all? If not, there is no remote first run.
+  return bindPolicy.describeBindState(config).wide === true || config.ingressMode === 'caddy';
+}
+
+/**
  * Is `Host` a name this install actually serves?
  *
  * The cross-site guards ask the request to vouch for itself: `Sec-Fetch-Site`
@@ -91,41 +142,32 @@ const CSRF_UNSAFE_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
  * @returns {boolean}
  */
 /**
- * Is this the first-run setup flow, which the Host allowlist cannot yet cover?
+ * Is this a first-run setup request the Host allowlist genuinely cannot cover?
  *
- * Setup is what *configures* `publicDomain` / `caddyTailnetHost`, so during
- * first run the install genuinely does not know the name a remote operator
- * reached it by — the `Host` header is how it learns it, and the wizard names
- * that address back so the operator knows where the gate will appear. Enforcing
- * the allowlist here would 403 the documented remote first-run flow, which is
- * the "reachable from another device" case this release exists to deliver.
+ * Setup is what *configures* `publicDomain` / `caddyTailnetHost`, so on an
+ * install a remote operator can actually reach, first run is the one moment the
+ * allowlist cannot contain the address they arrived by — the `Host` header is
+ * how the install learns it, and the wizard names that address back so the
+ * operator knows where the gate will appear.
  *
- * Deliberately the SMALLEST carve-out that works, on two axes at once: only the
- * setup routes, and only while setup is unfinished. Every other state-changing
- * route is guarded even before setup, and these routes rejoin the guard the
- * moment `setupComplete` flips.
+ * **Bounded on three axes, and the third is the one that matters.** An earlier
+ * version stopped at "a setup route, before `setupComplete`", reasoning that a
+ * fresh install is unprotected anyway. That reasoning was wrong: the default
+ * config is `bindAllInterfaces: false` with `ingressMode: 'direct'`, so the
+ * default install binds loopback only and **no remote operator can reach the
+ * wizard at all**. On that population the exemption protected no real flow, and
+ * the only request that could arrive at a setup route under an unserved `Host`
+ * was the rebound one — handing back exactly the attack this guard closes, on
+ * the route that sets the admin credential.
  *
- * The window it opens is real and bounded: on a fresh, network-reachable
- * install an attacker who can rebind DNS *and* get the operator to load their
- * page could complete setup with a credential of their choosing. That install
- * has no credential and no gate yet — it is unprotected by construction until
- * setup runs — so the guard begins protecting at exactly the point there is
- * something to protect. Narrowing it further means giving the wizard another
- * way to learn its own address (#864).
+ * So the carve-out applies only where the flow it exists for is possible: the
+ * socket is actually wide, or Caddy is in front. A loopback-only install gets
+ * no exemption, because it has no remote first run to protect.
  *
  * @param {string} pathname - Request path.
+ * @param {object} [config] - Loaded config; read from the store when omitted.
  * @returns {boolean}
  */
-function _setupRouteBeforeSetupComplete(pathname) {
-  if (!pathname.startsWith('/api/setup/')) return false;
-  try {
-    return store.config.load().setupComplete === false;
-  } catch {
-    // An unreadable config is not a reason to open the carve-out.
-    return false;
-  }
-}
-
 function _hostIsAllowed(host, allowlist) {
   if (!host) return false;
   let name;
@@ -4590,12 +4632,20 @@ function handleUpgrade(req, socket, head) {
   // not a cross-site vector. Without that gate this would refuse every
   // headless consumer that reaches the socket by an address the allowlist has
   // no way to know about.
-  if (origin && !_hostIsAllowed(req.headers.host)) {
-    log.warn('Refused WebSocket upgrade for an unserved Host', {
-      path: urlObj.pathname, origin, host: req.headers.host
-    });
-    socket.destroy();
-    return;
+  if (origin) {
+    const wsCfg = _loadConfigOrNull();
+    const wsAllowlist = wsCfg ? _servedHostsOrEmpty(wsCfg) : new Set();
+    // No setup carve-out here on purpose: the wizard completes over HTTP, and
+    // nothing in first run opens a terminal socket. An exemption would be dead
+    // code guarding the route with the worst payoff — `/terminal/*` proxies to
+    // a `--writable` ttyd.
+    if (!_hostIsAllowed(req.headers.host, wsAllowlist)) {
+      log.warn('Refused WebSocket upgrade for an unserved Host', {
+        path: urlObj.pathname, origin, host: req.headers.host
+      });
+      socket.destroy();
+      return;
+    }
   }
 
   // OpenClaw direct WebSocket proxy — /openclaw-direct/:connId/*
@@ -4838,14 +4888,31 @@ async function handleRequest(req, res) {
   // writes are refused with a named error" instead of taking the dashboard away
   // from a remote operator entirely. Tightening to an outright refusal is a
   // separate decision, to be made once the derivation has proven itself.
-  if (CSRF_UNSAFE_METHODS.has(method)
-      && !_setupRouteBeforeSetupComplete(pathname)
-      && !_hostIsAllowed(req.headers.host)) {
-    log.warn('Refused state-changing request for an unserved Host', {
-      method, path: pathname, host: req.headers.host
-    });
-    return errorResponse(res, 403,
-      'This server does not answer to that host name.', 'HOST_NOT_SERVED');
+  // Applied only to requests that look like they came from a browser, matching
+  // the contract both sibling guards state explicitly: `curl`, scripts and the
+  // agent-facing API in the project guide send neither header and are not a
+  // cross-site vector, so they keep working under any `Host` (a container name,
+  // a proxy rewrite). This costs the guard nothing — a rebound page IS a
+  // browser, and a browser cannot suppress `Sec-Fetch-Site` from script, so the
+  // attack always carries the marker that brings it back into scope.
+  const looksLikeBrowser = req.headers['sec-fetch-site'] !== undefined
+    || req.headers.origin !== undefined;
+  if (CSRF_UNSAFE_METHODS.has(method) && looksLikeBrowser) {
+    // ONE read of config, shared by both checks below. They used to load it
+    // separately and only one wrapped the call, so a corrupt config threw out
+    // of the request through the unguarded path instead of being refused.
+    // `null` here means "could not read it", which fails CLOSED: no exemption,
+    // and an empty name list (an IP-literal Host still passes on its own merit).
+    const cfg = _loadConfigOrNull();
+    const allowlist = cfg ? _servedHostsOrEmpty(cfg) : new Set();
+    if (!_setupRouteNeedingHostExemption(pathname, cfg)
+        && !_hostIsAllowed(req.headers.host, allowlist)) {
+      log.warn('Refused state-changing request for an unserved Host', {
+        method, path: pathname, host: req.headers.host
+      });
+      return errorResponse(res, 403,
+        'This server does not answer to that host name.', 'HOST_NOT_SERVED');
+    }
   }
 
   // API routes

--- a/test/https-setup.test.js
+++ b/test/https-setup.test.js
@@ -703,3 +703,56 @@ exit 1
     });
   });
 });
+
+/*
+ * #864 — the names a state-changing request or WebSocket upgrade is accepted
+ * under. Built from what the install is already configured to serve rather than
+ * a new setting, so it cannot drift from the certificate and the ingress config.
+ */
+describe('servedHostAllowlist (#864)', () => {
+  const { servedHostAllowlist } = require('../lib/https-setup');
+
+  it('always carries the mkcert defaults', () => {
+    const a = servedHostAllowlist({}, { hostname: 'studio' });
+    for (const h of ['localhost', '127.0.0.1', '::1']) {
+      assert.equal(a.has(h), true, `${h} must always be served`);
+    }
+  });
+
+  it('carries the mDNS name AND the bare machine name', () => {
+    // A browser sends whatever the operator typed, and the bare name resolves
+    // on many LANs without the suffix.
+    const a = servedHostAllowlist({}, { hostname: 'Studio.local' });
+    assert.equal(a.has('studio.local'), true);
+    assert.equal(a.has('studio'), true);
+  });
+
+  it('does not produce a doubled suffix from an already-.local hostname', () => {
+    const a = servedHostAllowlist({}, { hostname: 'Studio.local' });
+    assert.equal(a.has('studio.local.local'), false, 'the SAN bug, in allowlist form');
+  });
+
+  it('picks up both configured public names', () => {
+    const a = servedHostAllowlist(
+      { publicDomain: 'TC.example.com', caddyTailnetHost: 'Box.tail123.ts.net' },
+      { hostname: 'studio' }
+    );
+    assert.equal(a.has('tc.example.com'), true, 'lower-cased for comparison');
+    assert.equal(a.has('box.tail123.ts.net'), true);
+  });
+
+  it('degrades to the defaults when the machine has no usable hostname', () => {
+    const a = servedHostAllowlist(null, { hostname: null });
+    assert.deepEqual([...a].sort(), ['127.0.0.1', '::1', 'localhost']);
+  });
+
+  it('never contains an empty string, whatever the config holds', () => {
+    const a = servedHostAllowlist({ publicDomain: '   ', caddyTailnetHost: '' }, { hostname: '' });
+    assert.equal(a.has(''), false);
+  });
+
+  it('does not trust an arbitrary name', () => {
+    const a = servedHostAllowlist({ publicDomain: 'tc.example.com' }, { hostname: 'studio' });
+    assert.equal(a.has('evil.example'), false);
+  });
+});

--- a/test/https-setup.test.js
+++ b/test/https-setup.test.js
@@ -712,47 +712,65 @@ exit 1
 describe('servedHostAllowlist (#864)', () => {
   const { servedHostAllowlist } = require('../lib/https-setup');
 
-  it('always carries the mkcert defaults', () => {
-    const a = servedHostAllowlist({}, { hostname: 'studio' });
-    for (const h of ['localhost', '127.0.0.1', '::1']) {
-      assert.equal(a.has(h), true, `${h} must always be served`);
-    }
+  // `certHosts` stands in for `certHostUnion`, so these pin behaviour without
+  // minting a certificate or depending on whatever this machine happens to hold.
+  const CERT = ['localhost', '127.0.0.1', '::1'];
+
+  it('serves every name the certificate carries', () => {
+    const a = servedHostAllowlist({}, { hostname: 'studio', certHosts: CERT });
+    for (const h of CERT) assert.equal(a.has(h), true, `${h} is on the cert; it must be served`);
   });
 
-  it('carries the mDNS name AND the bare machine name', () => {
-    // A browser sends whatever the operator typed, and the bare name resolves
-    // on many LANs without the suffix.
-    const a = servedHostAllowlist({}, { hostname: 'Studio.local' });
+  it('serves an operator-added cert name that appears in NO config field', () => {
+    // The drift this derivation exists to prevent. `POST /api/setup/generate-cert`
+    // takes a caller-supplied hosts array that lands nowhere in config, and the
+    // cert is its own only record. A parallel allowlist built from config alone
+    // would load the dashboard over a valid cert, serve reads, then refuse every
+    // write and destroy every terminal upgrade.
+    const a = servedHostAllowlist({}, {
+      hostname: 'studio',
+      certHosts: [...CERT, 'box.tail123.ts.net']
+    });
+    assert.equal(a.has('box.tail123.ts.net'), true,
+      'a name only the certificate records must still be served');
+  });
+
+  it('adds the bare machine name, which a certificate has no reason to carry', () => {
+    const a = servedHostAllowlist({}, { hostname: 'Studio.local', certHosts: CERT });
     assert.equal(a.has('studio.local'), true);
-    assert.equal(a.has('studio'), true);
+    assert.equal(a.has('studio'), true, 'the short form resolves on many LANs');
   });
 
   it('does not produce a doubled suffix from an already-.local hostname', () => {
-    const a = servedHostAllowlist({}, { hostname: 'Studio.local' });
+    const a = servedHostAllowlist({}, { hostname: 'Studio.local', certHosts: CERT });
     assert.equal(a.has('studio.local.local'), false, 'the SAN bug, in allowlist form');
   });
 
-  it('picks up both configured public names', () => {
-    const a = servedHostAllowlist(
-      { publicDomain: 'TC.example.com', caddyTailnetHost: 'Box.tail123.ts.net' },
-      { hostname: 'studio' }
-    );
-    assert.equal(a.has('tc.example.com'), true, 'lower-cased for comparison');
-    assert.equal(a.has('box.tail123.ts.net'), true);
+  it('lower-cases everything, because host comparison is case-insensitive', () => {
+    const a = servedHostAllowlist({}, { hostname: 'studio', certHosts: [...CERT, 'TC.Example.COM'] });
+    assert.equal(a.has('tc.example.com'), true);
   });
 
-  it('degrades to the defaults when the machine has no usable hostname', () => {
-    const a = servedHostAllowlist(null, { hostname: null });
+  it('degrades to exactly the cert names when the machine has no usable hostname', () => {
+    const a = servedHostAllowlist(null, { hostname: null, certHosts: CERT });
     assert.deepEqual([...a].sort(), ['127.0.0.1', '::1', 'localhost']);
   });
 
-  it('never contains an empty string, whatever the config holds', () => {
-    const a = servedHostAllowlist({ publicDomain: '   ', caddyTailnetHost: '' }, { hostname: '' });
+  it('never contains an empty string, whatever it is handed', () => {
+    const a = servedHostAllowlist({}, { hostname: '', certHosts: [...CERT, '   ', ''] });
     assert.equal(a.has(''), false);
   });
 
   it('does not trust an arbitrary name', () => {
-    const a = servedHostAllowlist({ publicDomain: 'tc.example.com' }, { hostname: 'studio' });
+    const a = servedHostAllowlist({}, { hostname: 'studio', certHosts: CERT });
     assert.equal(a.has('evil.example'), false);
+  });
+
+  it('reads the real certHostUnion when no override is given', () => {
+    // Pins the WIRING, not the cert: without this, the override could be the
+    // only path anything ever exercises.
+    const a = servedHostAllowlist({ publicDomain: 'tc.example.com' }, { hostname: 'studio' });
+    assert.equal(a.has('tc.example.com'), true, 'publicDomain reaches the list via certHostUnion');
+    assert.equal(a.has('localhost'), true);
   });
 });

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -4,7 +4,7 @@ const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
 const {
   matchRoute, route, parseQuery, reqUrl, handleUpgrade, handleRequest,
-  _openclawProxyHeaders, _openclawWsRequestLines
+  _openclawProxyHeaders, _openclawWsRequestLines, _hostIsAllowed
 } = require('../server');
 
 describe('server', () => {
@@ -205,6 +205,117 @@ describe('server', () => {
         });
       }
 
+      /*
+       * #864 — the Sec-Fetch-Site check above trusts the browser's own verdict,
+       * and under DNS rebinding the browser honestly reports `same-origin`: the
+       * page really is on `evil.example`, which really does resolve to
+       * 127.0.0.1. Nothing is forged, so nothing above catches it. The Host
+       * allowlist is the independent fact the guard checks against.
+       */
+      describe('#864 — Host allowlist (DNS rebinding)', () => {
+        it('refuses a state-changing request under a rebound name, with no Sec-Fetch-Site at all', async () => {
+          const res = await send('POST', '/api/auth/credential', { host: 'evil.example:3102' });
+          assert.equal(res.statusCode, 403);
+          assert.match(res.body, /HOST_NOT_SERVED/,
+            'this is the rebinding path — the cross-site guard cannot see it');
+        });
+
+        it('a rebound name reporting same-origin is still refused', async () => {
+          // Precisely what the browser sends when the attack works.
+          const res = await send('POST', '/api/config', {
+            host: 'evil.example:3102', 'sec-fetch-site': 'same-origin'
+          });
+          assert.equal(res.statusCode, 403);
+          assert.match(res.body, /HOST_NOT_SERVED/);
+        });
+
+        it('does NOT refuse a GET under an unserved Host — reads stay working', async () => {
+          // The deliberate scope. A wrongly-derived allowlist (a proxy that
+          // rewrites Host, a container name) must degrade to "writes refused",
+          // never "the dashboard is gone" for a remote operator.
+          const res = await send('GET', '/api/health', { host: 'weird-proxy-name:3102' });
+          assert.notEqual(res.statusCode, 403,
+            'refusing reads too would take the dashboard away on a bad derivation');
+        });
+
+        it('allows the served host it was already using', async () => {
+          const res = await send('POST', '/api/config', { host: 'localhost:3102' });
+          assert.notEqual(res.statusCode, 403, 'localhost must never be refused');
+        });
+
+        for (const [label, host] of [
+          ['a bracketed IPv6 tailnet address', '[::1]:3102'],
+          ['a bare loopback IP', '127.0.0.1:3102']
+        ]) {
+          it(`allows ${label} — it is the machine, not a name that can be rebound`, async () => {
+            const res = await send('POST', '/api/config', { host });
+            assert.notEqual(res.statusCode, 403, `${host} must be allowed`);
+          });
+        }
+
+        it('allows ANY IP literal, not just this machine\'s — an IP cannot be rebound', async () => {
+          // The design decision, stated so it is a contract. Rebinding needs a
+          // NAME to point somewhere else; a literal has no DNS step. A page on
+          // a different address posting here yields Origin != Host, which the
+          // two guards above already refuse — so narrowing this to "IPs we
+          // hold" would buy nothing and would require enumerating interface
+          // addresses that change with the network.
+          const res = await send('POST', '/api/config', { host: '10.11.12.13:3102' });
+          assert.notEqual(res.statusCode, 403,
+            'an IP-literal Host is not a rebinding vector; cross-origin is caught above');
+        });
+
+        /*
+         * The setup carve-out. Setup CONFIGURES the public names, so during
+         * first run the allowlist cannot contain the address a remote operator
+         * arrived by — the Host header is how the install learns it. Bounded on
+         * two axes, and both are pinned here: only /api/setup/*, and only while
+         * setupComplete is false.
+         */
+        describe('first-run setup carve-out', () => {
+          it('does not exempt a non-setup route, even before setup completes', async () => {
+            const res = await send('POST', '/api/config', { host: 'evil.example:3102' });
+            assert.equal(res.statusCode, 403,
+              'the carve-out is for the routes that cannot know the name, not for everything');
+            assert.match(res.body, /HOST_NOT_SERVED/);
+          });
+
+          it('does not exempt a setup-PREFIXED path outside the namespace', async () => {
+            // `/api/setupsomething` starts with the same letters; the check is
+            // on the `/api/setup/` path segment, not a bare prefix match.
+            const res = await send('POST', '/api/setupsomething', { host: 'evil.example:3102' });
+            assert.equal(res.statusCode, 403);
+            assert.match(res.body, /HOST_NOT_SERVED/);
+          });
+        });
+
+        it('refuses a state-changing request with no Host header at all', async () => {
+          const res = await send('POST', '/api/config', { host: undefined });
+          assert.equal(res.statusCode, 403, 'HTTP/1.1 requires Host; absent is not a pass');
+          assert.match(res.body, /HOST_NOT_SERVED/);
+        });
+
+        describe('_hostIsAllowed', () => {
+          const allow = new Set(['localhost', 'studio.local', 'fd7a:115c::1']);
+          it('compares the parsed hostname, never a split on ":"', () => {
+            assert.equal(_hostIsAllowed('[fd7a:115c::1]:3102', allow), true,
+              'splitting a bracketed IPv6 Host on ":" yields "[" and refuses every tailnet request');
+          });
+          it('ignores the port', () => {
+            assert.equal(_hostIsAllowed('studio.local:8443', allow), true);
+          });
+          it('is case-insensitive, as host names are', () => {
+            assert.equal(_hostIsAllowed('STUDIO.local', allow), true);
+          });
+          it('refuses an unparseable Host rather than waving it through', () => {
+            assert.equal(_hostIsAllowed('http://not a host', allow), false);
+          });
+          it('refuses a name outside the list', () => {
+            assert.equal(_hostIsAllowed('evil.example', allow), false);
+          });
+        });
+      });
+
       // The first version of this guard lived inside the `/api/` branch, which
       // left these open — and they are the worse half. `_openclawProxyHeaders`
       // rewrites origin/referer to the local origin and attaches
@@ -241,6 +352,26 @@ describe('server', () => {
           } catch { /* downstream proxy setup is not what this asserts */ }
           return { destroyed: socket.destroyed };
         }
+
+        /*
+         * #864 — DNS rebinding. Both guards above decide "is this cross-site?"
+         * relative to the request itself, so an attacker who controls DNS
+         * satisfies them: point `evil.example` at 127.0.0.1, get the operator to
+         * load it, and the browser reports same-origin because as far as it
+         * knows it IS. Origin and Host agree — on a lie. The fix is to require
+         * the name be one this install actually serves.
+         */
+        it('destroys the rebinding upgrade: Origin and Host AGREE, on a name we do not serve', () => {
+          const r = upgrade({ host: 'evil.example:3102', origin: 'http://evil.example:3102' });
+          assert.equal(r.destroyed, true,
+            'agreeing with itself is not proof — /terminal/* proxies to a --writable ttyd');
+        });
+
+        it('still allows a no-Origin client under an unserved Host (not a browser, not a vector)', () => {
+          const r = upgrade({ host: 'container-internal:3102' });
+          assert.equal(r.destroyed, false,
+            'headless consumers reach the socket by names no allowlist can know');
+        });
 
         it('destroys an upgrade whose Origin is another site', () => {
           const r = upgrade({ host: 'localhost:3102', origin: 'https://evil.example' });

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -213,93 +213,81 @@ describe('server', () => {
        * allowlist is the independent fact the guard checks against.
        */
       describe('#864 — Host allowlist (DNS rebinding)', () => {
-        it('refuses a state-changing request under a rebound name, with no Sec-Fetch-Site at all', async () => {
-          const res = await send('POST', '/api/auth/credential', { host: 'evil.example:3102' });
+        // A rebound page IS a browser, so it always carries `Sec-Fetch-Site`,
+        // and it reports `same-origin` because as far as the browser knows it
+        // is: the page really is on evil.example, which really does resolve to
+        // 127.0.0.1. Nothing is forged, so nothing in the cross-site guard
+        // above catches it. These send that header for that reason — not as
+        // scaffolding.
+        const BROWSER = { 'sec-fetch-site': 'same-origin' };
+
+        it('refuses a state-changing request under a rebound name', async () => {
+          const res = await send('POST', '/api/auth/credential',
+            { host: 'evil.example:3102', ...BROWSER });
           assert.equal(res.statusCode, 403);
           assert.match(res.body, /HOST_NOT_SERVED/,
-            'this is the rebinding path — the cross-site guard cannot see it');
-        });
-
-        it('a rebound name reporting same-origin is still refused', async () => {
-          // Precisely what the browser sends when the attack works.
-          const res = await send('POST', '/api/config', {
-            host: 'evil.example:3102', 'sec-fetch-site': 'same-origin'
-          });
-          assert.equal(res.statusCode, 403);
-          assert.match(res.body, /HOST_NOT_SERVED/);
+            'the cross-site guard cannot see this — the browser is telling the truth');
         });
 
         it('does NOT refuse a GET under an unserved Host — reads stay working', async () => {
           // The deliberate scope. A wrongly-derived allowlist (a proxy that
           // rewrites Host, a container name) must degrade to "writes refused",
           // never "the dashboard is gone" for a remote operator.
-          const res = await send('GET', '/api/health', { host: 'weird-proxy-name:3102' });
+          const res = await send('GET', '/api/health', { host: 'weird-proxy-name:3102', ...BROWSER });
           assert.notEqual(res.statusCode, 403,
             'refusing reads too would take the dashboard away on a bad derivation');
         });
 
+        it('does NOT refuse a header-less client under any Host — curl, scripts, the agent API', async () => {
+          // The same exemption both sibling guards state explicitly. Costs the
+          // guard nothing: a browser cannot suppress Sec-Fetch-Site from
+          // script, so the attack always carries the marker that scopes it in.
+          const res = await send('POST', '/api/config', { host: 'container-internal:3102' });
+          assert.notEqual(res.statusCode, 403,
+            'a header-less caller is not a cross-site vector and must keep working');
+        });
+
         it('allows the served host it was already using', async () => {
-          const res = await send('POST', '/api/config', { host: 'localhost:3102' });
+          const res = await send('POST', '/api/config', { host: 'localhost:3102', ...BROWSER });
           assert.notEqual(res.statusCode, 403, 'localhost must never be refused');
         });
 
         for (const [label, host] of [
-          ['a bracketed IPv6 tailnet address', '[::1]:3102'],
-          ['a bare loopback IP', '127.0.0.1:3102']
+          ['a bracketed IPv6 address', '[::1]:3102'],
+          ['a bare loopback IP', '127.0.0.1:3102'],
+          ['ANY IP literal, not just ours', '10.11.12.13:3102']
         ]) {
-          it(`allows ${label} — it is the machine, not a name that can be rebound`, async () => {
-            const res = await send('POST', '/api/config', { host });
+          it(`allows ${label} — an IP cannot be rebound`, async () => {
+            // Rebinding needs a NAME to point somewhere else; a literal has no
+            // DNS step. A page at a different address posting here yields
+            // Origin != Host, which the guards above already refuse — so
+            // narrowing this would buy nothing and would require enumerating
+            // interface addresses that change with the network.
+            const res = await send('POST', '/api/config', { host, ...BROWSER });
             assert.notEqual(res.statusCode, 403, `${host} must be allowed`);
           });
         }
 
-        it('allows ANY IP literal, not just this machine\'s — an IP cannot be rebound', async () => {
-          // The design decision, stated so it is a contract. Rebinding needs a
-          // NAME to point somewhere else; a literal has no DNS step. A page on
-          // a different address posting here yields Origin != Host, which the
-          // two guards above already refuse — so narrowing this to "IPs we
-          // hold" would buy nothing and would require enumerating interface
-          // addresses that change with the network.
-          const res = await send('POST', '/api/config', { host: '10.11.12.13:3102' });
-          assert.notEqual(res.statusCode, 403,
-            'an IP-literal Host is not a rebinding vector; cross-origin is caught above');
-        });
-
-        /*
-         * The setup carve-out. Setup CONFIGURES the public names, so during
-         * first run the allowlist cannot contain the address a remote operator
-         * arrived by — the Host header is how the install learns it. Bounded on
-         * two axes, and both are pinned here: only /api/setup/*, and only while
-         * setupComplete is false.
-         */
-        describe('first-run setup carve-out', () => {
-          it('does not exempt a non-setup route, even before setup completes', async () => {
-            const res = await send('POST', '/api/config', { host: 'evil.example:3102' });
-            assert.equal(res.statusCode, 403,
-              'the carve-out is for the routes that cannot know the name, not for everything');
-            assert.match(res.body, /HOST_NOT_SERVED/);
-          });
-
-          it('does not exempt a setup-PREFIXED path outside the namespace', async () => {
-            // `/api/setupsomething` starts with the same letters; the check is
-            // on the `/api/setup/` path segment, not a bare prefix match.
-            const res = await send('POST', '/api/setupsomething', { host: 'evil.example:3102' });
-            assert.equal(res.statusCode, 403);
-            assert.match(res.body, /HOST_NOT_SERVED/);
-          });
-        });
-
-        it('refuses a state-changing request with no Host header at all', async () => {
-          const res = await send('POST', '/api/config', { host: undefined });
+        it('refuses a state-changing browser request with no Host header at all', async () => {
+          const res = await send('POST', '/api/config', { host: undefined, ...BROWSER });
           assert.equal(res.statusCode, 403, 'HTTP/1.1 requires Host; absent is not a pass');
           assert.match(res.body, /HOST_NOT_SERVED/);
         });
 
+        it('does not exempt a setup-PREFIXED path outside the namespace', async () => {
+          // `/api/setupsomething` shares the letters; the carve-out is on the
+          // `/api/setup/` path segment, not a bare prefix match.
+          const res = await send('POST', '/api/setupsomething',
+            { host: 'evil.example:3102', ...BROWSER });
+          assert.equal(res.statusCode, 403);
+          assert.match(res.body, /HOST_NOT_SERVED/);
+        });
+
         describe('_hostIsAllowed', () => {
-          const allow = new Set(['localhost', 'studio.local', 'fd7a:115c::1']);
+          const allow = new Set(['localhost', 'studio.local', 'box.tail123.ts.net']);
           it('compares the parsed hostname, never a split on ":"', () => {
-            assert.equal(_hostIsAllowed('[fd7a:115c::1]:3102', allow), true,
-              'splitting a bracketed IPv6 Host on ":" yields "[" and refuses every tailnet request');
+            assert.equal(_hostIsAllowed('[::1]:3102', allow), true,
+              'splitting a bracketed IPv6 Host on ":" yields "[" and refuses every such request');
           });
           it('ignores the port', () => {
             assert.equal(_hostIsAllowed('studio.local:8443', allow), true);
@@ -308,10 +296,22 @@ describe('server', () => {
             assert.equal(_hostIsAllowed('STUDIO.local', allow), true);
           });
           it('refuses an unparseable Host rather than waving it through', () => {
-            assert.equal(_hostIsAllowed('http://not a host', allow), false);
+            // A bare space cannot appear in a URL authority, so this reaches the
+            // catch — verified by the assertion below being unreachable otherwise.
+            assert.equal(_hostIsAllowed('a b', allow), false);
+          });
+          it('refuses an empty Host', () => {
+            assert.equal(_hostIsAllowed('', allow), false);
           });
           it('refuses a name outside the list', () => {
             assert.equal(_hostIsAllowed('evil.example', allow), false);
+          });
+          it('allows an IP literal even against an EMPTY list — the fail-closed path', () => {
+            // When the allowlist cannot be computed the caller passes an empty
+            // set. Names are then all refused, but an IP is allowed on its own
+            // reasoning, which does not depend on the list.
+            assert.equal(_hostIsAllowed('127.0.0.1:3102', new Set()), true);
+            assert.equal(_hostIsAllowed('evil.example', new Set()), false);
           });
         });
       });

--- a/test/setup-provisioning.test.js
+++ b/test/setup-provisioning.test.js
@@ -25,6 +25,7 @@ const store = require('../lib/store');
 const caddy = require('../lib/caddy');
 const provision = require('../lib/ingress-provision');
 const { createServer, _setRestartScheduler, _setCutoverSpawner } = require('../server');
+const server864 = require('../server');
 const { installCaddyStub, withoutCaddy } = require('./_caddy-stub');
 
 setLevel('error');
@@ -306,7 +307,46 @@ describe('setup provisions a login by default', () => {
         assert.match(res.raw, /HOST_NOT_SERVED/);
       });
 
-      it('does NOT exempt caddy mode — Caddy fronts a loopback socket a rebound page bypasses', async () => {
+      /*
+     * #864 — the allowlist is cached because computing it parses the
+     * certificate, and the cache's certificate term is load-bearing: a SAN
+     * added by `POST /api/setup/generate-cert` lands in NO config field, so the
+     * cert is its only record. Key on config alone and a freshly added name
+     * never enters the allowlist for the life of the process — the exact
+     * failure the derivation exists to prevent.
+     */
+    describe('#864 — the served-host cache invalidates on the certificate', () => {
+      it('recomputes when cert.pem changes, not just when config does', () => {
+        const httpsSetup = require('../lib/https-setup');
+        const certsDir = httpsSetup.getCertsDir();
+        fs.mkdirSync(certsDir, { recursive: true });
+        const certPath = path.join(certsDir, 'cert.pem');
+
+        const realFn = httpsSetup.servedHostAllowlist;
+        let calls = 0;
+        httpsSetup.servedHostAllowlist = () => { calls += 1; return new Set(['localhost']); };
+        try {
+          const cfg = store.config.load();
+          fs.writeFileSync(certPath, 'FIRST');
+          server864._servedHostsOrEmpty(cfg);
+          const afterFirst = calls;
+          server864._servedHostsOrEmpty(cfg);
+          assert.equal(calls, afterFirst, 'an unchanged cert must be served from cache');
+
+          // Rewrite with a DIFFERENT length so the key moves even if the
+          // filesystem's mtime resolution rounds two fast writes together.
+          fs.writeFileSync(certPath, 'SECOND-AND-LONGER');
+          server864._servedHostsOrEmpty(cfg);
+          assert.equal(calls, afterFirst + 1,
+            'a regenerated certificate must invalidate the cache — its SANs live nowhere else');
+        } finally {
+          httpsSetup.servedHostAllowlist = realFn;
+          fs.rmSync(certPath, { force: true });
+        }
+      });
+    });
+
+    it('does NOT exempt caddy mode — Caddy fronts a loopback socket a rebound page bypasses', async () => {
         // Caddy mode looks like "remotely reachable", and an earlier version
         // treated it as a second way to qualify. But bindPolicy REFUSES the wide
         // opt-in in caddy mode, so the listener is loopback-only there too; a

--- a/test/setup-provisioning.test.js
+++ b/test/setup-provisioning.test.js
@@ -366,7 +366,8 @@ describe('setup provisions a login by default', () => {
      */
     describe('#864 — the served-host cache invalidates on the certificate', () => {
       it('recomputes when a configured public name changes — the terms the record claimed', () => {
-        // publicDomain and caddyTailnetHost are PATCHable on a running server,
+        // Both are written on a RUNNING server — publicDomain via
+        // PATCH /api/config, caddyTailnetHost by the Caddyfile-adoption path —
         // so a stale memo would refuse writes and terminal upgrades under the
         // very name the operator had just configured, until a restart. The code
         // keys on them correctly; nothing moved them, and the change-log then

--- a/test/setup-provisioning.test.js
+++ b/test/setup-provisioning.test.js
@@ -307,46 +307,7 @@ describe('setup provisions a login by default', () => {
         assert.match(res.raw, /HOST_NOT_SERVED/);
       });
 
-      /*
-     * #864 — the allowlist is cached because computing it parses the
-     * certificate, and the cache's certificate term is load-bearing: a SAN
-     * added by `POST /api/setup/generate-cert` lands in NO config field, so the
-     * cert is its only record. Key on config alone and a freshly added name
-     * never enters the allowlist for the life of the process — the exact
-     * failure the derivation exists to prevent.
-     */
-    describe('#864 — the served-host cache invalidates on the certificate', () => {
-      it('recomputes when cert.pem changes, not just when config does', () => {
-        const httpsSetup = require('../lib/https-setup');
-        const certsDir = httpsSetup.getCertsDir();
-        fs.mkdirSync(certsDir, { recursive: true });
-        const certPath = path.join(certsDir, 'cert.pem');
-
-        const realFn = httpsSetup.servedHostAllowlist;
-        let calls = 0;
-        httpsSetup.servedHostAllowlist = () => { calls += 1; return new Set(['localhost']); };
-        try {
-          const cfg = store.config.load();
-          fs.writeFileSync(certPath, 'FIRST');
-          server864._servedHostsOrEmpty(cfg);
-          const afterFirst = calls;
-          server864._servedHostsOrEmpty(cfg);
-          assert.equal(calls, afterFirst, 'an unchanged cert must be served from cache');
-
-          // Rewrite with a DIFFERENT length so the key moves even if the
-          // filesystem's mtime resolution rounds two fast writes together.
-          fs.writeFileSync(certPath, 'SECOND-AND-LONGER');
-          server864._servedHostsOrEmpty(cfg);
-          assert.equal(calls, afterFirst + 1,
-            'a regenerated certificate must invalidate the cache — its SANs live nowhere else');
-        } finally {
-          httpsSetup.servedHostAllowlist = realFn;
-          fs.rmSync(certPath, { force: true });
-        }
-      });
-    });
-
-    it('does NOT exempt caddy mode — Caddy fronts a loopback socket a rebound page bypasses', async () => {
+      it('does NOT exempt caddy mode — Caddy fronts a loopback socket a rebound page bypasses', async () => {
         // Caddy mode looks like "remotely reachable", and an earlier version
         // treated it as a second way to qualify. But bindPolicy REFUSES the wide
         // opt-in in caddy mode, so the listener is loopback-only there too; a
@@ -392,6 +353,75 @@ describe('setup provisions a login by default', () => {
         assert.equal(res.status, 400);
         assert.match(res.raw, /ADMIN_REQUIRED/,
           'reaching the eyes-open guard is proof the carve-out let it through');
+      });
+    });
+
+      /*
+     * #864 — the allowlist is cached because computing it parses the
+     * certificate, and the cache's certificate term is load-bearing: a SAN
+     * added by `POST /api/setup/generate-cert` lands in NO config field, so the
+     * cert is its only record. Key on config alone and a freshly added name
+     * never enters the allowlist for the life of the process — the exact
+     * failure the derivation exists to prevent.
+     */
+    describe('#864 — the served-host cache invalidates on the certificate', () => {
+      it('recomputes when the machine is renamed — the term nothing else moves', () => {
+        // Same mutation class as the certificate term, one term over. Both
+        // certHostUnion and servedHostAllowlist derive names from os.hostname(),
+        // so without it in the key a machine renamed mid-run keeps answering to
+        // its old .local name and refuses every write under its new one until a
+        // restart. The JSDoc calls the key complete; this is what makes that true.
+        const os = require('node:os');
+        const httpsSetup = require('../lib/https-setup');
+        const realFn = httpsSetup.servedHostAllowlist;
+        const realHostname = os.hostname;
+        let calls = 0;
+        httpsSetup.servedHostAllowlist = () => { calls += 1; return new Set(['localhost']); };
+        os.hostname = () => 'before-rename';
+        try {
+          const cfg = store.config.load();
+          server864._servedHostsOrEmpty(cfg);
+          const afterFirst = calls;
+          server864._servedHostsOrEmpty(cfg);
+          assert.equal(calls, afterFirst, 'an unchanged hostname must be served from cache');
+
+          os.hostname = () => 'after-rename';
+          server864._servedHostsOrEmpty(cfg);
+          assert.equal(calls, afterFirst + 1,
+            'a renamed machine must invalidate the cache — its names derive from the hostname');
+        } finally {
+          httpsSetup.servedHostAllowlist = realFn;
+          os.hostname = realHostname;
+        }
+      });
+
+      it('recomputes when cert.pem changes, not just when config does', () => {
+        const httpsSetup = require('../lib/https-setup');
+        const certsDir = httpsSetup.getCertsDir();
+        fs.mkdirSync(certsDir, { recursive: true });
+        const certPath = path.join(certsDir, 'cert.pem');
+
+        const realFn = httpsSetup.servedHostAllowlist;
+        let calls = 0;
+        httpsSetup.servedHostAllowlist = () => { calls += 1; return new Set(['localhost']); };
+        try {
+          const cfg = store.config.load();
+          fs.writeFileSync(certPath, 'FIRST');
+          server864._servedHostsOrEmpty(cfg);
+          const afterFirst = calls;
+          server864._servedHostsOrEmpty(cfg);
+          assert.equal(calls, afterFirst, 'an unchanged cert must be served from cache');
+
+          // Rewrite with a DIFFERENT length so the key moves even if the
+          // filesystem's mtime resolution rounds two fast writes together.
+          fs.writeFileSync(certPath, 'SECOND-AND-LONGER');
+          server864._servedHostsOrEmpty(cfg);
+          assert.equal(calls, afterFirst + 1,
+            'a regenerated certificate must invalidate the cache — its SANs live nowhere else');
+        } finally {
+          httpsSetup.servedHostAllowlist = realFn;
+          fs.rmSync(certPath, { force: true });
+        }
       });
     });
 

--- a/test/setup-provisioning.test.js
+++ b/test/setup-provisioning.test.js
@@ -70,6 +70,39 @@ function request(server, method, urlPath, body) {
  * @param {object} body
  * @returns {Promise<{ status: number, data: any, raw: string }>}
  */
+/**
+ * Like `requestWithHost`, but carrying the header a real browser sends. The
+ * #864 Host guard only applies to browser-shaped requests, so a carve-out test
+ * that omits this proves nothing — it would pass with the carve-out deleted.
+ * @param {object} server
+ * @param {string} host - Host header value.
+ * @param {object} body
+ * @param {string} [path] - Route to hit.
+ * @param {string} [method] - HTTP method; Skip uses PATCH, not POST.
+ * @returns {Promise<{status:number, data:*, raw:string}>}
+ */
+function browserRequestWithHost(server, host, body, path = '/api/setup/complete', method = 'POST') {
+  return new Promise((resolve, reject) => {
+    const addr = server.address();
+    const req = http.request({
+      hostname: '127.0.0.1', port: addr.port, path, method,
+      headers: { 'Content-Type': 'application/json', Host: host, 'Sec-Fetch-Site': 'same-origin' }
+    }, (res) => {
+      const chunks = [];
+      res.on('data', (c) => chunks.push(c));
+      res.on('end', () => {
+        const raw = Buffer.concat(chunks).toString('utf8');
+        let data;
+        try { data = JSON.parse(raw); } catch { data = raw; }
+        resolve({ status: res.statusCode, data, raw });
+      });
+    });
+    req.on('error', reject);
+    req.write(JSON.stringify(body));
+    req.end();
+  });
+}
+
 function requestWithHost(server, host, body) {
   return new Promise((resolve, reject) => {
     const addr = server.address();
@@ -237,6 +270,71 @@ describe('setup provisions a login by default', () => {
       assert.equal(res.data.ingress.url, 'https://localhost:8443',
         'a malformed Host must fall back, not round-trip');
       assert.ok(!/alert\(1\)/.test(res.raw), 'the response echoed script-shaped text back');
+    });
+
+    /*
+     * #864 — the Host guard's first-run carve-out, exercised through a real
+     * /api/setup/* request. An earlier version of these tests posted only to
+     * /api/config and /api/setupsomething, so neither axis of the carve-out was
+     * pinned — including the axis that makes it CLOSE.
+     */
+    describe('#864 — the first-run Host carve-out', () => {
+      const BODY = { projectsDir: tmpDir, adminUser: 'jason', adminPassword: 'correct-horse-battery' };
+
+      it('exempts a remote first run when the install is actually reachable', async () => {
+        const c = store.config.load();
+        c.setupComplete = false;
+        c.bindAllInterfaces = true;   // wide: a remote operator can reach the wizard
+        store.config.save(c);
+        const res = await browserRequestWithHost(server, 'cursatory.tail123678.ts.net:8443', BODY);
+        assert.notEqual(res.status, 403,
+          'this is the flow the carve-out exists for — setup is what learns this name');
+      });
+
+      it('does NOT exempt the loopback default, where no remote first run is possible', async () => {
+        // The blocking defect in the first version. Default config binds
+        // 127.0.0.1 only, so no remote operator can reach the wizard — which
+        // means the only request that can arrive here under an unserved Host is
+        // the rebound one, on the route that sets the admin credential.
+        const c = store.config.load();
+        c.setupComplete = false;
+        c.bindAllInterfaces = false;
+        c.ingressMode = 'direct';
+        store.config.save(c);
+        const res = await browserRequestWithHost(server, 'evil.example:8443', BODY);
+        assert.equal(res.status, 403, 'a loopback-only install has no remote first run to protect');
+        assert.match(res.raw, /HOST_NOT_SERVED/);
+      });
+
+      it('closes the moment setup completes, even on a wide install', async () => {
+        const c = store.config.load();
+        c.setupComplete = true;
+        c.bindAllInterfaces = true;
+        store.config.save(c);
+        const res = await browserRequestWithHost(server, 'evil.example:8443', BODY);
+        assert.equal(res.status, 403, 'the carve-out is for FIRST run only');
+        assert.match(res.raw, /HOST_NOT_SERVED/);
+      });
+
+      it('covers the wizard\'s OTHER terminator — Skip, via PATCH /api/config', async () => {
+        // Two routes finish setup (ADR 0009 point 2). Guarding one and not the
+        // other is the half-swept-family defect: remote Finish would work while
+        // remote Skip 403'd.
+        const c = store.config.load();
+        c.setupComplete = false;
+        c.bindAllInterfaces = true;
+        store.config.save(c);
+        const res = await browserRequestWithHost(
+          server, 'cursatory.tail123678.ts.net:8443', { setupComplete: true }, '/api/config', 'PATCH');
+        assert.notEqual(res.status, 403, 'remote Skip must work wherever remote Finish does');
+        // It then hits the route's OWN refusal — Skip cannot finish setup with
+        // no credential on a machine that can run one (#710 chunk 2). Asserting
+        // that specific 400 proves the request reached the handler rather than
+        // merely avoiding the Host guard, which a bare notEqual(403) would not.
+        assert.equal(res.status, 400);
+        assert.match(res.raw, /ADMIN_REQUIRED/,
+          'reaching the eyes-open guard is proof the carve-out let it through');
+      });
     });
 
     it('keeps a legitimate hostname, so a remote operator gets their own address', async () => {

--- a/test/setup-provisioning.test.js
+++ b/test/setup-provisioning.test.js
@@ -356,7 +356,7 @@ describe('setup provisions a login by default', () => {
       });
     });
 
-      /*
+    /*
      * #864 — the allowlist is cached because computing it parses the
      * certificate, and the cache's certificate term is load-bearing: a SAN
      * added by `POST /api/setup/generate-cert` lands in NO config field, so the
@@ -365,6 +365,38 @@ describe('setup provisions a login by default', () => {
      * failure the derivation exists to prevent.
      */
     describe('#864 — the served-host cache invalidates on the certificate', () => {
+      it('recomputes when a configured public name changes — the terms the record claimed', () => {
+        // publicDomain and caddyTailnetHost are PATCHable on a running server,
+        // so a stale memo would refuse writes and terminal upgrades under the
+        // very name the operator had just configured, until a restart. The code
+        // keys on them correctly; nothing moved them, and the change-log then
+        // claimed every key term was pinned — which is what made the gap worse
+        // than an ordinary missing test.
+        const httpsSetup = require('../lib/https-setup');
+        const realFn = httpsSetup.servedHostAllowlist;
+        let calls = 0;
+        httpsSetup.servedHostAllowlist = () => { calls += 1; return new Set(['localhost']); };
+        try {
+          const cfg = store.config.load();
+          cfg.publicDomain = 'first.example.com';
+          server864._servedHostsOrEmpty(cfg);
+          const afterFirst = calls;
+          server864._servedHostsOrEmpty(cfg);
+          assert.equal(calls, afterFirst, 'an unchanged config must be served from cache');
+
+          cfg.publicDomain = 'second.example.com';
+          server864._servedHostsOrEmpty(cfg);
+          assert.equal(calls, afterFirst + 1, 'a new publicDomain must invalidate the memo');
+
+          cfg.caddyTailnetHost = 'box.tail123.ts.net';
+          const afterDomain = calls;
+          server864._servedHostsOrEmpty(cfg);
+          assert.equal(calls, afterDomain + 1, 'a new caddyTailnetHost must invalidate it too');
+        } finally {
+          httpsSetup.servedHostAllowlist = realFn;
+        }
+      });
+
       it('recomputes when the machine is renamed — the term nothing else moves', () => {
         // Same mutation class as the certificate term, one term over. Both
         // certHostUnion and servedHostAllowlist derive names from os.hostname(),

--- a/test/setup-provisioning.test.js
+++ b/test/setup-provisioning.test.js
@@ -306,6 +306,24 @@ describe('setup provisions a login by default', () => {
         assert.match(res.raw, /HOST_NOT_SERVED/);
       });
 
+      it('does NOT exempt caddy mode — Caddy fronts a loopback socket a rebound page bypasses', async () => {
+        // Caddy mode looks like "remotely reachable", and an earlier version
+        // treated it as a second way to qualify. But bindPolicy REFUSES the wide
+        // opt-in in caddy mode, so the listener is loopback-only there too; a
+        // remote operator arrives through Caddy under a name this list already
+        // holds, while a rebound page reaches 127.0.0.1 without traversing Caddy
+        // at all. Exempting it would have re-opened the blocking defect in the
+        // other arm. Untested, this reverts silently.
+        const c = store.config.load();
+        c.setupComplete = false;
+        c.bindAllInterfaces = false;
+        c.ingressMode = 'caddy';
+        store.config.save(c);
+        const res = await browserRequestWithHost(server, 'evil.example:8443', BODY);
+        assert.equal(res.status, 403, 'caddy mode is not a remote first run');
+        assert.match(res.raw, /HOST_NOT_SERVED/);
+      });
+
       it('closes the moment setup completes, even on a wide install', async () => {
         const c = store.config.load();
         c.setupComplete = true;


### PR DESCRIPTION
## What

Closes the DNS-rebinding path around both cross-site guards v5 added. A state-changing request or terminal socket must now arrive under a name this install actually serves.

## Why

Both v5 guards decide *"is this cross-site?"* **relative to the request itself** — `Sec-Fetch-Site` is what the browser computed from the page's own origin, and the upgrade check compares `Origin` against the request's own `Host`. An attacker controlling DNS satisfies both **without forging anything**: point `evil.example` at `127.0.0.1`, get the operator to load it, and the browser honestly reports `same-origin`, because as far as it knows it is. `Origin` and `Host` agree — on a lie.

The request then reaches the ungated loopback listener that exists in caddy mode, where `/terminal/*` proxies to a `--writable` ttyd.

## How

- `servedHostAllowlist` **derives from `certHostUnion`** rather than duplicating it. That matters: `POST /api/setup/generate-cert` accepts a host list that lands in **no config field**, so the certificate is those names' only record. A parallel list built from config alone would load the dashboard over a valid cert, serve reads, then refuse every write and kill every terminal. `certHostUnion` moved to `lib/https-setup.js`; the cutover script delegates.
- **Bare IPs are allowed outright** — rebinding needs a *name*; there is no DNS step for a literal, and a page at a different address yields `Origin ≠ Host`, already refused. This avoids enumerating interface addresses that change with the network.
- **Scoped to browser-shaped writes and WS upgrades.** `curl`, scripts and the agent API send neither marker, aren't a cross-site vector, and keep working under any `Host`. A mis-derived list degrades to *"reads work, writes return `HOST_NOT_SERVED`"* — never "the dashboard is gone" for a remote operator.
- **First-run carve-out applies only where a remote first run is possible** — a genuinely wide socket. Not the loopback default (where the only unserved-`Host` request possible is the rebound one), and not caddy mode (loopback-only behind Caddy; a rebound page bypasses Caddy entirely). Covers both wizard terminators, Finish and Skip.
- The allowlist is memoized on the configured names, hostname, and cert mtime/size — the uncached version parsed the certificate on every guarded request and logged a regeneration warning per request during setup.

## Test plan

Suite green: **5594 passed, 0 failed, 1 skipped**. Every guard and every cache key term mutation-verified — the named mutation applied and watched go red:

| Mutation | Reddens |
|---|---|
| remove HTTP `Host` guard | the rebinding tests |
| remove WS `Host` guard | the rebinding-upgrade test |
| restore the two-axis carve-out | the loopback-default test |
| restore the caddy arm | the caddy-mode test |
| drop cert / hostname / config terms from the memo key | each term's own test |

## Review

**Seven Critic rounds**, ending 0 blocking / 0 warning / 0 notes. It caught, in order: the drawer/server split, a real predicate bug (`autoMergeArmed`), the carve-out handing back the attack on the default install, the same defect again in the caddy arm, an untested cache, and two false completeness claims in durable records — including one where I recorded "`certHostUnion` does not exist" as a *verified finding* after grepping only two paths. It exists. Both records are corrected with an explicit correction block.

Fixes #864
