### PR TITLE
Identify the Medusa checkout by its contract, not by a project's name

### DIFF
--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -26,6 +26,52 @@ Tag-line conventions (ART-4K9M, ratified 2026-07-17):
 -->
 
 
+## 2026-08-06: a project's NAME stops establishing that it is the Medusa checkout (#873)
+
+<!-- prawduct: type=fix | scope=medusa-873 | status= -->
+
+**Why:** filed by a third-party installer (`GURULifeline`) — the class of report this machine
+structurally cannot reproduce, because here a project named Medusa genuinely *is* the switchboard
+repository, so the resolver's assumption never surfaced. `_medusaProjectPath()` took
+`store.projects.getByNameCaseInsensitive('medusa')` and passed `.path` to `medusa.readContract()`
+with no identity check. The reporter had an ordinary website project registered under that name, so
+every opted-in launch injected `### Medusa consumer contract — UNAVAILABLE` naming *their*
+project's `docs/CONSUMER-CONTRACT.md`, i.e. TangleClaw reporting an unrelated project as a broken
+Medusa install.
+
+Worth separating the two failures, because the visible one is the smaller: `readContract()` already
+fails closed on ENOENT, so the reporter got a wrong **diagnosis**, not a wrong contract. The silent
+one is that a project which happened to hold `docs/CONSUMER-CONTRACT.md` would have had that
+arbitrary document injected into every opted-in prime as the protocol contract. Corroboration
+closes both; the issue's own "expected behavior" only named the first.
+
+**What:** a display name is operator-chosen, so it can *locate* a candidate and cannot *establish*
+identity. `_medusaProjectPath()` (`lib/sessions.js`) now accepts the name-matched candidate only if
+it holds the contract at `medusa.CONTRACT_RELATIVE_PATH`, logging a WARN naming the rejected path
+when it does not, and returning null so the caller never speaks about it. The honest-absence note
+now reads "no local Medusa checkout identified" and names `MEDUSA_CONTRACT_PATH` — an operator whose
+checkout is registered under a different name gets a stated way out instead of a path they never
+connected to Medusa. `CONTRACT_RELATIVE_PATH` is exported from `lib/medusa.js` so the location
+vetted and the location read are one constant and cannot drift.
+
+**Decision — artifact, not git remote.** The issue suggested validating "a known remote/marker".
+Remote-sniffing was rejected: it misses forks and remote-less clones, costs a git read per launch,
+and adds failure modes, while the contract doc is the artifact actually being resolved. The residual
+is an unrelated project named Medusa that *also* carries `docs/CONSUMER-CONTRACT.md` — in which case
+the injected document is at least a consumer contract, and `MEDUSA_CONTRACT_PATH` overrides it.
+
+**Tests:** the name-match path had **zero** coverage — every prior test reaches the contract through
+the `MEDUSA_CONTRACT_PATH` seam, which is precisely why this shipped. `+3` in
+`test/sessions.test.js`: an unrelated same-named project is not selected and is not named in the
+prime; a corroborated checkout still resolves and injects (so the fix cannot degrade into disabling
+discovery); the env override still outranks a corroborated checkout. Mutation-verified in both
+directions, each killing a *different* test — forcing the guard false reddens the unrelated-project
+test, forcing it true reddens the genuine-checkout test. Full suite **5597 pass / 0 fail / 1 skip**
+on node v22.22.3, matching CI's `node --test 'test/*.test.js'` on node 22.
+
+**Note:** landed while GitHub Actions was in a **major outage**, so the required `test` context could
+not report. Verified locally with CI's exact command and runtime; the PR still waits on the gate.
+
 ## 2026-08-04: one unreadable folder can no longer take down the server (#859)
 
 <!-- prawduct: type=fix | scope=v5-acceptance-863 | status= -->

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -47,27 +47,42 @@ closes both; the issue's own "expected behavior" only named the first.
 
 **What:** a display name is operator-chosen, so it can *locate* a candidate and cannot *establish*
 identity. `_medusaProjectPath()` (`lib/sessions.js`) now accepts the name-matched candidate only if
-it holds the contract at `medusa.CONTRACT_RELATIVE_PATH`, logging a WARN naming the rejected path
-when it does not, and returning null so the caller never speaks about it. The honest-absence note
-now reads "no local Medusa checkout identified" and names `MEDUSA_CONTRACT_PATH` — an operator whose
-checkout is registered under a different name gets a stated way out instead of a path they never
-connected to Medusa. `CONTRACT_RELATIVE_PATH` is exported from `lib/medusa.js` so the location
-vetted and the location read are one constant and cannot drift.
+`medusa.hasContract()` corroborates it, logging a WARN naming the rejected path when it does not,
+and returning null so the caller never speaks about it. The honest-absence note now reads "no local
+Medusa checkout identified" and names `MEDUSA_CONTRACT_PATH` — an operator whose checkout is
+registered under a different name gets a stated way out instead of a path they never connected to
+Medusa. `contractPathIn()` is the single derivation of the doc's location, so the location vetted
+and the location read cannot drift.
+
+**Carried from the cumulative review (0 blocking; both items raised INDEPENDENTLY by two
+reviewers, which is why they were fixed rather than accepted):**
+- *Corroboration matched the reader.* `hasContract()` applies the same readable-and-non-blank test
+  `readContract()` accepts on. Existence alone would admit an empty or unreadable contract that the
+  read then rejects — the #873 shape in miniature, the prime naming a project just declined.
+- *Resolution made lazy.* `_medusaProjectPath` is passed to `readContract()` as a **thunk**, called
+  only if `MEDUSA_CONTRACT_PATH` did not resolve. Eager evaluation meant the store lookup and the
+  rejection WARN fired even on a launch the override had already answered — so an operator who took
+  the remedy this very fix recommends kept getting a per-launch warning naming their project.
 
 **Decision — artifact, not git remote.** The issue suggested validating "a known remote/marker".
 Remote-sniffing was rejected: it misses forks and remote-less clones, costs a git read per launch,
 and adds failure modes, while the contract doc is the artifact actually being resolved. The residual
-is an unrelated project named Medusa that *also* carries `docs/CONSUMER-CONTRACT.md` — in which case
-the injected document is at least a consumer contract, and `MEDUSA_CONTRACT_PATH` overrides it.
+is an unrelated project named Medusa that *also* carries a non-blank `docs/CONSUMER-CONTRACT.md` —
+in which case the injected document is at least a consumer contract, and `MEDUSA_CONTRACT_PATH`
+overrides it.
 
 **Tests:** the name-match path had **zero** coverage — every prior test reaches the contract through
-the `MEDUSA_CONTRACT_PATH` seam, which is precisely why this shipped. `+3` in
-`test/sessions.test.js`: an unrelated same-named project is not selected and is not named in the
-prime; a corroborated checkout still resolves and injects (so the fix cannot degrade into disabling
-discovery); the env override still outranks a corroborated checkout. Mutation-verified in both
-directions, each killing a *different* test — forcing the guard false reddens the unrelated-project
-test, forcing it true reddens the genuine-checkout test. Full suite **5597 pass / 0 fail / 1 skip**
-on node v22.22.3, matching CI's `node --test 'test/*.test.js'` on node 22.
+the `MEDUSA_CONTRACT_PATH` seam, which is precisely why this shipped. `+4` in
+`test/sessions.test.js` (unrelated same-named project not selected and not named in the prime; a
+corroborated checkout still resolves and injects; a BLANK contract corroborates nothing; the env
+override still outranks a corroborated checkout) and `+6` in `test/api-medusa.test.js`
+(`hasContract` matrix incl. blank + null-safety; the override short-circuits the thunk; the thunk is
+reached when the override is absent). Four mutations, each killing a *different* test: guard forced
+false → unrelated-project test; guard forced true → genuine-checkout test; corroboration reduced to
+`existsSync` → both blank-contract tests; checkout resolved eagerly → override-short-circuit test.
+Full suite **5604 pass / 0 fail / 1 skip** on node v22.22.3, matching CI's
+`node --test 'test/*.test.js'` on node 22, and recorded as machine evidence via
+`prawduct-hook test-evidence record` (the review's one WARNING was that this tree had none).
 
 **Note:** landed while GitHub Actions was in a **major outage**, so the required `test` context could
 not report. Verified locally with CI's exact command and runtime; the PR still waits on the gate.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -340,6 +340,41 @@ All notable changes to TangleClaw are documented in this file.
 
 ### Fixed
 
+- **A project merely NAMED "Medusa" is no longer mistaken for the switchboard checkout (#873).**
+  Reported from a third-party install, and structurally unreproducible here: on this machine a
+  project named Medusa *is* the switchboard repository, so the resolver's assumption was invisible.
+  `_medusaProjectPath()` selected `store.projects.getByNameCaseInsensitive('medusa')` and handed the
+  path straight to `readContract()` without ever asking whether that project was the Medusa
+  repository. The reporter had an ordinary website project registered under that name, so every
+  opted-in session launched carrying `### Medusa consumer contract — UNAVAILABLE` naming *their*
+  project's `docs/CONSUMER-CONTRACT.md` — TangleClaw diagnosing an unrelated project as a broken
+  Medusa install.
+
+  A display name is whatever the operator typed. It can locate a candidate; it cannot establish
+  identity. The name-match now only *finds* a candidate, and the consumer contract at
+  `medusa.CONTRACT_RELATIVE_PATH` is what corroborates it — present, this is a checkout; absent, it
+  is a different project that happens to share a name, and TangleClaw says so instead of naming it.
+  The honest-absence message now reads "no local Medusa checkout identified" and names
+  `MEDUSA_CONTRACT_PATH`, so an operator whose checkout is registered under another name has a
+  stated way out rather than a path to a project they never connected to Medusa.
+
+  **The narrower bug was the visible one; the wider one was silent.** Because `readContract()`
+  already failed closed on a missing file, the reporter got a wrong *diagnosis* rather than a wrong
+  *contract*. Had their project happened to contain `docs/CONSUMER-CONTRACT.md`, that arbitrary
+  document would have been injected into every opted-in prime as the protocol contract. Requiring
+  corroboration closes both.
+
+  Identity is corroborated by the artifact rather than by a git remote deliberately: a remote check
+  misses forks and remote-less clones, and the contract doc is the thing actually being resolved.
+  `CONTRACT_RELATIVE_PATH` is exported from `lib/medusa.js` so the location vetted and the location
+  read cannot drift apart.
+
+  The name-match path had **no test coverage at all** — every existing test reaches the contract
+  through the `MEDUSA_CONTRACT_PATH` seam, which is why this shipped. Three tests now exercise it
+  directly, and each direction is pinned by its own mutation: removing the corroboration reddens the
+  unrelated-project test, and rejecting every candidate reddens the genuine-checkout test, so the fix
+  cannot degrade into simply disabling discovery.
+
 - **A wrap that pushes its branch but never opens the PR now leaves a durable record (#867).** The
   outcome of the auto-PR close-loop reached exactly one place: a log line. When the PR failed to
   open, the wrap still reported `done` — correctly, since the commit had already landed — and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -376,8 +376,8 @@ All notable changes to TangleClaw are documented in this file.
 
   Identity is corroborated by the artifact rather than by a git remote deliberately: a remote check
   misses forks and remote-less clones, and the contract doc is the thing actually being resolved.
-  `CONTRACT_RELATIVE_PATH` is exported from `lib/medusa.js` so the location vetted and the location
-  read cannot drift apart.
+  A single `contractPathIn()` in `lib/medusa.js` derives the doc's location, and `hasContract()`
+  vets through it, so the location vetted and the location read cannot drift apart.
 
   The name-match path had **no test coverage at all** — every existing test reaches the contract
   through the `MEDUSA_CONTRACT_PATH` seam, which is why this shipped. It is now exercised directly,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -351,12 +351,22 @@ All notable changes to TangleClaw are documented in this file.
   Medusa install.
 
   A display name is whatever the operator typed. It can locate a candidate; it cannot establish
-  identity. The name-match now only *finds* a candidate, and the consumer contract at
-  `medusa.CONTRACT_RELATIVE_PATH` is what corroborates it — present, this is a checkout; absent, it
-  is a different project that happens to share a name, and TangleClaw says so instead of naming it.
-  The honest-absence message now reads "no local Medusa checkout identified" and names
-  `MEDUSA_CONTRACT_PATH`, so an operator whose checkout is registered under another name has a
-  stated way out rather than a path to a project they never connected to Medusa.
+  identity. The name-match now only *finds* a candidate, and a **usable** consumer contract is what
+  corroborates it — present, this is a checkout; absent, it is a different project that happens to
+  share a name, and TangleClaw says so instead of naming it. The honest-absence message now reads
+  "no local Medusa checkout identified" and names `MEDUSA_CONTRACT_PATH`, so an operator whose
+  checkout is registered under another name has a stated way out rather than a path to a project
+  they never connected to Medusa.
+
+  "Usable" is deliberately the *same* test the reader applies — readable and non-blank — via a new
+  `medusa.hasContract()`. Corroborating on mere existence would admit a project holding an empty or
+  unreadable `docs/CONSUMER-CONTRACT.md`, which the read then rejects: the same bug in miniature,
+  with the prime naming a project TangleClaw had just declined to trust.
+
+  Resolution is also **lazy**. The checkout resolver reads the project store and logs when it
+  rejects a candidate, so it is now passed as a thunk that `readContract` calls only if the override
+  did not answer. Otherwise an operator who took the remedy this feature itself recommends would
+  still get a warning naming their project on every launch that succeeded.
 
   **The narrower bug was the visible one; the wider one was silent.** Because `readContract()`
   already failed closed on a missing file, the reporter got a wrong *diagnosis* rather than a wrong
@@ -370,10 +380,12 @@ All notable changes to TangleClaw are documented in this file.
   read cannot drift apart.
 
   The name-match path had **no test coverage at all** — every existing test reaches the contract
-  through the `MEDUSA_CONTRACT_PATH` seam, which is why this shipped. Three tests now exercise it
-  directly, and each direction is pinned by its own mutation: removing the corroboration reddens the
-  unrelated-project test, and rejecting every candidate reddens the genuine-checkout test, so the fix
-  cannot degrade into simply disabling discovery.
+  through the `MEDUSA_CONTRACT_PATH` seam, which is why this shipped. It is now exercised directly,
+  and each direction is pinned by its own mutation, each killing a different test: removing the
+  corroboration reddens the unrelated-project test, rejecting every candidate reddens the
+  genuine-checkout test (so the fix cannot degrade into simply disabling discovery), corroborating on
+  existence alone reddens the blank-contract tests, and resolving the checkout eagerly reddens the
+  override-short-circuit test.
 
 - **A wrap that pushes its branch but never opens the PR now leaves a durable record (#867).** The
   outcome of the auto-PR close-loop reached exactly one place: a log line. When the PR failed to

--- a/lib/medusa.js
+++ b/lib/medusa.js
@@ -678,8 +678,10 @@ async function continueLoop({ sessionId, loopId, message, fetchImpl }) {
 
 /**
  * Where the consumer contract sits inside a Medusa checkout, relative to its
- * root. Exported so tests can seed a fixture checkout at the one location this
- * module actually reads.
+ * root. Exported for two live consumers, so do not unexport it: `lib/sessions.js`
+ * names it when logging a rejected candidate, and tests seed fixture checkouts
+ * through it. Code deriving the doc's absolute path should call
+ * `contractPathIn()` rather than joining this itself.
  * @type {string}
  */
 const CONTRACT_RELATIVE_PATH = path.join('docs', 'CONSUMER-CONTRACT.md');

