### PR TITLE
Require a browser-shaped write to declare a JSON body

### DIFF
--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -3363,3 +3363,42 @@ exempt, the loopback default is not, it closes on `setupComplete`, and Skip is c
 mutation-verified, including reverting to the exact two-axis form that was the blocking defect.
 
 **Classification:** fix
+
+## 2026-08-04: A browser body must be declared JSON, and CSRF is back in scope (#860)
+
+<!-- prawduct: type=fix | scope=auth-6-secure-by-default | status=shipped -->
+
+**Why:** `parseBody` JSON-parses any body whatever its `Content-Type`, which is what made the form
+attack a CORS *simple* request — the three encodings a `<form>` can send are exactly the three
+needing no preflight, and none is `application/json`. Target is `POST /api/auth/credential`, which
+authorizes on "arrived over loopback"; in caddy mode TC still binds an ungated `127.0.0.1` listener
+the operator's own browser reaches directly, so that reasoning never covered browser traffic.
+
+**The deferral reason dissolved rather than being accepted.** #860 was held out of v5 because
+enforcing `Content-Type` breaks the documented agent-facing API. It only does if enforced on every
+caller. Scoped to *browser-shaped* requests — carrying `Sec-Fetch-Site` or `Origin` — it closes the
+whole class while `curl`, scripts and the agent API stay untouched, so the guide needs no change. A
+browser cannot suppress `Sec-Fetch-Site` from script, so the attack always carries the marker that
+scopes it in. Same shape as #864's Host check.
+
+That also resolves the issue's part 2 for free: refusing `same-site` was on the table to close the
+sibling-subdomain attacker, but a same-site form still cannot send `application/json` — so this
+closes it without the breakage refusing `same-site` would cause to multi-subdomain deployments.
+
+**Verified before designing, and it changed the design.** The dashboard sends genuine bodyless
+writes (`medusa/toggle`, `medusa/read`, `wrap-sentinel/ack` via `api()` with no body and no
+`Content-Type`). Requiring the header on every browser write would have broken the operator's own UI
+to close nothing — a request with no body carries no forged payload. Keyed on a body being present
+instead. Grepping `public/` for this was the step that caught it; assuming would have shipped it.
+
+**Part 3 was a ratification, not code.** `security-model.md`'s CSRF acceptance rested on "no
+cookies, no tokens, no session state in the browser" — exactly what shipping browser-cached HTTP
+Basic invalidates. CSRF is now IN SCOPE, with all three guards recorded and, more importantly, their
+**residuals** written down rather than implied: `same-site` is still allowed at guard 1, and a
+bodyless same-site write to a route that acts without a body is not covered.
+
+**Mutation-verified on the arms not touched**, which is the failure this branch's predecessor
+repeated four times: removing the guard reddens six tests; dropping `hasBody` reddens the dashboard
+test; dropping the browser scoping reddens the agent-API test *and* a #864 test.
+
+**Classification:** fix

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -3402,3 +3402,16 @@ repeated four times: removing the guard reddens six tests; dropping `hasBody` re
 test; dropping the browser scoping reddens the agent-API test *and* a #864 test.
 
 **Classification:** fix
+
+**Critic round 1 (rev-20260804T094546Z-e54bf7ca, 0 blocking / 2 warnings) — the important catch was
+a break in code this repo does not own.** The guard runs ahead of route matching, so it also
+governed `/terminal/*`, `/openclaw/*` and `/openclaw-direct/*`. `public/openclaw-view.js` iframes
+`/openclaw-direct/:connId/chat` **same-origin**, so OpenClaw's gateway UI runs inside TC's page and
+its fetches are browser-shaped: the ordinary `fetch(url, {method:'POST', body: JSON.stringify(x)})`
+idiom is labelled `text/plain` by the browser and would have taken a 415 before reaching the
+gateway. Grepping `public/` — the step that correctly caught the bodyless-write case — structurally
+cannot see a third party's client. Now confined to `/api/`; those prefixes keep guards 1 and 2,
+which is what they had before, and the residual is recorded.
+
+Also corrected: the cross-site guard's comment still said Content-Type enforcement and the CSRF
+re-ratification were "tracked separately". Both shipped in this commit, 25 lines below it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -773,6 +773,40 @@ All notable changes to TangleClaw are documented in this file.
 
 ### Security
 
