### PR TITLE
Keep the credential out of the cutover log, and bound the log's growth

### DIFF
--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -26,6 +26,65 @@ Tag-line conventions (ART-4K9M, ratified 2026-07-17):
 -->
 
 
+## 2026-08-06: the cutover log stops holding a credential hash, and stops growing (#821)
+
+<!-- prawduct: type=fix | scope=ingress-821 | status= -->
+
+**Why:** v5 gate item, raised by the Critic on #819 (rev-20260731T232030Z-279745ce R-18) and filed
+rather than fixed there. `~/.tangleclaw/logs/ingress-cutover.log` is opened with a raw
+`fs.openSync(logPath,'a',0o600)` outside the logger that owns rotation — no cap, no rotation, no
+pruning — and `caddy validate` quotes the offending Caddyfile line, which for this project is
+`basic_auth <user> <hash>`. Caddy renamed `basicauth`→`basic_auth` in 2.8, so a version skew alone
+makes the credential line the one that fails to parse. v5 is the release that makes a credential
+mandatory, so it multiplies how many installs carry one of these files.
+
+**The framing correction that drove the design.** The issue offers "route through the rotating
+logger OR give it a size/age cap" as the fix, with redaction as a conditional extra. That is
+backwards for the stated concern, which is *retention of a secret*: this log takes kilobytes per
+run and an install performs a handful of cutovers ever, so it never reaches any sane threshold,
+never rotates, and keeps the hash for the life of the machine. **A size cap bounds growth and
+bounds the secret's lifetime not at all.** Redaction is therefore load-bearing, not the optional
+half — both were implemented, with the division of labour written down where each lives.
+
+**What (redaction, at the source):** `caddy.validateCaddyfile` now returns `redactHashes(detail)`.
+That single error string fans out to **three** sinks — the cutover log (via the child's stderr), the
+cutover result file (via `finish`), and the server log — and only the third was redacting, which is
+itself the evidence that per-caller redaction is the leaky shape (`feedback_verify_mechanism_uniformity`:
+one call site is not the family). Existing `caddy.redactHashes(...)` call sites are untouched;
+it is idempotent and defence in depth on a credential is worth a duplicate pass. `writeCutoverResult`
+scrubs `error`/`healthError` on the way out, and the script's catch-all stderr write scrubs
+`err.message`, because `finish` is also reached from the Caddyfile generator whose rejection can name
+the credential it rejected. The **username is deliberately preserved** — it is what makes the failure
+diagnosable and is already reported at the HTTP boundary.
+
+**What (rotation, for growth):** `rotateCutoverLogIfNeeded()` in `lib/ingress-provision.js`, 1 MB cap
+and one previous generation (vs the server log's 10 MB / 3 — a service-log threshold would never fire
+here). Called **only immediately before the log is opened**, never during a run: the fd becomes a
+detached child's stdout+stderr, so renaming mid-run leaves that child writing to a detached inode —
+the trap `logger.js` documents as "the owner of the log owns its rotation". Best-effort by design; an
+unrotatable log is appended to anyway, because housekeeping must not cost the operator their ingress.
+`0600` stays: it is the control that does not depend on every future writer remembering to redact.
+
+**Tests (+8):** `test/caddy.test.js` +1 (a Caddyfile whose *credential line* is the offending one, so
+the validator's own output carries the hash — the real #821 vector end-to-end);
+`test/ingress-provision.test.js` +7 (under-cap left alone, over-cap rotated with the live path
+cleared, oldest generation retired, rotated generation still 0600, `spawnCutover` rotates before
+opening, cutover survives an unrotatable log).
+
+**The fixture was the risk, and is guarded.** The local caddy stub emitted a FIXED error string and
+never quoted the offending line — so a redaction test written against it would have passed without
+redacting anything (`feedback_measure_against_the_real_shape`). The stub now quotes the line the way
+real caddy does, and the test carries an explicit assertion that the error actually contains the
+credential line, so losing that fidelity fails loudly instead of silently. Verified: reverting the
+stub's quoting reddens the test on *that* guard, naming the fixture.
+
+**Mutations, each killing a different test:** validateCaddyfile stops redacting → the redaction test;
+rotation call removed → `spawnCutover rotates BEFORE opening`; size check removed → `leaves a log
+under the cap`; stub stops quoting → the fixture guard. Full suite **5601 pass / 0 fail / 1 skip** on
+node v22.22.3, matching CI's `node --test 'test/*.test.js'` on node 22; recorded as machine evidence.
+
+**Note:** built during a GitHub Actions major outage, so the required `test` context could not report.
+
 ## 2026-08-04: one unreadable folder can no longer take down the server (#859)
 
 <!-- prawduct: type=fix | scope=v5-acceptance-863 | status= -->

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -82,7 +82,7 @@ stub's quoting reddens the test on *that* guard, naming the fixture.
 
 **Mutations, each killing a different test:** validateCaddyfile stops redacting → the redaction test;
 rotation call removed → `spawnCutover rotates BEFORE opening`; size check removed → `leaves a log
-under the cap`; stub stops quoting → the fixture guard. Full suite **5601 pass / 0 fail / 1 skip** on
+under the cap`; stub stops quoting → the fixture guard. Full suite **5606 pass / 0 fail / 1 skip** on
 node v22.22.3, matching CI's `node --test 'test/*.test.js'` on node 22; recorded as machine evidence.
 
 **Carried from the cumulative review (1 blocking, 10 warning, 7 note — all decided in one pass):**

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -65,11 +65,13 @@ the trap `logger.js` documents as "the owner of the log owns its rotation". Best
 unrotatable log is appended to anyway, because housekeeping must not cost the operator their ingress.
 `0600` stays: it is the control that does not depend on every future writer remembering to redact.
 
-**Tests (+8):** `test/caddy.test.js` +1 (a Caddyfile whose *credential line* is the offending one, so
-the validator's own output carries the hash — the real #821 vector end-to-end);
+**Tests (+12):** `test/caddy.test.js` +1 (a Caddyfile whose *credential line* is the offending one,
+so the validator's own output carries the hash — the real #821 vector end-to-end);
 `test/ingress-provision.test.js` +7 (under-cap left alone, over-cap rotated with the live path
-cleared, oldest generation retired, rotated generation still 0600, `spawnCutover` rotates before
-opening, cutover survives an unrotatable log).
+cleared, oldest generation retired, rotated generation still 0600, a legacy loose log tightened on
+rotation, `spawnCutover` rotates before opening, cutover survives and still logs when rotation
+fails); `test/ingress-cutover.test.js` +4 (result-file `error` and `healthError` scrubbed, ordinary
+text untouched, and a source-pin on the fatal stderr write).
 
 **The fixture was the risk, and is guarded.** The local caddy stub emitted a FIXED error string and
 never quoted the offending line — so a redaction test written against it would have passed without
@@ -82,6 +84,41 @@ stub's quoting reddens the test on *that* guard, naming the fixture.
 rotation call removed → `spawnCutover rotates BEFORE opening`; size check removed → `leaves a log
 under the cap`; stub stops quoting → the fixture guard. Full suite **5601 pass / 0 fail / 1 skip** on
 node v22.22.3, matching CI's `node --test 'test/*.test.js'` on node 22; recorded as machine evidence.
+
+**Carried from the cumulative review (1 blocking, 10 warning, 7 note — all decided in one pass):**
+- **BLOCKING R-1 — two of the three redaction sites were unpinned.** Deleting the result-file or
+  stderr redaction left the suite green. Fixed with 4 tests: `error` and `healthError` scrubbed
+  behaviourally, ordinary text proven untouched, and the fatal stderr write pinned by **source
+  assertion** — it lives in `main`, which no test may call, because running it performs a real
+  cutover on the developer's own box (the very thing `spawnCutover`'s interlock exists to prevent).
+  Source-pinning follows the existing precedent in `test/setup-provisioning.test.js`.
+- **R-2/R-10/R-15 (three reviewers, independently) — my rotation-failure test could not go red.**
+  A *directory* at the log path makes `statSync().size` ~64–128 B, so the size check returned early
+  and rotation's catch never ran; the test passed on `spawnCutover`'s pre-existing `openSync`
+  handler and would have passed with the catch deleted. Now an oversized real log whose destination
+  generation is a non-empty directory, so `renameSync` genuinely throws, and the assertion is
+  `stdio[1]` being a real descriptor — the arm that distinguishes swallowing from escaping. This is
+  the second vacuous-fixture near-miss on this branch; both were caught by the guard, not by luck.
+- **R-4/R-16 — nothing addressed a hash already on disk.** Both controls are prospective and a
+  sub-threshold log never rotates, so an existing log keeps its hash forever. `CHANGELOG.md` said
+  "can no longer hold", which over-claimed; it now says "no longer records" and states the limit,
+  and `deploy/INGRESS.md` carries a check + remedy. Related: rotation runs before the
+  `openSync(0600)`/`fchmod` pair and `rename` preserves mode, so a legacy 0644 log was carried into
+  the archive at 0644 — the rotated generation is now chmod'd too (test + mutation).
+- **R-3/R-7/R-8/R-14 — three durable records still asserted #821 was live.**
+  `observability-strategy.md` (ratified Direction), `boundary-patterns.md` (the contract-surface
+  file the Critic protocol sends every reviewer to), and `deploy/INGRESS.md` all updated. The
+  Direction gained the rule the fix actually establishes: **a producer of text that can embed a
+  secret owns the redaction; a reporter may add a pass but must never be the only one** (R-12).
+  `deploy/INGRESS.md`'s #846 decision had this hazard as its stated reason — the premise is now
+  recorded as expired, the decision left standing on its remaining (narrower) support, and whether
+  to revisit #846 flagged as the operator's call rather than taken as a side effect of this fix.
+- **R-6 — the stderr rationale overstated the carrier.** No generator path emits the hash today;
+  the comment now says the write is prophylactic and why that is still worth it.
+- **R-5/R-13 — test counts were one high** (+8 claimed, +12 actual across three files). Corrected.
+- **Accepted, not fixed:** R-11 (the shift loop duplicates `logger._rotateIfNeeded`) — divergent fd
+  ownership is exactly why this cannot call into the logger, and a shared helper for nine lines
+  would couple two lifecycles that must stay independent. R-17/R-18 informational.
 
 **Note:** built during a GitHub Actions major outage, so the required `test` context could not report.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -773,7 +773,7 @@ All notable changes to TangleClaw are documented in this file.
 
 ### Security
 
-- **The ingress cutover log can no longer hold your login's password hash, and no longer grows
+- **The ingress cutover log no longer records your login's password hash, and no longer grows
   without end (#821).** `~/.tangleclaw/logs/ingress-cutover.log` was opened with a raw append-mode
   descriptor outside the logger that owns rotation, so it had no size cap, no rotation and no
   pruning — and by the code's own admission it could capture a credential hash, because
@@ -803,7 +803,17 @@ All notable changes to TangleClaw are documented in this file.
   stderr, so renaming mid-run would leave that child writing to a detached inode — the same trap
   `logger.js` documents for the long-running server. A log that cannot be rotated is appended to
   anyway; housekeeping must never cost an operator their ingress. The existing `0600` mode stays,
-  because it is the control that does not depend on every future writer remembering to redact.
+  because it is the control that does not depend on every future writer remembering to redact —
+  and a rotated generation is now tightened too, since `rename` preserves mode and would otherwise
+  carry a pre-existing loose log's `0644` into the archive.
+
+  **Both controls are prospective, and an already-written log is not cleaned up.** If this machine
+  ran a cutover that hit the validate-failure path before this release, its existing log can still
+  hold a hash — rotation will not remove it either, because a log under the threshold never
+  rotates. TangleClaw does not silently truncate the operator's only record of what setup did.
+  `deploy/INGRESS.md` carries a one-line check and the remedy; in short, the file is narration
+  rather than state, nothing reads it back, and `rm ~/.tangleclaw/logs/ingress-cutover.log*` is
+  safe.
 
 - **A state-changing request or terminal socket must now arrive under a name this install
   actually serves — closing the DNS-rebinding path around both v5 cross-site guards (#864).**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -773,6 +773,38 @@ All notable changes to TangleClaw are documented in this file.
 
 ### Security
 
+- **The ingress cutover log can no longer hold your login's password hash, and no longer grows
+  without end (#821).** `~/.tangleclaw/logs/ingress-cutover.log` was opened with a raw append-mode
+  descriptor outside the logger that owns rotation, so it had no size cap, no rotation and no
+  pruning — and by the code's own admission it could capture a credential hash, because
+  `caddy validate` quotes the offending Caddyfile line back and for this project that line is
+  `basic_auth <user> <hash>`. Caddy renamed `basicauth` to `basic_auth` in 2.8, so a version skew
+  alone is enough to make the credential line itself the one that fails to parse.
+
+  **Redaction is the control for the secret; rotation is the control for growth.** They are not
+  interchangeable, and it is worth being exact because the obvious reading gets it backwards: a size
+  cap would not have bounded the credential's lifetime at all. This log gets kilobytes per run and an
+  install performs a handful of cutovers ever, so it would sit forever below any sane threshold,
+  never rotate, and keep the hash for the life of the machine. Only removing the hash removes the
+  hash.
+
+  So the hash is now redacted **at its source** — `caddy.validateCaddyfile` scrubs its own error
+  before returning it. That one string fanned out to three sinks: the cutover log, the cutover
+  result file, and the server log. Only the third was redacting, which is precisely the evidence
+  that per-caller redaction is the leaky shape. The cutover additionally scrubs what it writes to
+  its result file and its stderr, since the Caddyfile generator can reject a credential and name it.
+  The username is deliberately kept — it is what makes a failure diagnosable, and it is already
+  reported at the HTTP boundary.
+
+  Separately, the log now rotates at 1 MB keeping one previous generation — deliberately far below
+  the server log's 10 MB, since a threshold sized for a continuously-appended service log would
+  never be reached here and would bound nothing. Rotation happens **only immediately before the log
+  is opened for a new run**, never during one: the descriptor becomes a detached child's stdout and
+  stderr, so renaming mid-run would leave that child writing to a detached inode — the same trap
+  `logger.js` documents for the long-running server. A log that cannot be rotated is appended to
+  anyway; housekeeping must never cost an operator their ingress. The existing `0600` mode stays,
+  because it is the control that does not depend on every future writer remembering to redact.
+
 - **A state-changing request or terminal socket must now arrive under a name this install
   actually serves — closing the DNS-rebinding path around both v5 cross-site guards (#864).**
   Those guards decide "is this cross-site?" *relative to the request itself*: `Sec-Fetch-Site` is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -792,7 +792,8 @@ All notable changes to TangleClaw are documented in this file.
   before returning it. That one string fanned out to three sinks: the cutover log, the cutover
   result file, and the server log. Only the third was redacting, which is precisely the evidence
   that per-caller redaction is the leaky shape. The cutover additionally scrubs what it writes to
-  its result file and its stderr, since the Caddyfile generator can reject a credential and name it.
+  its result file and its stderr — prophylactically, since no path today builds such a message,
+  so that a future thrower near the credential cannot reopen this without knowing to.
   The username is deliberately kept — it is what makes a failure diagnosable, and it is already
   reported at the HTTP boundary.
 

--- a/deploy/INGRESS.md
+++ b/deploy/INGRESS.md
@@ -69,7 +69,30 @@ Two consequences fall out of the same fact:
 - **The child's stdout/stderr must go somewhere.** They are appended to
   `~/.tangleclaw/logs/ingress-cutover.log`. Discarding them would throw away the
   cutover's own "could not write result file" warning — the diagnostic that matters
-  precisely when the result channel is the thing that failed.
+  precisely when the result channel is the thing that failed. The log is `0600`,
+  rotates at 1 MB keeping one previous generation, and the credential hash that
+  `caddy validate` can quote back is redacted at its producer (#821).
+
+### If this machine ran a cutover before 2026-08-06, check its log once
+
+Both #821 controls are **prospective**. Redaction scrubs text as it is written, and a
+log below the rotation threshold never rotates — so a hash already sitting in
+`~/.tangleclaw/logs/ingress-cutover.log` stays there indefinitely. Nothing in the fix
+rewrites history, deliberately: silently truncating an operator's only record of what
+setup did is not a call TangleClaw should make on its own.
+
+It only happened if a cutover actually hit the validate-failure path (most installs
+never do). Check, and clear it yourself if so:
+
+```sh
+grep -c '\$2[aby]\$' ~/.tangleclaw/logs/ingress-cutover.log        # 0 means nothing to do
+grep -rl '\$2[aby]\$' ~/.tangleclaw/logs/ingress-cutover.log*      # includes rotated generations
+```
+
+If a match appears, the file is narration, not state — nothing reads it back, so it is
+safe to remove: `rm ~/.tangleclaw/logs/ingress-cutover.log*`. Changing the password
+itself is only warranted if that file left the machine (a pasted log, a bug report, a
+backup), since the hash is bcrypt and `0600`.
 
 Alternatives rejected, recorded so they are not re-proposed: executing the plan
 in-process minus the kickstart leaves the server bound wrong until some later
@@ -217,12 +240,24 @@ the generator reproduces the live file in full — see the parity caveat below.
 > Caddyfile that carries one by hand **ends Caddy access logging** — this is a real
 > loss, and it is not a bug to be fixed by teaching the generator to emit one.
 >
-> The reason is that an ingress log is not free: `~/.tangleclaw/logs/ingress-cutover.log`
-> already grows without rotation and can capture a `basic_auth` credential hash
-> (**#821**). Emitting an access-log block by default would propagate that hazard to
-> every new install, and TangleClaw would be writing a credential-adjacent, unrotated
-> file on machines whose operator never asked for one. A gap the operator opts into
-> is safer than a hazard they inherit.
+> The reason is that an ingress log is not free. As originally argued:
+> `~/.tangleclaw/logs/ingress-cutover.log` itself grew without rotation and could capture a
+> `basic_auth` credential hash (**#821**), so emitting an access-log block by default would
+> propagate that hazard to every new install.
+>
+> **That premise no longer holds — #821 closed 2026-08-06.** The cutover log now rotates
+> (1 MB, 2 files) and the hash is redacted at its producer. The nearest supporting
+> argument for this decision is therefore gone, and it is recorded here rather than
+> quietly dropped, because a decision whose stated reason has expired should be re-argued
+> on purpose or not at all.
+>
+> **The decision stands on what is left of it**, which is narrower but still real: an
+> access log is a file TangleClaw would be creating on a machine whose operator never
+> asked for one, and *whoever emits a log owns its rotation* — which for a Caddy-written
+> log is Caddy's `log` directive, not anything TangleClaw controls. A gap the operator
+> opts into is safer than a hazard they inherit. Whether the closed #821 changes the
+> balance enough to revisit #846 is a decision for the operator, not a side effect of
+> this fix.
 >
 > **If you want access logging, add the block by hand and own its rotation** — see
 > Caddy's `log` directive. Re-read this before any cutover on a machine that has one:

--- a/lib/caddy.js
+++ b/lib/caddy.js
@@ -543,7 +543,16 @@ function validateCaddyfile(caddyfilePath) {
   } catch (err) {
     // execFileSync surfaces validation failures via stderr in err.message/stderr.
     const detail = (err.stderr && err.stderr.toString().trim()) || err.message;
-    return { ok: false, error: detail };
+    // Redacted HERE, at the source, not at each place the error is reported
+    // (#821). `caddy validate` quotes the offending Caddyfile line, and for this
+    // project's config that line is `basic_auth <user> <hash>` — so this string
+    // is the one place a credential hash enters text nobody wrote by hand. It
+    // then fans out to three sinks: the cutover log, the cutover result file,
+    // and the server log. Only the third was redacting, so redacting per-caller
+    // was already proven to be the leaky shape. Callers that still call
+    // `redactHashes` are unaffected — it is idempotent, and defence in depth on
+    // a credential is worth the duplicate pass.
+    return { ok: false, error: redactHashes(detail) };
   }
 }
 

--- a/lib/ingress-provision.js
+++ b/lib/ingress-provision.js
@@ -50,8 +50,11 @@ const CUTOVER_SCRIPT = path.join('scripts', 'ingress-cutover.js');
 // that is redaction at the source (`caddy.validateCaddyfile`), which is why
 // this change is not rotation alone.
 const CUTOVER_LOG_MAX_BYTES = 1024 * 1024;
-// Current + this many rotated generations. The oldest is unlinked as
-// generations shift, which is what eventually retires old content.
+// TOTAL files kept, live one included — so 2 means `ingress-cutover.log` plus a
+// single `.1`. Nothing is unlinked: the shift renames the live log ONTO the
+// oldest generation, and that overwrite is what retires old content. Stated
+// precisely because this is the number a future writer changes, and "how many
+// backups" reads like it excludes the live file.
 const CUTOVER_LOG_MAX_FILES = 2;
 
 /**
@@ -112,7 +115,19 @@ function rotateCutoverLogIfNeeded(logPath) {
     for (let i = CUTOVER_LOG_MAX_FILES - 1; i >= 1; i--) {
       const from = i === 1 ? logPath : `${logPath}.${i - 1}`;
       const to = `${logPath}.${i}`;
-      if (fs.existsSync(from)) fs.renameSync(from, to);
+      if (!fs.existsSync(from)) continue;
+      fs.renameSync(from, to);
+      // `rename` preserves mode, and rotation deliberately runs BEFORE the
+      // `openSync(0600)`/`fchmodSync` pair that tightens the live log — so on an
+      // install predating that tightening, the loose 0644 log would be carried
+      // into the rotated generation and stay there, holding the same text the
+      // live one was tightened for. Tighten the generation too.
+      try {
+        fs.chmodSync(to, 0o600);
+      } catch (err) {
+        log.warn('Could not tighten permissions on the rotated cutover log',
+          { path: to, error: err.message });
+      }
     }
     log.info('Rotated the ingress cutover log', { path: logPath, maxBytes: CUTOVER_LOG_MAX_BYTES });
     return true;

--- a/lib/ingress-provision.js
+++ b/lib/ingress-provision.js
@@ -37,6 +37,23 @@ const RESULT_FILENAME = 'ingress-cutover-result.json';
 const CUTOVER_LOG_RELATIVE = '~/.tangleclaw/logs/ingress-cutover.log';
 const CUTOVER_SCRIPT = path.join('scripts', 'ingress-cutover.js');
 
+// Retention for the cutover log (#821). Deliberately far smaller than the
+// server log's 10 MB: a cutover writes kilobytes and an install performs a
+// handful in its lifetime, so a threshold sized for a continuously-appended
+// service log would never be reached here and would bound nothing at all.
+//
+// What this does and does not buy is worth being exact about, because the
+// issue's framing invites the wrong conclusion. Rotation bounds GROWTH — it is
+// what stops a retry loop appending forever. It does NOT bound how long a
+// secret lives: a file below the threshold never rotates, so a credential hash
+// written once could sit here for the life of the install. The control for
+// that is redaction at the source (`caddy.validateCaddyfile`), which is why
+// this change is not rotation alone.
+const CUTOVER_LOG_MAX_BYTES = 1024 * 1024;
+// Current + this many rotated generations. The oldest is unlinked as
+// generations shift, which is what eventually retires old content.
+const CUTOVER_LOG_MAX_FILES = 2;
+
 /**
  * Repository root — the directory holding `scripts/ingress-cutover.js`. This
  * module lives in `lib/`, so the repo is one level up.
@@ -67,6 +84,43 @@ function resultPath() {
  */
 function cutoverLogPath() {
   return path.join(store._getBasePath(), 'logs', 'ingress-cutover.log');
+}
+
+/**
+ * Rotate the cutover log if it has grown past its cap (#821).
+ *
+ * Called ONLY immediately before the log is opened for a new cutover, and that
+ * timing is the whole design. The fd becomes a detached child's stdout and
+ * stderr, so rotating while a cutover is running would rename the file out from
+ * under a process that goes on writing to the old inode — the same trap
+ * `logger.js` documents for the long-running server ("the owner of the log owns
+ * its rotation"). Between runs nobody holds the descriptor, so a rename here is
+ * safe by construction rather than by luck.
+ *
+ * Best-effort: a cutover that cannot rotate its log must still run. Failing the
+ * cutover to protect a log file would trade the operator's ingress for
+ * housekeeping.
+ * @param {string} logPath - Absolute path of the cutover log.
+ * @returns {boolean} Whether a rotation actually happened.
+ */
+function rotateCutoverLogIfNeeded(logPath) {
+  try {
+    if (!fs.existsSync(logPath)) return false;
+    if (fs.statSync(logPath).size < CUTOVER_LOG_MAX_BYTES) return false;
+
+    // Work backwards so a generation is never overwritten before it moves.
+    for (let i = CUTOVER_LOG_MAX_FILES - 1; i >= 1; i--) {
+      const from = i === 1 ? logPath : `${logPath}.${i - 1}`;
+      const to = `${logPath}.${i}`;
+      if (fs.existsSync(from)) fs.renameSync(from, to);
+    }
+    log.info('Rotated the ingress cutover log', { path: logPath, maxBytes: CUTOVER_LOG_MAX_BYTES });
+    return true;
+  } catch (err) {
+    log.warn('Could not rotate the ingress cutover log; appending to it anyway',
+      { path: logPath, error: err.message });
+    return false;
+  }
 }
 
 /**
@@ -320,12 +374,17 @@ function spawnCutover(opts = {}) {
   const logPath = cutoverLogPath();
   try {
     fs.mkdirSync(path.dirname(logPath), { recursive: true });
+    // Before the open, never during a run — see rotateCutoverLogIfNeeded.
+    rotateCutoverLogIfNeeded(logPath);
     // 0600 to match the result file the same run writes. The child's stderr lands
     // here verbatim, and on the validate-failed path that text is `caddy validate`
-    // output quoting a `basic_auth <user> <hash>` line — so this file can hold a
-    // credential hash even though nothing deliberately writes one to it. Mode is
-    // only applied on create; an existing log keeps its permissions, so tighten it
-    // as well rather than trusting the first-ever open to have set it.
+    // output quoting a `basic_auth <user> <hash>` line. The hash itself no longer
+    // reaches this file — `caddy.validateCaddyfile` redacts at the source and the
+    // cutover redacts what it writes (#821) — but 0600 stays: it is the control
+    // that does not depend on every future writer remembering, and the username
+    // is deliberately still here to keep failures diagnosable. Mode is only
+    // applied on create; an existing log keeps its permissions, so tighten it as
+    // well rather than trusting the first-ever open to have set it.
     logFd = fs.openSync(logPath, 'a', 0o600);
     try {
       fs.fchmodSync(logFd, 0o600);
@@ -376,6 +435,9 @@ module.exports = {
   clearResult,
   readResult,
   spawnCutover,
+  rotateCutoverLogIfNeeded,
   RESULT_FILENAME,
-  CUTOVER_LOG_RELATIVE
+  CUTOVER_LOG_RELATIVE,
+  CUTOVER_LOG_MAX_BYTES,
+  CUTOVER_LOG_MAX_FILES
 };

--- a/scripts/ingress-cutover.js
+++ b/scripts/ingress-cutover.js
@@ -630,8 +630,11 @@ function main() {
   } catch (err) { // prawduct:allow prawduct/broad-except -- planCutover's refusals and its generator's validation errors both arrive as Error; reported below, never swallowed
     // This script's stderr IS the cutover log — the parent hands it the log fd
     // as the child's stdio — so anything written here lands in a file that
-    // persists (#821). The generator validates the credential it is embedding,
-    // so a rejection message is a plausible carrier for the hash it rejected.
+    // persists (#821). No generator path today builds a message containing the
+    // hash, so this is prophylactic rather than a fix for a known carrier: it
+    // covers any future thrower in `planCutover`'s tree, which is where the
+    // credential is handled, without that author having to know this write ends
+    // up in a durable file. Cheap, and the alternative is finding out later.
     process.stderr.write(`ERROR: ${caddy.redactHashes(err.message)}\n`);
     // Only the tagged refusal is `ungate-refused`. Everything else the generator
     // raises is a plain build failure, and must not be reported as a credential

--- a/scripts/ingress-cutover.js
+++ b/scripts/ingress-cutover.js
@@ -314,7 +314,14 @@ function writeCutoverResult(resultFile, result) {
       ok: Boolean(result.ok),
       code: result.code,
       target: result.target,
-      error: result.error || null,
+      // Redacted on the way OUT, not trusted to arrive clean (#821). This file
+      // persists at 0600 and is read back by the server and the wizard, so it is
+      // a second at-rest home for whatever text a failure carried. The source
+      // that can hold a hash — `caddy validate` output — is redacted in
+      // `caddy.validateCaddyfile`, but `finish` is also reached with a plain
+      // Error message from the Caddyfile generator, and that path has no such
+      // guarantee. One pass here covers every code that routes through `finish`.
+      error: caddy.redactHashes(result.error) || null,
       healthUrl: result.healthUrl || null,
       healthOk: typeof result.healthOk === 'boolean' ? result.healthOk : null,
       // Distinct from `error` ON PURPOSE. `finish` derives both `ok` and the exit
@@ -324,7 +331,7 @@ function writeCutoverResult(resultFile, result) {
       // health result is a separate fact from whether the cutover succeeded, and
       // this key exists so it can be reported without inverting the outcome.
       // This builder names every key explicitly: anything absent here is dropped.
-      healthError: result.healthError || null,
+      healthError: caddy.redactHashes(result.healthError) || null,
       finishedAt: new Date().toISOString()
     })}\n`, { mode: 0o600 });
     return true;
@@ -620,8 +627,12 @@ function main() {
   let plan;
   try {
     plan = planCutover(target, ctx);
-  } catch (err) { // prawduct:allow prawduct/broad-except -- planCutover's refusals and its generator's validation errors both arrive as Error; reported verbatim below, never swallowed
-    process.stderr.write(`ERROR: ${err.message}\n`);
+  } catch (err) { // prawduct:allow prawduct/broad-except -- planCutover's refusals and its generator's validation errors both arrive as Error; reported below, never swallowed
+    // This script's stderr IS the cutover log — the parent hands it the log fd
+    // as the child's stdio — so anything written here lands in a file that
+    // persists (#821). The generator validates the credential it is embedding,
+    // so a rejection message is a plausible carrier for the hash it rejected.
+    process.stderr.write(`ERROR: ${caddy.redactHashes(err.message)}\n`);
     // Only the tagged refusal is `ungate-refused`. Everything else the generator
     // raises is a plain build failure, and must not be reported as a credential
     // problem — the two have completely different operator remedies.

--- a/test/caddy.test.js
+++ b/test/caddy.test.js
@@ -40,6 +40,15 @@ case "$1" in
     fi
     if grep -q INVALID "$cfg"; then
       echo "stub: adapting caddyfile: invalid directive" >&2
+      # Real caddy QUOTES the offending line back, and that is the only reason a
+      # credential can reach a log nobody wrote it to (#821): when the directive
+      # carrying \`basic_auth <user> <hash>\` is itself what failed to parse, the
+      # hash is inside the quoted text. Caddy renamed \`basicauth\` to
+      # \`basic_auth\` in 2.8, so a version skew alone produces exactly that.
+      # A stub that only ever emitted a fixed string could not express this, and
+      # a redaction test written against it would pass without redacting
+      # anything.
+      grep -n INVALID "$cfg" | head -1 | sed "s|^|  $cfg:|" >&2
       exit 1
     fi
     echo "Valid configuration"
@@ -493,6 +502,27 @@ describe('caddy', () => {
       const r = caddy.validateCaddyfile(cfg);
       assert.equal(r.ok, false);
       assert.match(r.error, /invalid directive/);
+    });
+
+    it('redacts a credential hash the validator quoted back at us (#821)', () => {
+      // The whole #821 vector in one test: the offending line IS the credential
+      // line, so the validator's own output carries the hash. This error string
+      // fans out to the cutover log, the cutover result file and the server log,
+      // so redacting it here is what keeps it out of all three at once.
+      const HASH = '$2a$14$' + 'q'.repeat(53);
+      const cfg = path.join(tmpDir, 'credential-Caddyfile');
+      fs.writeFileSync(cfg, `localhost {\n\tbasic_autth ops ${HASH} INVALID\n}\n`);
+
+      const r = caddy.validateCaddyfile(cfg);
+
+      assert.equal(r.ok, false);
+      // Guards the fixture, not the code: if the validator stopped quoting the
+      // line, this test would pass while redacting nothing.
+      assert.match(r.error, /basic_autth/,
+        'the fixture must actually put the offending credential line into the error');
+      assert.ok(!r.error.includes(HASH), 'the hash must not survive validation output');
+      assert.match(r.error, /\[redacted-hash\]/);
+      assert.match(r.error, /ops/, 'the username stays — it is what makes the failure diagnosable');
     });
 
     it('returns ok: false when caddy is not on PATH', () => {

--- a/test/ingress-cutover.test.js
+++ b/test/ingress-cutover.test.js
@@ -137,6 +137,68 @@ describe('ingress-cutover', () => {
       assert.equal(cutover.writeCutoverResult(null, { ok: true, code: 'ok', target: 'caddy' }), false);
     });
 
+    // #821 — this file is the SECOND at-rest home for a failure's text (the
+    // cutover log is the first), it is read back by the server and the wizard,
+    // and it persists at 0600. `caddy.validateCaddyfile` redacts at the source,
+    // but `finish` is also reached from throwers that carry their own message,
+    // so the write itself must not be the thing that trusts its input.
+    describe('credential redaction (#821)', () => {
+      const HASH = '$2a$14$' + 'z'.repeat(53);
+
+      it('scrubs a hash out of `error` before it reaches the file', () => {
+        const p = path.join(dir, 'redact-error.json');
+        cutover.writeCutoverResult(p, {
+          ok: false,
+          code: cutover.CUTOVER_CODES.VALIDATE_FAILED,
+          target: 'caddy',
+          error: `generated Caddyfile failed validation: basic_auth ops ${HASH}`
+        });
+        const raw = fs.readFileSync(p, 'utf8');
+        assert.ok(!raw.includes(HASH), 'no hash may reach the result file');
+        assert.match(raw, /\[redacted-hash\]/);
+        assert.match(raw, /ops/, 'the username stays — it is what makes the failure diagnosable');
+      });
+
+      it('scrubs `healthError` too, which travels a different key for a reason', () => {
+        // healthError is deliberately NOT routed through `error` (it would invert
+        // the outcome), so it is a genuinely separate path into the same file and
+        // redacting one says nothing about the other.
+        const p = path.join(dir, 'redact-health.json');
+        cutover.writeCutoverResult(p, {
+          ok: true,
+          code: cutover.CUTOVER_CODES.OK,
+          target: 'caddy',
+          healthError: `probe failed against basic_auth ops ${HASH}`
+        });
+        const raw = fs.readFileSync(p, 'utf8');
+        assert.ok(!raw.includes(HASH), 'no hash may reach the result file via the health key either');
+        assert.match(raw, /\[redacted-hash\]/);
+      });
+
+      it('leaves ordinary error text exactly as it was', () => {
+        // Redaction must not become a mangler: the common case carries no hash.
+        const p = path.join(dir, 'redact-none.json');
+        cutover.writeCutoverResult(p, {
+          ok: false, code: cutover.CUTOVER_CODES.FAILED, target: 'caddy', error: 'launchctl bootout failed'
+        });
+        assert.equal(JSON.parse(fs.readFileSync(p, 'utf8')).error, 'launchctl bootout failed');
+      });
+
+      it('the fatal stderr write redacts too — that stream IS the cutover log', () => {
+        // Asserted against the source because this write lives in `main`, which
+        // cannot be called from a test: running it would perform a real cutover
+        // on the developer's own box, which is exactly what the spawn interlock
+        // in lib/ingress-provision.js exists to prevent. The same source-pinning
+        // shape is already used for the redaction at
+        // test/setup-provisioning.test.js's `log.warn` assertion.
+        const src = fs.readFileSync(path.join(__dirname, '..', 'scripts', 'ingress-cutover.js'), 'utf8');
+        assert.match(
+          src, /process\.stderr\.write\(`ERROR: \$\{caddy\.redactHashes\(err\.message\)\}\\n`\)/,
+          'the catch-all fatal write must redact — its output lands in a file that persists'
+        );
+      });
+    });
+
     // The whole point of the best-effort contract: a cutover that has already
     // touched launchd must not abort because its status file is unwritable.
     it('never throws when the path cannot be written', () => {

--- a/test/ingress-provision.test.js
+++ b/test/ingress-provision.test.js
@@ -454,6 +454,23 @@ describe('spawnCutover', () => {
       assert.equal(fs.statSync(`${logPath}.1`).mode & 0o777, 0o600);
     });
 
+    it('tightens a LEGACY loose log on rotation instead of preserving its mode', () => {
+      // `rename` preserves mode, and rotation runs before the openSync/fchmod
+      // pair that tightens the live log — so an install predating that tightening
+      // would carry its 0644 straight into the generation and keep it there,
+      // holding exactly the text the live log was tightened for.
+      const logPath = requireSandboxed(provision.cutoverLogPath());
+      fs.rmSync(`${logPath}.1`, { force: true });
+      writeOversizedLog(logPath);
+      fs.chmodSync(logPath, 0o644);
+      assert.equal(fs.statSync(logPath).mode & 0o777, 0o644, 'precondition: the legacy log is loose');
+
+      provision.rotateCutoverLogIfNeeded(logPath);
+
+      assert.equal(fs.statSync(`${logPath}.1`).mode & 0o777, 0o600,
+        'the rotated generation must be tightened, not left at the mode it was renamed with');
+    });
+
     it('spawnCutover rotates BEFORE opening, never under a running child', () => {
       // The timing is the design: the fd becomes a detached child's stdout and
       // stderr, so renaming the file mid-run would leave that child writing to a
@@ -472,20 +489,42 @@ describe('spawnCutover', () => {
       assert.equal(fs.existsSync(`${logPath}.1`), true, 'the previous content is kept as one generation');
     });
 
-    it('still runs the cutover when the log cannot be rotated', () => {
+    it('still runs the cutover, and still logs, when rotation itself fails', () => {
       // Housekeeping must never cost the operator their ingress. An unrotatable
       // log degrades to appending, it does not abort the run.
+      //
+      // Reaching the failure branch is the hard part, and the obvious fixture
+      // does not: putting a DIRECTORY at the log path makes `statSync().size`
+      // ~64-128 bytes, so the size check returns early and rotation's catch never
+      // runs — the test then passes on `spawnCutover`'s pre-existing openSync
+      // handler instead, and would pass with the catch deleted. So: an oversized
+      // REAL log (clears the size check) whose destination generation is a
+      // non-empty directory, which is what makes `renameSync` throw.
       const logPath = requireSandboxed(provision.cutoverLogPath());
-      fs.rmSync(logPath, { force: true });
-      fs.mkdirSync(logPath, { recursive: true }); // a DIRECTORY where the log goes
+      const blocked = `${logPath}.1`;
+      fs.rmSync(blocked, { recursive: true, force: true });
+      writeOversizedLog(logPath);
+      fs.mkdirSync(blocked, { recursive: true });
+      fs.writeFileSync(path.join(blocked, 'occupied'), 'not empty, so rename cannot replace it');
       try {
+        assert.equal(provision.rotateCutoverLogIfNeeded(logPath), false,
+          'rotation reports failure rather than throwing');
+
+        let opts = null;
         const res = provision.spawnCutover({
           resultFile: path.join(os.tmpdir(), 'tc-rot2.json'),
-          spawnFn: () => ({ pid: 10, unref() {} })
+          spawnFn: (_c, _a, o) => { opts = o; return { pid: 10, unref() {} }; }
         });
-        assert.equal(res.ok, true, 'the cutover proceeds despite an unusable log path');
+
+        assert.equal(res.ok, true, 'the cutover proceeds despite an unrotatable log');
+        // The arm that actually distinguishes swallowing from not: without the
+        // catch, the throw escapes into spawnCutover's own try, `logFd` stays
+        // 'ignore', and the child's output is discarded — losing the one
+        // diagnostic that matters when things are already going wrong.
+        assert.equal(typeof opts.stdio[1], 'number',
+          'the run must still get a real log descriptor, not fall back to discarding output');
       } finally {
-        fs.rmSync(logPath, { recursive: true, force: true });
+        fs.rmSync(blocked, { recursive: true, force: true });
       }
     });
   });

--- a/test/ingress-provision.test.js
+++ b/test/ingress-provision.test.js
@@ -356,11 +356,13 @@ describe('spawnCutover', () => {
   });
 
   it('opens the cutover log 0600, like the result file it sits beside', () => {
-    // The child's stderr lands here verbatim, and on the validate-failed path that
-    // text is `caddy validate` output quoting a `basic_auth <user> <hash>` line —
-    // so this file can hold a credential hash without anything deliberately
-    // writing one to it. The result file, same rationale, has been 0600 all along;
-    // this one took the default until now.
+    // The child's stderr lands here verbatim, and on the validate-failed path
+    // that text is `caddy validate` output quoting a `basic_auth <user> <hash>`
+    // line. #821 stopped the hash itself from reaching this file, but 0600 is
+    // the control that does not depend on every future writer remembering to
+    // redact — and the username is deliberately still written here. The result
+    // file, same rationale, has been 0600 all along; this one took the default
+    // until now.
     const logPath = requireSandboxed(provision.cutoverLogPath());
     fs.rmSync(logPath, { force: true });
     provision.spawnCutover({
@@ -388,6 +390,104 @@ describe('spawnCutover', () => {
     });
     assert.equal(fs.statSync(logPath).mode & 0o777, 0o600,
       'an existing loose log must be tightened, not left as found');
+  });
+
+  // #821 — the log was opened append-only with no lifecycle at all: no cap, no
+  // rotation, no pruning, unlike the caddy access log beside it.
+  describe('cutover log retention (#821)', () => {
+    /**
+     * Write a log larger than the rotation cap.
+     * @param {string} p - Log path.
+     * @returns {string} The same path.
+     */
+    function writeOversizedLog(p) {
+      fs.mkdirSync(path.dirname(p), { recursive: true });
+      fs.writeFileSync(p, 'x'.repeat(provision.CUTOVER_LOG_MAX_BYTES + 1), { mode: 0o600 });
+      return p;
+    }
+
+    it('leaves a log under the cap exactly where it is', () => {
+      // The common case by far: a cutover writes kilobytes. Rotating here would
+      // churn the operator's only narration of what setup did.
+      const logPath = requireSandboxed(provision.cutoverLogPath());
+      fs.mkdirSync(path.dirname(logPath), { recursive: true });
+      fs.writeFileSync(logPath, 'a short run\n', { mode: 0o600 });
+
+      assert.equal(provision.rotateCutoverLogIfNeeded(logPath), false);
+      assert.equal(fs.readFileSync(logPath, 'utf8'), 'a short run\n');
+      assert.equal(fs.existsSync(`${logPath}.1`), false, 'nothing should have been rotated');
+    });
+
+    it('rotates a log past the cap, clearing the live path for a fresh one', () => {
+      const logPath = requireSandboxed(provision.cutoverLogPath());
+      fs.rmSync(`${logPath}.1`, { force: true });
+      writeOversizedLog(logPath);
+
+      assert.equal(provision.rotateCutoverLogIfNeeded(logPath), true);
+      assert.equal(fs.existsSync(logPath), false,
+        'the live path must be free so the next open starts a new file');
+      assert.equal(fs.statSync(`${logPath}.1`).size, provision.CUTOVER_LOG_MAX_BYTES + 1);
+    });
+
+    it('retires the oldest generation rather than keeping every one forever', () => {
+      // Rotation only bounds growth if generations are finite. With two, the
+      // previous .1 is displaced and its content is gone — which is the only
+      // thing here that ever actually retires old text.
+      const logPath = requireSandboxed(provision.cutoverLogPath());
+      fs.mkdirSync(path.dirname(logPath), { recursive: true });
+      fs.writeFileSync(`${logPath}.1`, 'the oldest run\n', { mode: 0o600 });
+      writeOversizedLog(logPath);
+
+      provision.rotateCutoverLogIfNeeded(logPath);
+
+      assert.equal(fs.readFileSync(`${logPath}.1`, 'utf8').startsWith('x'), true,
+        'the displaced current log becomes .1');
+      assert.equal(fs.existsSync(`${logPath}.${provision.CUTOVER_LOG_MAX_FILES}`), false,
+        'generations must not grow past the cap');
+    });
+
+    it('a rotated generation keeps 0600 — it holds the same text the live one did', () => {
+      const logPath = requireSandboxed(provision.cutoverLogPath());
+      fs.rmSync(`${logPath}.1`, { force: true });
+      writeOversizedLog(logPath);
+      provision.rotateCutoverLogIfNeeded(logPath);
+      assert.equal(fs.statSync(`${logPath}.1`).mode & 0o777, 0o600);
+    });
+
+    it('spawnCutover rotates BEFORE opening, never under a running child', () => {
+      // The timing is the design: the fd becomes a detached child's stdout and
+      // stderr, so renaming the file mid-run would leave that child writing to a
+      // detached inode. Between runs nobody holds it.
+      const logPath = requireSandboxed(provision.cutoverLogPath());
+      fs.rmSync(`${logPath}.1`, { force: true });
+      writeOversizedLog(logPath);
+
+      provision.spawnCutover({
+        resultFile: path.join(os.tmpdir(), 'tc-rot.json'),
+        spawnFn: () => ({ pid: 9, unref() {} })
+      });
+
+      assert.equal(fs.statSync(logPath).size, 0, 'the run appends to a fresh log');
+      assert.equal(fs.statSync(logPath).mode & 0o777, 0o600, 'and the fresh log is still 0600');
+      assert.equal(fs.existsSync(`${logPath}.1`), true, 'the previous content is kept as one generation');
+    });
+
+    it('still runs the cutover when the log cannot be rotated', () => {
+      // Housekeeping must never cost the operator their ingress. An unrotatable
+      // log degrades to appending, it does not abort the run.
+      const logPath = requireSandboxed(provision.cutoverLogPath());
+      fs.rmSync(logPath, { force: true });
+      fs.mkdirSync(logPath, { recursive: true }); // a DIRECTORY where the log goes
+      try {
+        const res = provision.spawnCutover({
+          resultFile: path.join(os.tmpdir(), 'tc-rot2.json'),
+          spawnFn: () => ({ pid: 10, unref() {} })
+        });
+        assert.equal(res.ok, true, 'the cutover proceeds despite an unusable log path');
+      } finally {
+        fs.rmSync(logPath, { recursive: true, force: true });
+      }
+    });
   });
 
   it('defaults to the caddy target and the shared result path', () => {


### PR DESCRIPTION
## What

`~/.tangleclaw/logs/ingress-cutover.log` no longer records the install's `basic_auth` credential hash, and no longer grows without end.

## Why

The log was opened with a raw `fs.openSync(logPath, 'a', 0o600)` outside the logger that owns rotation — no cap, no rotation, no pruning. And by the code's own admission it could capture a credential hash: `caddy validate` quotes the offending Caddyfile line back, and for this project that line is `basic_auth <user> <hash>`. Caddy renamed `basicauth` to `basic_auth` in 2.8, so a **version skew alone** makes the credential line the one that fails to parse. v5 is the release that makes a credential mandatory, so it multiplies how many installs carry one of these files.

### The issue's proposed fix would not have solved the concern it states

#821 offers "route through the rotating logger **or** give it a size/age cap", with redaction as a conditional extra. For the stated concern — *retention of a secret* — that is backwards. This log takes kilobytes per run and an install performs a handful of cutovers ever, so it sits forever below any sane threshold, never rotates, and keeps the hash for the life of the machine.

**A size cap bounds growth and bounds the secret's lifetime not at all.** Both controls are implemented, with the division of labour recorded where each one lives:

| Control | Bounds |
|---|---|
| Redaction at the producer | the secret |
| Rotation at open | growth |

### The leak was wider than the issue describes

One `validateCaddyfile` error string fanned out to **three** sinks — the cutover log, the cutover **result file**, and the server log — and only the third redacted. That is itself the evidence that per-caller redaction is the leaky shape, so redaction moved to the producer: `caddy.validateCaddyfile` scrubs its own returned error and every consumer inherits it. The username is deliberately kept — it is what makes a failure diagnosable and is already reported at the HTTP boundary.

Rotation runs **only immediately before the log is opened**, never during a run: the descriptor becomes a detached child's stdout and stderr, so renaming mid-run would leave that child writing to a detached inode — the trap `logger.js` documents as "the owner of the log owns its rotation". It is best-effort; an unrotatable log is appended to anyway, because housekeeping must not cost an operator their ingress.

## Limits, stated rather than implied

**Both controls are prospective.** A log written before this change keeps its hash, and rotation will not remove it either. TangleClaw does not silently truncate the operator's only record of what setup did — `deploy/INGRESS.md` gains a check and a remedy instead.

`deploy/INGRESS.md`'s **#846 decision had this hazard as its stated reason.** The premise is now recorded as expired and the decision left standing on its narrower remaining support (Caddy owns a Caddy-written log's rotation). Whether that changes the balance enough to revisit #846 is the operator's call, not a side effect of this fix.

## Test plan

**+12 tests** across three files. Six mutations, each killing a different test:

| Mutation | Test that reddens |
|---|---|
| `validateCaddyfile` stops redacting | the validator-output redaction test |
| result-file `error` redaction removed | `scrubs a hash out of error` |
| result-file `healthError` redaction removed | `scrubs healthError too` |
| fatal stderr redaction removed | the source-pin |
| rotation call removed | `spawnCutover rotates BEFORE opening` |
| size check removed | `leaves a log under the cap` |
| rotated-generation `chmod` removed | `tightens a LEGACY loose log` |
| rotation failure no longer swallowed | `still runs the cutover, and still logs` |

**The fixture was the real risk, twice.** The local `caddy` stub emitted a fixed error string and never quoted the offending line — a redaction test written against it would have passed without redacting anything. The stub now quotes the line the way real caddy does, and the test asserts the error genuinely contains the credential line, so losing that fidelity fails loudly. Separately, the first version of the rotation-failure test could not go red (a directory at the log path made `statSync().size` ~64–128 bytes, so the size check returned before the catch); it now uses an oversized real log with a blocked destination.

Full suite **5606 pass / 0 fail / 1 skipped** on node v22.22.3, matching CI's `node --test 'test/*.test.js'` on node 22.

## Governance

`/prawduct:critic cumulative` (1 blocking, 10 warning, 7 note) → all decided in one commit → `verify-resolutions` (all 11 blocking/warning verified resolved, 0 findings) → one free records-only commit. The blocking finding and the rotation-test defect were both real; three reviewers independently converged on the latter. Three findings accepted via `disposition` with recorded reasoning.

> **Note:** opened during a GitHub Actions major outage (webhooks throttled to ~15%), so the required `test` check may not report until it recovers. Verified locally with CI's exact command and runtime.

Fixes #821