--- a/lib/medusa.js
+++ b/lib/medusa.js
@@ -677,6 +677,16 @@ async function continueLoop({ sessionId, loopId, message, fetchImpl }) {
 }
 
 /**
+ * Where the consumer contract sits inside a Medusa checkout, relative to its
+ * root. Exported because it is load-bearing in two places that must agree:
+ * `readContract` reads it, and the caller uses it to decide whether a candidate
+ * directory is a Medusa checkout at all (#873). Two copies of this path could
+ * drift into a resolver that vets one location and then reads another.
+ * @type {string}
+ */
+const CONTRACT_RELATIVE_PATH = path.join('docs', 'CONSUMER-CONTRACT.md');
+
+/**
  * Resolve Medusa's public consumer-contract doc for prime injection
  * (MED-2K9P v2 T1). The Bridge does not serve its contract over HTTP yet
  * (probed 2026-07-12 — a filed Medusa feature; when it lands this becomes a
@@ -684,18 +694,22 @@ async function continueLoop({ sessionId, loopId, message, fetchImpl }) {
  *
  *   1. `MEDUSA_CONTRACT_PATH` env override (operator control; also the test seam).
  *   2. `<medusaProjectPath>/docs/CONSUMER-CONTRACT.md` — the caller passes the
- *      registered "Medusa" project's path when one exists.
+ *      path of a checkout it has already corroborated, never a bare name match
+ *      (#873).
  *
  * Honest resolution: the failure return names every path tried so the prime
- * can say WHY the contract is missing instead of silently omitting it.
+ * can say WHY the contract is missing instead of silently omitting it. It can
+ * only be honest about paths it is given — a caller that passes an unvetted
+ * directory makes this function report that directory as a failed Medusa
+ * checkout, which is the shape of #873.
  * @param {object} [options]
- * @param {string} [options.medusaProjectPath] - Root of a local Medusa checkout.
+ * @param {string} [options.medusaProjectPath] - Root of a corroborated local Medusa checkout.
  * @returns {{text: string, source: string}|{text: null, tried: string[]}}
  */
 function readContract({ medusaProjectPath } = {}) {
   const candidates = [];
   if (process.env.MEDUSA_CONTRACT_PATH) candidates.push(process.env.MEDUSA_CONTRACT_PATH);
-  if (medusaProjectPath) candidates.push(path.join(medusaProjectPath, 'docs', 'CONSUMER-CONTRACT.md'));
+  if (medusaProjectPath) candidates.push(path.join(medusaProjectPath, CONTRACT_RELATIVE_PATH));
 
   const tried = [];
   for (const candidate of candidates) {
@@ -729,5 +743,6 @@ module.exports = {
   continueLoop,
   mintWorkspaceId,
   readContract,
+  CONTRACT_RELATIVE_PATH,
   _setBridgeHttpUrl
 };

--- a/lib/medusa.js
+++ b/lib/medusa.js
@@ -678,13 +678,47 @@ async function continueLoop({ sessionId, loopId, message, fetchImpl }) {
 
 /**
  * Where the consumer contract sits inside a Medusa checkout, relative to its
- * root. Exported because it is load-bearing in two places that must agree:
- * `readContract` reads it, and the caller uses it to decide whether a candidate
- * directory is a Medusa checkout at all (#873). Two copies of this path could
- * drift into a resolver that vets one location and then reads another.
+ * root. Exported so tests can seed a fixture checkout at the one location this
+ * module actually reads.
  * @type {string}
  */
 const CONTRACT_RELATIVE_PATH = path.join('docs', 'CONSUMER-CONTRACT.md');
+
+/**
+ * The contract doc's absolute path inside a checkout root. The single
+ * derivation site — vetting one location and then reading another is precisely
+ * the drift `hasContract`/`readContract` must not develop between them.
+ * @param {string} rootPath - Checkout root.
+ * @returns {string} Absolute path to the contract doc.
+ */
+function contractPathIn(rootPath) {
+  return path.join(rootPath, CONTRACT_RELATIVE_PATH);
+}
+
+/**
+ * Does this directory hold a USABLE Medusa consumer contract? This is the
+ * corroboration that lets a caller treat a directory as the switchboard
+ * checkout (#873) — a name match alone never can.
+ *
+ * "Usable" is deliberately the same test `readContract` applies when accepting
+ * a candidate: readable AND non-blank. An existence-only check would admit a
+ * project holding an empty or unreadable `docs/CONSUMER-CONTRACT.md`, which
+ * `readContract` then rejects — reopening the #873 shape in miniature, with the
+ * prime naming a project we had just declined to trust.
+ * @param {string} [rootPath] - Candidate checkout root.
+ * @returns {boolean} True when the directory carries a usable contract.
+ */
+function hasContract(rootPath) {
+  if (!rootPath) return false;
+  try {
+    return fs.readFileSync(contractPathIn(rootPath), 'utf8').trim().length > 0;
+  } catch (err) {
+    // Any failure to read it — absent, unreadable, a directory — means this is
+    // not a checkout we can resolve a contract from. The caller logs the
+    // rejection; swallowing the errno here keeps that decision in one place.
+    return false;
+  }
+}
 
 /**
  * Resolve Medusa's public consumer-contract doc for prime injection
@@ -693,26 +727,25 @@ const CONTRACT_RELATIVE_PATH = path.join('docs', 'CONSUMER-CONTRACT.md');
  * Bridge fetch), so resolution is local-disk, in priority order:
  *
  *   1. `MEDUSA_CONTRACT_PATH` env override (operator control; also the test seam).
- *   2. `<medusaProjectPath>/docs/CONSUMER-CONTRACT.md` — the caller passes the
- *      path of a checkout it has already corroborated, never a bare name match
- *      (#873).
+ *   2. `<checkout>/docs/CONSUMER-CONTRACT.md` — the caller supplies the root of
+ *      a checkout it has already corroborated, never a bare name match (#873).
  *
- * Honest resolution: the failure return names every path tried so the prime
- * can say WHY the contract is missing instead of silently omitting it. It can
- * only be honest about paths it is given — a caller that passes an unvetted
+ * Honest resolution: the failure return names every path tried so the prime can
+ * say WHY the contract is missing instead of silently omitting it. It can only
+ * be honest about paths it is given — a caller that supplies an unvetted
  * directory makes this function report that directory as a failed Medusa
  * checkout, which is the shape of #873.
  * @param {object} [options]
- * @param {string} [options.medusaProjectPath] - Root of a corroborated local Medusa checkout.
+ * @param {string|function(): (string|null)} [options.medusaProjectPath] - Root of a
+ *   corroborated checkout, or a thunk returning one. A thunk is called ONLY if the
+ *   override did not resolve, so a resolver with side effects (a store lookup, a
+ *   warning about a rejected candidate) costs nothing on a launch the override
+ *   already answered.
  * @returns {{text: string, source: string}|{text: null, tried: string[]}}
  */
 function readContract({ medusaProjectPath } = {}) {
-  const candidates = [];
-  if (process.env.MEDUSA_CONTRACT_PATH) candidates.push(process.env.MEDUSA_CONTRACT_PATH);
-  if (medusaProjectPath) candidates.push(path.join(medusaProjectPath, CONTRACT_RELATIVE_PATH));
-
   const tried = [];
-  for (const candidate of candidates) {
+  const attempt = (candidate) => {
     try {
       const text = fs.readFileSync(candidate, 'utf8');
       if (text.trim()) return { text, source: candidate };
@@ -720,6 +753,21 @@ function readContract({ medusaProjectPath } = {}) {
     } catch (err) {
       tried.push(`${candidate} (${err.code || err.message})`);
     }
+    return null;
+  };
+
+  if (process.env.MEDUSA_CONTRACT_PATH) {
+    const hit = attempt(process.env.MEDUSA_CONTRACT_PATH);
+    if (hit) return hit;
+  }
+
+  // Resolved only now — see the thunk note on `options.medusaProjectPath`.
+  const checkoutRoot = typeof medusaProjectPath === 'function'
+    ? medusaProjectPath()
+    : medusaProjectPath;
+  if (checkoutRoot) {
+    const hit = attempt(contractPathIn(checkoutRoot));
+    if (hit) return hit;
   }
   if (tried.length > 0) {
     log.warn('Medusa consumer contract not resolvable for prime injection', { tried });
@@ -743,6 +791,7 @@ module.exports = {
   continueLoop,
   mintWorkspaceId,
   readContract,
+  hasContract,
   CONTRACT_RELATIVE_PATH,
   _setBridgeHttpUrl
 };

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -1320,7 +1320,12 @@ function _medusaContractSection(budget) {
   const lines = [];
   const contract = medusa.readContract({ medusaProjectPath: _medusaProjectPath() });
   if (!contract.text) {
-    const tried = contract.tried.length > 0 ? ` (tried: ${contract.tried.join(', ')})` : ' (no local Medusa checkout registered and MEDUSA_CONTRACT_PATH unset)';
+    // "identified", not "registered": a project named Medusa may well be
+    // registered and still be rejected as the checkout (#873), and the operator
+    // needs the override named to have any way to act on this.
+    const tried = contract.tried.length > 0
+      ? ` (tried: ${contract.tried.join(', ')})`
+      : ' (no local Medusa checkout identified, and MEDUSA_CONTRACT_PATH is unset — set it to the contract doc to resolve this)';
     lines.push('### Medusa consumer contract — UNAVAILABLE');
     lines.push(
       `The contract doc could not be resolved at launch${tried}. The TangleClaw `
@@ -1360,16 +1365,45 @@ function _medusaContractSection(budget) {
 }
 
 /**
- * Resolve the local Medusa checkout's path from the project store, for
- * consumer-contract resolution (MED-2K9P v2 T1). Case-insensitive on the
- * project name; returns null when no "Medusa" project is registered (or the
- * lookup fails) — `medusa.readContract` then reports honestly what was tried.
- * @returns {string|null} Absolute path to the Medusa project, or null.
+ * Resolve the local Medusa switchboard checkout's path from the project store,
+ * for consumer-contract resolution (MED-2K9P v2 T1).
+ *
+ * A case-insensitive name match finds a CANDIDATE; it never establishes
+ * identity, because "Medusa" is a name any project may carry. The candidate is
+ * accepted only if it actually holds the consumer contract at
+ * `medusa.CONTRACT_RELATIVE_PATH` (#873: a third-party install had an unrelated
+ * project named Medusa, and every opted-in session launched blaming that
+ * project for a contract it was never supposed to have). Rejecting an
+ * uncorroborated candidate is what keeps the honest-absence message honest —
+ * it can then say no checkout was identified instead of naming a project as a
+ * broken Medusa repository. It also refuses to inject whatever document happens
+ * to sit at that path in a project we have no reason to trust.
+ *
+ * Identity is deliberately corroborated by the artifact rather than by a git
+ * remote: a remote check misses forks and remote-less clones, and the contract
+ * doc is the thing actually being resolved. A checkout registered under another
+ * name — or not registered at all — is reached with the
+ * `MEDUSA_CONTRACT_PATH` override, which `readContract` tries first.
+ * @returns {string|null} Absolute path to a corroborated Medusa checkout, or null.
  */
 function _medusaProjectPath() {
   try {
-    const medusaProject = store.projects.getByNameCaseInsensitive('medusa');
-    return medusaProject && medusaProject.path ? medusaProject.path : null;
+    const candidate = store.projects.getByNameCaseInsensitive('medusa');
+    if (!candidate || !candidate.path) return null;
+
+    // A project's name is whatever the operator typed, so it locates a
+    // candidate and establishes nothing. The contract doc is the corroboration:
+    // present, this is a Medusa checkout; absent, it is some other project that
+    // happens to share the name, and we must not speak about it as though it
+    // were the switchboard repository.
+    if (!fs.existsSync(path.join(candidate.path, medusa.CONTRACT_RELATIVE_PATH))) {
+      log.warn(
+        'Project named "Medusa" carries no consumer contract — not treating it as the switchboard checkout',
+        { path: candidate.path, expected: medusa.CONTRACT_RELATIVE_PATH }
+      );
+      return null;
+    }
+    return candidate.path;
   } catch (err) {
     log.warn('Medusa project lookup failed during contract resolution', { error: err.message });
     return null;

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -1318,7 +1318,11 @@ const MEDUSA_CONTRACT_MIN_CHARS = 400;
  */
 function _medusaContractSection(budget) {
   const lines = [];
-  const contract = medusa.readContract({ medusaProjectPath: _medusaProjectPath() });
+  // Passed as a thunk, not a call: resolving the checkout hits the project
+  // store and can log a rejection, and an operator who took the remedy this
+  // very section recommends (MEDUSA_CONTRACT_PATH) should not still get a
+  // per-launch warning naming their project on a launch that succeeded.
+  const contract = medusa.readContract({ medusaProjectPath: _medusaProjectPath });
   if (!contract.text) {
     // "identified", not "registered": a project named Medusa may well be
     // registered and still be rejected as the checkout (#873), and the operator
@@ -1392,13 +1396,15 @@ function _medusaProjectPath() {
     if (!candidate || !candidate.path) return null;
 
     // A project's name is whatever the operator typed, so it locates a
-    // candidate and establishes nothing. The contract doc is the corroboration:
-    // present, this is a Medusa checkout; absent, it is some other project that
-    // happens to share the name, and we must not speak about it as though it
-    // were the switchboard repository.
-    if (!fs.existsSync(path.join(candidate.path, medusa.CONTRACT_RELATIVE_PATH))) {
+    // candidate and establishes nothing. A usable contract doc is the
+    // corroboration: present, this is a Medusa checkout; absent, it is some
+    // other project that happens to share the name, and we must not speak about
+    // it as though it were the switchboard repository. `hasContract` applies
+    // the same readable-and-non-blank test `readContract` accepts on, so a
+    // candidate can never pass the vetting and then fail the read.
+    if (!medusa.hasContract(candidate.path)) {
       log.warn(
-        'Project named "Medusa" carries no consumer contract — not treating it as the switchboard checkout',
+        'Project named "Medusa" carries no usable consumer contract — not treating it as the switchboard checkout',
         { path: candidate.path, expected: medusa.CONTRACT_RELATIVE_PATH }
       );
       return null;

--- a/test/api-medusa.test.js
+++ b/test/api-medusa.test.js
@@ -1623,6 +1623,71 @@ describe('MED-2K9P v2 T1 — medusa.readContract (consumer-contract resolution)'
     const got = medusa.readContract({});
     assert.deepEqual(got, { text: null, tried: [] });
   });
+
+  // #873 — the checkout resolver hits the project store and logs when it
+  // rejects a candidate. Calling it on a launch the override already answered
+  // means an operator who took the remedy the prime itself recommends still
+  // gets a per-launch warning naming their project. A thunk makes the laziness
+  // structural rather than a caller's good intention.
+  it('does not resolve the checkout at all when the override already answered', () => {
+    const envDoc = path.join(tempDir, 'override.md');
+    fs.writeFileSync(envDoc, '# Override Contract\n');
+    process.env.MEDUSA_CONTRACT_PATH = envDoc;
+
+    let calls = 0;
+    const got = medusa.readContract({ medusaProjectPath: () => { calls++; return tempDir; } });
+
+    assert.equal(got.source, envDoc, 'the override still resolves');
+    assert.equal(calls, 0, 'the checkout resolver must not run once the override has answered');
+  });
+
+  it('calls the checkout thunk when the override is absent', () => {
+    delete process.env.MEDUSA_CONTRACT_PATH;
+    const projDir = path.join(tempDir, 'medusa-thunk');
+    fs.mkdirSync(path.join(projDir, 'docs'), { recursive: true });
+    fs.writeFileSync(path.join(projDir, medusa.CONTRACT_RELATIVE_PATH), '# Thunk Contract\n');
+
+    let calls = 0;
+    const got = medusa.readContract({ medusaProjectPath: () => { calls++; return projDir; } });
+
+    assert.equal(calls, 1, 'with no override the thunk is the only way to reach a checkout');
+    assert.equal(got.text, '# Thunk Contract\n');
+  });
+});
+
+describe('#873 — medusa.hasContract (checkout corroboration)', () => {
+  let tempDir;
+
+  before(() => { tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-has-contract-')); });
+  after(() => { fs.rmSync(tempDir, { recursive: true, force: true }); });
+
+  it('corroborates a directory holding a non-blank contract', () => {
+    const root = path.join(tempDir, 'real');
+    fs.mkdirSync(path.join(root, 'docs'), { recursive: true });
+    fs.writeFileSync(path.join(root, medusa.CONTRACT_RELATIVE_PATH), '# Real\n');
+    assert.equal(medusa.hasContract(root), true);
+  });
+
+  it('refuses a directory with no contract at all', () => {
+    const root = path.join(tempDir, 'bare');
+    fs.mkdirSync(root, { recursive: true });
+    assert.equal(medusa.hasContract(root), false);
+  });
+
+  it('refuses a BLANK contract — the same test readContract accepts on', () => {
+    const root = path.join(tempDir, 'blank');
+    fs.mkdirSync(path.join(root, 'docs'), { recursive: true });
+    fs.writeFileSync(path.join(root, medusa.CONTRACT_RELATIVE_PATH), '  \n\t\n');
+    assert.equal(
+      medusa.hasContract(root), false,
+      'vetting must not admit a candidate the read then rejects'
+    );
+  });
+
+  it('refuses null/undefined rather than throwing on a path join', () => {
+    assert.equal(medusa.hasContract(null), false);
+    assert.equal(medusa.hasContract(undefined), false);
+  });
 });
 
 describe('lib/projects — medusaEnabled flip syncs the LIVE session listener (TC#549, v2 T3)', () => {

--- a/test/sessions.test.js
+++ b/test/sessions.test.js
@@ -221,6 +221,26 @@ describe('sessions', () => {
           assert.ok(prompt.includes(medusaProjDir), 'the resolved source is named');
         });
 
+        it('treats an EMPTY contract as no corroboration, not as a checkout', () => {
+          // `readContract` accepts only a non-blank doc, so corroborating on
+          // mere existence would admit a candidate the read then rejects — the
+          // #873 shape again, the prime naming a project we just declined to
+          // trust.
+          fs.mkdirSync(path.join(medusaProjDir, 'docs'), { recursive: true });
+          fs.writeFileSync(path.join(medusaProjDir, medusa.CONTRACT_RELATIVE_PATH), '   \n\n');
+
+          const project = store.projects.getByName('prime-test');
+          const engine = store.engines.get('claude');
+          const prompt = sessions.generatePrimePrompt(project, engine, { medusaWorkspaceId: 'prime-test-cafe0123' });
+
+          assert.ok(prompt.includes('consumer contract — UNAVAILABLE'), 'absence is still surfaced');
+          assert.equal(
+            prompt.includes(medusaProjDir), false,
+            'a blank contract must not promote an unrelated project into being named'
+          );
+          assert.ok(prompt.includes('no local Medusa checkout identified'), 'reports no checkout, not a broken one');
+        });
+
         it('lets the env override win over a corroborated checkout', () => {
           fs.mkdirSync(path.join(medusaProjDir, 'docs'), { recursive: true });
           fs.writeFileSync(

--- a/test/sessions.test.js
+++ b/test/sessions.test.js
@@ -10,6 +10,7 @@ const { setLevel } = require('../lib/logger');
 setLevel('error');
 
 const store = require('../lib/store');
+const medusa = require('../lib/medusa');
 
 describe('sessions', () => {
   let tmpDir;
@@ -156,6 +157,87 @@ describe('sessions', () => {
         assert.ok(prompt.includes('`prime-test-cafe0123`'), 'identity still injects');
         assert.ok(prompt.includes('consumer contract — UNAVAILABLE'), 'missing contract is surfaced, not silent');
         assert.ok(prompt.includes('no-such-contract.md'), 'the tried path is named');
+      });
+
+      // #873 — a third-party install registered an ordinary project named
+      // "Medusa". The resolver matched on the name alone, so every opted-in
+      // session probed that project and reported it as a broken Medusa
+      // checkout. The name-match path had NO coverage at all — every test above
+      // reaches the contract through the MEDUSA_CONTRACT_PATH seam — which is
+      // exactly why the defect shipped. These three exercise it directly.
+      describe('#873: a project named "Medusa" is a candidate, not an identity', () => {
+        let medusaProjDir;
+
+        beforeEach(() => {
+          // Registered under the switchboard's name, but an unrelated project.
+          medusaProjDir = path.join(projectsDir, 'Medusa');
+          fs.mkdirSync(medusaProjDir, { recursive: true });
+          store.projects.create({ name: 'Medusa', path: medusaProjDir, engine: 'claude' });
+          delete process.env.MEDUSA_CONTRACT_PATH;
+          store.projectConfig.save(projDir, { medusaEnabled: true });
+        });
+
+        afterEach(() => {
+          const registered = store.projects.getByNameCaseInsensitive('medusa');
+          if (registered) store.projects.delete(registered.id);
+          fs.rmSync(medusaProjDir, { recursive: true, force: true });
+        });
+
+        it('does not select an unrelated project that merely shares the name', () => {
+          const project = store.projects.getByName('prime-test');
+          const engine = store.engines.get('claude');
+          const prompt = sessions.generatePrimePrompt(project, engine, { medusaWorkspaceId: 'prime-test-cafe0123' });
+
+          assert.ok(prompt.includes('consumer contract — UNAVAILABLE'), 'absence is still surfaced');
+          assert.equal(
+            prompt.includes(medusaProjDir), false,
+            'the unrelated project must not be named — doing so asserts an identity never established'
+          );
+          assert.ok(
+            prompt.includes('no local Medusa checkout identified'),
+            'the message must report no checkout, not a broken one'
+          );
+          assert.ok(
+            prompt.includes('MEDUSA_CONTRACT_PATH'),
+            'the operator needs the override named to have any way to act on this'
+          );
+        });
+
+        it('selects it once it carries the contract, and injects that contract', () => {
+          fs.mkdirSync(path.join(medusaProjDir, 'docs'), { recursive: true });
+          fs.writeFileSync(
+            path.join(medusaProjDir, medusa.CONTRACT_RELATIVE_PATH),
+            '# Corroborated Consumer Contract\nRegister then drain.\n'
+          );
+
+          const project = store.projects.getByName('prime-test');
+          const engine = store.engines.get('claude');
+          const prompt = sessions.generatePrimePrompt(project, engine, { medusaWorkspaceId: 'prime-test-cafe0123' });
+
+          assert.ok(
+            prompt.includes('# Corroborated Consumer Contract'),
+            'a corroborated checkout still resolves — the fix must not disable name-based discovery'
+          );
+          assert.ok(prompt.includes(medusaProjDir), 'the resolved source is named');
+        });
+
+        it('lets the env override win over a corroborated checkout', () => {
+          fs.mkdirSync(path.join(medusaProjDir, 'docs'), { recursive: true });
+          fs.writeFileSync(
+            path.join(medusaProjDir, medusa.CONTRACT_RELATIVE_PATH),
+            '# Checkout Contract\n'
+          );
+          const envDoc = path.join(projDir, 'fixture-contract.md');
+          fs.writeFileSync(envDoc, '# Override Contract\n');
+          process.env.MEDUSA_CONTRACT_PATH = envDoc;
+
+          const project = store.projects.getByName('prime-test');
+          const engine = store.engines.get('claude');
+          const prompt = sessions.generatePrimePrompt(project, engine, { medusaWorkspaceId: 'prime-test-cafe0123' });
+
+          assert.ok(prompt.includes('# Override Contract'), 'the explicit override still takes priority');
+          assert.equal(prompt.includes('# Checkout Contract'), false, 'the checkout must not shadow the override');
+        });
       });
 
       it('tells the session participation is event-driven, not a boot task (#557)', () => {


### PR DESCRIPTION
## What

A project merely **named** "Medusa" no longer establishes that it is the switchboard checkout. The name-match now only nominates a *candidate*; a usable consumer contract is what corroborates it.

Reported by a third-party installer (@GURULifeline) — the class of bug this machine structurally cannot reproduce, because here a project named Medusa genuinely *is* the switchboard repository, so the assumption was invisible.

## Why

`_medusaProjectPath()` took `store.projects.getByNameCaseInsensitive('medusa')` and handed `.path` to `readContract()` without ever asking whether that project was the Medusa repository. The reporter had an ordinary website project registered under that name, so every opted-in session launched carrying:

```
### Medusa consumer contract — UNAVAILABLE
The contract doc could not be resolved at launch (tried: .../Projects/Medusa/docs/CONSUMER-CONTRACT.md (ENOENT)).
```

— TangleClaw diagnosing an unrelated project as a broken Medusa install.

**The visible failure was the smaller of two.** `readContract()` already fails closed on ENOENT, so what the reporter got was a wrong *diagnosis*, not a wrong *contract*. The silent one: a project that happened to hold `docs/CONSUMER-CONTRACT.md` would have had that arbitrary document injected into every opted-in prime **as the protocol contract**. The issue's stated expected behavior covers only the first; corroboration closes both.

## How

- **`medusa.hasContract(root)`** is the corroboration, and applies the *same* readable-and-non-blank test `readContract` accepts on. Corroborating on mere existence would admit an empty or unreadable doc that the read then rejects — the same bug in miniature, the prime naming a project TangleClaw had just declined to trust.
- **`medusa.contractPathIn(root)`** is the single derivation of the doc's location, so the location vetted and the location read cannot drift apart.
- **Resolution is lazy.** The resolver reads the project store and logs when it rejects a candidate, so it is passed as a **thunk** that `readContract` calls only if `MEDUSA_CONTRACT_PATH` did not answer. Eager evaluation meant an operator who took the remedy this feature itself recommends still got a per-launch warning naming their project on a launch that had *succeeded*.
- **The honest-absence message** now reads "no local Medusa checkout identified" and names `MEDUSA_CONTRACT_PATH`, so an operator whose checkout is registered under another name has a stated way out rather than a path to a project they never connected to Medusa.

### Decision: corroborate by artifact, not by git remote

The issue suggested validating "a known remote/marker". Remote-sniffing was rejected: it misses forks and remote-less clones, costs a git read per launch, and adds failure modes — while the contract doc is the artifact actually being resolved. **Residual:** an unrelated project named Medusa that *also* carries a non-blank `docs/CONSUMER-CONTRACT.md`, in which case the injected document is at least a consumer contract, and the override outranks it.

## Test plan

The name-match path had **zero coverage** — every prior test reaches the contract through the `MEDUSA_CONTRACT_PATH` seam, which is precisely why this shipped.

`+4` in `test/sessions.test.js` (unrelated same-named project not selected and not named in the prime; a corroborated checkout still resolves and injects; a **blank** contract corroborates nothing; the override still outranks a corroborated checkout) and `+6` in `test/api-medusa.test.js` (`hasContract` matrix incl. blank and null-safety; the override short-circuits the thunk; the thunk is reached when the override is absent).

**Four mutations, each killing a different test** — so no assertion is carrying another's weight:

| Mutation | Test that reddens |
|---|---|
| corroboration guard forced `false` (the shipped bug) | unrelated-project test |
| guard forced `true` (discovery disabled) | genuine-checkout test |
| corroboration reduced to `existsSync` | both blank-contract tests |
| checkout resolved eagerly | override-short-circuit test |

Full suite **5604 pass / 0 fail / 1 skipped** on node v22.22.3, matching CI's `node --test 'test/*.test.js'` on node 22.

## Governance

`/prawduct:critic cumulative` (0 blocking, 1 warning, 9 notes) → fixes → `verify-resolutions` (clean) → doc-accuracy commit → `verify-resolutions` (clean). The two findings fixed rather than accepted were each raised **independently by two reviewers**: existence-only corroboration, and the eagerly-evaluated resolver. The warning (no machine test evidence for this worktree) is resolved — `test-status` exits 0.

> **Note:** opened during a GitHub Actions major outage (webhook triggers throttled to ~15%), so the required `test` check may not report until it recovers. Verified locally with CI's exact command and runtime.

Fixes #873