### PR TITLE
Decide protection once, and state it so an unknown value fails safe

### DIFF
--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -70,10 +70,11 @@ future wizard change was invisible to returning operators until `CACHE_NAME` mov
 network-first. **Not** a `CACHE_NAME` bump: that tears down and reinstalls the worker for every
 browser, which behind the basic_auth gate is what produced the repeating credential prompt in #710.
 
-**Tests (+9):** `test/ingress-provision.test.js` +5 (`confirmed` only for the observed-gate state;
+**Tests (+13):** `test/ingress-provision.test.js` +5 (`confirmed` only for the observed-gate state;
 an UNKNOWN state fails safe across six values incl. `null`/`undefined`/`''`; stored-vs-confirmed
 separation; unknown never reads as stored; the flags are orthogonal across all six
-states, and that the flags are orthogonal rather than exclusive);
+states — three states asserted, not six — and one asserting that
+"saved but not confirmed" is the COMBINATION rather than either flag alone);
 `test/setup-wizard-login-gate.test.js` +3 (an unheard-of state does not dismiss; the
 browser obeys a server answer that CONTRADICTS the enum, which is what proves the second source of
 truth is gone; `setup.js` is network-first); `test/setup-provisioning.test.js` +2 assertions (the
@@ -112,6 +113,16 @@ caught as unpinned before review rather than during it. Full suite **5614 pass /
   code** — both fixed.
 - **Accepted:** R-4 (figure accurate), R-5 (#802 descoped by the issue's own sequencing), R-15/R-16
   (informational).
+
+**Observability, added in the review pass and pinned like any other behaviour.** Two log lines:
+`deriveProtectionFlags` warns on a state it cannot classify (otherwise the fail-safe path is
+indistinguishable from a correctly-classified one), and `POST /api/setup/complete` records its
+verdict on **every** arm. The second matters because every other log on that endpoint fires on a
+cutover or a failure, so a confirmed install left no server-side trace at all and "it says it is
+protected" was unanswerable. Logging both arms is also what makes an ABSENT line mean "the request
+never got here" rather than "everything was fine". Both are pinned by tests that go red when the
+line is removed — the verdict log was itself caught unpinned by the review, one commit after the
+same rule had been applied to the other one.
 
 **Not done here, on purpose:** #802's end-to-end verification. The issue prescribes doing both in
 one pass, and this is the half a machine can do — the screens still need a real no-caddy install

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -70,22 +70,23 @@ future wizard change was invisible to returning operators until `CACHE_NAME` mov
 network-first. **Not** a `CACHE_NAME` bump: that tears down and reinstalls the worker for every
 browser, which behind the basic_auth gate is what produced the repeating credential prompt in #710.
 
-**Tests (+13):** `test/ingress-provision.test.js` +5 (`confirmed` only for the observed-gate state;
-an UNKNOWN state fails safe across six values incl. `null`/`undefined`/`''`; stored-vs-confirmed
-separation; unknown never reads as stored; the flags are orthogonal across all six
-states — three states asserted, not six — and one asserting that
-"saved but not confirmed" is the COMBINATION rather than either flag alone);
-`test/setup-wizard-login-gate.test.js` +3 (an unheard-of state does not dismiss; the
-browser obeys a server answer that CONTRADICTS the enum, which is what proves the second source of
-truth is gone; `setup.js` is network-first); `test/setup-provisioning.test.js` +2 assertions (the
-real API response actually carries both flags — the producing half of the contract).
+**Tests (+12), counted from the diff rather than estimated:** `test/ingress-provision.test.js`
+**+7** — `confirmed` only for the observed-gate state; an UNKNOWN state fails safe across six values
+incl. `null`/`undefined`/`''`; `credentialStored` reports the fact it is named for (including on the
+confirmed state); an unknown state is never reported as holding a credential; the two flags are
+orthogonal rather than exclusive; "saved but not confirmed" is their COMBINATION; and an
+unclassifiable state is logged (while a recognised one stays quiet).
+`test/setup-wizard-login-gate.test.js` **+3** — an unheard-of state does not dismiss; the browser
+obeys a server answer that CONTRADICTS the enum, which is what proves the second source of truth is
+gone; `setup.js` is network-first. `test/setup-provisioning.test.js` **+2** — the verdict log on the
+confirmed arm and on an unconfirmed one (plus flag assertions added to three existing cases).
 
 **Five mutations, each killing a different test.** The load-bearing one reverts the allowlist to the
 old denylist form: it agrees on all five known states and differs ONLY on an unknown one, and it
 reddens the fail-safe test specifically. Also: `credentialStored` forced false; the server not
 shipping the flags; the browser re-reading the enum; and `setup.js` dropped from
 `NETWORK_FIRST_PATHS` — that last one initially reddened NOTHING, which is how the sw.js change was
-caught as unpinned before review rather than during it. Full suite **5614 pass / 0 fail / 1 skip**.
+caught as unpinned before review rather than during it. Full suite **5616 pass / 0 fail / 1 skip**.
 
 **Carried from the cumulative review (0 blocking, 10 warning, 6 note — all decided in one pass):**
 - **R-1/R-6 — I had the call-site count BACKWARDS**, and it shipped in four places (`server.js`

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -43,15 +43,17 @@ the branch that DISMISSES the warning — a newly-added state would silently sto
 nothing is enforcing their login. Nothing fails; a screen stops appearing. Restating it as an
 allowlist of the ONE state where a gate was positively observed makes an unknown value fail safe.
 
-**What:** `deriveProtectionFlags(protection)` in `lib/ingress-provision.js` — pure, exported,
-returning `{confirmedProtection, credentialStored}`. `server.js` `Object.assign`s it onto `ingress`
+**What:** `deriveProtectionFlags(protection)` in `lib/ingress-provision.js` — exported, returning
+`{confirmedProtection, credentialStored}` (not pure: it logs a state it cannot classify, see
+below). `server.js` `Object.assign`s it onto `ingress`
 after the arm chain, and the warning push now reads `!confirmedProtection && !provisioning`
 (`provisioning` is set in the same block as `pending` and is its only producer — checked, not
 assumed). `public/setup.js` branches on the two booleans and **no longer reads the enum at all**:
 the only remaining `protection ===` in non-test code is the line inside the named function.
 
-**Deliberately behaviour-preserving on the screens.** `credentialStored` keeps exactly the pair the
-browser used to test. These are the least-verified screens in the release (#802), so the commit
+**Deliberately behaviour-preserving on the screens.** `credentialStored` ended up a WIDER set than
+the pair the browser used to test (see the review block below), but the extra value is unreachable
+by the only consumer, so the screens are identical. These are the least-verified screens in the release (#802), so the commit
 that moves WHO decides must not also move WHAT is decided.
 
 **Extracted to a module rather than left inline, for a reason the tests surfaced.** ~25 browser
@@ -70,8 +72,9 @@ browser, which behind the basic_auth gate is what produced the repeating credent
 
 **Tests (+9):** `test/ingress-provision.test.js` +5 (`confirmed` only for the observed-gate state;
 an UNKNOWN state fails safe across six values incl. `null`/`undefined`/`''`; stored-vs-confirmed
-separation; unknown never reads as stored; the two flags are mutually exclusive across all six
-states); `test/setup-wizard-login-gate.test.js` +3 (an unheard-of state does not dismiss; the
+separation; unknown never reads as stored; the flags are orthogonal across all six
+states, and that the flags are orthogonal rather than exclusive);
+`test/setup-wizard-login-gate.test.js` +3 (an unheard-of state does not dismiss; the
 browser obeys a server answer that CONTRADICTS the enum, which is what proves the second source of
 truth is gone; `setup.js` is network-first); `test/setup-provisioning.test.js` +2 assertions (the
 real API response actually carries both flags — the producing half of the contract).

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -81,7 +81,34 @@ old denylist form: it agrees on all five known states and differs ONLY on an unk
 reddens the fail-safe test specifically. Also: `credentialStored` forced false; the server not
 shipping the flags; the browser re-reading the enum; and `setup.js` dropped from
 `NETWORK_FIRST_PATHS` — that last one initially reddened NOTHING, which is how the sw.js change was
-caught as unpinned before review rather than during it. Full suite **5612 pass / 0 fail / 1 skip**.
+caught as unpinned before review rather than during it. Full suite **5614 pass / 0 fail / 1 skip**.
+
+**Carried from the cumulative review (0 blocking, 10 warning, 6 note — all decided in one pass):**
+- **R-1/R-6 — I had the call-site count BACKWARDS**, and it shipped in four places (`server.js`
+  comment, the JSDoc, the test header, and `CHANGELOG.md`). The denylist was in `server.js` ONCE and
+  in `public/setup.js` TWICE — verified against `origin/main`, not taken on the reviewer's word. The
+  inversion mattered beyond pedantry: the browser held the majority of them, which is what made this
+  a re-deciding problem rather than a re-reading one.
+- **R-2/R-10/R-13 — `PROTECTION_CONFIRMED` was exported with no consumer.** Publishing the sentinel
+  invites exactly the fourth `protection === …` site this change exists to remove. Unexported.
+- **R-8 — the wire field lied in one state.** `credentialStored` was narrowed to "stored AND
+  unconfirmed", so `protection: 'existing'` shipped `false` while a credential was plainly stored.
+  Rather than rename it, the field now means what it says and is `true` there too: the two flags are
+  ORTHOGONAL facts and "saved but not confirmed" is their combination. Behaviour is unchanged (the
+  browser only reads it when protection is unconfirmed), but a public field on a security surface
+  must not answer `false` to a question whose answer is yes. The exclusivity test that encoded the
+  old wart was replaced by one asserting orthogonality plus one asserting the combination.
+- **R-14 — the fail-safe path was silent.** An unmapped value read as "not confirmed" and nobody
+  learned the map had drifted. It now logs, and the log is pinned (removing it reddens a test) —
+  including that a state it DOES understand stays quiet, since a warning that always fires is noise.
+- **R-7/R-12 — `api-contract.md` omitted the only fields a client may branch on.** Added, with the
+  orthogonality and the fail-safe direction stated.
+- **R-3 — the producing half was asserted on one arm only.** Added end-to-end assertions for
+  `pending` and `existing`.
+- **R-9 module header ("two things" → three), R-11 ephemeral `this chunk` reference in product
+  code** — both fixed.
+- **Accepted:** R-4 (figure accurate), R-5 (#802 descoped by the issue's own sequencing), R-15/R-16
+  (informational).
 
 **Not done here, on purpose:** #802's end-to-end verification. The issue prescribes doing both in
 one pass, and this is the half a machine can do — the screens still need a real no-caddy install

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -26,6 +26,67 @@ Tag-line conventions (ART-4K9M, ratified 2026-07-17):
 -->
 
 
+## 2026-08-06: one derivation of "are we protected", stated so an unknown state fails safe (#861)
+
+<!-- prawduct: type=fix | scope=ingress-861 | status= -->
+
+**Why:** last open item on the v5 gate. Raised by the cumulative Critic on the v5 bundle (R-9),
+filed rather than fixed. `ingress.protection` was produced by the server and its *meaning*
+re-derived by comparing against a literal list in three places — `server.js` (the warning push) and
+`public/setup.js` twice (screen routing, screen wording). Two sources of truth for a security
+decision, in front-end code, which is the same drift `lib/caddy.js` already refused for
+`safeToWrite`.
+
+**The substance is the direction of the predicate, not the de-duplication.** The lists enumerated
+the states meaning "NOT protected", so an unrecognised sixth value matched none and fell through to
+the branch that DISMISSES the warning — a newly-added state would silently stop telling an operator
+nothing is enforcing their login. Nothing fails; a screen stops appearing. Restating it as an
+allowlist of the ONE state where a gate was positively observed makes an unknown value fail safe.
+
+**What:** `deriveProtectionFlags(protection)` in `lib/ingress-provision.js` — pure, exported,
+returning `{confirmedProtection, credentialStored}`. `server.js` `Object.assign`s it onto `ingress`
+after the arm chain, and the warning push now reads `!confirmedProtection && !provisioning`
+(`provisioning` is set in the same block as `pending` and is its only producer — checked, not
+assumed). `public/setup.js` branches on the two booleans and **no longer reads the enum at all**:
+the only remaining `protection ===` in non-test code is the line inside the named function.
+
+**Deliberately behaviour-preserving on the screens.** `credentialStored` keeps exactly the pair the
+browser used to test. These are the least-verified screens in the release (#802), so the commit
+that moves WHO decides must not also move WHAT is decided.
+
+**Extracted to a module rather than left inline, for a reason the tests surfaced.** ~25 browser
+fixtures had to start carrying the new contract; had the derivation stayed inline in a route
+handler, the tests would have had to re-implement it, recreating the third source of truth this
+removes. As an exported pure function it is unit-testable on its own — which is what turns the
+fail-safe property into a contract instead of an intention.
+
+**Delivery defect found while doing it, and fixed here because otherwise this change does not
+ship.** `public/setup.js` is loaded from `index.html` as a plain `<script src>` — not a navigate
+request — so it fell to `sw.js`'s cache-first branch with no `NETWORK_FIRST_PATHS` carve-out. A
+browser with an active service worker keeps serving the copy it first fetched, so every past and
+future wizard change was invisible to returning operators until `CACHE_NAME` moved. Now
+network-first. **Not** a `CACHE_NAME` bump: that tears down and reinstalls the worker for every
+browser, which behind the basic_auth gate is what produced the repeating credential prompt in #710.
+
+**Tests (+9):** `test/ingress-provision.test.js` +5 (`confirmed` only for the observed-gate state;
+an UNKNOWN state fails safe across six values incl. `null`/`undefined`/`''`; stored-vs-confirmed
+separation; unknown never reads as stored; the two flags are mutually exclusive across all six
+states); `test/setup-wizard-login-gate.test.js` +3 (an unheard-of state does not dismiss; the
+browser obeys a server answer that CONTRADICTS the enum, which is what proves the second source of
+truth is gone; `setup.js` is network-first); `test/setup-provisioning.test.js` +2 assertions (the
+real API response actually carries both flags — the producing half of the contract).
+
+**Five mutations, each killing a different test.** The load-bearing one reverts the allowlist to the
+old denylist form: it agrees on all five known states and differs ONLY on an unknown one, and it
+reddens the fail-safe test specifically. Also: `credentialStored` forced false; the server not
+shipping the flags; the browser re-reading the enum; and `setup.js` dropped from
+`NETWORK_FIRST_PATHS` — that last one initially reddened NOTHING, which is how the sw.js change was
+caught as unpinned before review rather than during it. Full suite **5612 pass / 0 fail / 1 skip**.
+
+**Not done here, on purpose:** #802's end-to-end verification. The issue prescribes doing both in
+one pass, and this is the half a machine can do — the screens still need a real no-caddy install
+and a browser.
+
 ## 2026-08-06: a project's NAME stops establishing that it is the Medusa checkout (#873)
 
 <!-- prawduct: type=fix | scope=medusa-873 | status= -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -340,6 +340,35 @@ All notable changes to TangleClaw are documented in this file.
 
 ### Fixed
 
+- **Whether you are protected is now decided in one place, and an unknown state fails safe
+  (#861).** The wizard's terminal screens decided "is anything enforcing a login?" by comparing
+  `ingress.protection` against a literal list of states — in `server.js` twice and in
+  `public/setup.js` once. The server produced the value and the browser re-derived its *meaning*,
+  which is two sources of truth for a security decision.
+
+  **The direction of the test was the real defect.** Those lists enumerated the states meaning
+  "not protected", so a state they had never heard of matched none of them and fell through to
+  the branch that **dismisses** the warning. Add a sixth `protection` value later and the wizard
+  would quietly stop telling an operator that nothing is enforcing their login, landing them on a
+  dashboard indistinguishable from a protected one. Nothing would fail; a screen would simply
+  stop appearing.
+
+  The server now derives the answer once — in `deriveProtectionFlags`, beside where the value is
+  produced — and ships `confirmedProtection` and `credentialStored`. The browser branches on
+  those and no longer reads the enum at all. The predicate is stated as an **allowlist**: only
+  the single state in which TangleClaw positively observed a gate counts as confirmed, so an
+  unrecognised value is *not confirmed* and the operator is told. Which states produce which
+  screen is deliberately unchanged — this moves who decides, not what is decided.
+
+- **Setup-wizard changes reach browsers that have used TangleClaw before (#861).** `setup.js` is
+  loaded as a plain `<script src>`, which is not a navigate request, so it fell to the service
+  worker's cache-first branch with no carve-out: a browser with an active worker kept serving
+  whatever copy it fetched first, and any change to the wizard — including the one above — stayed
+  invisible until `CACHE_NAME` moved. That is the same stale-serve pattern already carved out for
+  `session.js` and `ui.js`. It is now network-first. Deliberately *not* a `CACHE_NAME` bump: that
+  tears down and reinstalls the worker for every browser, which behind the login gate is what
+  produced the repeating credential prompt in #710.
+
 - **A project merely NAMED "Medusa" is no longer mistaken for the switchboard checkout (#873).**
   Reported from a third-party install, and structurally unreproducible here: on this machine a
   project named Medusa *is* the switchboard repository, so the resolver's assumption was invisible.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -342,8 +342,8 @@ All notable changes to TangleClaw are documented in this file.
 
 - **Whether you are protected is now decided in one place, and an unknown state fails safe
   (#861).** The wizard's terminal screens decided "is anything enforcing a login?" by comparing
-  `ingress.protection` against a literal list of states — in `server.js` twice and in
-  `public/setup.js` once. The server produced the value and the browser re-derived its *meaning*,
+  `ingress.protection` against a literal list of states — once in `server.js` and twice in
+  `public/setup.js`. The server produced the value and the browser re-derived its *meaning*,
   which is two sources of truth for a security decision.
 
   **The direction of the test was the real defect.** Those lists enumerated the states meaning
@@ -357,8 +357,11 @@ All notable changes to TangleClaw are documented in this file.
   produced — and ships `confirmedProtection` and `credentialStored`. The browser branches on
   those and no longer reads the enum at all. The predicate is stated as an **allowlist**: only
   the single state in which TangleClaw positively observed a gate counts as confirmed, so an
-  unrecognised value is *not confirmed* and the operator is told. Which states produce which
-  screen is deliberately unchanged — this moves who decides, not what is decided.
+  unrecognised value is *not confirmed* and the operator is told — and an unclassified value is
+  logged, so the fail-safe path is not silent. The two flags are orthogonal facts ("is a gate
+  enforced" and "does a credential exist"); "saved but not confirmed" is their combination. Which
+  states produce which screen is deliberately unchanged — this moves who decides, not what is
+  decided.
 
 - **Setup-wizard changes reach browsers that have used TangleClaw before (#861).** `setup.js` is
   loaded as a plain `<script src>`, which is not a navigate request, so it fell to the service

--- a/deploy/VRF-auth-1-cutover.md
+++ b/deploy/VRF-auth-1-cutover.md
@@ -696,15 +696,31 @@ Then the honest-failure half, which matters more than the success half:
 #       the service's PATH so detection fails, and re-run first-run setup.
 ```
 
-- [ ] With no `caddy` on the service PATH, the wizard shows **no** Admin Login step, and completing  
-      *(not run this pass)*
+- [x] With no `caddy` on the service PATH, the wizard shows **no** Admin Login step, and completing  
+      *(habitat macOS/tart guest `tc-vrf-v5`, 2026-08-06, branch `vrf-802` @c8a91ab)*
       setup lands on **"TangleClaw has no login"** — naming `brew install caddy` and the cutover
       command. It must NOT collect a password first.
-- [ ] That screen does not dismiss itself; it waits for *Continue*.  
-      *(not run this pass)*
-- [ ] On an install whose `bindAllInterfaces` is `true`, the same screen says TangleClaw is  
-      *(not run this pass)*
+      Observed: the step rail rendered **seven** dots with no `admin` step, and no credential was
+      requested at any point. `GET /api/setup/ingress-state` answered `caddy.available: false`,
+      `plan.action: refuse`; `POST /api/setup/complete` answered `protection: "none"` with the
+      reason and remedy naming both commands. The rendered screen carried the heading verbatim
+      and **"Nothing is asking for a password."**
+- [x] That screen does not dismiss itself; it waits for *Continue*.  
+      *(same run — held on screen and re-confirmed by the operator after the fact; a Continue
+      button, no countdown, no redirect)*
+- [x] On an install whose `bindAllInterfaces` is `true`, the same screen says TangleClaw is  
+      *(same run — the guest was deliberately made wide, so this is the reachable branch, not the
+      loopback one)*
       **reachable from your network** with no login — not "this machine only".
+      Observed verbatim: *"The TangleClaw dashboard is currently reachable from your network with
+      no login in front of it — anyone who can reach this address can run commands as you."*
+
+> **How caddy was removed from the service PATH.** The plist hands the service
+> `/opt/homebrew/bin` first, so a shell test is not the arbiter — a non-interactive SSH shell
+> lacks that PATH and reports `caddy not found` while the service still sees it. The binary was
+> renamed (`/opt/homebrew/bin/caddy` → `caddy.vrf802-hidden`) and the service restarted; the
+> precondition was then confirmed **through the API** (`caddy.available: false`), not the shell.
+> Checking the shell alone is how this phase came to be skipped on the 2026-07-30 pass.
 
 ## Phase 8 — Roll back to direct (reversibility)
 
@@ -814,7 +830,7 @@ is the evidence, not the code review.
 | #710 — a successful cutover writes `"code": "ok"` to its result file | 7c | **PASS** — habitat guest, 2026-07-30, @4e4e55e |
 | #710 — an ungate refusal reports `ungate-refused`, not `failed` | 7d | **PASS** — `tc-cleanroom`, 2026-07-30, @e20c1a3 (corrected fixture) |
 | #710 — the wizard's detached cutover outlives the restart and reports `ok`; the named address prompts for a login | 7e | **PASS** — server PID 6053→6219, 401/401/200 |
-| #710 — with no caddy, setup collects no password and says "no login" (and names real exposure) | 7e.1 | **NOT RUN** — the guest had caddy installed and the run did not re-do first-run setup without it. The *decision* is unit-covered (`test/setup-wizard-login-gate.test.js`, `test/setup-provisioning.test.js`); what is unverified is that the honest-absence screen renders end-to-end — the same browser-only limit as 7e's `[~]` boxes |
+| #710 — with no caddy, setup collects no password and says "no login" (and names real exposure) | 7e.1 | **PASS** — habitat macOS/tart guest `tc-vrf-v5`, 2026-08-06, branch `vrf-802` @c8a91ab. All three boxes measured: no Admin Login step and no credential collected; the honest-absence screen rendered with both commands named; it held for *Continue* with no self-dismiss; and the `bindAllInterfaces: true` variant reported network reachability rather than "this machine only". Observed in a browser by the operator, not inferred |
 | Rollback restores direct mode cleanly | 8 | **PARTIAL** — after the #789 fix, re-run @ad280a7: caddy unloaded, `ingressMode` direct, 3102 answering 200. The direct-HTTPS and ttyd-on-3100 checks were NOT run |
 
 ### How to score this matrix

--- a/lib/ingress-provision.js
+++ b/lib/ingress-provision.js
@@ -2,8 +2,8 @@
 
 // Putting a login in front of TangleClaw from the setup wizard.
 //
-// Two things live here, and they are here together because each is useless
-// without the other:
+// Three things live here, and the first two are here together because each is
+// useless without the other:
 //
 //   1. `decideProvisioning` — the one derivation of "what may the wizard do
 //      about a login on this machine". The wizard asks the server (see
@@ -21,6 +21,10 @@
 //      wizard polls for that file afterwards. Codes come from
 //      scripts/ingress-cutover.js `CUTOVER_CODES` — this module never invents
 //      one, so the CLI and the wizard always describe a run the same way.
+//
+//   3. `deriveProtectionFlags` — the one derivation of what a `protection`
+//      value MEANS. It sits beside the decision table for the same reason that
+//      table does: the browser must consume an answer, never re-derive it.
 
 const fs = require('node:fs');
 const path = require('node:path');
@@ -42,19 +46,33 @@ const CUTOVER_SCRIPT = path.join('scripts', 'ingress-cutover.js');
 // "a credential exists but nothing here can say it is enforced" or "no answer
 // yet" — neither of which may be reported to an operator as protected.
 const PROTECTION_CONFIRMED = 'existing';
-// States meaning a credential IS stored while enforcement is unconfirmed. Selects
-// the wording of the unprotected screen; it does NOT soften the outcome.
-const PROTECTION_STORED_UNCONFIRMED = new Set(['unchanged', 'existing-unverified']);
+// States in which a credential EXISTS, whatever is or is not enforcing it —
+// including the confirmed one, because a gate that was observed obviously has a
+// credential behind it. Deliberately not narrowed to "stored but unconfirmed":
+// the field is named for a fact, so it must report that fact everywhere rather
+// than silently mean "…and also unconfirmed" (a public field on a security
+// surface answering `false` while a credential is stored is a trap).
+//
+// Orthogonal to `confirmedProtection` by design: "does a credential exist" and
+// "is one being enforced" are different questions, and only the consumer that
+// needs both should combine them.
+const PROTECTION_CREDENTIAL_STORED = new Set(['existing', 'unchanged', 'existing-unverified']);
+// Values this build knows how to classify. Used only to notice one it does not.
+const KNOWN_PROTECTION_STATES = new Set([
+  'none', 'pending', 'existing', 'unchanged', 'existing-unverified'
+]);
 
 /**
  * Turn the `protection` enum into the two answers a consumer actually needs
  * (#861).
  *
  * This exists because the judgement used to be re-made by comparing the enum
- * against a literal list in three places — twice in `server.js` and once in
+ * against a literal list in three places — once in `server.js` and TWICE in
  * `public/setup.js` — which made the browser a second source of truth for a
- * security decision. There is no build step here, so `public/` cannot import a
- * shared constant; the server derives the answer and ships it.
+ * security decision. The browser held the majority of them, which is the part
+ * that mattered: it was re-deciding, not merely re-reading. There is no build
+ * step here, so `public/` cannot import a shared constant; the server derives
+ * the answer and ships it.
  *
  * **Allowlist, not denylist, and that inversion is the point.** The old lists
  * enumerated the states meaning "not protected", so an unrecognised sixth value
@@ -62,13 +80,29 @@ const PROTECTION_STORED_UNCONFIRMED = new Set(['unchanged', 'existing-unverified
  * warning — a newly-added state would silently stop telling the operator that
  * nothing is enforcing a login. Naming the single confirmed state instead makes
  * an unknown value fail safe: not confirmed, so the operator is told.
+ *
+ * Not pure: an unrecognised value is logged, because the fail-safe path is
+ * otherwise indistinguishable from a correctly-classified one.
  * @param {string|null|undefined} protection - A value of the `ingress.protection` enum.
  * @returns {{confirmedProtection: boolean, credentialStored: boolean}}
+ *   `confirmedProtection` — a gate was positively observed. `credentialStored` —
+ *   a credential exists, independently of whether anything enforces it. The two
+ *   are orthogonal facts; a consumer needing "saved but not confirmed" combines
+ *   them rather than expecting either to imply the other.
  */
 function deriveProtectionFlags(protection) {
+  // The fail-safe path is silent by construction — an unmapped value simply
+  // reads as "not confirmed" and the operator gets the warning screen, which is
+  // the RIGHT outcome but leaves nobody any wiser that a state was added
+  // without being classified here. Say so once, at the moment it happens.
+  if (!KNOWN_PROTECTION_STATES.has(protection)) {
+    log.warn('Unclassified ingress protection state — reporting it as unconfirmed', {
+      protection: protection === undefined ? '(undefined)' : String(protection)
+    });
+  }
   return {
     confirmedProtection: protection === PROTECTION_CONFIRMED,
-    credentialStored: PROTECTION_STORED_UNCONFIRMED.has(protection)
+    credentialStored: PROTECTION_CREDENTIAL_STORED.has(protection)
   };
 }
 
@@ -412,7 +446,6 @@ module.exports = {
   readResult,
   spawnCutover,
   deriveProtectionFlags,
-  PROTECTION_CONFIRMED,
   RESULT_FILENAME,
   CUTOVER_LOG_RELATIVE
 };

--- a/lib/ingress-provision.js
+++ b/lib/ingress-provision.js
@@ -37,6 +37,41 @@ const RESULT_FILENAME = 'ingress-cutover-result.json';
 const CUTOVER_LOG_RELATIVE = '~/.tangleclaw/logs/ingress-cutover.log';
 const CUTOVER_SCRIPT = path.join('scripts', 'ingress-cutover.js');
 
+// The ONE protection state in which TangleClaw has positively observed a gate:
+// adoption read the live Caddyfile and matched it. Every other state is either
+// "a credential exists but nothing here can say it is enforced" or "no answer
+// yet" — neither of which may be reported to an operator as protected.
+const PROTECTION_CONFIRMED = 'existing';
+// States meaning a credential IS stored while enforcement is unconfirmed. Selects
+// the wording of the unprotected screen; it does NOT soften the outcome.
+const PROTECTION_STORED_UNCONFIRMED = new Set(['unchanged', 'existing-unverified']);
+
+/**
+ * Turn the `protection` enum into the two answers a consumer actually needs
+ * (#861).
+ *
+ * This exists because the judgement used to be re-made by comparing the enum
+ * against a literal list in three places — twice in `server.js` and once in
+ * `public/setup.js` — which made the browser a second source of truth for a
+ * security decision. There is no build step here, so `public/` cannot import a
+ * shared constant; the server derives the answer and ships it.
+ *
+ * **Allowlist, not denylist, and that inversion is the point.** The old lists
+ * enumerated the states meaning "not protected", so an unrecognised sixth value
+ * matched none of them and fell through to the branch that DISMISSES the
+ * warning — a newly-added state would silently stop telling the operator that
+ * nothing is enforcing a login. Naming the single confirmed state instead makes
+ * an unknown value fail safe: not confirmed, so the operator is told.
+ * @param {string|null|undefined} protection - A value of the `ingress.protection` enum.
+ * @returns {{confirmedProtection: boolean, credentialStored: boolean}}
+ */
+function deriveProtectionFlags(protection) {
+  return {
+    confirmedProtection: protection === PROTECTION_CONFIRMED,
+    credentialStored: PROTECTION_STORED_UNCONFIRMED.has(protection)
+  };
+}
+
 /**
  * Repository root — the directory holding `scripts/ingress-cutover.js`. This
  * module lives in `lib/`, so the repo is one level up.
@@ -376,6 +411,8 @@ module.exports = {
   clearResult,
   readResult,
   spawnCutover,
+  deriveProtectionFlags,
+  PROTECTION_CONFIRMED,
   RESULT_FILENAME,
   CUTOVER_LOG_RELATIVE
 };

--- a/public/setup.js
+++ b/public/setup.js
@@ -1121,12 +1121,14 @@ async function wizardComplete() {
     _showProvisioningScreen(ingress, carried);
     return;
   }
-  if (ingress && (ingress.protection === 'none' || ingress.protection === 'unchanged'
-      || ingress.protection === 'existing-unverified')) {
-    // 'unchanged' and 'existing-unverified' both mean a credential exists and
-    // TangleClaw cannot say it is in force. Dismissing into a dashboard that looks
-    // identical to a protected one is the failure this screen exists to prevent,
-    // so they route here rather than falling through.
+  // The server decides whether protection is CONFIRMED and ships the answer; this
+  // used to re-derive it by comparing `ingress.protection` against a literal list,
+  // which made the browser a second source of truth for a security decision (#861).
+  // Read as "anything not positively confirmed lands here", so a protection state
+  // this build has never heard of shows the warning instead of dismissing past it.
+  // Dismissing into a dashboard that looks identical to a protected one is the exact
+  // failure this screen exists to prevent.
+  if (ingress && !ingress.confirmedProtection) {
     _showUnprotectedScreen(ingress, carried);
     return;
   }
@@ -1489,11 +1491,12 @@ function _showUnprotectedScreen(ingress, warnings) {
   const body = document.getElementById('setupBody');
   if (!body) return;
 
-  // Three states land here and they are not the same claim. 'none' means there is
-  // no login at all. 'unchanged' and 'existing-unverified' mean a credential is
-  // stored while TangleClaw cannot say it is being enforced — asserting "nothing
-  // is asking for a password" there would be a guess in the other direction.
-  const stored = ingress.protection === 'unchanged' || ingress.protection === 'existing-unverified';
+  // Several states land here and they are not the same claim: a credential may be
+  // stored while TangleClaw cannot say it is being enforced, or there may be no login
+  // at all. Asserting "nothing is asking for a password" in the first case would be a
+  // guess in the other direction. Which of the two applies is the server's call and
+  // arrives as `credentialStored` (#861) — the enum is deliberately not read here.
+  const stored = ingress.credentialStored === true;
   const heading = stored ? 'Your login is saved, but not confirmed' : 'TangleClaw has no login';
   const lead = stored
     ? `<p class="setup-text">A login is saved, but TangleClaw <strong>cannot confirm anything is enforcing it</strong> — it did not change the Caddy config, which is maintained by hand.</p>`

--- a/public/sw.js
+++ b/public/sw.js
@@ -69,6 +69,15 @@ const NETWORK_FIRST_PATHS = new Set([
   // network-first index.html; both stay precached above for offline coherence.
   '/ui.js',
   '/style.css',
+  // setup.js runs the first-run wizard, including the terminal screens that tell an
+  // operator whether a login is in force. It was cache-first with no carve-out, so a
+  // browser with an active worker kept serving whatever copy it fetched first and any
+  // change to those screens stayed invisible — the same #271 stale-serve pattern
+  // called out for session.js and ui.js above, on the one screen whose whole job is to
+  // not be wrong about protection (#861). Network-first rather than a CACHE_NAME bump:
+  // a bump tears down and reinstalls the worker for every browser, which behind the
+  // basic_auth gate is what produced the repeating credential prompt in #710.
+  '/setup.js',
   '/landing.js',
   // sw-register.js is cache-bust-critical (category 1): its entire purpose is
   // service-worker lifecycle. Serving a stale copy would re-strand operators

--- a/server.js
+++ b/server.js
@@ -1998,6 +1998,28 @@ route('POST', '/api/setup/complete', (req, res, _params, body) => {
     }
   }
 
+  // THE derivation of what `protection` MEANS, in one place, next to where the value
+  // is produced (#861). Before this, the same judgement was re-made by comparing the
+  // enum against a literal list in three places — twice here and once in
+  // `public/setup.js` — so the browser was a second source of truth for a security
+  // decision. There is no build step, so a shared constant module is not importable by
+  // `public/`; deriving server-side and shipping the ANSWER is the available correct
+  // form, and it is the same one this chunk already chose for the provisioning table.
+  //
+  // Stated as an ALLOWLIST, and that inversion is the substance of the fix rather than
+  // a stylistic preference. The old lists enumerated the states meaning "not protected",
+  // so an unrecognised sixth value matched none of them and fell through to the path
+  // that DISMISSES the warning — a new state would silently stop telling the operator
+  // nothing is enforcing a login, which is the precise false-reassurance the v5 Secure
+  // Baseline exists to eliminate. Naming the one state that means "confirmed" instead
+  // makes an unknown value fail safe: not confirmed, so the operator is told.
+  //
+  // `credentialStored` is kept behaviour-identical to the pair `public/setup.js` used
+  // to test, deliberately: this change is a de-duplication, and these are the
+  // least-verified screens in the release (#802), so the set of states producing each
+  // screen must not move in the same commit that moves WHO decides it.
+  Object.assign(ingress, ingressProvision.deriveProtectionFlags(ingress.protection));
+
   // One place, after every branch, so the guarantee holds for outcomes that reach no
   // branch at all — `refuse` with no credential anywhere (no Caddy installed, or a
   // Caddyfile too ambiguous to adopt) sets `reason` from the plan and enters nothing
@@ -2008,15 +2030,16 @@ route('POST', '/api/setup/complete', (req, res, _params, body) => {
   // because its `reason` describes a gate that IS in force ("will be kept rather than
   // replaced") — restating that as a warning invents a problem. 'pending' is excluded
   // too, but is inert rather than dangerous: `decideProvisioning` returns an empty
-  // reason for `provision`, so there is nothing to push in that state either way.
+  // reason for `provision`, so there is nothing to push in that state either way. Both
+  // exclusions now read off the derived answers rather than re-listing the enum:
+  // `provisioning` is set in the same block as 'pending' and is its only producer.
   //
   // The `includes` check is a forward interlock, not a live de-duplicator: no arm above
   // pushes this exact string today, so it never fires. It is here so that adding an arm
   // that does push `reason` cannot silently double it.
   if (ingress.reason
-      && (ingress.protection === 'none'
-        || ingress.protection === 'unchanged'
-        || ingress.protection === 'existing-unverified')
+      && !ingress.confirmedProtection
+      && !ingress.provisioning
       && !warnings.includes(ingress.reason)) {
     warnings.push(ingress.reason);
   }

--- a/server.js
+++ b/server.js
@@ -2000,11 +2000,12 @@ route('POST', '/api/setup/complete', (req, res, _params, body) => {
 
   // THE derivation of what `protection` MEANS, in one place, next to where the value
   // is produced (#861). Before this, the same judgement was re-made by comparing the
-  // enum against a literal list in three places — twice here and once in
+  // enum against a literal list in three places — once here and TWICE in
   // `public/setup.js` — so the browser was a second source of truth for a security
   // decision. There is no build step, so a shared constant module is not importable by
   // `public/`; deriving server-side and shipping the ANSWER is the available correct
-  // form, and it is the same one this chunk already chose for the provisioning table.
+  // form, and it is the same one `decideProvisioning` already uses for the
+  // provisioning table.
   //
   // Stated as an ALLOWLIST, and that inversion is the substance of the fix rather than
   // a stylistic preference. The old lists enumerated the states meaning "not protected",

--- a/server.js
+++ b/server.js
@@ -2015,10 +2015,13 @@ route('POST', '/api/setup/complete', (req, res, _params, body) => {
   // Baseline exists to eliminate. Naming the one state that means "confirmed" instead
   // makes an unknown value fail safe: not confirmed, so the operator is told.
   //
-  // `credentialStored` is kept behaviour-identical to the pair `public/setup.js` used
-  // to test, deliberately: this change is a de-duplication, and these are the
-  // least-verified screens in the release (#802), so the set of states producing each
-  // screen must not move in the same commit that moves WHO decides it.
+  // Which states produce which SCREEN is unchanged, deliberately: this change is a
+  // de-duplication, and these are the least-verified screens in the release (#802),
+  // so what is decided must not move in the same commit that moves WHO decides it.
+  // `credentialStored` is a wider set than the pair `public/setup.js` used to test —
+  // it includes the confirmed state, because the field is named for a fact and must
+  // report it — but that value is unreachable by the only consumer, which reads it
+  // solely inside the not-confirmed branch. Wider field, identical screens.
   Object.assign(ingress, ingressProvision.deriveProtectionFlags(ingress.protection));
 
   // One place, after every branch, so the guarantee holds for outcomes that reach no
@@ -2044,6 +2047,19 @@ route('POST', '/api/setup/complete', (req, res, _params, body) => {
       && !warnings.includes(ingress.reason)) {
     warnings.push(ingress.reason);
   }
+
+  // Whether setup ended with a login in force is the outcome this endpoint exists to
+  // get right, and until now only the unhappy arms left a trace: the confirmed arm
+  // dismissed into the dashboard silently, so a support question about an install
+  // that "says it is protected" had nothing on the server to read back. Logged at
+  // both outcomes so the record is symmetric — an absent line means the request never
+  // reached here, rather than meaning everything was fine.
+  log.info('Setup reported its protection verdict', {
+    protection: ingress.protection,
+    confirmedProtection: ingress.confirmedProtection,
+    credentialStored: ingress.credentialStored,
+    provisioning: ingress.provisioning === true
+  });
 
   // Decide whether to schedule a restart so the server re-binds with the new protocol
   const prevWillServeHttps = !!(prevHttps.enabled && prevHttps.certPath && prevHttps.keyPath);

--- a/test/ingress-provision.test.js
+++ b/test/ingress-provision.test.js
@@ -169,7 +169,7 @@ describe('decideProvisioning', () => {
 });
 
 // #861 — this judgement used to be re-made by comparing `ingress.protection`
-// against a literal list in three places, twice in server.js and once in
+// against a literal list in three places, once in server.js and twice in
 // public/setup.js, so the browser was a second source of truth for a security
 // decision. It now lives here once, and these tests are what make the
 // fail-safe property a contract rather than an intention.
@@ -197,12 +197,16 @@ describe('deriveProtectionFlags (#861)', () => {
     }
   });
 
-  it('reports a stored-but-unenforced credential separately from a confirmed one', () => {
+  it('reports whether a credential EXISTS, independently of whether it is enforced', () => {
     // Selects the WORDING of the unprotected screen — "your login is saved but
-    // not confirmed" vs "there is no login". It must not soften the outcome:
-    // both still land on the same screen.
+    // not confirmed" vs "there is no login" — but it is named for a fact and so
+    // must report that fact everywhere, including the confirmed state. A public
+    // field on a security surface answering `false` while a credential IS stored
+    // is a trap, even if today's only reader never looks there.
     assert.equal(derive('unchanged').credentialStored, true);
     assert.equal(derive('existing-unverified').credentialStored, true);
+    assert.equal(derive('existing').credentialStored, true,
+      'a gate that was observed obviously has a credential behind it');
     assert.equal(derive('none').credentialStored, false);
     assert.equal(derive('pending').credentialStored, false);
   });
@@ -211,12 +215,49 @@ describe('deriveProtectionFlags (#861)', () => {
     assert.equal(derive('some-future-state').credentialStored, false);
   });
 
-  it('the two flags are never both true — confirmed and unconfirmed are exclusive', () => {
-    for (const state of ['none', 'pending', 'existing', 'unchanged', 'existing-unverified', 'unknown']) {
-      const f = derive(state);
-      assert.equal(f.confirmedProtection && f.credentialStored, false,
-        `${state} must not claim a credential is both confirmed and merely stored`);
+  it('the flags are orthogonal — neither implies the other', () => {
+    // The combination is the consumer's job. Asserting exclusivity here would
+    // re-encode "stored means unconfirmed", which is the conflation this pair
+    // exists to take apart.
+    assert.deepEqual(derive('existing'), { confirmedProtection: true, credentialStored: true });
+    assert.deepEqual(derive('unchanged'), { confirmedProtection: false, credentialStored: true });
+    assert.deepEqual(derive('none'), { confirmedProtection: false, credentialStored: false });
+  });
+
+  it('says so when it meets a state it cannot classify', () => {
+    // The fail-safe path is correct but SILENT: an unmapped value reads as "not
+    // confirmed", the operator gets the warning screen, and nobody ever learns a
+    // state was added without being classified here. The log line is the only
+    // signal that the map has drifted, so it is pinned like any other behaviour.
+    const logger = require('../lib/logger');
+    const captured = [];
+    const prevLevel = logger.getLevel();
+    logger.setLevel('warn');
+    logger.setConsoleStream({ write: (s) => captured.push(s) });
+    try {
+      derive('a-state-nobody-mapped');
+      derive('existing');
+    } finally {
+      logger.setConsoleStream(null);
+      logger.setLevel(prevLevel);
     }
+    const joined = captured.join('');
+    assert.match(joined, /Unclassified ingress protection state/);
+    assert.match(joined, /a-state-nobody-mapped/, 'the offending value is named, or it is undiagnosable');
+    assert.equal(/existing/.test(joined.replace(/a-state-nobody-mapped/g, '')), false,
+      'a state it DOES understand must not be logged — a warning that always fires is noise');
+  });
+
+  it('"saved but not confirmed" is the COMBINATION, and only the unconfirmed states match it', () => {
+    const savedButUnconfirmed = (s) => {
+      const f = derive(s);
+      return f.credentialStored && !f.confirmedProtection;
+    };
+    assert.equal(savedButUnconfirmed('unchanged'), true);
+    assert.equal(savedButUnconfirmed('existing-unverified'), true);
+    assert.equal(savedButUnconfirmed('existing'), false, 'a confirmed gate is not merely saved');
+    assert.equal(savedButUnconfirmed('none'), false);
+    assert.equal(savedButUnconfirmed('a-future-state'), false);
   });
 });
 

--- a/test/ingress-provision.test.js
+++ b/test/ingress-provision.test.js
@@ -168,6 +168,58 @@ describe('decideProvisioning', () => {
   });
 });
 
+// #861 — this judgement used to be re-made by comparing `ingress.protection`
+// against a literal list in three places, twice in server.js and once in
+// public/setup.js, so the browser was a second source of truth for a security
+// decision. It now lives here once, and these tests are what make the
+// fail-safe property a contract rather than an intention.
+describe('deriveProtectionFlags (#861)', () => {
+  const derive = provision.deriveProtectionFlags;
+
+  it('confirms protection ONLY for the state where a gate was actually observed', () => {
+    assert.equal(derive('existing').confirmedProtection, true);
+    for (const state of ['none', 'pending', 'unchanged', 'existing-unverified']) {
+      assert.equal(derive(state).confirmedProtection, false,
+        `${state} means no gate was observed, so it must never read as confirmed`);
+    }
+  });
+
+  it('an UNKNOWN protection state fails safe — the operator is told, not dismissed', () => {
+    // The whole reason the predicate was inverted. The old form enumerated the
+    // states meaning "not protected", so a value it had never heard of matched
+    // none of them and fell through to the branch that DISMISSES the warning:
+    // adding a sixth state would have silently stopped telling an operator that
+    // nothing was enforcing a login. This is the assertion that stops that
+    // returning — it must hold for any value, not just the five known today.
+    for (const unknown of ['adopted-pending-reload', 'partially-enforced', '', null, undefined]) {
+      assert.equal(derive(unknown).confirmedProtection, false,
+        `an unrecognised state (${String(unknown)}) must never read as confirmed protection`);
+    }
+  });
+
+  it('reports a stored-but-unenforced credential separately from a confirmed one', () => {
+    // Selects the WORDING of the unprotected screen — "your login is saved but
+    // not confirmed" vs "there is no login". It must not soften the outcome:
+    // both still land on the same screen.
+    assert.equal(derive('unchanged').credentialStored, true);
+    assert.equal(derive('existing-unverified').credentialStored, true);
+    assert.equal(derive('none').credentialStored, false);
+    assert.equal(derive('pending').credentialStored, false);
+  });
+
+  it('never reports an unknown state as holding a stored credential either', () => {
+    assert.equal(derive('some-future-state').credentialStored, false);
+  });
+
+  it('the two flags are never both true — confirmed and unconfirmed are exclusive', () => {
+    for (const state of ['none', 'pending', 'existing', 'unchanged', 'existing-unverified', 'unknown']) {
+      const f = derive(state);
+      assert.equal(f.confirmedProtection && f.credentialStored, false,
+        `${state} must not claim a credential is both confirmed and merely stored`);
+    }
+  });
+});
+
 describe('cutover result file', () => {
   let tmpBase;
   let prevBase;

--- a/test/setup-provisioning.test.js
+++ b/test/setup-provisioning.test.js
@@ -231,6 +231,12 @@ describe('setup provisions a login by default', () => {
       assert.equal(res.data.ingress.action, 'provision');
       assert.equal(res.data.ingress.provisioning, true);
       assert.equal(res.data.ingress.protection, 'pending');
+      // #861 — the flags ship on every arm, not just the one this fix was
+      // written against. 'pending' means the answer is not in yet, which is
+      // emphatically not confirmed protection.
+      assert.equal(res.data.ingress.confirmedProtection, false,
+        'a cutover still running has not confirmed anything');
+      assert.equal(res.data.ingress.credentialStored, false);
       assert.equal(res.data.ingress.user, 'jason');
       // Delivered with the COMPLETION, not only from the poll. The cutover closes
       // the address this response was served from, and for a remote operator that
@@ -515,6 +521,11 @@ describe('setup provisions a login by default', () => {
       assert.equal(res.status, 200);
       assert.equal(res.data.ingress.action, 'adopt');
       assert.equal(res.data.ingress.protection, 'existing');
+      // #861 — the one arm that IS confirmed. Both flags true: a gate was
+      // observed, and it obviously has a credential behind it.
+      assert.equal(res.data.ingress.confirmedProtection, true,
+        'an adopted, observed gate is the only state that reads as confirmed');
+      assert.equal(res.data.ingress.credentialStored, true);
       assert.equal(res.data.ingress.user, 'jason');
       assert.equal(cutovers.length, 0, 'adopting must never regenerate the file');
 

--- a/test/setup-provisioning.test.js
+++ b/test/setup-provisioning.test.js
@@ -572,6 +572,14 @@ describe('setup provisions a login by default', () => {
       assert.equal(res.status, 200);
       assert.equal(res.data.ingress.protection, 'existing-unverified',
         'must not report the existing login as simply kept');
+      // #861 — the browser branches on these, not on the enum, so the response
+      // must actually carry them. This is the producing half of the contract;
+      // `test/ingress-provision.test.js` pins the derivation and
+      // `test/setup-wizard-login-gate.test.js` pins the consuming half.
+      assert.equal(res.data.ingress.confirmedProtection, false,
+        'a credential the live config may not enforce is not confirmed protection');
+      assert.equal(res.data.ingress.credentialStored, true,
+        'a credential IS stored, so the screen must say saved-but-unconfirmed rather than no-login');
       assert.equal(res.data.ingress.user, 'newadmin', 'must name the account THEY set, not the adopted one');
       assert.equal(store.config.load().basicAuthUser, 'newadmin',
         'config holds the typed credential — which is precisely why the mismatch must be reported');

--- a/test/setup-provisioning.test.js
+++ b/test/setup-provisioning.test.js
@@ -534,6 +534,62 @@ describe('setup provisions a login by default', () => {
       assert.equal(config.basicAuthUser, 'jason');
     });
 
+    it('#861: records the protection verdict on the CONFIRMED arm too, not only the unhappy ones', async () => {
+      // The symmetry is the point, and it is why this is a deliverable rather
+      // than incidental tracing. Every other log on this endpoint fires on a
+      // cutover or a failure, so a confirmed install left no server-side trace
+      // at all — and a support question about a machine that "says it is
+      // protected" had nothing to read back. Logging both arms also means an
+      // ABSENT line reads as "the request never got here" instead of as
+      // "everything was fine", which is the whole value of the symmetry.
+      const logger = require('../lib/logger');
+      const captured = [];
+      const prevLevel = logger.getLevel();
+      logger.setLevel('info');
+      logger.setConsoleStream({ write: (s) => captured.push(s) });
+      let res;
+      try {
+        writeLive(handEdited([`jason ${BCRYPT_A}`]));
+        caddyIsLive();
+        res = await request(server, 'POST', '/api/setup/complete', { projectsDir: tmpDir });
+      } finally {
+        logger.setConsoleStream(null);
+        logger.setLevel(prevLevel);
+      }
+      assert.equal(res.data.ingress.confirmedProtection, true, 'precondition: this is the confirmed arm');
+      const line = captured.join('');
+      assert.match(line, /Setup reported its protection verdict/,
+        'a confirmed outcome must leave a trace, or "it says it is protected" is unanswerable');
+      // The logger renders context as key=value, not JSON — asserted against the
+      // real emitted shape rather than an assumed one.
+      assert.match(line, /confirmedProtection=true/);
+      assert.match(line, /protection=existing/);
+      assert.match(line, /credentialStored=true/);
+    });
+
+    it('#861: and on the UNCONFIRMED arm, so an absent line means the request never got here', async () => {
+      // The other half of the symmetry. If only one arm logged, a missing line
+      // would be ambiguous between "unconfirmed" and "never reached" — which is
+      // exactly the ambiguity the confirmed-arm log was added to remove.
+      const logger = require('../lib/logger');
+      const captured = [];
+      const prevLevel = logger.getLevel();
+      logger.setLevel('info');
+      logger.setConsoleStream({ write: (s2) => captured.push(s2) });
+      let res;
+      try {
+        // No caddy at all: the plainest ungated outcome there is.
+        res = await withoutCaddy(() => request(server, 'POST', '/api/setup/complete', { projectsDir: tmpDir }));
+      } finally {
+        logger.setConsoleStream(null);
+        logger.setLevel(prevLevel);
+      }
+      assert.equal(res.data.ingress.confirmedProtection, false, 'precondition: this is an unconfirmed arm');
+      const line = captured.join('');
+      assert.match(line, /Setup reported its protection verdict/);
+      assert.match(line, /confirmedProtection=false/);
+    });
+
     it('does not restate a login that IS in force as a warning', async () => {
       // `reason` on the adopt-success path describes a working gate — "will be kept
       // rather than replaced". The post-chain push is scoped to the ungated protection

--- a/test/setup-wizard-login-gate.test.js
+++ b/test/setup-wizard-login-gate.test.js
@@ -819,9 +819,9 @@ describe('Setup wizard — the login gate is the default (#710)', () => {
       { name: 'stored-unconfirmed', expect: /saved, but not confirmed/,
         ingress: { action: 'refuse', provisioning: false, protection: 'unchanged', credentialStored: true } },
       { name: 'adopted', expect: /did not change it/,
-        ingress: { action: 'adopt', provisioning: false, protection: 'existing', confirmedProtection: true, user: 'jason' } },
+        ingress: { action: 'adopt', provisioning: false, protection: 'existing', confirmedProtection: true, credentialStored: true, user: 'jason' } },
       { name: 'restarting', expect: /Restarting TangleClaw/, restart: true,
-        ingress: { action: 'adopt', provisioning: false, protection: 'existing', confirmedProtection: true, user: 'jason' } }
+        ingress: { action: 'adopt', provisioning: false, protection: 'existing', confirmedProtection: true, credentialStored: true, user: 'jason' } }
     ];
 
     /** Finish setup with the given ingress block and report what the body became. */
@@ -887,7 +887,7 @@ describe('Setup wizard — the login gate is the default (#710)', () => {
         // NOT /Setup finished/ — that string also appears on the failed-provisioning
         // screen, so it cannot prove this fixture landed on the adopted one.
         { name: 'adopted', expect: /did not change it/,
-          ingress: { action: 'adopt', provisioning: false, protection: 'existing', confirmedProtection: true, user: 'jason', reason: REASON } },
+          ingress: { action: 'adopt', provisioning: false, protection: 'existing', confirmedProtection: true, credentialStored: true, user: 'jason', reason: REASON } },
         [REASON]
       );
       assert.equal(html.split(REASON).length - 1, 1,
@@ -1096,9 +1096,9 @@ describe('Setup wizard — the login gate is the default (#710)', () => {
         { name: 'no login', expect: /TangleClaw has no login/, restart: false,
           ingress: { action: 'refuse', provisioning: false, protection: 'none', reason: 'no caddy' } },
         { name: 'adopted', expect: /did not change it/, restart: false,
-          ingress: { action: 'adopt', provisioning: false, protection: 'existing', confirmedProtection: true, user: 'jason' } },
+          ingress: { action: 'adopt', provisioning: false, protection: 'existing', confirmedProtection: true, credentialStored: true, user: 'jason' } },
         { name: 'restarting', expect: /Restarting TangleClaw/, restart: true,
-          ingress: { action: 'adopt', provisioning: false, protection: 'existing', confirmedProtection: true, user: 'jason' } }
+          ingress: { action: 'adopt', provisioning: false, protection: 'existing', confirmedProtection: true, credentialStored: true, user: 'jason' } }
       ];
       for (const c of CASES) {
         const ctx = loadSetup({
@@ -1171,7 +1171,7 @@ describe('Setup wizard — the login gate is the default (#710)', () => {
         plan: ADOPT_PLAN,
         apiMutate: async () => ({
           ok: true, setupComplete: true, attached: [], warnings: [], restart: false,
-          ingress: { action: 'adopt', provisioning: false, protection: 'existing', confirmedProtection: true, user: 'jason' }
+          ingress: { action: 'adopt', provisioning: false, protection: 'existing', confirmedProtection: true, credentialStored: true, user: 'jason' }
         })
       });
       ctx.showWizard();

--- a/test/setup-wizard-login-gate.test.js
+++ b/test/setup-wizard-login-gate.test.js
@@ -250,7 +250,7 @@ describe('Setup wizard — the login gate is the default (#710)', () => {
         apiMutate: async (_url, _method, body) => {
           sent = body;
           return { ok: true, setupComplete: true, attached: [], warnings: [], restart: false,
-            ingress: ingressResponse || { action: 'refuse', provisioning: false, protection: 'unchanged' } };
+            ingress: ingressResponse || { action: 'refuse', provisioning: false, protection: 'unchanged', credentialStored: true } };
         }
       });
       ctx.showWizard();
@@ -566,7 +566,7 @@ describe('Setup wizard — the login gate is the default (#710)', () => {
       // alone, so nothing is known to be enforcing it. Dismissing closed the
       // overlay that carried the server's own warning about exactly that.
       const { html, dismissed } = await completeWith({
-        action: 'refuse', provisioning: false, protection: 'unchanged',
+        action: 'refuse', provisioning: false, protection: 'unchanged', credentialStored: true,
         remedy: 'Run `node scripts/ingress-cutover.js --to caddy`.'
       });
       assert.equal(dismissed, false);
@@ -577,12 +577,63 @@ describe('Setup wizard — the login gate is the default (#710)', () => {
 
     it('gives the same treatment to an adoption that could not be verified', async () => {
       const { html, dismissed } = await completeWith({
-        action: 'adopt', provisioning: false, protection: 'existing-unverified',
+        action: 'adopt', provisioning: false, protection: 'existing-unverified', credentialStored: true,
         reason: 'TangleClaw cannot tell whether they carry the same credential.'
       });
       assert.equal(dismissed, false);
       assert.match(html, /saved, but not confirmed/);
       assert.match(html, /cannot tell whether/);
+    });
+
+    it('#861: setup.js is network-first, or this fix never reaches an installed browser', async () => {
+      // Delivery, not behaviour — and without it the rest of this change is
+      // invisible to exactly the operators who have used TangleClaw before.
+      // setup.js is loaded from index.html as a plain <script src>, which is not
+      // a navigate request, so it fell to sw.js's cache-first branch: a browser
+      // with an active worker keeps serving whatever copy it fetched first,
+      // until CACHE_NAME moves. That is the #271 stale-serve pattern already
+      // carved out for session.js and ui.js, here on the one screen whose whole
+      // job is to not be wrong about whether a login is in force.
+      //
+      // Asserted against sw.js's source because the alternative fix — bumping
+      // CACHE_NAME — tears down and reinstalls the worker for every browser,
+      // which behind the basic_auth gate is what produced the repeating
+      // credential prompt in #710. Network-first achieves the same freshness
+      // with none of that blast radius.
+      const sw = fs.readFileSync(path.join(__dirname, '..', 'public', 'sw.js'), 'utf8');
+      const block = sw.match(/const NETWORK_FIRST_PATHS = new Set\(\[([\s\S]*?)\]\)/);
+      assert.ok(block, 'NETWORK_FIRST_PATHS is still declared as a Set literal');
+      assert.match(block[1], /'\/setup\.js'/,
+        'setup.js must be network-first so wizard changes are not stranded behind an active worker');
+    });
+
+    it('#861: a protection state this build has never heard of does NOT dismiss', async () => {
+      // The hazard the issue names. The browser used to decide "is this
+      // unprotected?" by matching against a literal list of states, so a value
+      // added server-side later matched nothing and fell through to the dismiss
+      // path — the wizard would quietly stop saying nothing is enforcing a
+      // login, and the operator would land on a dashboard indistinguishable from
+      // a protected one. It now reads the server's answer, so anything not
+      // positively confirmed shows the screen.
+      const { html, dismissed } = await completeWith({
+        action: 'refuse', provisioning: false, protection: 'a-state-added-after-this-build',
+        confirmedProtection: false, credentialStored: false,
+        reason: 'TangleClaw cannot confirm a login is in force.'
+      });
+      assert.equal(dismissed, false, 'an unrecognised state must not dismiss into the dashboard');
+      assert.match(html, /Nothing is asking for a password/);
+    });
+
+    it('#861: the browser obeys the server\'s answer rather than re-reading the enum', async () => {
+      // Deliberately contradictory: an enum value that USED to route to the
+      // unprotected screen, with the server saying protection is confirmed. If
+      // the browser still consulted `protection`, it would show the warning
+      // screen and this would fail. Pins that the second source of truth is gone.
+      const { dismissed } = await completeWith({
+        action: 'adopt', provisioning: false, protection: 'unchanged',
+        confirmedProtection: true, credentialStored: false, user: 'jason'
+      });
+      assert.equal(dismissed, true, 'the server owns the decision; the enum is not re-read');
     });
 
     it('carries the server\'s warnings onto the screen that replaces the one reporting them', async () => {
@@ -739,7 +790,7 @@ describe('Setup wizard — the login gate is the default (#710)', () => {
     // shipped with no assertion at all — revert the lines and the suite stayed
     // green. These cases cover the family, not a member.
     // Each entry must actually REACH the screen it names. Two earlier versions of
-    // this table did not: a `restarting` row carrying `protection: 'unchanged'`
+    // this table did not: a `restarting` row carrying `protection: 'unchanged', credentialStored: true`
     // returned at the unprotected branch before the restart check, and a
     // `provisioning` row with an unreachable status route ended on 'unconfirmed'
     // rather than the success screen — so two mutations survived a suite that
@@ -766,11 +817,11 @@ describe('Setup wizard — the login gate is the default (#710)', () => {
       { name: 'unprotected', expect: /TangleClaw has no login/,
         ingress: { action: 'refuse', provisioning: false, protection: 'none', reason: 'no caddy' } },
       { name: 'stored-unconfirmed', expect: /saved, but not confirmed/,
-        ingress: { action: 'refuse', provisioning: false, protection: 'unchanged' } },
+        ingress: { action: 'refuse', provisioning: false, protection: 'unchanged', credentialStored: true } },
       { name: 'adopted', expect: /did not change it/,
-        ingress: { action: 'adopt', provisioning: false, protection: 'existing', user: 'jason' } },
+        ingress: { action: 'adopt', provisioning: false, protection: 'existing', confirmedProtection: true, user: 'jason' } },
       { name: 'restarting', expect: /Restarting TangleClaw/, restart: true,
-        ingress: { action: 'adopt', provisioning: false, protection: 'existing', user: 'jason' } }
+        ingress: { action: 'adopt', provisioning: false, protection: 'existing', confirmedProtection: true, user: 'jason' } }
     ];
 
     /** Finish setup with the given ingress block and report what the body became. */
@@ -816,7 +867,7 @@ describe('Setup wizard — the login gate is the default (#710)', () => {
         { name: 'unprotected', expect: /TangleClaw has no login/,
           ingress: { action: 'refuse', provisioning: false, protection: 'none', reason: REASON } },
         { name: 'stored-unconfirmed', expect: /saved, but not confirmed/,
-          ingress: { action: 'refuse', provisioning: false, protection: 'existing-unverified', reason: REASON } }
+          ingress: { action: 'refuse', provisioning: false, protection: 'existing-unverified', credentialStored: true, reason: REASON } }
       ];
       for (const screen of printsTheReason) {
         const { html } = await endOn(screen, [REASON, OTHER]);
@@ -836,7 +887,7 @@ describe('Setup wizard — the login gate is the default (#710)', () => {
         // NOT /Setup finished/ — that string also appears on the failed-provisioning
         // screen, so it cannot prove this fixture landed on the adopted one.
         { name: 'adopted', expect: /did not change it/,
-          ingress: { action: 'adopt', provisioning: false, protection: 'existing', user: 'jason', reason: REASON } },
+          ingress: { action: 'adopt', provisioning: false, protection: 'existing', confirmedProtection: true, user: 'jason', reason: REASON } },
         [REASON]
       );
       assert.equal(html.split(REASON).length - 1, 1,
@@ -1045,9 +1096,9 @@ describe('Setup wizard — the login gate is the default (#710)', () => {
         { name: 'no login', expect: /TangleClaw has no login/, restart: false,
           ingress: { action: 'refuse', provisioning: false, protection: 'none', reason: 'no caddy' } },
         { name: 'adopted', expect: /did not change it/, restart: false,
-          ingress: { action: 'adopt', provisioning: false, protection: 'existing', user: 'jason' } },
+          ingress: { action: 'adopt', provisioning: false, protection: 'existing', confirmedProtection: true, user: 'jason' } },
         { name: 'restarting', expect: /Restarting TangleClaw/, restart: true,
-          ingress: { action: 'adopt', provisioning: false, protection: 'existing', user: 'jason' } }
+          ingress: { action: 'adopt', provisioning: false, protection: 'existing', confirmedProtection: true, user: 'jason' } }
       ];
       for (const c of CASES) {
         const ctx = loadSetup({
@@ -1120,7 +1171,7 @@ describe('Setup wizard — the login gate is the default (#710)', () => {
         plan: ADOPT_PLAN,
         apiMutate: async () => ({
           ok: true, setupComplete: true, attached: [], warnings: [], restart: false,
-          ingress: { action: 'adopt', provisioning: false, protection: 'existing', user: 'jason' }
+          ingress: { action: 'adopt', provisioning: false, protection: 'existing', confirmedProtection: true, user: 'jason' }
         })
       });
       ctx.showWizard();


### PR DESCRIPTION
The last open item on the v5 gate. **Code complete and reviewed; #802's clean-room verification is still outstanding and is the reason this is not merged yet** — see *Before merging* below.

## What

Whether an install has confirmed protection is now derived **once**, server-side, and shipped as `confirmedProtection` / `credentialStored`. The browser branches on those and no longer reads the `protection` enum at all.

## Why

The judgement was re-made by comparing `ingress.protection` against a literal list — **once** in `server.js` and **twice** in `public/setup.js`. The server produced the value and the browser re-derived its *meaning*, which is two sources of truth for a security decision. The browser held the majority of them, which is what made this a re-*deciding* problem rather than a re-*reading* one.

### The direction of the test was the real defect

Those lists enumerated the states meaning **"not protected"**, so a state they had never heard of matched none of them and fell through to the branch that **dismisses** the warning. Add a sixth `protection` value later and the wizard would quietly stop telling an operator that nothing is enforcing their login, landing them on a dashboard indistinguishable from a protected one. Nothing fails; a screen simply stops appearing.

Stated as an **allowlist** of the one state where a gate was positively observed, an unknown value is *not confirmed* — so the operator is told. An unclassifiable value is also logged, because the fail-safe path is otherwise indistinguishable from a correctly-classified one.

**Which states produce which screen is deliberately unchanged.** These are the least-verified screens in the release (#802), so the commit that moves *who decides* must not also move *what is decided*.

## A delivery bug found on the way, without which none of this ships

`public/setup.js` is loaded from `index.html` as a plain `<script src>` — not a navigate request — so it fell to the service worker's **cache-first** branch with no `NETWORK_FIRST_PATHS` carve-out. A browser with an active worker keeps serving whatever copy it first fetched, so this change *and every past wizard change* stayed invisible to returning operators until `CACHE_NAME` moved.

It is now network-first. **Deliberately not a `CACHE_NAME` bump**: that tears down and reinstalls the worker for every browser, which behind the basic_auth gate is what produced the repeating credential prompt in #710.

## Design notes

- **`deriveProtectionFlags` is an exported pure-ish function, not inline code**, and the tests are why: ~25 browser fixtures had to start carrying the new contract, and with the derivation inline the tests would have had to re-implement it — recreating the third source of truth this removes.
- **The two flags are orthogonal.** `confirmedProtection` = is a gate enforced; `credentialStored` = does a credential exist. "Saved but not confirmed" is their *combination*. `credentialStored` is true for the confirmed state too, because a public field on a security surface must not answer `false` to a question whose answer is yes.

## Test plan

**+12 tests** (counted from the diff). Six mutations, each killing a different test:

| Mutation | Test that reddens |
|---|---|
| allowlist reverted to the old fail-**open** denylist | the unknown-state fail-safe test |
| `credentialStored` forced false | orthogonality + combination tests |
| server stops shipping the flags | end-to-end response assertions |
| browser re-reads the enum | the contradicting-answer test |
| `setup.js` dropped from `NETWORK_FIRST_PATHS` | the delivery test |
| verdict log removed | both log-symmetry tests |

The load-bearing mutation is the first: it agrees on all five known states and differs **only** on an unknown one, which is precisely the regression this exists to prevent.

Full suite **5616 pass / 0 fail / 1 skipped** on node v22.22.3, matching CI.

## Governance

`cumulative` (0 blocking, 10 warning, 6 note) → fixes → `verify-resolutions` → fixes → `verify-resolutions` (**1 blocking**: the verdict log was unpinned) → fixed → `verify-resolutions` clean. Two changes were caught unpinned — `sw.js` by my own mutation run before review, the verdict log by the reviewer.

## Before merging

**#802's end-to-end verification is outstanding and this should not merge without it.** The issue prescribes doing both in one pass. On a macOS clean room with **no `caddy`** on the service PATH:

1. First-run setup shows **no Admin Login step** and collects **no password**.
2. It lands on **"TangleClaw has no login"**, naming `brew install caddy` and the cutover command.
3. The screen **waits for Continue** — it must not dismiss itself.
4. 7e's outstanding `[~]` browser assertions close in the same session.

Refs #861, #802