+- **A browser request body must be declared `application/json` — closing the CSRF class that made
+  the form attack a CORS *simple* request (#860).** `parseBody` JSON-parses any body whatever its
+  `Content-Type`, and the three encodings a `<form>` can send (`text/plain`,
+  `application/x-www-form-urlencoded`, `multipart/form-data`) are exactly the three that need no
+  preflight. So a page on another site could post a form to
+  `POST /api/auth/credential` — a route that authorizes on "arrived over loopback", reasoning that a
+  live gate means Caddy already authenticated the caller. In caddy mode TangleClaw still binds an
+  ungated `127.0.0.1` listener the operator's own browser reaches directly, so that reasoning never
+  covered browser traffic. The attacker cannot read the reply, which does not matter for a write:
+  the admin credential is already changed.
+
+  Requiring `application/json` forces a preflight the server never answers affirmatively, and a form
+  cannot send that type at all. **It also closes the `same-site` residual** the `Sec-Fetch-Site`
+  guard deliberately allows — a sibling-subdomain attacker — without refusing `same-site` outright,
+  which would break a legitimate multi-subdomain deployment.
+
+  **This was deferred from v5 as a breaking change to the agent-facing API, and it is not one.** The
+  check applies only to *browser-shaped* requests — those carrying `Sec-Fetch-Site` or `Origin`.
+  `curl`, scripts and the agent API send neither, so the guide's PortHub and shared-docs examples,
+  which show a JSON body and no header, keep working exactly as written. A browser cannot suppress
+  `Sec-Fetch-Site` from script, so the attack always carries the marker that brings it into scope.
+
+  **Bodyless writes are unaffected, deliberately.** The dashboard sends genuine ones —
+  `medusa/toggle`, `medusa/read`, `wrap-sentinel/ack` all go through `api()` with no body and no
+  `Content-Type` — and refusing them would break the operator's own UI to close nothing, since a
+  request with no body carries no forged payload. The remaining exposure is a bodyless *same-site*
+  write to a route that acts without one; `Sec-Fetch-Site` still refuses the cross-site case, which
+  is the one an arbitrary page can mount. Recorded in `security-model.md` rather than implied.
+
+  The security model's CSRF acceptance is **re-argued, not re-cited**. Its stated premise was "no
+  cookies, no tokens, no session state in the browser" — precisely what shipping browser-cached HTTP
+  Basic by default invalidates. CSRF is now in scope, with the three guards and their residuals
+  written down.
+
 - **A state-changing request or terminal socket must now arrive under a name this install
   actually serves — closing the DNS-rebinding path around both v5 cross-site guards (#864).**
   Those guards decide "is this cross-site?" *relative to the request itself*: `Sec-Fetch-Site` is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -795,6 +795,17 @@ All notable changes to TangleClaw are documented in this file.
   which show a JSON body and no header, keep working exactly as written. A browser cannot suppress
   `Sec-Fetch-Site` from script, so the attack always carries the marker that brings it into scope.
 
+  **Confined to TangleClaw's own API, and that is not a detail.** The guard runs ahead of route
+  matching, so unscoped it would also govern `/terminal/*`, `/openclaw/*` and `/openclaw-direct/*` —
+  reverse proxies whose browser client is not ours. `public/openclaw-view.js` iframes
+  `/openclaw-direct/:connId/chat` **same-origin**, so OpenClaw's gateway UI runs inside our page:
+  any of its fetches using the ordinary `fetch(url, {method:'POST', body: JSON.stringify(x)})`
+  idiom — no explicit header, which the browser labels `text/plain;charset=UTF-8` — would take a 415
+  before reaching the gateway, and multipart attachment paths would break the same way. Imposing a
+  media-type contract on a third party's client through a proxy is not ours to do. Those prefixes
+  keep the cross-site and served-`Host` guards, exactly what they had before, so this is a narrower
+  new rule rather than a regression.
+
   **Bodyless writes are unaffected, deliberately.** The dashboard sends genuine ones —
   `medusa/toggle`, `medusa/read`, `wrap-sentinel/ack` all go through `api()` with no body and no
   `Content-Type` — and refusing them would break the operator's own UI to close nothing, since a

--- a/server.js
+++ b/server.js
@@ -4951,6 +4951,48 @@ async function handleRequest(req, res) {
   const looksLikeBrowser = req.headers['sec-fetch-site'] !== undefined
     || req.headers.origin !== undefined;
   if (CSRF_UNSAFE_METHODS.has(method) && looksLikeBrowser) {
+    // #860 — a browser-shaped write that carries a BODY must declare JSON.
+    //
+    // This is what makes the form attack a CORS *simple* request in the first
+    // place: `parseBody` JSON-parses any body whatever its Content-Type, and
+    // the three encodings a `<form>` can send (`text/plain`,
+    // `application/x-www-form-urlencoded`, `multipart/form-data`) are exactly
+    // the three that need no preflight. Requiring `application/json` forces a
+    // preflight the server never answers affirmatively, and a form cannot send
+    // that type at all — so the class closes without depending on
+    // `Sec-Fetch-Site` being present or being `cross-site`. That is the point:
+    // it also covers the `same-site` sibling-subdomain residual the
+    // Sec-Fetch-Site guard deliberately allows, without refusing `same-site`
+    // outright and breaking legitimate multi-subdomain deployments.
+    //
+    // Scoped to browser-shaped requests for the same reason the guards below
+    // are: `curl`, scripts and the agent-facing API send no `Sec-Fetch-Site`
+    // and no `Origin`, so they are unaffected whatever Content-Type they use.
+    // That is what lets this land without breaking the documented agent API —
+    // the guide's PortHub and shared-docs examples show a JSON body and no
+    // header, and they keep working exactly as written.
+    //
+    // Keyed on a body being PRESENT, not on the method. The dashboard sends
+    // genuine bodyless writes (`medusa/toggle`, `medusa/read`,
+    // `wrap-sentinel/ack` go through `api()` with no body and no
+    // Content-Type), and refusing those would break the operator's own UI to
+    // close nothing — a request with no body carries no forged payload. The
+    // residual is a bodyless same-site POST to a route that acts without one;
+    // `Sec-Fetch-Site` still refuses the cross-site case, which is the one an
+    // arbitrary page can mount.
+    const hasBody = Number(req.headers['content-length'] || 0) > 0
+      || req.headers['transfer-encoding'] !== undefined;
+    const declaredType = String(req.headers['content-type'] || '')
+      .split(';')[0].trim().toLowerCase();
+    if (hasBody && declaredType !== 'application/json') {
+      log.warn('Refused browser write whose body is not declared JSON', {
+        method, path: pathname, contentType: declaredType || '(none)'
+      });
+      return errorResponse(res, 415,
+        'A request body from a browser must be declared as application/json.',
+        'JSON_BODY_REQUIRED');
+    }
+
     // ONE read of config, shared by both checks below. They used to load it
     // separately and only one wrapped the call, so a corrupt config threw out
     // of the request through the unguarded path instead of being refused.

--- a/server.js
+++ b/server.js
@@ -4920,11 +4920,14 @@ async function handleRequest(req, res) {
   // Deliberately narrow: only `cross-site` is refused. Rejecting `same-site`
   // as well would need an attacker controlling a sibling subdomain of the
   // operator's own host, and would risk breaking a legitimate multi-subdomain
-  // deployment. The residual, plus the broader question of enforcing
-  // Content-Type on JSON bodies and re-ratifying the blanket CSRF acceptance
-  // in security-model.md — whose stated premise, "no session state in the
-  // browser", is exactly what shipping browser-cached HTTP Basic invalidates —
-  // is tracked separately.
+  // deployment. That residual is closed a different way — the JSON-body rule
+  // below refuses a form from a sibling subdomain too, since a `<form>` cannot
+  // send `application/json` — so `same-site` stays allowed and nothing
+  // multi-subdomain breaks (#860). The CSRF acceptance in security-model.md,
+  // whose premise "no session state in the browser" is what shipping
+  // browser-cached HTTP Basic invalidated, has been re-argued rather than
+  // re-cited: CSRF is now in scope, with all three guards and their residuals
+  // recorded there.
   if (CSRF_UNSAFE_METHODS.has(method) && req.headers['sec-fetch-site'] === 'cross-site') {
     log.warn('Refused cross-site state-changing request', { method, path: pathname });
     return errorResponse(res, 403,
@@ -4980,11 +4983,30 @@ async function handleRequest(req, res) {
     // residual is a bodyless same-site POST to a route that acts without one;
     // `Sec-Fetch-Site` still refuses the cross-site case, which is the one an
     // arbitrary page can mount.
+    // Confined to TangleClaw's OWN API. This block runs ahead of route
+    // matching, so without the check it would also govern `/terminal/*`,
+    // `/openclaw/*` and `/openclaw-direct/*` — reverse proxies whose browser
+    // client is NOT ours: `public/openclaw-view.js` iframes
+    // `/openclaw-direct/:connId/chat` SAME-ORIGIN, so OpenClaw's gateway UI
+    // runs inside our page and its fetches are browser-shaped. Any of them
+    // using the ordinary `fetch(url, {method:'POST', body: JSON.stringify(x)})`
+    // idiom — no explicit header, which the browser labels
+    // `text/plain;charset=UTF-8` — would take a 415 before reaching the
+    // gateway, and multipart attachment paths would break the same way.
+    // Imposing a media-type contract on a third party's client through a proxy
+    // is not ours to do, and grepping `public/` cannot see it.
+    //
+    // Those prefixes keep the two guards below (cross-site refusal, and the
+    // served-Host check), which is exactly what they had before this change —
+    // so this is no regression, only a narrower new rule. The residual is a
+    // same-site body-carrying write to a proxied path, recorded in
+    // `security-model.md` beside the others.
+    const ownApiSurface = pathname.startsWith('/api/');
     const hasBody = Number(req.headers['content-length'] || 0) > 0
       || req.headers['transfer-encoding'] !== undefined;
     const declaredType = String(req.headers['content-type'] || '')
       .split(';')[0].trim().toLowerCase();
-    if (hasBody && declaredType !== 'application/json') {
+    if (ownApiSurface && hasBody && declaredType !== 'application/json') {
       log.warn('Refused browser write whose body is not declared JSON', {
         method, path: pathname, contentType: declaredType || '(none)'
       });

--- a/server.js
+++ b/server.js
@@ -4920,10 +4920,13 @@ async function handleRequest(req, res) {
   // Deliberately narrow: only `cross-site` is refused. Rejecting `same-site`
   // as well would need an attacker controlling a sibling subdomain of the
   // operator's own host, and would risk breaking a legitimate multi-subdomain
-  // deployment. That residual is closed a different way — the JSON-body rule
-  // below refuses a form from a sibling subdomain too, since a `<form>` cannot
-  // send `application/json` — so `same-site` stays allowed and nothing
-  // multi-subdomain breaks (#860). The CSRF acceptance in security-model.md,
+  // deployment. On TangleClaw's own `/api/` surface that residual is closed a
+  // different way — the JSON-body rule below refuses a form from a sibling
+  // subdomain too, since a `<form>` cannot send `application/json` — so
+  // `same-site` stays allowed and nothing multi-subdomain breaks (#860). That
+  // rule is confined to `/api/` (its own comment says why), so on the proxied
+  // prefixes the sibling-subdomain residual still stands, recorded in
+  // security-model.md rather than implied here. The CSRF acceptance there,
   // whose premise "no session state in the browser" is what shipping
   // browser-cached HTTP Basic invalidated, has been re-argued rather than
   // re-cited: CSRF is now in scope, with all three guards and their residuals

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -287,6 +287,50 @@ describe('server', () => {
             'curl/scripts/the agent API are not a cross-site vector');
         });
 
+        for (const prefix of ['/terminal/x', '/openclaw-direct/abc/chat', '/openclaw/proj/thing']) {
+          it(`does NOT impose JSON on the proxied path ${prefix} — that client is not ours`, async () => {
+            // This block runs ahead of route matching, so without the
+            // own-API check it would govern the reverse proxies too. TC
+            // iframes /openclaw-direct/:connId/chat SAME-ORIGIN
+            // (public/openclaw-view.js), so OpenClaw's gateway UI runs inside
+            // our page: any fetch(url, {method:'POST', body: JSON.stringify(x)})
+            // with no explicit header is labelled text/plain by the browser and
+            // would 415 before reaching the gateway. Grepping public/ cannot
+            // see a third party's client. These prefixes keep the cross-site
+            // and served-Host guards, which is what they had before #860.
+            // Non-vacuous BY CONSTRUCTION, via a paired control: the same
+            // headers are sent to a /api/ path and to the proxied one, and the
+            // pair must disagree. The 415 is returned before routing, so if the
+            // guard governed both, both would return it; if the harness were
+            // broken, neither would. Downstream failures on the proxied path
+            // (a missing .pipe on the mock, an uninitialised store) are all
+            // proof of passage, so the path's outcome is deliberately not
+            // pinned to any one of them.
+            const HDRS = {
+              'sec-fetch-site': 'same-origin', 'content-type': 'text/plain', 'content-length': '9'
+            };
+            const control = await send('POST', '/api/config', HDRS);
+            assert.equal(control.statusCode, 415,
+              'control: the identical request to our own API must be refused');
+
+            let proxied = null;
+            try { proxied = (await send('POST', prefix, HDRS)).statusCode; } catch { /* reached downstream code */ }
+            assert.notEqual(proxied, 415,
+              `${prefix} proxies a client whose media types are not ours to dictate`);
+          });
+        }
+
+        it('still refuses a cross-site POST to a proxied path — the sibling guard is untouched', async () => {
+          // Confirms the exclusion above narrows THIS rule only. Pinned because
+          // a careless widening of the exclusion would silently reopen the
+          // proxies, which carry the operator's gateway token.
+          const res = await send('POST', '/openclaw-direct/abc/chat', {
+            'sec-fetch-site': 'cross-site', 'content-type': 'text/plain', 'content-length': '9'
+          });
+          assert.equal(res.statusCode, 403);
+          assert.match(res.body, /CROSS_SITE_FORBIDDEN/);
+        });
+
         it('still checks a chunked body with no content-length', async () => {
           const res = await send('POST', '/api/config', {
             'sec-fetch-site': 'same-origin', 'transfer-encoding': 'chunked', 'content-type': 'text/plain'

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -212,6 +212,89 @@ describe('server', () => {
        * 127.0.0.1. Nothing is forged, so nothing above catches it. The Host
        * allowlist is the independent fact the guard checks against.
        */
+      /*
+       * #860 — parseBody JSON-parses any body whatever its Content-Type, which
+       * is what makes the form attack a CORS *simple* request: the three
+       * encodings a <form> can send are exactly the three that need no
+       * preflight. Requiring application/json forces a preflight the server
+       * never answers, and a form cannot send that type at all.
+       */
+      describe('#860 — a browser body must be declared JSON', () => {
+        /** A browser-shaped request carrying a body of `type`. */
+        function browserBody(type, len = '42') {
+          const h = { 'sec-fetch-site': 'same-origin', 'content-length': len };
+          if (type !== null) h['content-type'] = type;
+          return h;
+        }
+
+        it('refuses the actual attack: a text/plain form POST to the credential route', async () => {
+          const res = await send('POST', '/api/auth/credential',
+            browserBody('text/plain;charset=UTF-8'));
+          assert.equal(res.statusCode, 415);
+          assert.match(res.body, /JSON_BODY_REQUIRED/);
+        });
+
+        for (const type of ['application/x-www-form-urlencoded', 'multipart/form-data']) {
+          it(`refuses the other form encoding: ${type}`, async () => {
+            // All three form encodings must close, not just the one in the PoC.
+            const res = await send('POST', '/api/config', browserBody(type));
+            assert.equal(res.statusCode, 415, `${type} must be refused`);
+          });
+        }
+
+        it('refuses a same-site body too — the residual Sec-Fetch-Site deliberately allows', async () => {
+          // The sibling-subdomain attacker. Closing it here is why `same-site`
+          // need not be refused outright, which would break legitimate
+          // multi-subdomain deployments.
+          const res = await send('POST', '/api/config', {
+            'sec-fetch-site': 'same-site', 'content-type': 'text/plain', 'content-length': '9'
+          });
+          assert.equal(res.statusCode, 415);
+        });
+
+        it('refuses a body with NO Content-Type at all', async () => {
+          const res = await send('POST', '/api/config', browserBody(null));
+          assert.equal(res.statusCode, 415, 'an undeclared body is not a JSON body');
+        });
+
+        it('accepts application/json with parameters (charset)', async () => {
+          const res = await send('POST', '/api/config',
+            browserBody('application/json; charset=utf-8'));
+          assert.notEqual(res.statusCode, 415, 'the media type is the part that matters');
+        });
+
+        it('accepts a case-varied Content-Type — media types are case-insensitive', async () => {
+          const res = await send('POST', '/api/config', browserBody('APPLICATION/JSON'));
+          assert.notEqual(res.statusCode, 415);
+        });
+
+        it('does NOT refuse a bodyless browser write — the dashboard sends these', async () => {
+          // medusa/toggle, medusa/read and wrap-sentinel/ack all go through
+          // api() with no body and no Content-Type. Refusing them would break
+          // the operator's own UI to close nothing: no body, no forged payload.
+          const res = await send('POST', '/api/config', { 'sec-fetch-site': 'same-origin' });
+          assert.notEqual(res.statusCode, 415, 'a bodyless write carries no payload to forge');
+        });
+
+        it('does NOT refuse a header-less client sending any Content-Type', async () => {
+          // The whole reason this can ship: the guide's PortHub and shared-docs
+          // examples show a JSON body and no Content-Type header, and agents
+          // following them keep working exactly as written.
+          const res = await send('POST', '/api/ports/lease', {
+            'content-type': 'text/plain', 'content-length': '42'
+          });
+          assert.notEqual(res.statusCode, 415,
+            'curl/scripts/the agent API are not a cross-site vector');
+        });
+
+        it('still checks a chunked body with no content-length', async () => {
+          const res = await send('POST', '/api/config', {
+            'sec-fetch-site': 'same-origin', 'transfer-encoding': 'chunked', 'content-type': 'text/plain'
+          });
+          assert.equal(res.statusCode, 415, 'a chunked body is still a body');
+        });
+      });
+
       describe('#864 — Host allowlist (DNS rebinding)', () => {
         // A rebound page IS a browser, so it always carries `Sec-Fetch-Site`,
         // and it reports `same-origin` because as far as the browser knows it


### PR DESCRIPTION
## What

A state-changing request that is **browser-shaped** (carries `Sec-Fetch-Site` or `Origin`) and carries a **body** must declare `Content-Type: application/json` on TangleClaw's own `/api/` surface, or it takes a `415 JSON_BODY_REQUIRED`. Also re-ratifies the CSRF posture in `security-model.md`, which had been accepted on a premise v5 invalidated.

## Why

`parseBody` JSON-parses any body whatever its Content-Type. That is what made the form attack a CORS **simple** request: the three encodings a `<form>` can send are exactly the three that need no preflight, and none of them is `application/json`. The target is `POST /api/auth/credential`, which authorizes on "arrived over loopback" — reasoning that a live Caddy gate means the caller was already authenticated. In caddy mode TC still binds an ungated `127.0.0.1` listener the operator's own browser reaches directly, so that reasoning never covered browser traffic. The attacker cannot read the reply, which is irrelevant to a write.

`security-model.md`'s blanket CSRF acceptance rested on "no cookies, no tokens, no session state in the browser" — precisely what shipping browser-cached HTTP Basic by default invalidates. It could not be re-cited; it had to be re-argued. CSRF is now in scope, with all three guards and their residuals written down rather than implied.

### Why this is not the breaking change #860 was deferred for

#860 was held out of v5 as a breaking change to the agent-facing API. It only is one if enforced on **every** caller. Scoped to browser-shaped requests, `curl`, scripts and the agent API are untouched — the project guide's PortHub and shared-docs examples keep working exactly as written. A browser cannot suppress `Sec-Fetch-Site` from script, so the attack always carries the marker that scopes it in.

Two scoping decisions came from checking rather than assuming:

- **Keyed on a body being present**, not on the method. The dashboard sends genuine bodyless writes (`medusa/toggle`, `medusa/read`, `wrap-sentinel/ack` go through `api()` with no body and no Content-Type). Requiring the header on every browser write would have broken the operator's own UI to close nothing.
- **Confined to `/api/`.** The guard runs ahead of route matching, so unconfined it would also govern `/terminal/*`, `/openclaw/*` and `/openclaw-direct/*`. `public/openclaw-view.js` iframes `/openclaw-direct/:connId/chat` **same-origin**, so OpenClaw's gateway UI runs inside TC's page and its fetches are browser-shaped; any using the ordinary `fetch(url, {method:'POST', body: JSON.stringify(x)})` idiom — no explicit header, which the browser labels `text/plain;charset=UTF-8` — would have taken a 415 before reaching the gateway. Imposing a media-type contract on a third party's client through a proxy is not ours to do. Those prefixes keep the cross-site and served-Host guards exactly as before, so this is a narrower new rule, not a regression.

This also closes part 2 of the issue for free: a same-site form still cannot send `application/json`, so the sibling-subdomain residual shuts on `/api/` without refusing `same-site` outright and breaking multi-subdomain deployments.

## Residuals (recorded, not implied)

- A bodyless same-site POST to a route that acts without a body. `Sec-Fetch-Site` still refuses the cross-site case, which is the one an arbitrary page can mount.
- A same-site body-carrying write to a **proxied** path, which the `/api/` confinement leaves open.

Both are in `security-model.md` beside the other guards.

## Test plan

- `test/server.test.js` +127 lines. The proxy-scoping tests are non-vacuous by construction rather than by pinning a downstream error: each sends identical headers to `/api/config` and to a proxied path and asserts the pair **disagrees**. If the guard governed both, both would 415; if the harness were broken, neither would.
- Mutation-verified both directions: removing the guard reddens six tests; dropping `hasBody` reddens the dashboard test; dropping the browser scoping reddens the agent-API test and a #864 test; dropping the `/api/` confinement reddens the three proxy tests; widening the exclusion into the cross-site guard reddens the test that exists to stop exactly that.
- Full suite **5608 pass / 0 fail / 1 skipped**.

## Governance

`/prawduct:critic cumulative` then `verify-resolutions`: 0 blocking throughout. Both warnings from the cumulative round (a stale "tracked separately" comment, and the guard governing proxy prefixes) were fixed and independently verified resolved. Final review recorded **0 blocking, 0 warning, 0 note**.

Fixes #860