### PR TITLE
Scan directories in a killable child, so one hung folder cannot take the server's filesystem

### DIFF
--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -3745,3 +3745,45 @@ which is what they had before, and the residual is recorded.
 
 Also corrected: the cross-site guard's comment still said Content-Type enforcement and the CSRF
 re-ratification were "tracked separately". Both shipped in this commit, 25 lines below it.
+
+## 2026-08-07: A hung directory can no longer take the server's filesystem with it (#883)
+
+<!-- prawduct: type=fix | chunks=1,2,3 | scope=883-threadpool-leak | status=shipped -->
+
+**Why:** the #859 fix bounded the RESPONSE, not the OPERATION. `fs.promises` performs a read on
+libuv's threadpool — four threads shared by the whole process — and a deadline abandons the promise
+without cancelling the syscall, so every hung read cost a thread permanently. On a TCC-protected
+macOS path the read never returns at all, so four of them left the server unable to touch the
+filesystem **on any path, permanently**, while `/api/health` kept answering `200`. Worse than the
+outage was the diagnosis: with the pool gone every operation timed out, and `tcTimedOut` was the
+only signal, so the product told operators that healthy directories were protected and sent them to
+grant Full Disk Access for a problem that had nothing to do with permissions.
+
+Only killing the process that owns a thread blocked in the kernel reclaims it. `worker_threads`
+cannot substitute — workers share the process-wide pool and `terminate()` does not interrupt a
+blocked syscall. So the walks moved into a forked child the deadline kills (`lib/dir-scanner.js`,
+`lib/dir-scanner-child.js`), the three operator-path entry points in `lib/projects.js` route through
+it, and a per-path failure backoff bounds what a permanently-broken directory costs.
+
+**Chunk 1** — the supervisor. **Chunk 2** — `listAllProjects`, `scanDirectoryForProjects` and
+`createProjectsDir` behind it; `git.getInfo`'s `execSync` moved with the walk, taking a second
+event-loop hazard off the server. **Chunk 3** — the backoff: 30s doubling to a five-minute ceiling,
+opt-in, taken only by the polled route.
+
+**The rejection vocabulary is the load-bearing design.** `tcTimedOut` means "this path did not
+answer" and nothing else, because it is the sole input to the Full Disk Access advice. Collateral
+work gets `tcAborted`, a walk that ran out of budget gets `tcTruncated`, and a filesystem that
+replied gets its errno. Every one of those used to arrive wearing `tcTimedOut`.
+
+**Mutation-verified**, and one mutation mattered more than the rest: deleting the collateral guard
+left the suite green, because the test covered only one of that guard's two failure directions —
+it asserted collateral must not MARK a path bad, while the deletion's real effect was ERASING an
+existing backoff and silently dropping the rate bound. Second test written, mutation re-run, red.
+
+**Known and NOT fixed, recorded rather than implied:** `enrichProject` still calls
+`fs.existsSync(project.path)` synchronously for every registered project on `GET /api/projects`, so
+a *registered* project on a protected path still blocks the event loop — the #859 wedge, on the
+route this fixed the other half of. The family is ~31 synchronous reads in `lib/projects.js` plus
+`lib/uploads.js`; it needs its own issue — filed as #884.
+
+**Classification:** fix

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -3783,7 +3783,7 @@ existing backoff and silently dropping the rate bound. Second test written, muta
 **Known and NOT fixed, recorded rather than implied:** `enrichProject` still calls
 `fs.existsSync(project.path)` synchronously for every registered project on `GET /api/projects`, so
 a *registered* project on a protected path still blocks the event loop — the #859 wedge, on the
-route this fixed the other half of. The family is ~31 synchronous reads in `lib/projects.js` plus
+route this fixed the other half of. The family is 32 synchronous reads in `lib/projects.js` plus 7 in
 `lib/uploads.js`; it needs its own issue — filed as #884.
 
 **Classification:** fix

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -28,7 +28,7 @@ Tag-line conventions (ART-4K9M, ratified 2026-07-17):
 
 ## 2026-08-07: first run stops dead-ending — the wedge, the PATH, and three screens with no way forward (#859, #346)
 
-<!-- prawduct: type=fix | scope=first-run-859 | status= -->
+<!-- prawduct: type=fix | scope=first-run-859 | status=shipped -->
 
 **Why:** #859 opened this — a single `GET /api/projects` could kill the server permanently — but
 tracing the first-run path from a stranger's point of view found three more places the wizard
@@ -98,7 +98,7 @@ Nothing detected them, which is filed separately.
 
 ## 2026-08-06: one derivation of "are we protected", stated so an unknown state fails safe (#861)
 
-<!-- prawduct: type=fix | scope=ingress-861 | status= -->
+<!-- prawduct: type=fix | scope=ingress-861 | status=shipped -->
 
 **Why:** last open item on the v5 gate. Raised by the cumulative Critic on the v5 bundle (R-9),
 filed rather than fixed. `ingress.protection` was produced by the server and its *meaning*
@@ -200,7 +200,7 @@ one pass, and this is the half a machine can do — the screens still need a rea
 and a browser.
 ## 2026-08-06: the cutover log stops holding a credential hash, and stops growing (#821)
 
-<!-- prawduct: type=fix | scope=ingress-821 | status= -->
+<!-- prawduct: type=fix | scope=ingress-821 | status=shipped -->
 
 **Why:** v5 gate item, raised by the Critic on #819 (rev-20260731T232030Z-279745ce R-18) and filed
 rather than fixed there. `~/.tangleclaw/logs/ingress-cutover.log` is opened with a raw
@@ -296,7 +296,7 @@ node v22.22.3, matching CI's `node --test 'test/*.test.js'` on node 22; recorded
 
 ## 2026-08-06: a project's NAME stops establishing that it is the Medusa checkout (#873)
 
-<!-- prawduct: type=fix | scope=medusa-873 | status= -->
+<!-- prawduct: type=fix | scope=medusa-873 | status=shipped -->
 
 **Why:** filed by a third-party installer (`GURULifeline`) — the class of report this machine
 structurally cannot reproduce, because here a project named Medusa genuinely *is* the switchboard
@@ -358,7 +358,7 @@ not report. Verified locally with CI's exact command and runtime; the PR still w
 
 ## 2026-08-04: one unreadable folder can no longer take down the server (#859)
 
-<!-- prawduct: type=fix | scope=v5-acceptance-863 | status= -->
+<!-- prawduct: type=fix | scope=v5-acceptance-863 | status=shipped -->
 
 `listAllProjects` ran `fs.readdirSync` on the event loop over the operator-chosen projects
 directory, and the shipped default (`~/Documents/Projects`) is TCC-protected on macOS. A launchd
@@ -381,7 +381,7 @@ each call separately bounded. It can make this route slow; it can no longer stop
 
 ## 2026-08-04: cross-site guards extended to WebSockets, and Caddyfile inputs shape-checked (#860, #864)
 
-<!-- prawduct: type=fix | scope=v5-acceptance-863 | status= -->
+<!-- prawduct: type=fix | scope=v5-acceptance-863 | status=shipped -->
 
 **Why:** the cumulative review's reachable findings, plus the delta review that followed it. Recorded
 here because the previous entry's own lesson was that CHANGELOG-only updates leave every derived
@@ -420,7 +420,7 @@ eliminate.
 
 ## 2026-08-04: the dashboard answers to the machine's own name, and cert regeneration stops shrinking (#863, #862, #859, #846)
 
-<!-- prawduct: type=fix | scope=v5-acceptance-863 | status= -->
+<!-- prawduct: type=fix | scope=v5-acceptance-863 | status=shipped -->
 
 **Why:** four issues' worth of shipped v5 behaviour reached `CHANGELOG.md` and never reached this
 file, so every view that derives from these tags — Status, `release-notes.md`, `scope_rollups` —
@@ -459,7 +459,7 @@ which was true of the running service and false of the file it reloads from.
 
 ## 2026-08-01: the upstream half of the install-reference check is parsed, not scraped (#807, #816)
 
-<!-- prawduct: type=fix | scope=plugin-ref-807 | status= -->
+<!-- prawduct: type=fix | scope=plugin-ref-807 | status=shipped -->
 
 **Why:** the 2026-07-31 entry below records the cross-check as shipped state, and that half of it was
 weaker than the entry implies. Entries are append-only, so this supersedes rather than edits it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -515,9 +515,10 @@ All notable changes to TangleClaw are documented in this file.
   `engines.governanceState` reads more files under it. A *registered* project whose directory is
   TCC-protected therefore still blocks the event loop, exactly as #859 described. The comment on
   `listAllProjects` used to say the registered list "cannot be affected by a stuck filesystem";
-  that was overstated and now says otherwise. It is **not yet filed as an issue** — said plainly
-  rather than as "tracked separately", which would cite nothing. The real unit of work is the whole
-  family of ~31 synchronous reads on operator-chosen paths in that file, not this call site.
+  that was overstated and now says otherwise. Tracked as **#884**, scoped to the whole family — 32
+  synchronous reads on operator-chosen paths in `lib/projects.js` plus 7 in `lib/uploads.js` —
+  rather than to this call site, because the last time this family was fixed one site at a time the
+  sweep missed the one that wedged a clean-room install.
 
 - **The installer's TCC check now folds case too.** `tcc_protected_path` in `deploy/install.sh`
   matched `$HOME/Documents/` with literal capitals, so a config carrying `~/documents/Projects`
@@ -1617,7 +1618,10 @@ All notable changes to TangleClaw are documented in this file.
   misdiagnosis this work exists to remove.
 
   **The regression test reproduces the defect rather than describing it.** A companion process
-  issues `UV_THREADPOOL_SIZE + 1` blocking reads through the shipped `projects._withTimeout`, then
+  issues `UV_THREADPOOL_SIZE + 1` blocking reads through the deadline-race shape that shipped
+  before this change (`projects._withTimeout`, deleted by chunk 2 below along with its last
+  caller, so the demo carries a verbatim copy rather than keeping dead code alive to be a
+  fixture), then
   times an ordinary `readdir` on an unrelated path: every call rejects on schedule and the readdir
   never completes again — that assertion is the bug, executable. The same workload through the
   scanner leaves the parent's `readdir` at ~35ms. Isolated in its own process because a test that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -463,6 +463,33 @@ All notable changes to TangleClaw are documented in this file.
 
 ### Fixed
 
+- **A projects folder that never answers no longer costs the server its ability to read ANY
+  file.** (#883, chunk 2 — the fix reaching the routes.) `GET /api/projects`,
+  `POST /api/setup/scan` and `POST /api/setup/create-dir` now do their filesystem work in the
+  scanner child added in chunk 1, so a directory that hangs costs a disposable process instead of
+  one of the four libuv threadpool threads the whole server shares. Before this, four hung scans
+  left the server unable to touch the filesystem at all, on any path, permanently — while
+  `/api/health` still answered `200` and every later failure was misreported as a Full Disk Access
+  problem, sending operators to change a permission that was never at fault.
+
+  **Proven through the real route, not at the unit level:** `test/api-projects.test.js` issues
+  `UV_THREADPOOL_SIZE + 1` hung scans at one running server, then times an ordinary `readdir` on
+  an unrelated path. Verified by mutation — putting the hang back in the server process makes that
+  readdir never complete, which is the defect exactly.
+
+  A second win comes free: `git.getInfo` shells out with `execSync` from *inside* the walk, and a
+  synchronous call cannot be interrupted by any deadline. That is now in the child too, so a
+  directory whose `git` calls stall no longer blocks the server's event loop either. Its
+  two-minute cache moves with it, so a child killed for a hang starts cold — a few repeated `git`
+  calls after a kill, in exchange for never blocking the server.
+
+  **Known and NOT fixed by this, stated plainly:** `enrichProject` still calls
+  `fs.existsSync(project.path)` synchronously for every registered project on that same route, and
+  `engines.governanceState` reads more files under it. A *registered* project whose directory is
+  TCC-protected therefore still blocks the event loop, exactly as #859 described. The comment on
+  `listAllProjects` used to say the registered list "cannot be affected by a stuck filesystem";
+  that was overstated and now says so.
+
 - **The installer's TCC check now folds case too.** `tcc_protected_path` in `deploy/install.sh`
   matched `$HOME/Documents/` with literal capitals, so a config carrying `~/documents/Projects`
   reported "safe" and the preflight said nothing — the same quiet-wrong-answer failure the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -488,7 +488,9 @@ All notable changes to TangleClaw are documented in this file.
   `engines.governanceState` reads more files under it. A *registered* project whose directory is
   TCC-protected therefore still blocks the event loop, exactly as #859 described. The comment on
   `listAllProjects` used to say the registered list "cannot be affected by a stuck filesystem";
-  that was overstated and now says so.
+  that was overstated and now says otherwise. It is **not yet filed as an issue** — said plainly
+  rather than as "tracked separately", which would cite nothing. The real unit of work is the whole
+  family of ~31 synchronous reads on operator-chosen paths in that file, not this call site.
 
 - **The installer's TCC check now folds case too.** `tcc_protected_path` in `deploy/install.sh`
   matched `$HOME/Documents/` with literal capitals, so a config carrying `~/documents/Projects`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -463,6 +463,33 @@ All notable changes to TangleClaw are documented in this file.
 
 ### Fixed
 
+- **An unreadable projects folder is now cheap, not merely survivable.** (#883, chunk 3.) With
+  chunks 1–2 the dashboard's ten-second poll still cost a five-second stall and a killed scanner
+  process *on every tick, forever* — and a process blocked in the kernel may never leave the
+  process table, so that was roughly six unreapable processes a minute for as long as a browser
+  tab stayed open. A path that does not answer is now remembered and refused immediately, so the
+  cost is one attempt per backoff interval (30s, doubling to a 5-minute ceiling) instead of one
+  per poll.
+
+  **A directory that starts working recovers on its own** — no restart, no button. That is the
+  half of a failure cache that is easy to get wrong, and this project has the bug on record: a
+  memoization that cached *failures* permanently because only the success case was thought
+  through. So the rule here is narrow on purpose — **only "it did not answer" is remembered.**
+  Anything else is an *answer*: a success clears the memory, and so does an ordinary error.
+  `ENOENT` in particular must never stick, because the wizard's Create button exists to turn it
+  into a directory and the scan straight afterwards has to see the folder that was just made.
+  Work killed as collateral for a *sibling* request is recorded neither way — it says nothing
+  about its own path, and treating it as evidence would let one bad directory either blame or
+  absolve a healthy one.
+
+  **The backoff is opt-in, and only the polled route takes it.** The wizard's Scan and Create
+  buttons deliberately do not: someone who has just granted Full Disk Access and pressed the
+  button again is entitled to a real answer, not a remembered one, and the cost of leaving them
+  out is bounded by how fast a person can click. Repeated refusals log at debug rather than warn,
+  so one broken directory no longer buries its own diagnosis under six identical warnings a
+  minute; a genuinely new failure, and each escalation of the backoff, still warn with the
+  consecutive count.
+
 - **A projects folder that never answers no longer costs the server its ability to read ANY
   file.** (#883, chunk 2 — the fix reaching the routes.) `GET /api/projects`,
   `POST /api/setup/scan` and `POST /api/setup/create-dir` now do their filesystem work in the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1540,6 +1540,41 @@ All notable changes to TangleClaw are documented in this file.
 
 ### Internal
 
+- **A killable scanner process, so a hung directory can no longer take the server's filesystem with
+  it.** (#883, chunk 1 — the mechanism only; nothing routes through it yet, so no behavior changes
+  in this entry.) A read of a TCC-protected macOS path does not fail, it never returns, and
+  `fs.promises` performs it on libuv's threadpool — four threads, shared by every async filesystem
+  call in the process. A deadline can abandon the promise but cannot cancel the syscall, so each
+  hung read costs a thread permanently. Four of them and the server can no longer touch the
+  filesystem **at all, on any path**, while `/api/health` still answers `200`.
+
+  New `lib/dir-scanner.js` supervises a forked `lib/dir-scanner-child.js`: filesystem work happens
+  in a process that can be killed, and the deadline kills it, which is the only way to reclaim a
+  thread blocked in the kernel. `worker_threads` cannot substitute — workers share the process-wide
+  pool and `terminate()` does not interrupt a blocked syscall. The child is long-lived rather than
+  forked per scan because the dashboard polls `GET /api/projects` every ten seconds for as long as a
+  tab is open, and a process spawn per poll is a permanent cost paid against a rare failure.
+
+  Collateral requests — work travelling in a child killed for a *sibling's* deadline — reject as
+  `tcAborted`, deliberately **not** `tcTimedOut`. Only `tcTimedOut` earns the Full Disk Access hint,
+  and their paths may be perfectly healthy; labelling them timed-out would reproduce the exact
+  misdiagnosis this work exists to remove.
+
+  **The regression test reproduces the defect rather than describing it.** A companion process
+  issues `UV_THREADPOOL_SIZE + 1` blocking reads through the shipped `projects._withTimeout`, then
+  times an ordinary `readdir` on an unrelated path: every call rejects on schedule and the readdir
+  never completes again — that assertion is the bug, executable. The same workload through the
+  scanner leaves the parent's `readdir` at ~35ms. Isolated in its own process because a test that
+  destroys its own threadpool would take the rest of the file with it; measured along the way,
+  such a process cannot even finish `process.exit(0)`, so it is SIGKILLed.
+
+  **What the test does not prove, stated plainly:** a real hung `readdir` is not reproducible in CI.
+  A FIFO — the one portable way to block a filesystem call — answers `readdir` with `ENOTDIR`
+  immediately (measured); only `open`/`readFile` blocks on one. The hang is therefore produced with
+  the operation that does block, in a fixture child standing in for the real one. That covers the
+  supervisor's contract against a genuinely blocked syscall holding a genuine pool thread, and
+  nothing specific to `readdir`.
+
 - **Seven tests stopped asking the host a question the code should answer.** The new
   no-engine refusal on `POST /api/setup/complete` broke `test/api-setup-https.test.js`, which had
   never needed an engine before: the bundled profiles detect real CLIs, so the suite passed on a

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -42,6 +42,20 @@ fails any auto-stub section older than 14 days.
 
 - **HTTP entrypoint + route table** — `server.js` (single-file router; `route(method, path, handler)` registrations throughout). API families summarized below; find any route by grepping its literal route string in `server.js`.
 - **Projects family** — `GET/POST /api/projects`, `GET/PATCH/DELETE /api/projects/:name`, `POST .../archive`, `POST .../unarchive`, `POST /api/projects/attach`, `POST /api/projects/import`, orphan-hooks scan/repair routes. Enrichment: `lib/projects.js#enrichProject`. Updates: `lib/projects.js#updateProject`.
+- **Directory scanner — filesystem work in a killable child** (#883) — every read of an
+  operator-chosen path happens in a forked process, never on the server's event loop, because a
+  TCC-protected path on macOS never returns a read and a deadline cannot cancel a syscall (it
+  abandons the promise and the libuv threadpool thread is gone for good; four of those and the
+  server can no longer touch the filesystem at all). Supervisor: `lib/dir-scanner.js` —
+  correlation ids, per-request child ownership, `SIGKILL` on the deadline, lazy respawn, and a
+  per-path failure backoff (30s → 5min ceiling) that only the polled route opts into. Walks:
+  `lib/dir-scanner-child.js#HANDLERS` (`listUnregistered`, `scanEntries`, `createDir`). Two
+  scanners: a background one for `listAllProjects`, an interactive one for the wizard's
+  `scanDirectoryForProjects`/`createProjectsDir`, so a hung poll cannot kill a child out from
+  under an operator's click. Rejection vocabulary is contractual — `tcTimedOut` (did not answer;
+  the sole input to the Full Disk Access advice), `tcCached`, `tcAborted` (collateral),
+  `tcTruncated` (ran out of budget). Callers: `lib/projects.js#listAllProjects`,
+  `#scanDirectoryForProjects`, `#createProjectsDir`.
 - **Project-action invocation** — `POST /api/projects/:name/actions/:command`. Dispatcher: `lib/actions.js#runAction`; availability predicate shared with the button: `lib/actions.js#availableActions`.
 - **Sessions family** — `POST /api/sessions/:project` (launch), `DELETE` (kill), `GET .../status`, `POST .../command`, `POST .../wrap`, `POST .../wrap/complete`, `GET .../wrap/status` (#583 reattach), `GET .../peek`, `GET .../history`. Core: `lib/sessions.js#launchSession`, `#generatePrimePrompt`.
 - **Wrap pipeline runner** — `lib/wrap-pipeline.js#runWrapPipeline`; single-flight per project via `lib/wrap-run-registry.js` (#583).

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -614,6 +614,35 @@ tail -50 ~/.tangleclaw/logs/tangleclaw.log
 curl -s http://localhost:3102/api/health | python3 -m json.tool
 ```
 
+### Leftover `dir-scanner-child` Processes
+
+TangleClaw reads your project folders in a small helper process rather than in the server, so
+a folder that never responds cannot take the whole dashboard down with it. If a folder does
+stop responding, that helper is killed — but a process stuck waiting on the operating system
+cannot always be killed immediately, and those can pile up.
+
+**This is a symptom, not the problem. Fix the folder and the pile-up stops.**
+
+```bash
+# How many are there? Two is normal — one for the dashboard, one for the setup wizard.
+pgrep -fl dir-scanner-child
+
+# Which folder is not responding, and how often it has failed
+grep -E "did not answer|did not exit after SIGKILL" ~/.tangleclaw/logs/tangleclaw.log | tail -20
+```
+
+The fix is whatever the log names: usually granting Full Disk Access to your `node` binary
+(System Settings → Privacy & Security → Full Disk Access), or moving your projects folder
+outside `~/Documents`, `~/Desktop` and `~/Downloads`. While a folder stays unreadable,
+TangleClaw backs off and retries at most once every 30 seconds, widening to 5 minutes — so
+the pile-up is slow, not runaway.
+
+To clear the ones already there, restart the server. Nothing else releases them:
+
+```bash
+launchctl kickstart -k gui/$(id -u)/com.tangleclaw.server
+```
+
 ### Terminal Not Connecting
 
 ```bash

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -225,6 +225,14 @@ Privacy & Security → Full Disk Access), or keep your projects somewhere outsid
 directories. The scan gives up after five seconds and tells you which it was, rather than waiting
 forever.
 
+**After you grant access, you may wait up to half a minute for the dashboard to notice.** The
+project list stops re-reading a directory that has not answered — otherwise it would retry every
+ten seconds forever, and each attempt leaves a stuck process behind. It tries again on its own,
+starting half a minute after the last failure and backing off to at most five minutes if the
+directory keeps failing. **You do not need to restart anything**; the list fills in by itself on
+the next attempt that succeeds. The wizard's Scan and Create buttons are not affected — those
+always read the directory for real, because you just asked them to.
+
 ## Sessions
 
 Sessions are the core of TangleClaw — they're how you interact with AI engines on your projects.

--- a/lib/dir-scanner-child.js
+++ b/lib/dir-scanner-child.js
@@ -1,0 +1,170 @@
+'use strict';
+
+/**
+ * The sacrificial half of the directory scanner: a forked process that performs
+ * filesystem work on paths the operator chose, so the server never does.
+ *
+ * WHY A SEPARATE PROCESS AND NOT A THREAD. A TCC-protected path on macOS does
+ * not fail a read, it never answers one — the `open()` stays in the kernel for
+ * the life of the process. `fs.promises` puts that call on libuv's threadpool,
+ * which defaults to FOUR threads and is shared by every async filesystem call
+ * in the process. A deadline can abandon the promise; it cannot cancel the
+ * syscall, so the thread is gone for good. Four such reads and the process can
+ * no longer perform ANY filesystem operation, on any path, while `/api/health`
+ * keeps answering 200 and nothing surfaces.
+ *
+ * `worker_threads` is not a substitute: workers share the process-wide libuv
+ * pool, and `terminate()` cannot interrupt a thread blocked in a syscall. Only
+ * killing the process that owns the blocked thread reclaims the resource, and
+ * that is what this file exists to be — the thing that can be killed.
+ *
+ * It therefore holds no state worth keeping and nothing else depends on it
+ * being alive. The supervisor in `dir-scanner.js` kills it on a deadline and
+ * forks a replacement on the next request.
+ */
+
+const fsp = require('node:fs').promises;
+
+/**
+ * Reduce a `Dirent` to the fields that survive a structured-clone IPC hop.
+ *
+ * `Dirent` answers its questions through methods, and a method does not cross a
+ * process boundary — a caller that received the object verbatim would find
+ * `entry.isDirectory` undefined and silently classify every entry as a file.
+ * Flattening to booleans here is what makes the answer usable on the far side.
+ *
+ * @param {import('node:fs').Dirent} entry - One entry from a `withFileTypes` read.
+ * @returns {{name: string, isDirectory: boolean, isFile: boolean, isSymbolicLink: boolean}}
+ */
+function _plainDirent(entry) {
+  return {
+    name: entry.name,
+    isDirectory: entry.isDirectory(),
+    isFile: entry.isFile(),
+    isSymbolicLink: entry.isSymbolicLink()
+  };
+}
+
+/**
+ * The operations this child will perform. Anything not named here is refused
+ * rather than guessed at, so a typo in a caller is a clear error instead of a
+ * silent no-op.
+ *
+ * Each handler takes the request payload and resolves with a JSON-serialisable
+ * value. Handlers may hang forever — that is the case this whole design exists
+ * for — so none of them may hold state the supervisor would miss.
+ */
+const HANDLERS = {
+  /**
+   * Confirm the child is alive and answering, and say which process answered.
+   *
+   * The pid is the point: it is how a caller tells "the same child replied"
+   * from "a replacement child replied", which is the difference between a
+   * healthy round trip and a silent respawn after a crash.
+   *
+   * @returns {Promise<{pid: number}>}
+   */
+  async ping() {
+    return { pid: process.pid };
+  },
+
+  /**
+   * Read the immediate entries of a directory.
+   *
+   * Always reads with file types and flattens them: the caller's next question
+   * is invariably "which of these are directories", and answering it here costs
+   * nothing while answering it on the parent side would mean a `stat` per entry
+   * over the very tree suspected of not answering.
+   *
+   * @param {object} payload - Request payload.
+   * @param {string} payload.dir - Absolute directory to read.
+   * @returns {Promise<{entries: Array<{name: string, isDirectory: boolean, isFile: boolean, isSymbolicLink: boolean}>}>}
+   */
+  async readdir({ dir }) {
+    const entries = await fsp.readdir(dir, { withFileTypes: true });
+    return { entries: entries.map(_plainDirent) };
+  }
+};
+
+/**
+ * Flatten an error into something IPC can carry.
+ *
+ * `code` travels separately from the message because callers branch on it —
+ * `ENOENT` means "offer to create this directory" and a reworded sentence must
+ * not be able to change that. The stack is deliberately dropped: it describes
+ * this file, not the caller's problem.
+ *
+ * @param {Error|any} err - Whatever the handler threw.
+ * @returns {{message: string, code: string|undefined}}
+ */
+function _plainError(err) {
+  if (err && typeof err === 'object') {
+    return { message: String(err.message || err), code: err.code };
+  }
+  return { message: String(err), code: undefined };
+}
+
+/**
+ * Run one request and reply with its outcome.
+ *
+ * Never throws and never rejects: this is the top of the child's call stack, so
+ * an escaping error would kill the process and strand the supervisor's pending
+ * request until its deadline — a five-second wait for a failure already known.
+ * A reply that says "this failed, and why" is strictly better.
+ *
+ * @param {{id: number, op: string, payload: object}} msg - Request from the supervisor.
+ * @returns {Promise<void>}
+ */
+async function _handle(msg) {
+  const { id, op, payload } = msg || {};
+  const handler = HANDLERS[op];
+
+  if (!handler) {
+    _reply({ id, ok: false, error: { message: `unknown scanner operation: ${op}`, code: 'ENOSYS' } });
+    return;
+  }
+
+  try {
+    const value = await handler(payload || {});
+    _reply({ id, ok: true, value });
+  } catch (err) { // prawduct:allow prawduct/broad-except -- top of the child's call stack; the error is reported to the supervisor, not swallowed
+    _reply({ id, ok: false, error: _plainError(err) });
+  }
+}
+
+/**
+ * Send a reply, tolerating a supervisor that has already gone away.
+ *
+ * `process.send` throws on a closed channel, and the channel closing is the
+ * NORMAL end of this process's life — the supervisor kills children that took
+ * too long, and a killed child's last in-flight reply races the kill. Throwing
+ * there would turn an expected shutdown into an unhandled rejection in the logs.
+ *
+ * @param {object} message - The reply envelope.
+ * @returns {void}
+ */
+function _reply(message) {
+  if (!process.connected) return;
+  try {
+    process.send(message);
+  } catch { // prawduct:allow prawduct/broad-except -- the channel closed between the check and the send; there is no one left to tell
+    // The supervisor is gone. It has already failed this request on its side.
+  }
+}
+
+// Only when actually forked. A test that requires this file for its helpers must
+// not thereby install a `disconnect` handler on ITS OWN process — the test runner
+// forks test files too, so the handler would fire on the runner's channel and
+// exit the test process mid-suite. `require.main` is the exact distinction:
+// `fork()` makes this file the entry point, `require()` never does.
+if (require.main === module) {
+  process.on('message', (msg) => { _handle(msg); });
+
+  // Outlive nothing. If the supervisor dies — crash, kill, server restart — this
+  // process has no reason to exist and no one to answer; without this it would be
+  // reparented to init and linger, holding whatever it was blocked on. Children
+  // that survive their parent are how a leak becomes permanent.
+  process.on('disconnect', () => { process.exit(0); });
+}
+
+module.exports = { HANDLERS, _plainDirent, _plainError, _handle };

--- a/lib/dir-scanner-child.js
+++ b/lib/dir-scanner-child.js
@@ -23,7 +23,66 @@
  * forks a replacement on the next request.
  */
 
+const path = require('node:path');
 const fsp = require('node:fs').promises;
+const git = require('./git');
+
+// What makes a directory look like a project to the first-run wizard. Presence
+// of any one of these, a git branch, or TangleClaw's own config is enough to
+// pre-tick it for import; everything else is still listed, just unticked.
+const PROJECT_MARKERS = [
+  'package.json', 'Cargo.toml', 'pyproject.toml', 'go.mod',
+  'Makefile', 'Gemfile', 'pom.xml', 'build.gradle',
+  'CMakeLists.txt', 'setup.py', 'composer.json', 'mix.exs'
+];
+
+/**
+ * Does `p` exist? Answers off the main thread and never throws.
+ *
+ * The synchronous `fs.existsSync` this replaces is the same hazard as a
+ * synchronous readdir: on a path the kernel never answers for, it does not
+ * return false, it does not return at all.
+ *
+ * @param {string} p - Absolute path to test.
+ * @returns {Promise<boolean>}
+ */
+async function _exists(p) {
+  try {
+    await fsp.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Git branch/dirty info for `dir`, or null when it is not a repo.
+ *
+ * WHY THIS RUNS HERE AND NOT IN THE SERVER. `git.getInfo` shells out with
+ * `execSync`, and `lib/git`'s 5s cap is per command while reading a repo takes
+ * several — so a directory whose git calls all stall blocks the calling process's
+ * event loop for far longer than any scan deadline, which cannot fire while a
+ * synchronous call is running. In the server that was a second way to wedge the
+ * same request. Here the caller is a process that exists to be killed, so a
+ * stalled `git` costs the same as a stalled `readdir` and no more.
+ *
+ * One consequence worth knowing: `git.getInfo`'s two-minute cache now lives in
+ * this process, so a child killed for a hang starts cold. That trades a few
+ * repeated `git` calls after a kill for never blocking the server, which is the
+ * right way round.
+ *
+ * @param {string} dir - Directory to inspect.
+ * @returns {object|null}
+ */
+function _gitInfo(dir) {
+  try {
+    return git.getInfo(dir);
+  } catch {
+    // Not a git repo, or git is not installed. Either way there is no branch to
+    // report and the directory is still worth listing.
+    return null;
+  }
+}
 
 /**
  * Reduce a `Dirent` to the fields that survive a structured-clone IPC hop.
@@ -69,20 +128,166 @@ const HANDLERS = {
   },
 
   /**
-   * Read the immediate entries of a directory.
+   * The subdirectories of `dir` that are not already registered projects, shaped
+   * like project records so the dashboard can render both from one list.
    *
-   * Always reads with file types and flattens them: the caller's next question
-   * is invariably "which of these are directories", and answering it here costs
-   * nothing while answering it on the parent side would mean a `stat` per entry
-   * over the very tree suspected of not answering.
+   * Stopping at the budget TRUNCATES rather than throwing: a discovery walk that
+   * ran out of time has still discovered everything it got to, and this backs the
+   * dashboard's project list. Throwing would take a slow directory — hundreds of
+   * projects, a sluggish disk — from "the list took a while" to "the list is
+   * empty", silently, because the caller degrades a failure to the registered
+   * projects alone.
    *
    * @param {object} payload - Request payload.
-   * @param {string} payload.dir - Absolute directory to read.
-   * @returns {Promise<{entries: Array<{name: string, isDirectory: boolean, isFile: boolean, isSymbolicLink: boolean}>}>}
+   * @param {string} payload.dir - Absolute projects directory to walk.
+   * @param {string[]} payload.skipNames - Names already registered or archived.
+   * @param {number} payload.budgetMs - How long the whole walk may take.
+   * @returns {Promise<{unregistered: object[], truncated: boolean}>}
    */
-  async readdir({ dir }) {
+  async listUnregistered({ dir, skipNames = [], budgetMs }) {
+    const deadlineAt = Date.now() + budgetMs;
+    // A Set does not survive JSON, so it arrives as an array and is rebuilt
+    // here — membership is tested once per entry and this list is not short.
+    const skip = new Set(skipNames);
     const entries = await fsp.readdir(dir, { withFileTypes: true });
-    return { entries: entries.map(_plainDirent) };
+    const unregistered = [];
+    let truncated = false;
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      if (entry.name.startsWith('.')) continue;
+      if (skip.has(entry.name)) continue;
+
+      if (Date.now() >= deadlineAt) {
+        truncated = true;
+        break;
+      }
+
+      const dirPath = path.join(dir, entry.name);
+      unregistered.push({
+        id: null,
+        name: entry.name,
+        path: dirPath,
+        registered: false,
+        engine: null,
+        tags: [],
+        ports: {},
+        session: null,
+        git: _gitInfo(dirPath),
+        status: null,
+        hasTangleclawConfig: await _exists(path.join(dirPath, '.tangleclaw', 'project.json')),
+        createdAt: null,
+        updatedAt: null,
+        archived: false
+      });
+    }
+
+    return { unregistered, truncated };
+  },
+
+  /**
+   * Enumerate and classify the immediate subdirectories of `dir` for the
+   * first-run wizard.
+   *
+   * ONE budget covers the whole walk rather than each call within it: a directory
+   * with hundreds of children can exhaust any reasonable budget in per-call
+   * increments while every individual call stays under it.
+   *
+   * Unlike the dashboard's list this one cannot return a partial answer quietly —
+   * the operator is about to tick boxes from it, and a list silently missing half
+   * the directories reads as "those are not there". So it throws, carrying
+   * `tcTruncated`, which is deliberately NOT `tcTimedOut`: this walk was being
+   * answered, just not fast enough, and blaming Full Disk Access for a large
+   * directory on a slow disk sends the operator to fix the wrong thing.
+   *
+   * @param {object} payload - Request payload.
+   * @param {string} payload.dir - Absolute, already-resolved directory to scan.
+   * @param {number} payload.budgetMs - How long the whole walk may take.
+   * @returns {Promise<{projects: object[]}>}
+   */
+  async scanEntries({ dir, budgetMs }) {
+    const deadlineAt = Date.now() + budgetMs;
+
+    const stat = await fsp.stat(dir);
+    if (!stat.isDirectory()) {
+      throw Object.assign(new Error(`not a directory: ${dir}`), { code: 'ENOTDIR' });
+    }
+
+    const entries = await fsp.readdir(dir, { withFileTypes: true });
+    const candidates = entries.filter(e => e.isDirectory() && !e.name.startsWith('.'));
+    const detected = [];
+
+    for (const entry of candidates) {
+      if (Date.now() >= deadlineAt) {
+        throw Object.assign(
+          new Error(`checked ${detected.length} of ${candidates.length} subdirectories `
+            + `in ${budgetMs}ms and gave up`),
+          { tcTruncated: true }
+        );
+      }
+
+      const dirPath = path.join(dir, entry.name);
+      const gitInfo = _gitInfo(dirPath);
+      const hasTangleclawConfig = await _exists(path.join(dirPath, '.tangleclaw', 'project.json'));
+
+      // Sequential and short-circuiting, deliberately. Probing all twelve markers
+      // concurrently would issue twelve threadpool calls per directory to answer
+      // a question the first hit settles — cheap against a healthy filesystem,
+      // and against a blocked one it is twelve stuck slots instead of one.
+      let hasProjectMarker = false;
+      for (const marker of PROJECT_MARKERS) {
+        if (await _exists(path.join(dirPath, marker))) {
+          hasProjectMarker = true;
+          break;
+        }
+      }
+
+      detected.push({
+        name: entry.name,
+        path: dirPath,
+        hasTangleclawConfig,
+        git: gitInfo ? { branch: gitInfo.branch, dirty: gitInfo.dirty } : null,
+        detected: !!((gitInfo && gitInfo.branch) || hasTangleclawConfig || hasProjectMarker)
+      });
+    }
+
+    return { projects: detected };
+  },
+
+  /**
+   * Create `dir` if it is absent and its parent is present.
+   *
+   * PERFORMS NO PATH VALIDATION — deliberately. The rule that this may only
+   * create a folder inside the operator's home directory is a security boundary
+   * enforced by the only caller (`projects.createProjectsDir`), where it can be
+   * stated once and tested once. Duplicating it here would create a second copy
+   * to keep in sync, and a boundary in two places is a boundary in neither.
+   * Anything calling this op is responsible for having checked.
+   *
+   * Reports which of the three outcomes happened rather than throwing for two of
+   * them: "it was already there" is a success (two clicks on the same button), and
+   * "the parent is missing" is an operator-fixable condition with its own message,
+   * not an error.
+   *
+   * @param {object} payload - Request payload.
+   * @param {string} payload.dir - Absolute directory to create.
+   * @returns {Promise<{status: 'exists'|'parent-missing'|'created', parent: string}>}
+   */
+  async createDir({ dir }) {
+    const parent = path.dirname(dir);
+
+    if (await _exists(dir)) {
+      return { status: 'exists', parent };
+    }
+    // The parent must already exist. Creating ONE level is "you pointed at
+    // ~/Documents/Projects and it wasn't there yet"; creating five is building a
+    // tree nobody asked for at a path nobody checked.
+    if (!await _exists(parent)) {
+      return { status: 'parent-missing', parent };
+    }
+
+    await fsp.mkdir(dir);
+    return { status: 'created', parent };
   }
 };
 
@@ -99,9 +304,23 @@ const HANDLERS = {
  */
 function _plainError(err) {
   if (err && typeof err === 'object') {
-    return { message: String(err.message || err), code: err.code };
+    return {
+      message: String(err.message || err),
+      code: err.code,
+      // The one condition this side is entitled to declare. `tcTruncated` means
+      // "the directory WAS answering, there was just more of it than the budget
+      // allowed" — a healthy machine with a big folder on a slow disk. It has to
+      // survive the hop because the caller words a different sentence for it, and
+      // because the alternative sentence tells the operator to change a privacy
+      // setting that was never the problem.
+      //
+      // `tcTimedOut` is deliberately NOT carried: only the supervisor's own
+      // deadline may declare a path unresponsive, and that is the one flag that
+      // earns the Full Disk Access remedy. A child cannot be allowed to claim it.
+      tcTruncated: err.tcTruncated ? true : undefined
+    };
   }
-  return { message: String(err), code: undefined };
+  return { message: String(err), code: undefined, tcTruncated: undefined };
 }
 
 /**
@@ -167,4 +386,10 @@ if (require.main === module) {
   process.on('disconnect', () => { process.exit(0); });
 }
 
-module.exports = { _plainDirent, _plainError };
+// HANDLERS is exported because the walks are where the product's behavior lives —
+// marker short-circuiting, deadline truncation, what counts as a candidate — and
+// that behavior is only testable by stubbing `fs`, which cannot be done across a
+// process boundary. Tests exercise the walks directly here, in-process, and prove
+// the delegation separately. Nothing in the server calls these except through the
+// supervisor.
+module.exports = { HANDLERS, PROJECT_MARKERS, _plainDirent, _plainError };

--- a/lib/dir-scanner-child.js
+++ b/lib/dir-scanner-child.js
@@ -85,26 +85,6 @@ function _gitInfo(dir) {
 }
 
 /**
- * Reduce a `Dirent` to the fields that survive a structured-clone IPC hop.
- *
- * `Dirent` answers its questions through methods, and a method does not cross a
- * process boundary — a caller that received the object verbatim would find
- * `entry.isDirectory` undefined and silently classify every entry as a file.
- * Flattening to booleans here is what makes the answer usable on the far side.
- *
- * @param {import('node:fs').Dirent} entry - One entry from a `withFileTypes` read.
- * @returns {{name: string, isDirectory: boolean, isFile: boolean, isSymbolicLink: boolean}}
- */
-function _plainDirent(entry) {
-  return {
-    name: entry.name,
-    isDirectory: entry.isDirectory(),
-    isFile: entry.isFile(),
-    isSymbolicLink: entry.isSymbolicLink()
-  };
-}
-
-/**
  * The operations this child will perform. Anything not named here is refused
  * rather than guessed at, so a typo in a caller is a clear error instead of a
  * silent no-op.
@@ -392,4 +372,4 @@ if (require.main === module) {
 // process boundary. Tests exercise the walks directly here, in-process, and prove
 // the delegation separately. Nothing in the server calls these except through the
 // supervisor.
-module.exports = { HANDLERS, PROJECT_MARKERS, _plainDirent, _plainError };
+module.exports = { HANDLERS, PROJECT_MARKERS, _plainError };

--- a/lib/dir-scanner-child.js
+++ b/lib/dir-scanner-child.js
@@ -167,4 +167,4 @@ if (require.main === module) {
   process.on('disconnect', () => { process.exit(0); });
 }
 
-module.exports = { HANDLERS, _plainDirent, _plainError, _handle };
+module.exports = { _plainDirent, _plainError };

--- a/lib/dir-scanner.js
+++ b/lib/dir-scanner.js
@@ -111,6 +111,10 @@ function _aborted(reason) {
 function _rehydrate(plain) {
   const err = new Error((plain && plain.message) || 'directory scan failed');
   if (plain && plain.code) err.code = plain.code;
+  // A walk that ran out of budget, as opposed to a path that never answered.
+  // The caller words a different sentence for each, and only the second earns
+  // the Full Disk Access remedy.
+  if (plain && plain.tcTruncated) err.tcTruncated = true;
   return err;
 }
 
@@ -329,6 +333,14 @@ function createScanner(options = {}) {
       spawned.stderr.on('data', (chunk) => {
         if (stderr.length < 4096) stderr += chunk;
       });
+      // MUST be unref'd, and it is easy to miss. A piped stdio stream is a
+      // socket, and a socket with a `data` listener holds the event loop open on
+      // its own — independently of the child handle and the IPC channel, both
+      // unref'd below. Without this, any process that forks a scanner and does
+      // not explicitly shut it down never exits: the work finishes, the tests
+      // pass, and the runner hangs afterwards with no failing assertion to point
+      // at. That is exactly how it was found.
+      spawned.stderr.unref();
     }
 
     spawned.on('message', (msg) => {

--- a/lib/dir-scanner.js
+++ b/lib/dir-scanner.js
@@ -25,14 +25,18 @@
  * supervised child answers a warm IPC round trip instead, and is killed and
  * replaced only when it actually hangs.
  *
- * THE LIMIT, STATED HONESTLY. `SIGKILL` removes the child from the scheduler,
- * but a thread already blocked inside an uninterruptible kernel call does not
- * necessarily unwind, so a killed child can linger in the process table until
- * this process exits and reaps it. The parent's threadpool is unaffected either
- * way — that is the defect being fixed — but the exchange is one stuck process
- * per hang rather than one stuck server thread, not zero cost. A child that does
- * not exit within the grace window is logged by pid rather than passed over in
- * silence.
+ * THE LIMIT, STATED HONESTLY, AS A RATE. `SIGKILL` removes the child from the
+ * scheduler, but a thread already blocked inside an uninterruptible kernel call
+ * does not necessarily unwind, so a killed child can linger in the process table
+ * until this process exits and reaps it. The parent's threadpool is unaffected
+ * either way — that is the defect being fixed — but the exchange is one stuck
+ * process per hung REQUEST, and requests are not rare on the install this fixes:
+ * the dashboard polls every ten seconds for as long as a tab is open, so an
+ * unreadable projects directory produces roughly six unreapable processes per
+ * minute, indefinitely. "One per hang" would read bounded and it is not. Each is
+ * logged with a running total rather than only its pid, so the shape is visible
+ * as a trend; capping the RATE is the per-path failure cache, which is why that
+ * cache is part of this fix rather than a refinement of it.
  */
 
 const path = require('node:path');
@@ -126,7 +130,7 @@ function _rehydrate(plain) {
  * @param {number} [options.exitGraceMs] - How long a killed child may take to exit
  *   before that is logged.
  * @param {Function} [options.forkFn] - Injectable `child_process.fork`.
- * @returns {{request: Function, shutdown: Function, childPid: Function, pendingCount: Function}}
+ * @returns {{request: Function, shutdown: Function, childPid: Function}}
  */
 function createScanner(options = {}) {
   const childPath = options.childPath || DEFAULT_CHILD_PATH;
@@ -136,10 +140,26 @@ function createScanner(options = {}) {
 
   /** @type {import('node:child_process').ChildProcess|null} */
   let child = null;
-  /** @type {Map<number, {reject: Function, resolve: Function, timer: NodeJS.Timeout, what: string}>} */
+
+  // EVERY PENDING REQUEST NAMES THE CHILD IT WAS SENT TO. Ownership used to be
+  // inferred from whichever child was current at the moment something happened,
+  // and that inference is wrong in both directions: a dying child's late `exit`
+  // would fail work already in flight on its replacement, and a child replaced
+  // before its `exit` arrived would never fail the work it was actually holding
+  // — that work then waited out its full deadline and was reported `tcTimedOut`,
+  // the Full Disk Access misdiagnosis this module exists to remove, on a path
+  // that may be perfectly healthy. `owner` makes it a fact instead of a guess.
+  /** @type {Map<number, {resolve: Function, reject: Function, timer: NodeJS.Timeout, owner: object, what: string}>} */
   const pending = new Map();
+
+  // Children already written off, so a second signal about the same one — an
+  // `exit` following the kill that caused it, a `disconnect` racing both — is a
+  // no-op rather than a second kill and a second sweep.
+  const discarded = new WeakSet();
+
   let nextId = 0;
   let shuttingDown = false;
+  let orphanCount = 0;
 
   /**
    * Settle a pending request exactly once, clearing its deadline.
@@ -160,65 +180,90 @@ function createScanner(options = {}) {
     if (!entry) return false;
     pending.delete(id);
     clearTimeout(entry.timer);
-    _releaseChannel();
+    _syncChannel(entry.owner);
     if (err) entry.reject(err); else entry.resolve(value);
     return true;
   }
 
   /**
-   * Fail every outstanding request, for a reason that is not any one request's
-   * fault.
+   * Fail the work `victim` was holding, and say how much there was.
    *
-   * Callers hang forever otherwise. A child that dies takes its in-flight work
-   * with it and sends nothing to say so, so the supervisor is the only thing
-   * that can tell them.
+   * Scoped to one child rather than to everything outstanding: a supervisor that
+   * failed the whole map on any child's death would reject healthy requests
+   * belonging to a successor.
    *
+   * The count is logged because a kill sweeps N requests and only ONE of them —
+   * the deadline's owner — is logged anywhere else. Without this, N-1 rejections
+   * reaching callers have no server-side record at all.
+   *
+   * @param {object|null} victim - The child whose work is being failed.
    * @param {string} reason - Caller-facing phrase for what happened.
-   * @returns {void}
+   * @returns {number} How many requests were swept.
    */
-  function _failAll(reason) {
-    for (const id of [...pending.keys()]) {
+  function _failFor(victim, reason) {
+    if (!victim) return 0;
+    let swept = 0;
+    for (const [id, entry] of [...pending]) {
+      if (entry.owner !== victim) continue;
+      swept++;
       _settle(id, _aborted(reason));
     }
+    if (swept > 0) {
+      log.warn('Directory scans abandoned with the scanner process that was holding them',
+        { count: swept, pid: victim.pid, reason });
+    }
+    return swept;
   }
 
   /**
-   * Keep the event loop alive only while work is actually outstanding.
+   * Hold the event loop open for `target` exactly while it owes a reply.
    *
    * An idle scanner must not be a reason for the process to stay up: a CLI that
    * listed one directory would never exit, and a test that forgot to shut down
-   * would hang rather than fail. Referencing the channel per in-flight request
-   * makes the reply able to wake the loop exactly when a reply is expected.
+   * would hang rather than fail.
    *
+   * Computed from the map rather than tracked as a count, and taken against the
+   * child that OWNS the work rather than whichever child is current. The earlier
+   * shape leaked: with two requests in flight, killing the child settled one,
+   * dropped the reference, then settled the rest against a null `child` — so a
+   * killed child's channel was never released, and a child that lingers (the
+   * expected case for a thread blocked in the kernel) held the loop open forever.
+   *
+   * @param {object|null} target - The child whose channel to re-evaluate.
    * @returns {void}
    */
-  function _holdChannel() {
-    if (pending.size === 1 && child && child.channel) child.channel.ref();
+  function _syncChannel(target) {
+    if (!target || !target.channel) return;
+    let outstanding = false;
+    for (const entry of pending.values()) {
+      if (entry.owner === target) { outstanding = true; break; }
+    }
+    if (outstanding) target.channel.ref();
+    else target.channel.unref();
   }
 
   /**
-   * Release the loop hold once nothing is outstanding.
-   * @returns {void}
-   */
-  function _releaseChannel() {
-    if (pending.size === 0 && child && child.channel) child.channel.unref();
-  }
-
-  /**
-   * Stop trusting `child`, and say so if it does not actually die.
+   * Write off a child: fail what it was holding, release it, and kill it.
    *
-   * The reference is dropped BEFORE the kill so the next request forks a
-   * replacement rather than sending into a corpse. `SIGKILL` rather than
+   * Idempotent, because the signals that mean "this child is finished" arrive in
+   * no guaranteed order and sometimes all three arrive. `SIGKILL` rather than
    * `SIGTERM` because the reason for killing is that the child is wedged, and a
    * wedged child cannot run a signal handler.
    *
    * @param {import('node:child_process').ChildProcess|null} victim - Child to kill.
-   * @param {string} reason - Why, for the log.
+   * @param {string} reason - Caller-facing phrase, used for both the rejections and the log.
    * @returns {void}
    */
   function _discardChild(victim, reason) {
-    if (!victim) return;
+    if (!victim || discarded.has(victim)) return;
+    discarded.add(victim);
     if (child === victim) child = null;
+
+    _failFor(victim, reason);
+    // Released by the same code that drops the child, so the hold cannot outlive
+    // the thing it was taken for.
+    if (victim.channel) victim.channel.unref();
+
     if (victim.exitCode !== null || victim.signalCode !== null) return;
 
     const pid = victim.pid;
@@ -229,12 +274,19 @@ function createScanner(options = {}) {
     if (exitGraceMs > 0) {
       const check = setTimeout(() => {
         if (exited) return;
-        // Not a formality. A thread blocked inside an uninterruptible kernel
-        // call does not unwind on SIGKILL, so the process can sit in the table
-        // until this one exits and reaps it. Naming the pid is the difference
-        // between an operator who can see them accumulating and one who cannot.
-        log.warn('Scanner child did not exit after SIGKILL — it is likely blocked in the kernel '
-          + 'and will be reaped when the server exits', { pid, reason });
+        // Not a formality, and not a one-off. A thread blocked inside an
+        // uninterruptible kernel call does not unwind on SIGKILL, so the process
+        // sits in the table until this one exits and reaps it — and on the very
+        // install this module fixes, the dashboard's ten-second poll produces
+        // another one every ten seconds for as long as the directory stays
+        // unreadable. The running total is logged, not just the latest pid,
+        // because one line per kill reads like an incident while the number
+        // reads like a trend. TangleClaw has been here before: architecture.md
+        // calls ttyd's identical accumulation of kernel-wedged children the
+        // machine's first hard ceiling.
+        orphanCount++;
+        log.warn('Scanner child did not exit after SIGKILL — it is blocked in the kernel and can '
+          + 'only be reaped by the server exiting', { pid, reason, orphansThisRun: orphanCount });
       }, exitGraceMs);
       check.unref();
     }
@@ -251,6 +303,12 @@ function createScanner(options = {}) {
    */
   function _ensureChild() {
     if (child && child.connected) return child;
+
+    // A child whose channel has closed is dead, whether or not its `exit` event
+    // has arrived — Node does not order those two. Forking PAST it, as this used
+    // to, left an orphan nobody killed (so the blocked thread this module exists
+    // to reclaim was not reclaimed) whose in-flight work nobody failed.
+    if (child) _discardChild(child, 'the scanner process closed its channel');
 
     const spawned = forkFn(childPath, [], {
       // stdout is inherited by nothing: the child says everything it has to say
@@ -279,16 +337,14 @@ function createScanner(options = {}) {
       else _settle(msg.id, _rehydrate(msg.error));
     });
 
-    // A child that has ALREADY been replaced must not settle anything. Its exit
-    // event arrives after the kill that caused it, by which time the next
-    // request has forked a successor and may be in flight on it — and `pending`
-    // does not distinguish whose work it holds. Failing it here would reject a
-    // perfectly healthy request because an unrelated predecessor finished dying.
-    // The identity check is the whole guard; without it every kill takes the
-    // next request with it, which looks exactly like a flaky scanner.
+    // Settles only the work THIS child was holding. A dying child's `exit`
+    // arrives after the kill that caused it, by which time the next request may
+    // already be in flight on a successor — failing the whole map here would
+    // reject a healthy request because an unrelated predecessor finished dying.
+    // Ownership answers that, so this no longer needs to guard on being current.
     spawned.on('exit', (code, signal) => {
-      if (child !== spawned) return;
-      child = null;
+      if (child === spawned) child = null;
+      discarded.add(spawned);
       // An unexpected death is worth a line with whatever the child managed to
       // say. A deliberate kill is not: the deadline path has already logged the
       // reason, and repeating it as a failure would read like two problems.
@@ -300,19 +356,17 @@ function createScanner(options = {}) {
         if (stderr.trim()) detail.stderr = stderr.trim();
         log.warn('Scanner child exited unexpectedly', detail);
       }
-      if (pending.size > 0) {
-        _failAll(`the scanner process exited (code ${code}, signal ${signal})`);
-      }
+      _failFor(spawned, `the scanner process exited (code ${code}, signal ${signal})`);
     });
 
     spawned.on('error', (err) => {
       log.warn('Scanner child failed', { error: err && err.message });
-      if (child !== spawned) return;
-      child = null;
-      _failAll('the scanner process could not be started');
+      if (child === spawned) child = null;
+      discarded.add(spawned);
+      _failFor(spawned, 'the scanner process could not be started');
     });
 
-    // Never a reason for the process to stay alive on its own; see _holdChannel.
+    // Never a reason for the process to stay alive on its own; see _syncChannel.
     spawned.unref();
     if (spawned.channel) spawned.channel.unref();
 
@@ -358,16 +412,23 @@ function createScanner(options = {}) {
         // cannot relabel it as abandoned. This request is the one that timed
         // out; it is the only one entitled to say the path did not answer.
         _settle(id, _timedOut(timeoutMs, what));
+        // The path comes from the PAYLOAD, not from the caller's optional
+        // phrase: `what` falls back to `running readdir`, and the child holding
+        // the only other copy is about to be killed. An operator reading this
+        // line afterwards must be able to tell WHICH directory hung — otherwise
+        // the log misattributes at one layer down exactly as the product did at
+        // the top. The id is here so the kill can be tied to the abandonment
+        // sweep that follows it.
         log.warn('Directory scan did not answer — killing the scanner process to reclaim the '
-          + 'thread it blocked', { op, what, timeoutMs, pid: target.pid });
-        _discardChild(target, 'request deadline expired');
-        _failAll('the scanner process was killed after another request stopped responding');
+          + 'thread it blocked', { id, op, dir: payload && payload.dir, timeoutMs, pid: target.pid });
+        _discardChild(target,
+          'the scanner process was killed after another request stopped responding');
       }, timeoutMs);
       // Deliberately NOT unref'd: an unref'd deadline does not fire when nothing
       // else keeps the loop alive, which is precisely the case it exists for.
 
-      pending.set(id, { resolve, reject, timer, what });
-      _holdChannel();
+      pending.set(id, { resolve, reject, timer, owner: target, what });
+      _syncChannel(target);
 
       target.send({ id, op, payload }, (err) => {
         if (err) _settle(id, _aborted(`the scanner process could not be reached (${err.message})`));
@@ -395,9 +456,13 @@ function createScanner(options = {}) {
    */
   async function shutdown() {
     shuttingDown = true;
-    const victim = child;
-    _failAll('the scanner is shutting down');
-    _discardChild(victim, 'shutdown');
+    _discardChild(child, 'the scanner is shutting down');
+    // Anything still outstanding belongs to a child already written off — an
+    // orphan that outlived its kill. It is nobody's collateral now, and a caller
+    // left waiting on it would wait for a process that will never reply.
+    for (const id of [...pending.keys()]) {
+      _settle(id, _aborted('the scanner is shutting down'));
+    }
     child = null;
   }
 

--- a/lib/dir-scanner.js
+++ b/lib/dir-scanner.js
@@ -253,12 +253,25 @@ function createScanner(options = {}) {
     if (child && child.connected) return child;
 
     const spawned = forkFn(childPath, [], {
-      // The child's own stdio is not a channel anyone reads; inheriting it would
-      // interleave with the server's log stream and attribute the child's output
-      // to the server. Errors travel over IPC, where they belong to a request.
-      stdio: ['ignore', 'ignore', 'ignore', 'ipc'],
+      // stdout is inherited by nothing: the child says everything it has to say
+      // over IPC, where it belongs to a request. stderr is PIPED rather than
+      // ignored because one class of failure never reaches IPC at all — a child
+      // that dies before it can reply, or fails to load. Discarding it leaves
+      // `exited (code 1, signal null)` as the entire diagnosis.
+      stdio: ['ignore', 'ignore', 'pipe', 'ipc'],
       serialization: 'json'
     });
+
+    // Bounded on purpose. This exists to explain a death, and the first lines do
+    // that; an unbounded buffer on a child that decided to log in a loop would be
+    // a memory leak in the supervisor guarding against a resource leak.
+    let stderr = '';
+    if (spawned.stderr) {
+      spawned.stderr.setEncoding('utf8');
+      spawned.stderr.on('data', (chunk) => {
+        if (stderr.length < 4096) stderr += chunk;
+      });
+    }
 
     spawned.on('message', (msg) => {
       if (!msg || typeof msg.id !== 'number') return;
@@ -276,6 +289,17 @@ function createScanner(options = {}) {
     spawned.on('exit', (code, signal) => {
       if (child !== spawned) return;
       child = null;
+      // An unexpected death is worth a line with whatever the child managed to
+      // say. A deliberate kill is not: the deadline path has already logged the
+      // reason, and repeating it as a failure would read like two problems.
+      if (code) {
+        const detail = { pid: spawned.pid, code, signal };
+        // Only when there is something to say. A child killed by `process.exit`
+        // writes nothing, and a logged `stderr=undefined` is noise that reads
+        // like a second missing thing.
+        if (stderr.trim()) detail.stderr = stderr.trim();
+        log.warn('Scanner child exited unexpectedly', detail);
+      }
       if (pending.size > 0) {
         _failAll(`the scanner process exited (code ${code}, signal ${signal})`);
       }
@@ -358,6 +382,15 @@ function createScanner(options = {}) {
    * no loop reference, but it is still a live process, and a suite that forks one
    * per case would leave them behind.
    *
+   * TERMINAL. Later requests are refused rather than forking a replacement — a
+   * scanner that quietly came back to life after shutdown would leave a process
+   * running past the teardown that was supposed to end it. Build a new scanner
+   * instead.
+   *
+   * Returns once the kill has been ISSUED, not once the child is reaped: a child
+   * blocked in an uninterruptible syscall may never be, and shutdown must not be
+   * the thing that waits forever on it.
+   *
    * @returns {Promise<void>}
    */
   async function shutdown() {
@@ -381,15 +414,7 @@ function createScanner(options = {}) {
     return child && child.connected ? child.pid : null;
   }
 
-  /**
-   * How many requests are outstanding.
-   * @returns {number}
-   */
-  function pendingCount() {
-    return pending.size;
-  }
-
-  return { request, shutdown, childPid, pendingCount };
+  return { request, shutdown, childPid };
 }
 
 // The scanner the server uses. One per process: the child multiplexes correlated
@@ -400,11 +425,7 @@ const _defaultScanner = createScanner();
 
 module.exports = {
   createScanner,
-  DEFAULT_TIMEOUT_MS,
-  CHILD_EXIT_GRACE_MS,
-  DEFAULT_CHILD_PATH,
   request: (op, payload, opts) => _defaultScanner.request(op, payload, opts),
   shutdown: () => _defaultScanner.shutdown(),
-  childPid: () => _defaultScanner.childPid(),
-  pendingCount: () => _defaultScanner.pendingCount()
+  childPid: () => _defaultScanner.childPid()
 };

--- a/lib/dir-scanner.js
+++ b/lib/dir-scanner.js
@@ -1,0 +1,410 @@
+'use strict';
+
+/**
+ * Supervisor for the forked directory scanner.
+ *
+ * WHAT THIS BUYS. A directory read on a TCC-protected macOS path never returns.
+ * Run in-process, `fs.promises` hands that read a libuv threadpool thread — four
+ * by default, shared by every async filesystem call in the process — and a
+ * deadline cannot get it back, because abandoning a promise does not cancel a
+ * syscall. Four such reads and the server can no longer touch the filesystem AT
+ * ALL, on any path, permanently, while `/api/health` still answers 200. Worse
+ * than the outage is the diagnosis: every subsequent failure then times out, so
+ * the product blames Full Disk Access for directories that were never protected
+ * and sends the operator to change a permission that was never the problem.
+ *
+ * Moving the read into a child process makes the blocked thread belong to
+ * something disposable. The deadline stops being a way to answer the request and
+ * starts being a way to RECLAIM the resource: kill the child, and the threads it
+ * had blocked in the kernel go with it.
+ *
+ * WHY ONE LONG-LIVED CHILD RATHER THAN A FORK PER SCAN. The dashboard polls
+ * `GET /api/projects` every ten seconds for as long as a browser tab is open.
+ * Fork-per-request means a node process spawn every ten seconds, forever, on the
+ * healthy path, to guard against a failure almost no install ever hits. A
+ * supervised child answers a warm IPC round trip instead, and is killed and
+ * replaced only when it actually hangs.
+ *
+ * THE LIMIT, STATED HONESTLY. `SIGKILL` removes the child from the scheduler,
+ * but a thread already blocked inside an uninterruptible kernel call does not
+ * necessarily unwind, so a killed child can linger in the process table until
+ * this process exits and reaps it. The parent's threadpool is unaffected either
+ * way — that is the defect being fixed — but the exchange is one stuck process
+ * per hang rather than one stuck server thread, not zero cost. A child that does
+ * not exit within the grace window is logged by pid rather than passed over in
+ * silence.
+ */
+
+const path = require('node:path');
+const { fork } = require('node:child_process');
+const { createLogger } = require('./logger');
+
+const log = createLogger('dir-scanner');
+
+// How long a scanner request may take before the child is written off. Not a
+// performance budget — a local readdir is sub-millisecond. It is the point at
+// which "slow" becomes indistinguishable from "never going to answer", and the
+// only remedy for the second is to kill the process holding the blocked thread.
+// Generous enough that a slow network mount still succeeds.
+const DEFAULT_TIMEOUT_MS = 5000;
+
+// How long to wait for a `SIGKILL`ed child to actually leave the process table
+// before saying so. A child blocked in an uninterruptible syscall may never go,
+// and that is worth one log line naming the pid — silent accumulation of stuck
+// processes is how the leak this file fixes would come back wearing a different
+// hat.
+const CHILD_EXIT_GRACE_MS = 2000;
+
+const DEFAULT_CHILD_PATH = path.join(__dirname, 'dir-scanner-child.js');
+
+/**
+ * Build an error that says the path never answered.
+ *
+ * Carries `tcTimedOut` so callers can tell "this directory is not responding"
+ * from an ordinary filesystem error and offer the Full Disk Access remedy —
+ * which is only ever the right advice for THIS failure.
+ *
+ * @param {number} ms - The deadline that expired.
+ * @param {string} what - Short description of the work, e.g. `reading /a/b`.
+ * @returns {Error}
+ */
+function _timedOut(ms, what) {
+  const err = new Error(`timed out after ${ms}ms ${what}`);
+  err.tcTimedOut = true;
+  return err;
+}
+
+/**
+ * Build an error for work that was cut short by something other than its own
+ * deadline — a sibling request's kill, a child crash, or shutdown.
+ *
+ * DELIBERATELY NOT `tcTimedOut`. Collateral work did not time out; it was
+ * travelling in a child that had to die for another request's sake, and its path
+ * may be perfectly healthy. Marking it timed-out would resurrect the exact
+ * misdiagnosis this whole change exists to remove: the operator told to grant
+ * Full Disk Access for a directory that was never protected.
+ *
+ * @param {string} reason - Why the work was abandoned, in a caller-facing phrase.
+ * @returns {Error}
+ */
+function _aborted(reason) {
+  const err = new Error(`directory scan abandoned: ${reason}`);
+  err.tcAborted = true;
+  return err;
+}
+
+/**
+ * Rebuild an error from the child's flattened form.
+ *
+ * `code` is restored as a property rather than folded into the message because
+ * callers branch on it — `ENOENT` is what makes the wizard offer to create a
+ * directory — and a condition that travels as prose breaks when the prose is
+ * reworded.
+ *
+ * @param {{message: string, code: string|undefined}} plain - Serialised error.
+ * @returns {Error}
+ */
+function _rehydrate(plain) {
+  const err = new Error((plain && plain.message) || 'directory scan failed');
+  if (plain && plain.code) err.code = plain.code;
+  return err;
+}
+
+/**
+ * Create a scanner: a lazily-forked, supervised child process that performs
+ * filesystem work, plus the request/response protocol over it.
+ *
+ * The child is not forked until the first request, so a server that never lists
+ * a directory never pays for one. It is re-forked on the next request after any
+ * death, whatever the cause, so a crash degrades one request rather than every
+ * request from then on.
+ *
+ * @param {object} [options] - Overrides.
+ * @param {string} [options.childPath] - Module to fork. Injectable so a test can
+ *   supply a child that genuinely hangs; production never passes it.
+ * @param {number} [options.timeoutMs] - Default per-request deadline.
+ * @param {number} [options.exitGraceMs] - How long a killed child may take to exit
+ *   before that is logged.
+ * @param {Function} [options.forkFn] - Injectable `child_process.fork`.
+ * @returns {{request: Function, shutdown: Function, childPid: Function, pendingCount: Function}}
+ */
+function createScanner(options = {}) {
+  const childPath = options.childPath || DEFAULT_CHILD_PATH;
+  const defaultTimeoutMs = options.timeoutMs || DEFAULT_TIMEOUT_MS;
+  const exitGraceMs = options.exitGraceMs === undefined ? CHILD_EXIT_GRACE_MS : options.exitGraceMs;
+  const forkFn = options.forkFn || fork;
+
+  /** @type {import('node:child_process').ChildProcess|null} */
+  let child = null;
+  /** @type {Map<number, {reject: Function, resolve: Function, timer: NodeJS.Timeout, what: string}>} */
+  const pending = new Map();
+  let nextId = 0;
+  let shuttingDown = false;
+
+  /**
+   * Settle a pending request exactly once, clearing its deadline.
+   *
+   * Every settlement path routes through here — reply, deadline, child death,
+   * shutdown — because they race each other by nature: a child's last reply can
+   * arrive after the kill that was meant to pre-empt it. Removing the entry
+   * before settling makes the loser of that race a no-op instead of a
+   * double-settle.
+   *
+   * @param {number} id - Correlation id.
+   * @param {Error|null} err - Rejection cause, or null to resolve.
+   * @param {any} [value] - Resolution value when `err` is null.
+   * @returns {boolean} Whether this call was the one that settled it.
+   */
+  function _settle(id, err, value) {
+    const entry = pending.get(id);
+    if (!entry) return false;
+    pending.delete(id);
+    clearTimeout(entry.timer);
+    _releaseChannel();
+    if (err) entry.reject(err); else entry.resolve(value);
+    return true;
+  }
+
+  /**
+   * Fail every outstanding request, for a reason that is not any one request's
+   * fault.
+   *
+   * Callers hang forever otherwise. A child that dies takes its in-flight work
+   * with it and sends nothing to say so, so the supervisor is the only thing
+   * that can tell them.
+   *
+   * @param {string} reason - Caller-facing phrase for what happened.
+   * @returns {void}
+   */
+  function _failAll(reason) {
+    for (const id of [...pending.keys()]) {
+      _settle(id, _aborted(reason));
+    }
+  }
+
+  /**
+   * Keep the event loop alive only while work is actually outstanding.
+   *
+   * An idle scanner must not be a reason for the process to stay up: a CLI that
+   * listed one directory would never exit, and a test that forgot to shut down
+   * would hang rather than fail. Referencing the channel per in-flight request
+   * makes the reply able to wake the loop exactly when a reply is expected.
+   *
+   * @returns {void}
+   */
+  function _holdChannel() {
+    if (pending.size === 1 && child && child.channel) child.channel.ref();
+  }
+
+  /**
+   * Release the loop hold once nothing is outstanding.
+   * @returns {void}
+   */
+  function _releaseChannel() {
+    if (pending.size === 0 && child && child.channel) child.channel.unref();
+  }
+
+  /**
+   * Stop trusting `child`, and say so if it does not actually die.
+   *
+   * The reference is dropped BEFORE the kill so the next request forks a
+   * replacement rather than sending into a corpse. `SIGKILL` rather than
+   * `SIGTERM` because the reason for killing is that the child is wedged, and a
+   * wedged child cannot run a signal handler.
+   *
+   * @param {import('node:child_process').ChildProcess|null} victim - Child to kill.
+   * @param {string} reason - Why, for the log.
+   * @returns {void}
+   */
+  function _discardChild(victim, reason) {
+    if (!victim) return;
+    if (child === victim) child = null;
+    if (victim.exitCode !== null || victim.signalCode !== null) return;
+
+    const pid = victim.pid;
+    let exited = false;
+    victim.once('exit', () => { exited = true; });
+    victim.kill('SIGKILL');
+
+    if (exitGraceMs > 0) {
+      const check = setTimeout(() => {
+        if (exited) return;
+        // Not a formality. A thread blocked inside an uninterruptible kernel
+        // call does not unwind on SIGKILL, so the process can sit in the table
+        // until this one exits and reaps it. Naming the pid is the difference
+        // between an operator who can see them accumulating and one who cannot.
+        log.warn('Scanner child did not exit after SIGKILL — it is likely blocked in the kernel '
+          + 'and will be reaped when the server exits', { pid, reason });
+      }, exitGraceMs);
+      check.unref();
+    }
+  }
+
+  /**
+   * The live child, forked on demand.
+   *
+   * Lazy because most of this server's life involves no directory scan at all,
+   * and re-forked after any death because the alternative — a supervisor that
+   * gives up once — turns one crash into a permanently broken route.
+   *
+   * @returns {import('node:child_process').ChildProcess}
+   */
+  function _ensureChild() {
+    if (child && child.connected) return child;
+
+    const spawned = forkFn(childPath, [], {
+      // The child's own stdio is not a channel anyone reads; inheriting it would
+      // interleave with the server's log stream and attribute the child's output
+      // to the server. Errors travel over IPC, where they belong to a request.
+      stdio: ['ignore', 'ignore', 'ignore', 'ipc'],
+      serialization: 'json'
+    });
+
+    spawned.on('message', (msg) => {
+      if (!msg || typeof msg.id !== 'number') return;
+      if (msg.ok) _settle(msg.id, null, msg.value);
+      else _settle(msg.id, _rehydrate(msg.error));
+    });
+
+    // A child that has ALREADY been replaced must not settle anything. Its exit
+    // event arrives after the kill that caused it, by which time the next
+    // request has forked a successor and may be in flight on it — and `pending`
+    // does not distinguish whose work it holds. Failing it here would reject a
+    // perfectly healthy request because an unrelated predecessor finished dying.
+    // The identity check is the whole guard; without it every kill takes the
+    // next request with it, which looks exactly like a flaky scanner.
+    spawned.on('exit', (code, signal) => {
+      if (child !== spawned) return;
+      child = null;
+      if (pending.size > 0) {
+        _failAll(`the scanner process exited (code ${code}, signal ${signal})`);
+      }
+    });
+
+    spawned.on('error', (err) => {
+      log.warn('Scanner child failed', { error: err && err.message });
+      if (child !== spawned) return;
+      child = null;
+      _failAll('the scanner process could not be started');
+    });
+
+    // Never a reason for the process to stay alive on its own; see _holdChannel.
+    spawned.unref();
+    if (spawned.channel) spawned.channel.unref();
+
+    child = spawned;
+    return spawned;
+  }
+
+  /**
+   * Ask the child to perform one operation, bounded by a deadline.
+   *
+   * On expiry the child is KILLED, not merely abandoned — that is the whole
+   * point of this module. Requests travelling in the same child die with it and
+   * are rejected as abandoned rather than timed out, so a healthy path caught in
+   * someone else's kill is not reported as an unresponsive directory.
+   *
+   * @param {string} op - Operation name the child recognises.
+   * @param {object} [payload] - Operation arguments.
+   * @param {object} [opts] - Per-request overrides.
+   * @param {number} [opts.timeoutMs] - Deadline for this request.
+   * @param {string} [opts.what] - Short phrase for the timeout message, e.g. `reading /a/b`.
+   * @returns {Promise<any>} The child's result, or a rejection carrying
+   *   `tcTimedOut` (the path never answered) or `tcAborted` (collateral).
+   */
+  function request(op, payload = {}, opts = {}) {
+    if (shuttingDown) {
+      return Promise.reject(_aborted('the scanner is shutting down'));
+    }
+
+    const timeoutMs = opts.timeoutMs || defaultTimeoutMs;
+    const what = opts.what || `running ${op}`;
+    const id = ++nextId;
+
+    let target;
+    try {
+      target = _ensureChild();
+    } catch (err) {
+      return Promise.reject(err);
+    }
+
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        // Settle the owner of the deadline FIRST, so the kill's collateral sweep
+        // cannot relabel it as abandoned. This request is the one that timed
+        // out; it is the only one entitled to say the path did not answer.
+        _settle(id, _timedOut(timeoutMs, what));
+        log.warn('Directory scan did not answer — killing the scanner process to reclaim the '
+          + 'thread it blocked', { op, what, timeoutMs, pid: target.pid });
+        _discardChild(target, 'request deadline expired');
+        _failAll('the scanner process was killed after another request stopped responding');
+      }, timeoutMs);
+      // Deliberately NOT unref'd: an unref'd deadline does not fire when nothing
+      // else keeps the loop alive, which is precisely the case it exists for.
+
+      pending.set(id, { resolve, reject, timer, what });
+      _holdChannel();
+
+      target.send({ id, op, payload }, (err) => {
+        if (err) _settle(id, _aborted(`the scanner process could not be reached (${err.message})`));
+      });
+    });
+  }
+
+  /**
+   * Stop the scanner and release its child.
+   *
+   * Required for an orderly server shutdown and for tests: an idle child holds
+   * no loop reference, but it is still a live process, and a suite that forks one
+   * per case would leave them behind.
+   *
+   * @returns {Promise<void>}
+   */
+  async function shutdown() {
+    shuttingDown = true;
+    const victim = child;
+    _failAll('the scanner is shutting down');
+    _discardChild(victim, 'shutdown');
+    child = null;
+  }
+
+  /**
+   * The live child's pid, or null when none is running.
+   *
+   * Exposed because "was the child actually replaced" is not otherwise
+   * observable, and it is the assertion that distinguishes a real kill from a
+   * request that merely gave up.
+   *
+   * @returns {number|null}
+   */
+  function childPid() {
+    return child && child.connected ? child.pid : null;
+  }
+
+  /**
+   * How many requests are outstanding.
+   * @returns {number}
+   */
+  function pendingCount() {
+    return pending.size;
+  }
+
+  return { request, shutdown, childPid, pendingCount };
+}
+
+// The scanner the server uses. One per process: the child multiplexes correlated
+// requests, and there is exactly one route family calling it, polling every ten
+// seconds — a queue of at most a few requests, not a case for parallelism. If a
+// second consumer with different latency appears, revisit before adding more.
+const _defaultScanner = createScanner();
+
+module.exports = {
+  createScanner,
+  DEFAULT_TIMEOUT_MS,
+  CHILD_EXIT_GRACE_MS,
+  DEFAULT_CHILD_PATH,
+  request: (op, payload, opts) => _defaultScanner.request(op, payload, opts),
+  shutdown: () => _defaultScanner.shutdown(),
+  childPid: () => _defaultScanner.childPid(),
+  pendingCount: () => _defaultScanner.pendingCount()
+};

--- a/lib/dir-scanner.js
+++ b/lib/dir-scanner.js
@@ -667,6 +667,9 @@ module.exports = {
   shutdown: async () => {
     await _backgroundScanner.shutdown();
     await _interactiveScanner.shutdown();
-  },
-  childPid: () => _backgroundScanner.childPid()
+  }
+  // No module-level `childPid`. It reported only the background scanner while
+  // `shutdown` covers both, which is an asymmetric surface that would read as a
+  // whole-module answer and give half of one. Nothing called it — tests ask the
+  // instance they built — so the honest fix is not to offer it.
 };

--- a/lib/dir-scanner.js
+++ b/lib/dir-scanner.js
@@ -638,11 +638,35 @@ function createScanner(options = {}) {
 // A teardown hook would add a shutdown path that has to be correct on every exit
 // route to buy nothing the child's own `disconnect` handler does not already
 // guarantee. Tests DO call it, because they outlive their scanners.
-const _defaultScanner = createScanner();
+const _backgroundScanner = createScanner();
+
+// A SECOND scanner, for work an operator is waiting on. This is the plan's
+// "one child is enough" assumption being revisited at the trigger it named —
+// a second consumer with different latency appeared, and it appeared inside the
+// same change.
+//
+// Sharing one child makes every caller collateral for every other: a hung
+// ten-second poll of the projects directory times out, the supervisor kills the
+// child to reclaim its thread, and an operator's wizard scan of a completely
+// healthy folder dies alongside it. They would be told their directory failed,
+// which is the misdiagnosis this whole issue exists to remove, arriving by
+// another door. Splitting them means a poll can only ever cost the poll.
+//
+// Cheap: forked lazily, so a server whose wizard is never opened never pays for
+// this one, and unref'd like the other, so an idle one holds nothing open.
+const _interactiveScanner = createScanner();
 
 module.exports = {
   createScanner,
-  request: (op, payload, opts) => _defaultScanner.request(op, payload, opts),
-  shutdown: () => _defaultScanner.shutdown(),
-  childPid: () => _defaultScanner.childPid()
+  // Background/polled work. Callers here may pass `pathKey` to opt into the
+  // failure backoff, because nobody is waiting on any individual request.
+  request: (op, payload, opts) => _backgroundScanner.request(op, payload, opts),
+  // Work an operator pressed a button for. Deliberately NOT backed off, and
+  // deliberately not sharing a child with the poll.
+  interactiveRequest: (op, payload, opts) => _interactiveScanner.request(op, payload, opts),
+  shutdown: async () => {
+    await _backgroundScanner.shutdown();
+    await _interactiveScanner.shutdown();
+  },
+  childPid: () => _backgroundScanner.childPid()
 };

--- a/lib/dir-scanner.js
+++ b/lib/dir-scanner.js
@@ -61,6 +61,20 @@ const CHILD_EXIT_GRACE_MS = 2000;
 
 const DEFAULT_CHILD_PATH = path.join(__dirname, 'dir-scanner-child.js');
 
+// How long a path that did not answer is taken at its word before anyone tries
+// it again. Sized against the dashboard's ten-second poll: without it, an
+// unreadable projects directory costs a five-second stall and a killed child
+// every ten seconds for as long as a browser tab is open, and a killed child
+// blocked in the kernel may never leave the process table.
+const PATH_FAILURE_TTL_MS = 30000;
+
+// The ceiling on that backoff. A path that has failed repeatedly is almost
+// certainly still failing, so the interval doubles — but it stops here, because
+// an operator who fixes the permission must not wait an unbounded time to see
+// the product notice. Five minutes is the longest anyone should sit looking at a
+// stale dashboard after granting Full Disk Access.
+const PATH_FAILURE_MAX_TTL_MS = 300000;
+
 /**
  * Build an error that says the path never answered.
  *
@@ -94,6 +108,31 @@ function _timedOut(ms, what) {
 function _aborted(reason) {
   const err = new Error(`directory scan abandoned: ${reason}`);
   err.tcAborted = true;
+  return err;
+}
+
+/**
+ * Build the answer given for a path already known not to answer.
+ *
+ * Carries `tcTimedOut` because the CONDITION is unchanged — the directory is
+ * still not responding, and the operator still needs the Full Disk Access
+ * remedy. Adds `tcCached` because the COST is not: this answer took no child, no
+ * five-second wait and no killed process, which is the whole point, and callers
+ * log it differently so a polling route cannot turn one broken directory into a
+ * warning every ten seconds forever.
+ *
+ * @param {string} pathKey - The path being refused.
+ * @param {{until: number, consecutive: number}} entry - Its failure record.
+ * @returns {Error}
+ */
+function _notAnswering(pathKey, entry) {
+  const waitS = Math.max(1, Math.round((entry.until - Date.now()) / 1000));
+  const err = new Error(
+    `${pathKey} did not answer the last ${entry.consecutive} time(s) it was read; `
+    + `not trying again for ${waitS}s`
+  );
+  err.tcTimedOut = true;
+  err.tcCached = true;
   return err;
 }
 
@@ -134,6 +173,8 @@ function _rehydrate(plain) {
  * @param {number} [options.exitGraceMs] - How long a killed child may take to exit
  *   before that is logged.
  * @param {Function} [options.forkFn] - Injectable `child_process.fork`.
+ * @param {number} [options.pathFailureTtlMs] - First backoff after a path fails to answer.
+ * @param {number} [options.pathFailureMaxTtlMs] - Ceiling that backoff doubles up to.
  * @returns {{request: Function, shutdown: Function, childPid: Function}}
  */
 function createScanner(options = {}) {
@@ -141,6 +182,8 @@ function createScanner(options = {}) {
   const defaultTimeoutMs = options.timeoutMs || DEFAULT_TIMEOUT_MS;
   const exitGraceMs = options.exitGraceMs === undefined ? CHILD_EXIT_GRACE_MS : options.exitGraceMs;
   const forkFn = options.forkFn || fork;
+  const pathFailureTtlMs = options.pathFailureTtlMs || PATH_FAILURE_TTL_MS;
+  const pathFailureMaxTtlMs = options.pathFailureMaxTtlMs || PATH_FAILURE_MAX_TTL_MS;
 
   /** @type {import('node:child_process').ChildProcess|null} */
   let child = null;
@@ -164,6 +207,14 @@ function createScanner(options = {}) {
   let nextId = 0;
   let shuttingDown = false;
   let orphanCount = 0;
+
+  // Paths that did not answer, and until when we take that at its word.
+  // Keyed by the caller's `pathKey`, which is opt-in: a generic supervisor
+  // silently declining to do what it was asked would be a bad surprise, so only
+  // a caller that says "this request is about this path, and a repeat is not
+  // worth a second process" gets short-circuited.
+  /** @type {Map<string, {until: number, ttlMs: number, consecutive: number}>} */
+  const failures = new Map();
 
   /**
    * Settle a pending request exactly once, clearing its deadline.
@@ -399,8 +450,14 @@ function createScanner(options = {}) {
    * @param {object} [opts] - Per-request overrides.
    * @param {number} [opts.timeoutMs] - Deadline for this request.
    * @param {string} [opts.what] - Short phrase for the timeout message, e.g. `reading /a/b`.
+   * @param {string} [opts.pathKey] - Opt in to the failure backoff for this path. A path
+   *   that recently did not answer is refused immediately, with `tcCached` set, instead of
+   *   costing another child. Omit it for anything an operator just asked for by hand: a
+   *   person who has changed a setting and pressed the button again must be given a real
+   *   answer, not a remembered one.
    * @returns {Promise<any>} The child's result, or a rejection carrying
-   *   `tcTimedOut` (the path never answered) or `tcAborted` (collateral).
+   *   `tcTimedOut` (the path never answered; also `tcCached` when that is remembered
+   *   rather than newly observed) or `tcAborted` (collateral).
    */
   function request(op, payload = {}, opts = {}) {
     if (shuttingDown) {
@@ -409,6 +466,23 @@ function createScanner(options = {}) {
 
     const timeoutMs = opts.timeoutMs || defaultTimeoutMs;
     const what = opts.what || `running ${op}`;
+    const pathKey = opts.pathKey;
+
+    if (pathKey) {
+      const known = failures.get(pathKey);
+      if (known) {
+        if (Date.now() < known.until) {
+          return Promise.reject(_notAnswering(pathKey, known));
+        }
+        // The backoff has expired, so this request becomes the ONE retry — and
+        // the door is pushed shut again before it runs, not after. A five-second
+        // probe against a ten-second poll would otherwise let a second request
+        // in while the first is still outstanding, and the point of the backoff
+        // is one process per interval, not one per interval that has returned.
+        known.until = Date.now() + known.ttlMs;
+      }
+    }
+
     const id = ++nextId;
 
     let target;
@@ -450,7 +524,10 @@ function createScanner(options = {}) {
       target.send({ id, op, payload }, (err) => {
         if (err) _settle(id, _aborted(`the scanner process could not be reached (${err.message})`));
       });
-    });
+    }).then(
+      (value) => { _recordOutcome(pathKey, null); return value; },
+      (err) => { _recordOutcome(pathKey, err); throw err; }
+    );
   }
 
   /**
@@ -481,6 +558,55 @@ function createScanner(options = {}) {
       _settle(id, _aborted('the scanner is shutting down'));
     }
     child = null;
+  }
+
+  /**
+   * Update what we believe about `pathKey` from how its request ended.
+   *
+   * THE ONLY THING WORTH CACHING IS "IT DID NOT ANSWER". Everything else is an
+   * answer, and an answer means the path is reachable right now:
+   *
+   * - Resolved → reachable. Forget the failure; this is how a directory that
+   *   starts working recovers with no restart and no operator action.
+   * - `ENOENT` / `ENOTDIR` / `EACCES` / any ordinary error → ALSO reachable. The
+   *   filesystem replied, it just replied "no". Caching these would break the
+   *   wizard outright: its Create button exists to turn `ENOENT` into a
+   *   directory, and the scan immediately afterwards must see the folder that
+   *   was just made. This is the exact shape of a caching bug already recorded
+   *   in this project's learnings — a memoization that cached failures
+   *   permanently because only the success case was thought through.
+   * - `tcAborted` → says nothing either way. That request died because a SIBLING
+   *   request forced a kill; its path may be perfectly healthy. Recording it
+   *   would let one bad directory mark a good one as broken, which is the
+   *   misdiagnosis this whole issue exists to remove.
+   * - `tcTimedOut` → did not answer. Record it, and back off.
+   *
+   * @param {string|undefined} pathKey - The caller's cache key, if it opted in.
+   * @param {Error|null} err - How the request ended, or null if it resolved.
+   * @returns {void}
+   */
+  function _recordOutcome(pathKey, err) {
+    if (!pathKey) return;
+    if (err && err.tcAborted) return;
+
+    if (!err || !err.tcTimedOut) {
+      failures.delete(pathKey);
+      return;
+    }
+    if (err.tcCached) return; // this answer came FROM the cache; it is not new evidence
+
+    const prev = failures.get(pathKey);
+    const consecutive = prev ? prev.consecutive + 1 : 1;
+    const ttlMs = Math.min(pathFailureTtlMs * (2 ** (consecutive - 1)), pathFailureMaxTtlMs);
+    failures.set(pathKey, { until: Date.now() + ttlMs, ttlMs, consecutive });
+
+    // Escalating, not repeated: one line per real attempt, carrying the count so
+    // a rising number is visible as a trend. The polling route that provoked
+    // this logs the cached refusals at debug, so this is the only WARN a stuck
+    // directory produces — once per backoff interval rather than once per poll.
+    log.warn('Directory did not answer — not reading it again until the backoff expires', {
+      path: pathKey, consecutive, retryInMs: ttlMs
+    });
   }
 
   /**

--- a/lib/dir-scanner.js
+++ b/lib/dir-scanner.js
@@ -431,8 +431,13 @@ function createScanner(options = {}) {
         // the log misattributes at one layer down exactly as the product did at
         // the top. The id is here so the kill can be tied to the abandonment
         // sweep that follows it.
+        const detail = { id, op, timeoutMs, pid: target.pid };
+        // Only when there is one. Every production op carries `dir`, but logging
+        // `dir=undefined` for one that does not reads like a second missing
+        // thing rather than an op that was never about a path.
+        if (payload && payload.dir) detail.dir = payload.dir;
         log.warn('Directory scan did not answer — killing the scanner process to reclaim the '
-          + 'thread it blocked', { id, op, dir: payload && payload.dir, timeoutMs, pid: target.pid });
+          + 'thread it blocked', detail);
         _discardChild(target,
           'the scanner process was killed after another request stopped responding');
       }, timeoutMs);
@@ -498,6 +503,15 @@ function createScanner(options = {}) {
 // requests, and there is exactly one route family calling it, polling every ten
 // seconds — a queue of at most a few requests, not a case for parallelism. If a
 // second consumer with different latency appears, revisit before adding more.
+//
+// THE SERVER DELIBERATELY NEVER CALLS `shutdown()` ON THIS, and that is a
+// decision rather than an omission. Nothing is left behind without it: the child
+// handle, its IPC channel and its stderr are all unref'd, so an idle scanner
+// never holds the process open, and the child exits on IPC `disconnect` when the
+// parent goes — however the parent goes, including a signal it never handled.
+// A teardown hook would add a shutdown path that has to be correct on every exit
+// route to buy nothing the child's own `disconnect` handler does not already
+// guarantee. Tests DO call it, because they outlive their scanners.
 const _defaultScanner = createScanner();
 
 module.exports = {

--- a/lib/projects.js
+++ b/lib/projects.js
@@ -1631,12 +1631,12 @@ function _scanFailureHint(err) {
  * half standing. Do not read "degrades to the registered projects" as "cannot
  * hang".
  *
- * NOT YET FILED as of this writing — deliberately stated that way rather than
- * as "tracked separately", which would be a citation to nothing. The sweep is
- * the whole family of ~31 synchronous `existsSync`/`readdirSync`/`statSync`
- * calls on operator-chosen paths in this file, not this call site alone; the
- * project's own learnings entry on this failure family says fix the family, not
- * the call site, and that is the shape the work should take.
+ * Tracked as #884, which covers the whole family — 32 synchronous
+ * `existsSync`/`readdirSync`/`statSync` calls on operator-chosen paths in this
+ * file plus 7 in `lib/uploads.js` — rather than this call site alone. The
+ * project's learnings entry on this failure family says fix the family, not the
+ * call site, after #859's first fix landed on `listAllProjects` and missed
+ * `POST /api/setup/scan`. `lib/dir-scanner.js` is the mechanism to use.
  *
  * @param {object} [options] - Filter options passed to store.projects.list for registered projects
  * @returns {Promise<object[]>}
@@ -1761,7 +1761,7 @@ async function scanDirectoryForProjects(directory) {
   const dir = resolveProjectsDir(directory);
 
   try {
-    const { projects } = await dirScanner.request(
+    const { projects } = await dirScanner.interactiveRequest(
       'scanEntries',
       { dir, budgetMs: PROJECT_WALK_BUDGET_MS },
       { timeoutMs: PROJECT_SCAN_TIMEOUT_MS, what: `scanning ${dir}` }
@@ -1777,6 +1777,23 @@ async function scanDirectoryForProjects(directory) {
     }
     if (err && err.code === 'ENOTDIR') {
       return { ok: false, code: 'BAD_REQUEST', error: `Path is not a directory: ${directory}` };
+    }
+    // Collateral: this scan never got to run, because a concurrent request in
+    // the same scanner process stopped responding and the process had to be
+    // killed. It says NOTHING about the directory the operator chose, so it must
+    // not reach `_scanFailureHint` below — telling someone to grant Full Disk
+    // Access for a folder that was never read is the misdiagnosis this whole
+    // change exists to remove. The honest answer is "we did not get to look;
+    // try again", and trying again is genuinely likely to work, since the
+    // scanner forks a fresh child for the next request.
+    if (err && err.tcAborted) {
+      return {
+        ok: false,
+        code: 'SCAN_INTERRUPTED',
+        error: `Could not finish reading ${directory} — another directory being read at the `
+          + 'same time stopped responding, and this scan was interrupted with it. Nothing is '
+          + 'known to be wrong with this folder; try again.'
+      };
     }
     // 4xx rather than 5xx: nothing is wrong with the server, and the operator
     // is the only one who can act — by granting Full Disk Access or choosing a
@@ -1869,12 +1886,23 @@ async function createProjectsDir(directory) {
   // may be told.
   let outcome;
   try {
-    outcome = await dirScanner.request(
+    outcome = await dirScanner.interactiveRequest(
       'createDir',
       { dir },
       { timeoutMs: PROJECT_SCAN_TIMEOUT_MS, what: `creating ${dir}` }
     );
   } catch (err) {
+    // Same reasoning as the scan above: collateral means this never ran, so it
+    // is not evidence about the path and must not earn the Full Disk Access
+    // remedy. Nothing was created, so retrying is safe as well as sensible.
+    if (err && err.tcAborted) {
+      return {
+        ok: false,
+        code: 'CREATE_INTERRUPTED',
+        error: `Could not create ${directory} — another directory being read at the same time `
+          + 'stopped responding, and this was interrupted with it. Nothing was created; try again.'
+      };
+    }
     const hint = _scanFailureHint(err);
     return {
       ok: false,

--- a/lib/projects.js
+++ b/lib/projects.js
@@ -16,7 +16,7 @@ const tmux = require('./tmux');
 const sessions = require('./sessions');
 const sessionOwnership = require('./session-ownership');
 const continuity = require('./continuity');
-const fsp = require('node:fs').promises;
+const dirScanner = require('./dir-scanner');
 const { createLogger } = require('./logger');
 
 const log = createLogger('projects');
@@ -37,51 +37,6 @@ const PROJECT_SCAN_TIMEOUT_MS = 5000;
 // leaving the race as what it is for: the backstop for a call that never returns
 // at all, where there is nothing to hand back and nobody to hand it to.
 const PROJECT_SCAN_WALK_MARGIN_MS = 250;
-
-/**
- * Resolve `promise`, or reject once `ms` has passed.
- *
- * The rejection carries `tcTimedOut` so a caller can tell "this path is not
- * answering" from an ordinary filesystem error and say something useful about it.
- * The underlying operation is NOT cancellable — it keeps occupying its threadpool
- * slot — so this bounds the REQUEST, not the syscall. That is the honest limit of
- * what can be done here without a child process.
- *
- * @param {Promise<any>} promise - Work to bound.
- * @param {number} ms - Milliseconds to wait.
- * @param {string} what - Short description used in the timeout message.
- * @returns {Promise<any>}
- */
-function _withTimeout(promise, ms, what) {
-  let timer;
-  const timeout = new Promise((_resolve, reject) => {
-    timer = setTimeout(() => {
-      const err = new Error(`timed out after ${ms}ms ${what}`);
-      err.tcTimedOut = true;
-      reject(err);
-    }, ms);
-    // Deliberately NOT unref'd. An unref'd deadline does not fire when nothing
-    // else keeps the loop alive — precisely the case where the awaited call is
-    // stuck and the deadline is the only thing that can end the wait. `finally`
-    // clears it on every path, so it holds the process open for at most `ms`
-    // and only while something is genuinely pending.
-  });
-  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
-}
-
-/**
- * Milliseconds left before `deadlineAt`, never less than 1.
- *
- * Lets a sequence of awaited calls share ONE budget rather than each getting a
- * fresh full one — three calls at five seconds each is a fifteen-second request
- * wearing a five-second label.
- *
- * @param {number} deadlineAt - Epoch ms the whole operation must finish by.
- * @returns {number}
- */
-function _remaining(deadlineAt) {
-  return Math.max(1, deadlineAt - Date.now());
-}
 
 const PROJECT_NAME_REGEX = /^[a-zA-Z0-9 _-]+$/;
 
@@ -1656,10 +1611,20 @@ function _scanFailureHint(err) {
  * and dropping the await now yields a Promise that silently renders as nothing.
  *
  * Never rejects on a scan failure: a directory that is missing, unreadable or
- * unresponsive degrades to the registered projects (which come from SQLite and
- * cannot be affected by a stuck filesystem) and logs why. Callers get a SHORT
- * list, never an error, so absence of unregistered entries is not proof there
- * are none.
+ * unresponsive degrades to the registered projects and logs why. Callers get a
+ * SHORT list, never an error, so absence of unregistered entries is not proof
+ * there are none.
+ *
+ * THE DEGRADATION IS NOT AS COMPLETE AS IT LOOKS. The registered rows come from
+ * SQLite, but `listProjects` runs each one through `enrichProject`, which still
+ * calls `fs.existsSync(project.path)` — and `engines.governanceState` below it
+ * reads more files — SYNCHRONOUSLY, on paths the operator chose. So a registered
+ * project whose own directory is TCC-protected still blocks this process's event
+ * loop, on this route, exactly as #859 described. Moving the unregistered walk
+ * into the scanner child fixed the discovery half of this function and left that
+ * half standing. Do not read "degrades to the registered projects" as "cannot
+ * hang": tracked separately, and the sweep belongs with the rest of the
+ * synchronous readers in this file rather than bolted onto this comment.
  *
  * @param {object} [options] - Filter options passed to store.projects.list for registered projects
  * @returns {Promise<object[]>}
@@ -1675,32 +1640,37 @@ async function listAllProjects(options = {}) {
   const config = store.config.load();
   const projectsDir = resolveProjectsDir(config.projectsDir);
 
-  // OFF THE MAIN THREAD, AND BOUNDED. This scan reads a directory the operator
+  // IN ANOTHER PROCESS, AND BOUNDED. This scan reads a directory the operator
   // chooses, and the shipped default (`~/Documents/Projects`) is TCC-protected
   // on macOS. A launchd-spawned node without Full Disk Access does not get
-  // `EPERM` there — the `open()` never returns at all. Done synchronously that
-  // blocked the event loop, so ONE request to `GET /api/projects` took down every
-  // route in the server: `/api/health` answered 200 seconds earlier and then
-  // nothing, with no error, no log line, no recovery, while launchd still
-  // reported the process alive. Measured on a clean-room install; the dashboard
-  // loads this route, so it was the first thing a new operator hit.
+  // `EPERM` there — the `open()` never returns at all.
   //
-  // `fs.promises` runs the call on libuv's threadpool, so a stuck path costs one
-  // pool slot instead of the whole server, and the timeout means this request
-  // still ANSWERS rather than hanging forever. Degrading to the registered list
-  // is honest: those come from the database and are unaffected; only the
-  // discovery of not-yet-registered directories is lost, and it is reported.
-  // The deadline covers the WALK, not just the readdir. Bounding only the
-  // directory read leaves the per-entry probes below unbounded, over the same
-  // protected tree, in a loop that would otherwise keep going long after the
-  // request it belongs to has been answered.
-  const deadlineAt = Date.now() + PROJECT_SCAN_TIMEOUT_MS - PROJECT_SCAN_WALK_MARGIN_MS;
+  // Two earlier shapes of this call both failed, and the second is why the walk
+  // is no longer here at all. Synchronous, it blocked the event loop, so ONE
+  // request to `GET /api/projects` took down every route in the server.
+  // Asynchronous with a deadline, it stopped blocking the loop but still lost a
+  // libuv threadpool thread per hung read — abandoning a promise does not cancel
+  // a syscall — and the pool is four threads shared by the whole process, so
+  // four such reads left the server unable to touch the filesystem at all while
+  // `/api/health` kept answering 200 (#883). Only killing the process that owns
+  // a thread blocked in the kernel reclaims it, so the walk happens in a child
+  // this deadline can kill.
+  //
+  // Degrading to the registered list is honest: those come from SQLite and are
+  // unaffected; only the discovery of not-yet-registered directories is lost,
+  // and it is reported. The child's own budget is SHORTER than this request's
+  // deadline (see PROJECT_SCAN_WALK_MARGIN_MS) so a walk that is merely slow
+  // truncates and hands back what it found, instead of being killed with it.
   let walk;
   try {
-    walk = await _withTimeout(
-      _listUnregisteredDirs(projectsDir, allRegisteredNames, deadlineAt),
-      PROJECT_SCAN_TIMEOUT_MS,
-      `reading ${projectsDir}`
+    walk = await dirScanner.request(
+      'listUnregistered',
+      {
+        dir: projectsDir,
+        skipNames: [...allRegisteredNames],
+        budgetMs: PROJECT_SCAN_TIMEOUT_MS - PROJECT_SCAN_WALK_MARGIN_MS
+      },
+      { timeoutMs: PROJECT_SCAN_TIMEOUT_MS, what: `reading ${projectsDir}` }
     );
   } catch (err) {
     if (err && err.code === 'ENOENT') {
@@ -1731,186 +1701,6 @@ async function listAllProjects(options = {}) {
 }
 
 /**
- * The subdirectories of `projectsDir` that are not registered projects, shaped
- * like project records so the dashboard can render both from one list.
- *
- * WHY EVERY WALK OVER THIS TREE STOPS ITSELF. `_withTimeout` answers the
- * REQUEST at the deadline; it cannot stop the walk it raced, because a promise
- * cannot be cancelled. Left running, the loop keeps issuing filesystem calls
- * into a path already known not to answer, long after nobody is waiting for
- * them — and each holds a libuv threadpool slot (four by default) until the
- * kernel returns, which for the failure this guards is never. A few repeat
- * attempts and the pool is gone, taking every other async filesystem call in
- * the process with it.
- *
- * Stopping at the deadline TRUNCATES rather than throwing: a discovery walk that
- * ran out of budget has still discovered everything it got to, and this route
- * backs the dashboard's project list. Throwing here would take a slow directory
- * — hundreds of projects, a sluggish disk — from "the list took a while" to "the
- * list is empty", silently, since the caller degrades a failure to the
- * registered projects alone.
- *
- * @param {string} projectsDir - Absolute path to the projects directory.
- * @param {Set<string>} registeredNames - Names to skip (registered or archived).
- * @param {number} deadlineAt - Epoch ms after which to stop walking.
- * @returns {Promise<{unregistered: object[], truncated: boolean}>}
- */
-async function _listUnregisteredDirs(projectsDir, registeredNames, deadlineAt) {
-  const entries = await fsp.readdir(projectsDir, { withFileTypes: true });
-  const unregistered = [];
-  let truncated = false;
-
-  for (const entry of entries) {
-    if (!entry.isDirectory()) continue;
-    if (entry.name.startsWith('.')) continue;
-    if (registeredNames.has(entry.name)) continue;
-
-    if (Date.now() >= deadlineAt) {
-      truncated = true;
-      break;
-    }
-
-    const dirPath = path.join(projectsDir, entry.name);
-
-    let gitInfo = null;
-    try {
-      gitInfo = git.getInfo(dirPath);
-    } catch {
-      // Not a git repo or git not available
-    }
-
-    unregistered.push({
-      id: null,
-      name: entry.name,
-      path: dirPath,
-      registered: false,
-      engine: null,
-      tags: [],
-      ports: {},
-      session: null,
-      git: gitInfo,
-      status: null,
-      hasTangleclawConfig: await _exists(path.join(dirPath, '.tangleclaw', 'project.json')),
-      createdAt: null,
-      updatedAt: null,
-      archived: false
-    });
-  }
-
-  return { unregistered, truncated };
-}
-
-/**
- * Does `p` exist? Answers off the main thread and never throws.
- *
- * The synchronous `fs.existsSync` this replaces is the same event-loop hazard as
- * a synchronous readdir: on a path the kernel never answers for, it does not
- * return false, it does not return at all. Both walks over the projects tree use
- * this; a bounded `readdir` followed by unbounded synchronous probes of what it
- * returned is not a bounded scan.
- *
- * @param {string} p - Absolute path to test.
- * @returns {Promise<boolean>}
- */
-async function _exists(p) {
-  try {
-    await fsp.access(p);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-// What makes a directory look like a project to the first-run wizard. Presence
-// of any one of these, a git branch, or TangleClaw's own config is enough to
-// pre-tick it for import; everything else is still listed, just unticked.
-const PROJECT_MARKERS = [
-  'package.json', 'Cargo.toml', 'pyproject.toml', 'go.mod',
-  'Makefile', 'Gemfile', 'pom.xml', 'build.gradle',
-  'CMakeLists.txt', 'setup.py', 'composer.json', 'mix.exs'
-];
-
-/**
- * Enumerate and classify the immediate subdirectories of `dir`.
- *
- * Split out from `scanDirectoryForProjects` so ONE deadline can cover the whole
- * walk rather than each call within it: a directory with hundreds of children
- * can exhaust any reasonable budget in per-call increments while every
- * individual call stays under it.
- *
- * @param {string} dir - Absolute, already-resolved directory to scan.
- * @param {number} deadlineAt - Epoch ms after which to abandon the walk.
- * @returns {Promise<object[]>} One entry per subdirectory, in readdir order.
- */
-async function _scanDirectoryEntries(dir, deadlineAt) {
-  const stat = await fsp.stat(dir);
-  if (!stat.isDirectory()) {
-    throw Object.assign(new Error(`not a directory: ${dir}`), { code: 'ENOTDIR' });
-  }
-
-  const entries = await fsp.readdir(dir, { withFileTypes: true });
-  const candidates = entries.filter(e => e.isDirectory() && !e.name.startsWith('.'));
-  const detected = [];
-
-  for (const entry of candidates) {
-    // Stop, and say how far we got. Unlike the dashboard's list this one cannot
-    // return a partial answer quietly: the operator is about to tick boxes from
-    // it, and a list silently missing half the directories reads as "those are
-    // not there". `tcTruncated` is deliberately NOT `tcTimedOut` — this walk was
-    // being answered, just not fast enough, and blaming Full Disk Access for a
-    // large directory on a slow disk sends the operator to fix the wrong thing.
-    if (Date.now() >= deadlineAt) {
-      throw Object.assign(
-        new Error(`checked ${detected.length} of ${candidates.length} subdirectories `
-          + `in ${PROJECT_SCAN_TIMEOUT_MS}ms and gave up`),
-        { tcTruncated: true }
-      );
-    }
-
-    const dirPath = path.join(dir, entry.name);
-
-    // The one call here that is NOT off the main thread. git.getInfo shells out
-    // with execSync, and lib/git's 5s cap is per command while reading a repo
-    // takes several — so a directory whose git calls all stall can block the
-    // loop for far longer than this scan's own deadline, which cannot fire
-    // while a synchronous call is running. Bounded, unlike the read this change
-    // fixes, but not free: the deadline check above is what keeps one slow
-    // directory from being followed by a hundred more.
-    let gitInfo = null;
-    try {
-      gitInfo = git.getInfo(dirPath);
-    } catch {
-      // Not a git repo, or git is not installed. Either way there is no branch
-      // to report and the directory is still worth listing.
-    }
-
-    const hasTangleclawConfig = await _exists(path.join(dirPath, '.tangleclaw', 'project.json'));
-
-    // Sequential and short-circuiting, deliberately. Probing all twelve markers
-    // concurrently would issue twelve threadpool calls per directory to answer
-    // a question the first hit settles — cheap against a healthy filesystem,
-    // and against a blocked one it is twelve stuck slots instead of one.
-    let hasProjectMarker = false;
-    for (const marker of PROJECT_MARKERS) {
-      if (await _exists(path.join(dirPath, marker))) {
-        hasProjectMarker = true;
-        break;
-      }
-    }
-
-    detected.push({
-      name: entry.name,
-      path: dirPath,
-      hasTangleclawConfig,
-      git: gitInfo ? { branch: gitInfo.branch, dirty: gitInfo.dirty } : null,
-      detected: !!((gitInfo && gitInfo.branch) || hasTangleclawConfig || hasProjectMarker)
-    });
-  }
-
-  return detected;
-}
-
-/**
  * Scan an operator-supplied directory for candidate projects, bounded in time
  * and off the main thread.
  *
@@ -1936,13 +1726,12 @@ async function _scanDirectoryEntries(dir, deadlineAt) {
  */
 async function scanDirectoryForProjects(directory) {
   const dir = resolveProjectsDir(directory);
-  const deadlineAt = Date.now() + PROJECT_SCAN_TIMEOUT_MS - PROJECT_SCAN_WALK_MARGIN_MS;
 
   try {
-    const projects = await _withTimeout(
-      _scanDirectoryEntries(dir, deadlineAt),
-      PROJECT_SCAN_TIMEOUT_MS,
-      `scanning ${dir}`
+    const { projects } = await dirScanner.request(
+      'scanEntries',
+      { dir, budgetMs: PROJECT_SCAN_TIMEOUT_MS - PROJECT_SCAN_WALK_MARGIN_MS },
+      { timeoutMs: PROJECT_SCAN_TIMEOUT_MS, what: `scanning ${dir}` }
     );
     return { ok: true, projects };
   } catch (err) {
@@ -2034,33 +1823,25 @@ async function createProjectsDir(directory) {
     };
   }
 
-  // OFF THE MAIN THREAD AND BOUNDED, for the reason the rest of this file is.
-  // The path this exists to create is `~/Documents/Projects`, so the parent
-  // probe lands on `~/Documents` — TCC-protected, where a launchd-spawned node
-  // gets no EPERM and no answer at all. Written with `existsSync`/`mkdirSync`
-  // this button was the #859 wedge again, in the one place most certain to
-  // touch a protected directory.
+  // IN THE SCANNER CHILD, for the reason the rest of this file is. The path this
+  // exists to create is `~/Documents/Projects`, so the parent probe lands on
+  // `~/Documents` — TCC-protected, where a launchd-spawned node gets no EPERM and
+  // no answer at all. Written with `existsSync`/`mkdirSync` this button was the
+  // #859 wedge; written with `fs.promises` and a deadline it was the #883 thread
+  // leak, in the one place most certain to touch a protected directory.
+  //
+  // The home-directory constraint above stays HERE and is not repeated in the
+  // child: it is the security boundary for a route reachable before any
+  // credential exists, and a boundary stated in two places is a boundary in
+  // neither. The child does as it is told; this function is what decides what it
+  // may be told.
+  let outcome;
   try {
-    if (await _withTimeout(_exists(dir), _remaining(deadlineAt), `checking ${dir}`)) {
-      // Already there. Not an error — two clicks on the same button, or a folder
-      // made in Finder while this screen was open, should both end well.
-      return { ok: true, path: dir, created: false };
-    }
-
-    // The parent must already exist. Creating ONE level is "you pointed at
-    // ~/Documents/Projects and it wasn't there yet"; creating five is building a
-    // tree nobody asked for at a path nobody checked.
-    const parent = path.dirname(dir);
-    if (!await _withTimeout(_exists(parent), _remaining(deadlineAt), `checking ${parent}`)) {
-      return {
-        ok: false,
-        code: 'BAD_REQUEST',
-        error: `The folder above it does not exist either (${parent}) — create that first, `
-          + 'or choose a different path.'
-      };
-    }
-
-    await _withTimeout(fsp.mkdir(dir), _remaining(deadlineAt), `creating ${dir}`);
+    outcome = await dirScanner.request(
+      'createDir',
+      { dir },
+      { timeoutMs: PROJECT_SCAN_TIMEOUT_MS, what: `creating ${dir}` }
+    );
   } catch (err) {
     const hint = _scanFailureHint(err);
     return {
@@ -2069,6 +1850,20 @@ async function createProjectsDir(directory) {
       error: `Could not create ${directory}: ${hint || (err && err.message)}`
     };
   }
+  if (outcome.status === 'exists') {
+    // Already there. Not an error — two clicks on the same button, or a folder
+    // made in Finder while this screen was open, should both end well.
+    return { ok: true, path: dir, created: false };
+  }
+  if (outcome.status === 'parent-missing') {
+    return {
+      ok: false,
+      code: 'BAD_REQUEST',
+      error: `The folder above it does not exist either (${outcome.parent}) — create that first, `
+        + 'or choose a different path.'
+    };
+  }
+
   log.info('Created the projects directory at the operator\'s request', { path: dir });
   return { ok: true, path: dir, created: true };
 }
@@ -3019,7 +2814,6 @@ module.exports = {
   // Exported for tests: the deadline is what turns a path that never answers
   // into an answered request, and `tcTimedOut` is what lets the caller name the
   // real cause. Both need pinning directly.
-  _withTimeout,
   _scanFailureHint,
   scanDirectoryForProjects,
   createProjectsDir,

--- a/lib/projects.js
+++ b/lib/projects.js
@@ -38,6 +38,12 @@ const PROJECT_SCAN_TIMEOUT_MS = 5000;
 // at all, where there is nothing to hand back and nobody to hand it to.
 const PROJECT_SCAN_WALK_MARGIN_MS = 250;
 
+// What the CHILD is actually given, derived once so the two request sites and the
+// log that reports it cannot disagree. They already did: the truncation warning
+// printed the full 5000 while the walk had been handed 4750, so an operator
+// reading the log was told a budget nothing was ever measured against.
+const PROJECT_WALK_BUDGET_MS = PROJECT_SCAN_TIMEOUT_MS - PROJECT_SCAN_WALK_MARGIN_MS;
+
 const PROJECT_NAME_REGEX = /^[a-zA-Z0-9 _-]+$/;
 
 // ── Password Hashing ──
@@ -1623,8 +1629,14 @@ function _scanFailureHint(err) {
  * loop, on this route, exactly as #859 described. Moving the unregistered walk
  * into the scanner child fixed the discovery half of this function and left that
  * half standing. Do not read "degrades to the registered projects" as "cannot
- * hang": tracked separately, and the sweep belongs with the rest of the
- * synchronous readers in this file rather than bolted onto this comment.
+ * hang".
+ *
+ * NOT YET FILED as of this writing — deliberately stated that way rather than
+ * as "tracked separately", which would be a citation to nothing. The sweep is
+ * the whole family of ~31 synchronous `existsSync`/`readdirSync`/`statSync`
+ * calls on operator-chosen paths in this file, not this call site alone; the
+ * project's own learnings entry on this failure family says fix the family, not
+ * the call site, and that is the shape the work should take.
  *
  * @param {object} [options] - Filter options passed to store.projects.list for registered projects
  * @returns {Promise<object[]>}
@@ -1668,7 +1680,7 @@ async function listAllProjects(options = {}) {
       {
         dir: projectsDir,
         skipNames: [...allRegisteredNames],
-        budgetMs: PROJECT_SCAN_TIMEOUT_MS - PROJECT_SCAN_WALK_MARGIN_MS
+        budgetMs: PROJECT_WALK_BUDGET_MS
       },
       { timeoutMs: PROJECT_SCAN_TIMEOUT_MS, what: `reading ${projectsDir}` }
     );
@@ -1690,7 +1702,7 @@ async function listAllProjects(options = {}) {
       + 'the cut-off were not checked', {
       projectsDir,
       listed: walk.unregistered.length,
-      budgetMs: PROJECT_SCAN_TIMEOUT_MS
+      budgetMs: PROJECT_WALK_BUDGET_MS
     });
   }
 
@@ -1730,7 +1742,7 @@ async function scanDirectoryForProjects(directory) {
   try {
     const { projects } = await dirScanner.request(
       'scanEntries',
-      { dir, budgetMs: PROJECT_SCAN_TIMEOUT_MS - PROJECT_SCAN_WALK_MARGIN_MS },
+      { dir, budgetMs: PROJECT_WALK_BUDGET_MS },
       { timeoutMs: PROJECT_SCAN_TIMEOUT_MS, what: `scanning ${dir}` }
     );
     return { ok: true, projects };
@@ -1808,7 +1820,6 @@ async function scanDirectoryForProjects(directory) {
 async function createProjectsDir(directory) {
   const dir = resolveProjectsDir(directory);
   const home = process.env.HOME || '';
-  const deadlineAt = Date.now() + PROJECT_SCAN_TIMEOUT_MS;
 
   if (!home) {
     return { ok: false, code: 'BAD_REQUEST', error: 'No home directory is set for this server.' };

--- a/lib/projects.js
+++ b/lib/projects.js
@@ -1682,13 +1682,34 @@ async function listAllProjects(options = {}) {
         skipNames: [...allRegisteredNames],
         budgetMs: PROJECT_WALK_BUDGET_MS
       },
-      { timeoutMs: PROJECT_SCAN_TIMEOUT_MS, what: `reading ${projectsDir}` }
+      {
+        timeoutMs: PROJECT_SCAN_TIMEOUT_MS,
+        what: `reading ${projectsDir}`,
+        // THE ONLY CALLER THAT OPTS INTO THE BACKOFF, and the reason it exists.
+        // The dashboard polls this route every ten seconds for as long as a tab
+        // is open. Without a backoff an unreadable projects directory costs a
+        // five-second stall and a killed child on every tick, forever — and a
+        // child blocked in the kernel may never leave the process table, so that
+        // is a process accumulating every ten seconds, not a cost that settles.
+        // Nobody asked for each of those reads; they are a poll. The wizard's
+        // scan and create-directory deliberately do NOT opt in, because a person
+        // who just changed a permission and pressed the button again must get a
+        // real answer rather than a remembered one.
+        pathKey: projectsDir
+      }
     );
   } catch (err) {
     if (err && err.code === 'ENOENT') {
       return registered.map(p => ({ ...p, registered: true }));
     }
-    log.warn('Could not scan the projects directory — registered projects are unaffected, '
+    // A remembered refusal is not news. The scanner already logged a WARN naming
+    // this path when it really failed, and it logs another each time the backoff
+    // escalates — so warning again on every poll would bury those behind six
+    // identical lines a minute and turn one broken directory into a log flood.
+    // The condition is unchanged and still degrades the list; only its novelty
+    // has gone, so it drops to debug rather than disappearing.
+    const say = (err && err.tcCached) ? log.debug : log.warn;
+    say('Could not scan the projects directory — registered projects are unaffected, '
       + 'but unregistered folders will not be listed', {
       projectsDir,
       error: err && err.message,

--- a/test/_dir-scanner-hang-child.js
+++ b/test/_dir-scanner-hang-child.js
@@ -1,0 +1,53 @@
+'use strict';
+
+/**
+ * A scanner child that really hangs, for exercising the supervisor's deadline.
+ *
+ * WHY A FIXTURE CHILD RATHER THAN THE REAL ONE. The failure being guarded
+ * against is a `readdir` that never returns, which happens on a TCC-protected
+ * macOS path and cannot be produced on a CI runner: a FIFO — the one portable
+ * way to make a filesystem call block — answers `readdir` with `ENOTDIR`
+ * immediately (measured; only `open`/`readFile` blocks on one). So the hang is
+ * reproduced with the operation that DOES block, in a child that stands in for
+ * the real one.
+ *
+ * What that costs is honesty about scope: this proves the supervisor's contract
+ * — a child that stops answering is killed, its callers are told, and the parent
+ * process keeps its threadpool — against a genuinely blocked syscall holding a
+ * genuine libuv thread. It does not prove anything about `readdir` in
+ * particular, and nothing here should be read as if it did.
+ */
+
+const fsp = require('node:fs').promises;
+
+process.on('message', (msg) => {
+  const { id, op, payload } = msg || {};
+
+  if (op === 'ping') {
+    process.send({ id, ok: true, value: { pid: process.pid } });
+    return;
+  }
+
+  if (op === 'echo') {
+    process.send({ id, ok: true, value: payload });
+    return;
+  }
+
+  if (op === 'crash') {
+    process.exit(7);
+    return;
+  }
+
+  if (op === 'hang') {
+    // Opening a FIFO for reading blocks until a writer appears, and libuv
+    // performs that open on the threadpool — so this occupies a real pool
+    // thread in a real blocked syscall, exactly like the failure it stands in
+    // for. Deliberately never replies and never settles.
+    fsp.readFile(payload.fifo).catch(() => {});
+    return;
+  }
+
+  process.send({ id, ok: false, error: { message: `fixture does not know: ${op}`, code: 'ENOSYS' } });
+});
+
+process.on('disconnect', () => { process.exit(0); });

--- a/test/_dir-scanner-pool-demo.js
+++ b/test/_dir-scanner-pool-demo.js
@@ -10,9 +10,13 @@
  * would take every later test in the file down with it. The damage has to be
  * contained by exiting.
  *
- * WHY IT USES `projects._withTimeout` AND NOT A COPY. The claim being made is
- * about the code that ships, so `leak` mode calls the real exported helper. A
- * lookalike could drift into demonstrating something the product no longer does.
+ * WHY THE LEAKING HELPER LIVES HERE NOW. `leak` mode used to call
+ * `projects._withTimeout`, the real shipped helper, so the demonstration could not
+ * be dismissed as a strawman. Chunk 2 moved every operator-path read into the
+ * scanner child and that helper became dead code, so keeping it in `lib/` purely
+ * to be a fixture would misrepresent the product to anyone reading it. It is
+ * reproduced below instead, verbatim — `git log -S_withTimeout -- lib/projects.js`
+ * shows the original, and `4b44b2e^` is the last commit where the product used it.
  *
  * Usage: node _dir-scanner-pool-demo.js <leak|scanner> <fifoDir>
  * Prints one line of JSON: {"mode":…,"rejections":N,"readdirMs":N|null,"readdirStuck":bool}
@@ -85,19 +89,44 @@ async function probeOrdinaryReaddir() {
  * @returns {Promise<number>} How many calls rejected as expected.
  */
 async function runLeak() {
-  const projects = require('../lib/projects');
   let rejections = 0;
 
   const races = [];
   for (let i = 0; i < HUNG_CALLS; i++) {
     const fifo = makeFifo(i);
     races.push(
-      projects._withTimeout(fsp.readFile(fifo), DEADLINE_MS, `reading ${fifo}`)
+      _withTimeoutAsItShipped(fsp.readFile(fifo), DEADLINE_MS, `reading ${fifo}`)
         .then(() => {}, () => { rejections++; })
     );
   }
   await Promise.all(races);
   return rejections;
+}
+
+/**
+ * `projects._withTimeout` as it shipped before this branch, reproduced verbatim.
+ *
+ * The rejection carries `tcTimedOut` so a caller could tell "this path is not
+ * answering" from an ordinary filesystem error. The underlying operation is NOT
+ * cancellable — it keeps occupying its threadpool slot — so this bounds the
+ * REQUEST, not the syscall. That limit is the whole of #883, and this function
+ * exists so the limit can be demonstrated rather than asserted.
+ *
+ * @param {Promise<any>} promise - Work to bound.
+ * @param {number} ms - Milliseconds to wait.
+ * @param {string} what - Short description used in the timeout message.
+ * @returns {Promise<any>}
+ */
+function _withTimeoutAsItShipped(promise, ms, what) {
+  let timer;
+  const timeout = new Promise((_resolve, reject) => {
+    timer = setTimeout(() => {
+      const err = new Error(`timed out after ${ms}ms ${what}`);
+      err.tcTimedOut = true;
+      reject(err);
+    }, ms);
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
 }
 
 /**

--- a/test/_dir-scanner-pool-demo.js
+++ b/test/_dir-scanner-pool-demo.js
@@ -1,0 +1,143 @@
+'use strict';
+
+/**
+ * Demonstrate, in a throwaway process, what abandoning a blocked filesystem call
+ * costs — and that routing the same work through the scanner costs nothing.
+ *
+ * WHY THIS IS A SEPARATE PROCESS. The `leak` mode deliberately destroys its own
+ * libuv threadpool. A process that has done that cannot perform another async
+ * filesystem call for as long as it lives, so running it inside the test process
+ * would take every later test in the file down with it. The damage has to be
+ * contained by exiting.
+ *
+ * WHY IT USES `projects._withTimeout` AND NOT A COPY. The claim being made is
+ * about the code that ships, so `leak` mode calls the real exported helper. A
+ * lookalike could drift into demonstrating something the product no longer does.
+ *
+ * Usage: node _dir-scanner-pool-demo.js <leak|scanner> <fifoDir>
+ * Prints one line of JSON: {"mode":…,"rejections":N,"readdirMs":N|null,"readdirStuck":bool}
+ *
+ * `UV_THREADPOOL_SIZE` is expected to be set small by the caller; the number of
+ * blocking calls issued is read from it, so the demo scales with the pool rather
+ * than hard-coding a size that a future runtime could change underneath it.
+ */
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const fsp = require('node:fs').promises;
+const { execFileSync } = require('node:child_process');
+
+const MODE = process.argv[2];
+const FIFO_DIR = process.argv[3];
+
+// One more blocking call than the pool has threads: the point of the exercise is
+// to cross the cliff, not to approach it.
+const POOL_SIZE = Number(process.env.UV_THREADPOOL_SIZE) || 4;
+const HUNG_CALLS = POOL_SIZE + 1;
+
+// Long enough that a healthy call would obviously have finished, short enough
+// that the demo is not the slowest thing in the suite.
+const DEADLINE_MS = 300;
+
+// How long an ordinary readdir is given before it is declared stuck. Timers do
+// not use the threadpool, so this still fires with the pool destroyed — which is
+// the whole reason the stuck case is observable at all.
+const PROBE_MS = 1500;
+
+/**
+ * Make a FIFO whose `open` for reading will block, because nothing will ever
+ * write to it.
+ *
+ * @param {number} i - Distinguishes one FIFO from the next.
+ * @returns {string} Absolute path to the new FIFO.
+ */
+function makeFifo(i) {
+  const p = path.join(FIFO_DIR, `pipe-${i}`);
+  execFileSync('mkfifo', [p]);
+  return p;
+}
+
+/**
+ * Time an ordinary directory read that has nothing to do with the blocked paths.
+ *
+ * This is the measurement that matters: whether unrelated filesystem work in
+ * THIS process still completes. With the pool exhausted it never will, so the
+ * result is bounded rather than awaited.
+ *
+ * @returns {Promise<{readdirMs: number|null, readdirStuck: boolean}>}
+ */
+async function probeOrdinaryReaddir() {
+  const started = Date.now();
+  const outcome = await Promise.race([
+    fsp.readdir(os.tmpdir()).then(() => 'ok', () => 'ok'),
+    new Promise((res) => setTimeout(() => res('stuck'), PROBE_MS))
+  ]);
+  return outcome === 'stuck'
+    ? { readdirMs: null, readdirStuck: true }
+    : { readdirMs: Date.now() - started, readdirStuck: false };
+}
+
+/**
+ * The shape that ships today: race a blocking call against a timer and walk away
+ * from the loser. The rejection arrives on time; the syscall keeps its thread.
+ *
+ * @returns {Promise<number>} How many calls rejected as expected.
+ */
+async function runLeak() {
+  const projects = require('../lib/projects');
+  let rejections = 0;
+
+  const races = [];
+  for (let i = 0; i < HUNG_CALLS; i++) {
+    const fifo = makeFifo(i);
+    races.push(
+      projects._withTimeout(fsp.readFile(fifo), DEADLINE_MS, `reading ${fifo}`)
+        .then(() => {}, () => { rejections++; })
+    );
+  }
+  await Promise.all(races);
+  return rejections;
+}
+
+/**
+ * The same workload through the scanner: the blocked threads belong to a child
+ * process, and the deadline kills it rather than abandoning it.
+ *
+ * @returns {Promise<number>} How many requests rejected as expected.
+ */
+async function runScanner() {
+  const dirScanner = require('../lib/dir-scanner');
+  const scanner = dirScanner.createScanner({
+    childPath: path.join(__dirname, '_dir-scanner-hang-child.js'),
+    timeoutMs: DEADLINE_MS,
+    exitGraceMs: 0
+  });
+
+  let rejections = 0;
+  // Sequential on purpose. Concurrent requests would share one child and die
+  // together in the first kill, which would prove the collateral rule rather
+  // than the one under test — that N separate hangs, each with its own child,
+  // still leave this process's threadpool untouched.
+  for (let i = 0; i < HUNG_CALLS; i++) {
+    const fifo = makeFifo(i);
+    try {
+      await scanner.request('hang', { fifo }, { what: `reading ${fifo}` });
+    } catch {
+      rejections++;
+    }
+  }
+
+  await scanner.shutdown();
+  return rejections;
+}
+
+(async () => {
+  fs.mkdirSync(FIFO_DIR, { recursive: true });
+  const rejections = MODE === 'leak' ? await runLeak() : await runScanner();
+  const probe = await probeOrdinaryReaddir();
+  process.stdout.write(JSON.stringify({ mode: MODE, rejections, ...probe }) + '\n');
+  // Hard exit: in `leak` mode the abandoned reads still hold their threads, so
+  // waiting for a clean drain would wait forever.
+  process.exit(0);
+})();

--- a/test/api-projects.test.js
+++ b/test/api-projects.test.js
@@ -282,4 +282,78 @@ describe('api-projects', () => {
       assert.ok(data.ok);
     });
   });
+
+  describe('GET /api/projects — a directory that never answers must not wedge the server (#883)', () => {
+    const dirScanner = require('../lib/dir-scanner');
+    const fsp = require('node:fs').promises;
+    const { execFileSync } = require('node:child_process');
+
+    it('survives more hung scans than the threadpool has threads', async () => {
+      // THE WHOLE POINT, asserted through the real route rather than at the unit
+      // level. Before #883 this route answered every request on time and lost a
+      // libuv threadpool thread each time — four of them and the server could no
+      // longer touch the filesystem AT ALL, on any path, while /api/health kept
+      // returning 200. Every earlier test and every VRF row used a fresh process,
+      // which is exactly how that survived six Critic rounds and 5,700 tests.
+      //
+      // The hang is produced by a fixture child blocking on a reader-less FIFO —
+      // a real blocked syscall holding a real pool thread. A real `readdir` hang
+      // needs TCC and cannot be reproduced on a CI runner (a FIFO answers
+      // `readdir` with ENOTDIR in 0ms), so what this proves is the property that
+      // matters here: hung scans, however induced, no longer cost THIS process
+      // anything.
+      const fifoDir = fs.mkdtempSync(path.join(tmpDir, 'fifo-'));
+      const hungScanner = dirScanner.createScanner({
+        childPath: path.join(__dirname, '_dir-scanner-hang-child.js'),
+        timeoutMs: 300,
+        exitGraceMs: 0
+      });
+
+      const poolSize = Number(process.env.UV_THREADPOOL_SIZE) || 4;
+      const attempts = poolSize + 1;
+      const real = dirScanner.request;
+      let n = 0;
+      dirScanner.request = () => {
+        const fifo = path.join(fifoDir, `pipe-${n++}`);
+        execFileSync('mkfifo', [fifo]);
+        return hungScanner.request('hang', { fifo });
+      };
+
+      try {
+        for (let i = 0; i < attempts; i++) {
+          const { status, data } = await request('GET', '/api/projects');
+          // Degraded, not failed: registered projects come from SQLite and are
+          // unaffected, so the dashboard still renders.
+          assert.equal(status, 200, `request ${i + 1} of ${attempts} must still be answered`);
+          assert.ok(Array.isArray(data.projects), 'must answer with a list, not an error');
+        }
+        assert.equal(n, attempts, 'the fixture must actually have reached the scanner each time');
+
+        // The assertion #883 is about, and the reason it is RACED rather than
+        // awaited: with the pool destroyed this readdir never resolves at all, so
+        // awaiting it would hang the suite instead of failing it. Timers do not
+        // use the threadpool, which is what makes the stuck case observable.
+        // Verified by mutation — putting the hang back in this process makes this
+        // line report, where a bare await simply never returned.
+        const started = Date.now();
+        const outcome = await Promise.race([
+          fsp.readdir(tmpDir).then(() => 'ok', () => 'ok'),
+          new Promise((resolve) => setTimeout(() => resolve('stuck'), 2000))
+        ]);
+        assert.equal(outcome, 'ok',
+          `the server's own filesystem must still work after ${attempts} hung scans — `
+          + 'an ordinary readdir on an unrelated path never completed, which is #883 exactly');
+        assert.ok(Date.now() - started < 2000, 'and it must be prompt, not merely eventual');
+
+        // And the route is genuinely healthy again, not merely returning cached
+        // work: a normal request still answers once the scanner is restored.
+        dirScanner.request = real;
+        const { status } = await request('GET', '/api/projects');
+        assert.equal(status, 200);
+      } finally {
+        dirScanner.request = real;
+        await hungScanner.shutdown();
+      }
+    });
+  });
 });

--- a/test/dir-scanner-child.test.js
+++ b/test/dir-scanner-child.test.js
@@ -1,0 +1,268 @@
+'use strict';
+
+/**
+ * The walks themselves — marker short-circuiting, deadline truncation, what
+ * counts as a candidate directory.
+ *
+ * WHY THESE RUN IN-PROCESS AND NOT THROUGH THE SUPERVISOR. This behavior is only
+ * observable by stubbing `fs`, and a stub cannot cross a process boundary: these
+ * assertions used to live in `test/projects.test.js` against `fsp.readdir`, and
+ * when the walk moved into the scanner child (#883) every one of those fixtures
+ * stopped reaching its subject. Rather than weaken them into end-to-end tests
+ * that can no longer see what they were pinning, they moved here, where the code
+ * they describe now lives and where the stubs still work.
+ *
+ * `test/dir-scanner.test.js` covers the supervisor; `test/projects.test.js`
+ * covers the delegation and the operator-facing wording.
+ */
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const fsp = require('node:fs').promises;
+
+const { HANDLERS, PROJECT_MARKERS } = require('../lib/dir-scanner-child');
+
+let tmpRoot;
+
+before(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-scanner-child-'));
+});
+
+after(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+/**
+ * A fresh scratch directory, so no test can see another's entries.
+ * @param {string} name - Distinguishing name.
+ * @returns {string} Absolute path.
+ */
+function scratch(name) {
+  const p = path.join(tmpRoot, name);
+  fs.mkdirSync(p, { recursive: true });
+  return p;
+}
+
+describe('dir-scanner child — scanEntries (the wizard walk)', () => {
+  test('classifies a marker-bearing directory as detected and a bare one as not', async () => {
+    const root = scratch('classify');
+    fs.mkdirSync(path.join(root, 'with-marker'));
+    fs.writeFileSync(path.join(root, 'with-marker', 'go.mod'), 'module example.com/x\n');
+    fs.mkdirSync(path.join(root, 'bare'));
+    fs.mkdirSync(path.join(root, '.hidden'));
+    fs.writeFileSync(path.join(root, 'loose-file.txt'), 'x');
+
+    const { projects } = await HANDLERS.scanEntries({ dir: root, budgetMs: 5000 });
+    const names = projects.map(p => p.name).sort();
+
+    assert.deepEqual(names, ['bare', 'with-marker'],
+      'hidden directories and loose files are not candidate projects');
+    assert.equal(projects.find(p => p.name === 'with-marker').detected, true);
+    assert.equal(projects.find(p => p.name === 'bare').detected, false);
+  });
+
+  test('stops probing markers once one has answered', async () => {
+    // Twelve concurrent probes to settle a question the first hit answers is
+    // twelve threadpool slots against a filesystem that may not return any of
+    // them. The short-circuit is the difference between costing one stuck slot
+    // per directory and costing twelve.
+    const root = scratch('short-circuit');
+    fs.mkdirSync(path.join(root, 'js-project'));
+    fs.writeFileSync(path.join(root, 'js-project', 'package.json'), '{}');
+
+    const realAccess = fsp.access;
+    const probed = [];
+    fsp.access = (p, ...rest) => {
+      if (String(p).startsWith(root)) probed.push(path.basename(String(p)));
+      return realAccess(p, ...rest);
+    };
+    try {
+      const { projects } = await HANDLERS.scanEntries({ dir: root, budgetMs: 5000 });
+      assert.equal(projects[0].detected, true);
+      // The TangleClaw config probe, then package.json — first in the marker
+      // list, and the last thing that should have been looked at.
+      assert.deepEqual(probed, ['project.json', 'package.json'],
+        'must stop at the first marker that answers');
+    } finally {
+      fsp.access = realAccess;
+    }
+  });
+
+  test('package.json is the first marker, so the common case short-circuits soonest', () => {
+    // The assertion above encodes this ordering; without pinning it here, a
+    // reorder would break that test for a reason its name does not suggest.
+    assert.equal(PROJECT_MARKERS[0], 'package.json');
+  });
+
+  test('abandons the walk at the deadline instead of running it to the end', async () => {
+    // A walk left running keeps issuing filesystem calls into a path already
+    // known not to answer, long after nobody is waiting — and each holds a libuv
+    // threadpool slot in THIS process until the kernel returns. That the process
+    // is now disposable does not make the walk free: the supervisor kills the
+    // child on ITS deadline, and a walk that stops itself first is what lets a
+    // merely-slow directory report how far it got instead of being killed.
+    // Mutation: delete the per-entry deadline check and the walk runs every entry.
+    const realReaddir = fsp.readdir;
+    const realAccess = fsp.access;
+    const realStat = fsp.stat;
+    let accessCalls = 0;
+    let entriesWalked = 0;
+    const fakeDir = '/tc-fake-scan-root';
+    const ENTRY_COUNT = 200;
+    const dirents = Array.from({ length: ENTRY_COUNT }, (_, i) => ({
+      name: `proj-${i}`, isDirectory: () => true
+    }));
+
+    fsp.stat = (p, ...rest) => (p === fakeDir
+      ? Promise.resolve({ isDirectory: () => true })
+      : realStat(p, ...rest));
+    fsp.readdir = (p, ...rest) => (p === fakeDir
+      ? Promise.resolve(dirents)
+      : realReaddir(p, ...rest));
+    fsp.access = (p, ...rest) => {
+      if (String(p).startsWith(fakeDir)) {
+        accessCalls++;
+        // One TangleClaw-config probe per entry, so this counts entries.
+        if (path.basename(String(p)) === 'project.json') entriesWalked++;
+        // Slow, but finite — the shape a deadline race alone cannot catch,
+        // because every individual call does eventually return.
+        return new Promise((resolve) => setTimeout(resolve, 20));
+      }
+      return realAccess(p, ...rest);
+    };
+
+    try {
+      await assert.rejects(
+        () => HANDLERS.scanEntries({ dir: fakeDir, budgetMs: 400 }),
+        (err) => {
+          // NOT tcTimedOut: this walk was being answered, just not fast enough.
+          // Blaming Full Disk Access for a large directory on a slow disk sends
+          // the operator to fix something that was never wrong.
+          assert.equal(err.tcTruncated, true, 'a slow walk is truncated, not timed out');
+          assert.ok(!err.tcTimedOut);
+          assert.match(err.message, /checked \d+ of 200 subdirectories/,
+            'must say how far it got, so the operator can tell slow from blocked');
+          return true;
+        }
+      );
+
+      // Without this the test passes vacuously: every other assertion here also
+      // holds if the stubs were never reached and the path simply 404'd.
+      assert.ok(entriesWalked > 0, 'the fixture must actually reach the walk');
+      assert.ok(entriesWalked < ENTRY_COUNT,
+        `must not have walked every entry (${entriesWalked} of ${ENTRY_COUNT})`);
+
+      // Sample after a grace longer than one entry's worth of probes, so the
+      // entry in flight at the deadline has finished and the next check fired.
+      await new Promise((resolve) => setTimeout(resolve, 600));
+      const settled = accessCalls;
+      await new Promise((resolve) => setTimeout(resolve, 600));
+      assert.equal(accessCalls, settled,
+        `the walk must stop when the deadline passes (kept going: ${settled} → ${accessCalls})`);
+    } finally {
+      fsp.stat = realStat;
+      fsp.readdir = realReaddir;
+      fsp.access = realAccess;
+    }
+  });
+
+  test('reports a missing directory as ENOENT and a file as ENOTDIR', async () => {
+    // Both travel as codes rather than prose: the browser offers to CREATE on
+    // the first, and it used to decide which failure it was by regex-matching
+    // the message, so rewording a sentence silently removed the button.
+    await assert.rejects(
+      () => HANDLERS.scanEntries({ dir: path.join(tmpRoot, 'nope'), budgetMs: 5000 }),
+      (err) => { assert.equal(err.code, 'ENOENT'); return true; }
+    );
+
+    const filePath = path.join(scratch('notdir'), 'a-file.txt');
+    fs.writeFileSync(filePath, 'x');
+    await assert.rejects(
+      () => HANDLERS.scanEntries({ dir: filePath, budgetMs: 5000 }),
+      (err) => { assert.equal(err.code, 'ENOTDIR'); return true; }
+    );
+  });
+});
+
+describe('dir-scanner child — listUnregistered (the dashboard walk)', () => {
+  test('skips registered names, hidden directories and loose files', async () => {
+    const root = scratch('unregistered');
+    fs.mkdirSync(path.join(root, 'known'));
+    fs.mkdirSync(path.join(root, 'unknown'));
+    fs.mkdirSync(path.join(root, '.hidden'));
+    fs.writeFileSync(path.join(root, 'loose.txt'), 'x');
+
+    const { unregistered, truncated } = await HANDLERS.listUnregistered({
+      dir: root, skipNames: ['known'], budgetMs: 5000
+    });
+
+    assert.deepEqual(unregistered.map(u => u.name), ['unknown']);
+    assert.equal(truncated, false);
+    assert.equal(unregistered[0].registered, false,
+      'the dashboard renders these alongside registered projects and must tell them apart');
+  });
+
+  test('TRUNCATES rather than throwing when the budget runs out', async () => {
+    // This walk backs the dashboard's project list, and the caller degrades a
+    // failure to the registered projects alone. Throwing would turn "the list
+    // took a while" into "the list is empty", silently, for a slow disk.
+    const realAccess = fsp.access;
+    const realReaddir = fsp.readdir;
+    const fakeDir = '/tc-fake-unregistered-root';
+    const dirents = Array.from({ length: 200 }, (_, i) => ({
+      name: `proj-${i}`, isDirectory: () => true
+    }));
+    let probed = 0;
+
+    fsp.readdir = (p, ...rest) => (p === fakeDir
+      ? Promise.resolve(dirents)
+      : realReaddir(p, ...rest));
+    fsp.access = (p, ...rest) => {
+      if (String(p).startsWith(fakeDir)) {
+        probed++;
+        return new Promise((resolve) => setTimeout(resolve, 20));
+      }
+      return realAccess(p, ...rest);
+    };
+
+    try {
+      const { unregistered, truncated } = await HANDLERS.listUnregistered({
+        dir: fakeDir, skipNames: [], budgetMs: 300
+      });
+      assert.ok(probed > 0, 'the fixture must actually reach the walk');
+      assert.equal(truncated, true, 'a walk that ran out of budget must say so');
+      assert.ok(unregistered.length > 0,
+        'what it DID find must still come back — a short list, not an empty one');
+      assert.ok(unregistered.length < 200, 'it cannot have walked every entry');
+    } finally {
+      fsp.access = realAccess;
+      fsp.readdir = realReaddir;
+    }
+  });
+});
+
+describe('dir-scanner child — createDir', () => {
+  test('creates one level and reports which of the three things happened', async () => {
+    const root = scratch('createdir');
+    const target = path.join(root, 'Projects');
+
+    const first = await HANDLERS.createDir({ dir: target });
+    assert.equal(first.status, 'created');
+    assert.ok(fs.existsSync(target));
+
+    // Two clicks on the same button, or a folder made in Finder while the screen
+    // was open, must both end well rather than reporting an error.
+    const second = await HANDLERS.createDir({ dir: target });
+    assert.equal(second.status, 'exists');
+
+    // Creating ONE level is "it wasn't there yet"; creating five is building a
+    // tree nobody asked for at a path nobody checked.
+    const deep = await HANDLERS.createDir({ dir: path.join(root, 'a', 'b') });
+    assert.equal(deep.status, 'parent-missing');
+    assert.equal(deep.parent, path.join(root, 'a'));
+    assert.ok(!fs.existsSync(path.join(root, 'a')));
+  });
+});

--- a/test/dir-scanner.test.js
+++ b/test/dir-scanner.test.js
@@ -184,6 +184,117 @@ describe('lib/dir-scanner — failures that are not hangs', () => {
     }
   });
 
+  test('a child that closed its channel is written off, not forked past', async () => {
+    const { EventEmitter } = require('node:events');
+    const made = [];
+    const forkFn = () => {
+      const fake = new EventEmitter();
+      fake.pid = 900000 + made.length;
+      fake.connected = true;
+      fake.channel = null;
+      fake.stderr = null;
+      fake.exitCode = null;
+      fake.signalCode = null;
+      fake.killed = false;
+      fake.unref = () => {};
+      fake.kill = () => { fake.killed = true; };
+      fake.send = () => true; // accepts the request and never answers it
+      made.push(fake);
+      return fake;
+    };
+
+    const scanner = dirScanner.createScanner({ forkFn, timeoutMs: 5000, exitGraceMs: 0 });
+    try {
+      const stranded = scanner.request('ping');
+
+      // Node does not guarantee `exit` precedes the channel close. This is the
+      // window: the child is unusable, but nothing has announced its death.
+      made[0].connected = false;
+
+      const successor = scanner.request('ping');
+      successor.catch(() => {}); // never answered either; shutdown settles it
+
+      const started = Date.now();
+      const err = await rejection(stranded);
+
+      // Left to the old behavior this request waited out its full deadline and
+      // was then labelled `tcTimedOut` — the Full Disk Access misdiagnosis this
+      // module exists to remove, on a path that was never even read.
+      assert.ok(err.tcAborted, 'stranded work should be abandoned, not timed out');
+      assert.ok(!err.tcTimedOut, 'a closed channel is not an unresponsive directory');
+      assert.ok(Date.now() - started < 3000, 'should fail immediately, not on the deadline');
+
+      // And the orphan must actually be killed: leaving it alive leaves the
+      // blocked thread this whole module exists to reclaim.
+      assert.ok(made[0].killed, 'the superseded child should have been killed');
+      assert.equal(made.length, 2, 'a replacement should have been forked');
+    } finally {
+      await scanner.shutdown();
+    }
+  });
+
+  test('a fork that emits an error fails the request rather than hanging it', async () => {
+    const { EventEmitter } = require('node:events');
+
+    // A fork can fail without ever producing a process — EMFILE, a spawn the OS
+    // refuses. The supervisor only learns via the `error` event, and if it did
+    // not translate that into a rejection the caller would wait out the full
+    // deadline and then be told the DIRECTORY was unresponsive.
+    const forkFn = () => {
+      const fake = new EventEmitter();
+      fake.pid = undefined;
+      fake.connected = true;
+      fake.channel = null;
+      fake.stderr = null;
+      fake.exitCode = null;
+      fake.signalCode = null;
+      fake.unref = () => {};
+      fake.kill = () => {};
+      fake.send = () => true;
+      setImmediate(() => fake.emit('error', new Error('spawn EMFILE')));
+      return fake;
+    };
+
+    const scanner = dirScanner.createScanner({ forkFn, timeoutMs: 4000 });
+    try {
+      const started = Date.now();
+      const err = await rejection(scanner.request('ping'));
+      assert.ok(err.tcAborted, 'a fork that failed is not an unresponsive path');
+      assert.ok(!err.tcTimedOut);
+      assert.ok(Date.now() - started < 3000, 'should fail on the error event, not the deadline');
+    } finally {
+      await scanner.shutdown();
+    }
+  });
+
+  test('a request whose send fails is rejected, not left outstanding', async () => {
+    const { EventEmitter } = require('node:events');
+
+    const forkFn = () => {
+      const fake = new EventEmitter();
+      fake.pid = 424242;
+      fake.connected = true;
+      fake.channel = null;
+      fake.stderr = null;
+      fake.exitCode = null;
+      fake.signalCode = null;
+      fake.unref = () => {};
+      fake.kill = () => {};
+      // The channel closed between the liveness check and the write.
+      fake.send = (_msg, cb) => { setImmediate(() => cb(new Error('channel closed'))); return false; };
+      return fake;
+    };
+
+    const scanner = dirScanner.createScanner({ forkFn, timeoutMs: 4000 });
+    try {
+      const err = await rejection(scanner.request('ping'));
+      assert.ok(err.tcAborted);
+      assert.match(err.message, /could not be reached/);
+    } finally {
+      await scanner.shutdown();
+    }
+  });
+
   test('a child that dies is replaced on the next request', async () => {
     const scanner = dirScanner.createScanner({ childPath: HANG_CHILD });
     try {

--- a/test/dir-scanner.test.js
+++ b/test/dir-scanner.test.js
@@ -114,6 +114,30 @@ describe('lib/dir-scanner — the healthy round trip', () => {
     assert.equal(scanner.childPid(), null);
   });
 
+  test('carries tcTruncated across the REAL hop, not just in principle', async () => {
+    // The one protocol field with no end-to-end coverage: both sides agreed by
+    // inspection, and the parent-side test synthesises the flag. Delete the
+    // rehydrate line for it and every other test stays green while the wizard
+    // silently loses its distinct "big folder, slow disk" sentence and starts
+    // telling operators to grant Full Disk Access instead.
+    const dir = scratch('truncate-hop');
+    for (let i = 0; i < 40; i++) fs.mkdirSync(path.join(dir, `proj-${i}`));
+
+    const scanner = dirScanner.createScanner();
+    try {
+      // A budget of 0 makes the walk give up at its first entry check, which is
+      // the truncation path, without depending on how fast the machine is.
+      const err = await rejection(
+        scanner.request('scanEntries', { dir, budgetMs: 0 }, { timeoutMs: 10000 })
+      );
+      assert.equal(err.tcTruncated, true, 'the flag must survive the process boundary');
+      assert.ok(!err.tcTimedOut, 'a walk that was being answered is not an unresponsive path');
+      assert.match(err.message, /checked \d+ of 40 subdirectories/);
+    } finally {
+      await scanner.shutdown();
+    }
+  });
+
   test('carries a real walk result back across the process boundary', async () => {
     const dir = scratch('walk');
     fs.mkdirSync(path.join(dir, 'a-project'));
@@ -790,15 +814,14 @@ describe('lib/dir-scanner — the threadpool leak (#883)', () => {
 });
 
 describe('lib/dir-scanner-child — serialisation helpers', () => {
-  test('_plainDirent flattens the methods IPC would drop', () => {
-    const dir = scratch('dirent');
-    fs.mkdirSync(path.join(dir, 'sub'));
-    const [entry] = fs.readdirSync(dir, { withFileTypes: true });
-
-    assert.deepEqual(_plainDirent(entry), {
-      name: 'sub', isDirectory: true, isFile: false, isSymbolicLink: false
-    });
-  });
+  // `_plainDirent` used to be tested here. It went with the `readdir` op in
+  // chunk 2 — no handler returns a `Dirent` any more, the walks consume them
+  // inside the child — and a unit test kept giving a dead function the look of a
+  // covered contract while `boundary-patterns.md` still listed it as a
+  // load-bearing property of the IPC surface. The property it described is real
+  // and still holds; it is now stated as "only plain data crosses" and enforced
+  // by the round-trip tests above, which assert real walk results arriving
+  // intact rather than a helper nothing calls.
 
   test('_plainError keeps the code, which callers branch on', () => {
     const err = Object.assign(new Error('nope'), { code: 'ENOENT' });

--- a/test/dir-scanner.test.js
+++ b/test/dir-scanner.test.js
@@ -8,7 +8,7 @@ const path = require('node:path');
 const { execFile, execFileSync } = require('node:child_process');
 
 const dirScanner = require('../lib/dir-scanner');
-const { _plainDirent, _plainError } = require('../lib/dir-scanner-child');
+const { _plainError } = require('../lib/dir-scanner-child');
 
 const HANG_CHILD = path.join(__dirname, '_dir-scanner-hang-child.js');
 const POOL_DEMO = path.join(__dirname, '_dir-scanner-pool-demo.js');
@@ -785,7 +785,7 @@ describe('lib/dir-scanner — the threadpool leak (#883)', () => {
     });
   }
 
-  test('the shipped in-process deadline DOES exhaust the pool — the defect, reproduced', async () => {
+  test('the in-process deadline that shipped before this branch DOES exhaust the pool', async () => {
     const verdict = await runDemo('leak', path.join(tmpRoot, 'demo-leak'));
 
     // Every call rejected on time. That is exactly what made this invisible:

--- a/test/dir-scanner.test.js
+++ b/test/dir-scanner.test.js
@@ -163,6 +163,27 @@ describe('lib/dir-scanner — failures that are not hangs', () => {
     }
   });
 
+  test('a child that cannot even start fails the request instead of hanging it', async () => {
+    const scanner = dirScanner.createScanner({
+      childPath: path.join(tmpRoot, 'no-such-child.js'),
+      timeoutMs: 4000
+    });
+    try {
+      // A broken install is the realistic cause. The request must come back on
+      // the child's exit — well inside the deadline — because a supervisor that
+      // let it run the full timeout would report a missing file as an
+      // unresponsive directory, and send the operator to grant Full Disk Access
+      // for it.
+      const started = Date.now();
+      const err = await rejection(scanner.request('ping'));
+      assert.ok(err.tcAborted, 'a child that never started is not a timed-out path');
+      assert.ok(!err.tcTimedOut);
+      assert.ok(Date.now() - started < 3000, 'should fail on exit, not on the deadline');
+    } finally {
+      await scanner.shutdown();
+    }
+  });
+
   test('a child that dies is replaced on the next request', async () => {
     const scanner = dirScanner.createScanner({ childPath: HANG_CHILD });
     try {

--- a/test/dir-scanner.test.js
+++ b/test/dir-scanner.test.js
@@ -441,6 +441,281 @@ describe('lib/dir-scanner — the deadline kills, it does not merely give up', (
   });
 });
 
+describe('lib/dir-scanner — the failure backoff (#883 chunk 3)', () => {
+  /**
+   * A fork stand-in whose children answer according to a script.
+   *
+   * Real children are not usable here: the questions are about how MANY child
+   * processes a sequence of requests costs, and about time, and a real fork adds
+   * tens of milliseconds of noise to both. Each script entry is `'hang'` (never
+   * reply — the case the backoff exists for), `{ok: value}`, or `{err: {...}}`;
+   * the script is consumed per child, and it repeats its last entry once
+   * exhausted so a test only has to state the part it cares about.
+   *
+   * @param {Array<'hang'|{ok?: any, err?: object}>} script - Behavior per child.
+   * @returns {Function} A `forkFn`, carrying `.made` — the children it created.
+   */
+  function scriptedForkFn(script) {
+    const made = [];
+    const fn = () => {
+      const index = made.length;
+      const fake = new (require('node:events').EventEmitter)();
+      fake.pid = 700000 + index;
+      fake.connected = true;
+      fake.channel = null;
+      fake.stderr = null;
+      fake.exitCode = null;
+      fake.signalCode = null;
+      fake.unref = () => {};
+      fake.kill = () => { fake.connected = false; };
+      fake.send = (msg) => {
+        const step = script[Math.min(index, script.length - 1)];
+        if (step === 'hang') return true;
+        setImmediate(() => fake.emit('message', step.err
+          ? { id: msg.id, ok: false, error: step.err }
+          : { id: msg.id, ok: true, value: step.ok }));
+        return true;
+      };
+      made.push(fake);
+      return fake;
+    };
+    fn.made = made;
+    return fn;
+  }
+
+  /**
+   * A scanner wired for fast, deterministic backoff tests.
+   * @param {Function} forkFn - From scriptedForkFn.
+   * @param {object} [over] - Option overrides.
+   * @returns {object} The scanner.
+   */
+  function backoffScanner(forkFn, over = {}) {
+    return dirScanner.createScanner({
+      forkFn, timeoutMs: 60, exitGraceMs: 0,
+      pathFailureTtlMs: 200, pathFailureMaxTtlMs: 800, ...over
+    });
+  }
+
+  const KEY = '/some/protected/dir';
+
+  test('a path that did not answer is refused without costing another process', async () => {
+    const forkFn = scriptedForkFn(['hang']);
+    const scanner = backoffScanner(forkFn);
+    try {
+      const first = await rejection(scanner.request('listUnregistered', {}, { pathKey: KEY }));
+      assert.ok(first.tcTimedOut);
+      assert.ok(!first.tcCached, 'the first failure is observed, not remembered');
+      assert.equal(forkFn.made.length, 1);
+
+      const started = Date.now();
+      const second = await rejection(scanner.request('listUnregistered', {}, { pathKey: KEY }));
+
+      // The whole point: no second child, and no five-second wait to find out.
+      assert.equal(forkFn.made.length, 1, 'a known-bad path must not cost another process');
+      assert.ok(Date.now() - started < 40, 'and must be refused promptly, not on the deadline');
+
+      // The CONDITION is unchanged, so the operator still gets the Full Disk
+      // Access remedy — `_scanFailureHint` keys on exactly this flag.
+      assert.ok(second.tcTimedOut, 'a remembered refusal is still an unresponsive path');
+      assert.ok(second.tcCached, 'but callers must be able to tell it cost nothing');
+    } finally {
+      await scanner.shutdown();
+    }
+  });
+
+  test('exactly one real attempt per backoff interval, however often it is asked', async () => {
+    const forkFn = scriptedForkFn(['hang']);
+    const scanner = backoffScanner(forkFn, { pathFailureTtlMs: 250 });
+    try {
+      for (let i = 0; i < 6; i++) {
+        await rejection(scanner.request('listUnregistered', {}, { pathKey: KEY }));
+      }
+      assert.equal(forkFn.made.length, 1, 'six requests inside one interval is one attempt');
+
+      await new Promise((r) => setTimeout(r, 300));
+      await rejection(scanner.request('listUnregistered', {}, { pathKey: KEY }));
+      assert.equal(forkFn.made.length, 2, 'and one more once the interval has passed');
+    } finally {
+      await scanner.shutdown();
+    }
+  });
+
+  test('concurrent requests during the retry do not each become a retry', async () => {
+    // The interval is shorter than the deadline here on purpose. A probe that is
+    // still outstanding when the next poll arrives would let a second process be
+    // forked if the door were only pushed shut after the probe returned.
+    const forkFn = scriptedForkFn(['hang']);
+    const scanner = backoffScanner(forkFn, { timeoutMs: 300, pathFailureTtlMs: 100 });
+    try {
+      await rejection(scanner.request('listUnregistered', {}, { pathKey: KEY }));
+      assert.equal(forkFn.made.length, 1);
+
+      await new Promise((r) => setTimeout(r, 150));
+      const probe = rejection(scanner.request('listUnregistered', {}, { pathKey: KEY }));
+      await new Promise((r) => setTimeout(r, 30));
+      const overlapping = await rejection(
+        scanner.request('listUnregistered', {}, { pathKey: KEY })
+      );
+
+      assert.ok(overlapping.tcCached, 'the overlapping request must be served from memory');
+      assert.equal(forkFn.made.length, 2, 'the in-flight probe is the only new process');
+      await probe;
+    } finally {
+      await scanner.shutdown();
+    }
+  });
+
+  test('a directory that starts working recovers with no restart', async () => {
+    // The first child hangs; the second answers. Nothing intervenes — no
+    // operator action inside the product, no process restart.
+    const forkFn = scriptedForkFn(['hang', { ok: { unregistered: [], truncated: false } }]);
+    const scanner = backoffScanner(forkFn, { pathFailureTtlMs: 120 });
+    try {
+      await rejection(scanner.request('listUnregistered', {}, { pathKey: KEY }));
+      await new Promise((r) => setTimeout(r, 160));
+
+      const recovered = await scanner.request('listUnregistered', {}, { pathKey: KEY });
+      assert.deepEqual(recovered, { unregistered: [], truncated: false });
+
+      // And the memory of the failure is gone, not merely expired: the very next
+      // request goes straight through rather than waiting out another interval.
+      const after = await scanner.request('listUnregistered', {}, { pathKey: KEY });
+      assert.deepEqual(after, { unregistered: [], truncated: false });
+    } finally {
+      await scanner.shutdown();
+    }
+  });
+
+  test('an ordinary error clears the memory too — the path ANSWERED', async () => {
+    // ENOENT is not a hang, it is a reply. Caching it would break the wizard
+    // outright: its Create button turns ENOENT into a directory, and the scan
+    // immediately afterwards has to see the folder that was just made.
+    const forkFn = scriptedForkFn(['hang', { err: { message: 'nope', code: 'ENOENT' } }]);
+    const scanner = backoffScanner(forkFn, { pathFailureTtlMs: 120 });
+    try {
+      await rejection(scanner.request('listUnregistered', {}, { pathKey: KEY }));
+      await new Promise((r) => setTimeout(r, 160));
+
+      const answered = await rejection(scanner.request('listUnregistered', {}, { pathKey: KEY }));
+      assert.equal(answered.code, 'ENOENT');
+
+      const next = await rejection(scanner.request('listUnregistered', {}, { pathKey: KEY }));
+      // Reaching the child is what matters, and these two prove it: a remembered
+      // refusal would carry `tcTimedOut` and `tcCached`, never an errno.
+      assert.equal(next.code, 'ENOENT', 'not a remembered timeout');
+      assert.ok(!next.tcCached, 'a path that replies is not a path being backed off');
+
+      // Two children, not three — and that is correct rather than a miss. Only
+      // the hung one was killed; the one that answered ENOENT is healthy, so the
+      // third request reuses it. That reuse is the long-lived child doing its
+      // job, and counting forks here would punish it.
+      assert.equal(forkFn.made.length, 2);
+    } finally {
+      await scanner.shutdown();
+    }
+  });
+
+  test('collateral does NOT mark a path as bad', async () => {
+    // The killed request's path may be perfectly healthy — it died because a
+    // SIBLING forced a kill. Recording that would let one bad directory blame a
+    // good one, which is the misdiagnosis this whole issue exists to remove.
+    const forkFn = scriptedForkFn(['hang']);
+    const scanner = backoffScanner(forkFn, { timeoutMs: 5000 });
+    try {
+      const doomed = rejection(scanner.request('a', {}, { pathKey: '/bad', timeoutMs: 60 }));
+      const bystander = rejection(scanner.request('b', {}, { pathKey: '/healthy' }));
+
+      assert.ok((await doomed).tcTimedOut);
+      const collateral = await bystander;
+      assert.ok(collateral.tcAborted, 'and it is reported as collateral, not as a timeout');
+
+      // The bystander's path must be untouched: the next request for it is a
+      // real attempt, not a remembered refusal.
+      const forksBefore = forkFn.made.length;
+      const retry = await rejection(
+        scanner.request('b', {}, { pathKey: '/healthy', timeoutMs: 60 })
+      );
+      assert.ok(!retry.tcCached, '/healthy must not have been marked bad by /bad\'s kill');
+      assert.ok(forkFn.made.length > forksBefore, 'it must really have been tried');
+    } finally {
+      await scanner.shutdown();
+    }
+  });
+
+  test('collateral does not ERASE an existing backoff either', async () => {
+    // The other direction of the same rule, and the one that actually costs
+    // something. A probe for an already-bad path can be killed by an unrelated
+    // path's deadline; if that abort were read as "this path is fine now", the
+    // backoff would be dropped and the next poll would fork again — the rate
+    // bound quietly gone, with nothing failing to show it.
+    const forkFn = scriptedForkFn(['hang']);
+    const scanner = backoffScanner(forkFn, { pathFailureTtlMs: 200 });
+    try {
+      await rejection(scanner.request('b', {}, { pathKey: '/b', timeoutMs: 60 }));
+      await new Promise((r) => setTimeout(r, 250));
+
+      // /b's retry goes out, then /a's deadline kills the child under it.
+      const probe = rejection(scanner.request('b', {}, { pathKey: '/b', timeoutMs: 5000 }));
+      const doomed = rejection(scanner.request('a', {}, { pathKey: '/a', timeoutMs: 60 }));
+      assert.ok((await doomed).tcTimedOut);
+      assert.ok((await probe).tcAborted, 'the retry must have died as collateral');
+
+      const after = await rejection(scanner.request('b', {}, { pathKey: '/b' }));
+      assert.ok(after.tcCached,
+        '/b must still be backed off — an abort is not evidence that it recovered');
+    } finally {
+      await scanner.shutdown();
+    }
+  });
+
+  test('the backoff escalates, and the escalation is visible', async () => {
+    const forkFn = scriptedForkFn(['hang']);
+    const scanner = backoffScanner(forkFn, { pathFailureTtlMs: 100, pathFailureMaxTtlMs: 100 });
+    try {
+      await rejection(scanner.request('listUnregistered', {}, { pathKey: KEY }));
+      const firstRefusal = await rejection(
+        scanner.request('listUnregistered', {}, { pathKey: KEY })
+      );
+      assert.match(firstRefusal.message, /the last 1 time\(s\)/);
+
+      await new Promise((r) => setTimeout(r, 140));
+      await rejection(scanner.request('listUnregistered', {}, { pathKey: KEY }));
+      const secondRefusal = await rejection(
+        scanner.request('listUnregistered', {}, { pathKey: KEY })
+      );
+      // The count rises, which is what makes a persistent failure legible in the
+      // log as a trend rather than as a repeated incident.
+      assert.match(secondRefusal.message, /the last 2 time\(s\)/);
+
+      // Capped: with max == ttl, the third interval is still ~100ms rather than
+      // having doubled to 400. Without a ceiling, a directory fixed after a few
+      // failures would stay unnoticed for an unbounded time.
+      await new Promise((r) => setTimeout(r, 140));
+      const forksBefore = forkFn.made.length;
+      await rejection(scanner.request('listUnregistered', {}, { pathKey: KEY }));
+      assert.ok(forkFn.made.length > forksBefore,
+        'the backoff must not have grown past its ceiling');
+    } finally {
+      await scanner.shutdown();
+    }
+  });
+
+  test('without a pathKey nothing is remembered — the backoff is opt-in', async () => {
+    // A generic supervisor silently declining to do what it was asked would be a
+    // bad surprise. Only a caller that says "a repeat of this is not worth a
+    // second process" gets short-circuited.
+    const forkFn = scriptedForkFn(['hang']);
+    const scanner = backoffScanner(forkFn);
+    try {
+      await rejection(scanner.request('listUnregistered', { dir: KEY }));
+      await rejection(scanner.request('listUnregistered', { dir: KEY }));
+      assert.equal(forkFn.made.length, 2, 'both were really attempted');
+    } finally {
+      await scanner.shutdown();
+    }
+  });
+});
+
 describe('lib/dir-scanner — the threadpool leak (#883)', () => {
   /**
    * Run the pool demo in one mode and read its verdict.

--- a/test/dir-scanner.test.js
+++ b/test/dir-scanner.test.js
@@ -114,23 +114,24 @@ describe('lib/dir-scanner — the healthy round trip', () => {
     assert.equal(scanner.childPid(), null);
   });
 
-  test('reads a directory and reports which entries are directories', async () => {
-    const dir = scratch('readdir');
+  test('carries a real walk result back across the process boundary', async () => {
+    const dir = scratch('walk');
     fs.mkdirSync(path.join(dir, 'a-project'));
     fs.writeFileSync(path.join(dir, 'a-file.txt'), 'x');
 
     const scanner = dirScanner.createScanner();
     try {
-      const { entries } = await scanner.request('readdir', { dir });
-      const byName = Object.fromEntries(entries.map((e) => [e.name, e]));
+      const { unregistered, truncated } = await scanner.request(
+        'listUnregistered', { dir, skipNames: [], budgetMs: 4000 }
+      );
 
-      assert.deepEqual(Object.keys(byName).sort(), ['a-file.txt', 'a-project']);
-      // Flattened booleans, not Dirent methods: a method does not survive the
-      // IPC hop, and a caller reading `entry.isDirectory` on the far side would
-      // get `undefined` and silently classify every entry as a file.
-      assert.equal(byName['a-project'].isDirectory, true);
-      assert.equal(byName['a-file.txt'].isDirectory, false);
-      assert.equal(byName['a-file.txt'].isFile, true);
+      // The walk's own behavior is pinned in test/dir-scanner-child.test.js.
+      // What THIS asserts is that a structured result survives the hop intact —
+      // the file excluded, the directory kept, the fields populated.
+      assert.deepEqual(unregistered.map(u => u.name), ['a-project']);
+      assert.equal(truncated, false);
+      assert.equal(unregistered[0].path, path.join(dir, 'a-project'));
+      assert.equal(unregistered[0].registered, false);
     } finally {
       await scanner.shutdown();
     }
@@ -142,7 +143,8 @@ describe('lib/dir-scanner — failures that are not hangs', () => {
     const scanner = dirScanner.createScanner();
     try {
       const err = await rejection(
-        scanner.request('readdir', { dir: path.join(tmpRoot, 'does-not-exist') })
+        scanner.request('scanEntries',
+          { dir: path.join(tmpRoot, 'does-not-exist'), budgetMs: 4000 })
       );
       // The wizard offers to CREATE a directory on ENOENT. If the condition did
       // not survive IPC as a value, that button would depend on matching prose.
@@ -404,6 +406,27 @@ describe('lib/dir-scanner — the deadline kills, it does not merely give up', (
     }
   });
 
+  test('an idle scanner does not hold the process open', async () => {
+    // Every stdio handle has to be unref'd, not just the child and the IPC
+    // channel: a piped stderr is a socket, and a socket with a `data` listener
+    // keeps the event loop alive by itself. When that was missed, every process
+    // that forked a scanner and did not explicitly shut it down simply never
+    // exited — the work finished, the assertions passed, and the runner hung
+    // afterwards with nothing failing to point at. A whole test file was lost to
+    // it before the cause was found, which is why this is pinned in a real
+    // process rather than by inspecting handles.
+    const script = `
+      const s = require(${JSON.stringify(path.join(__dirname, '..', 'lib', 'dir-scanner'))});
+      s.request('ping').then(() => {});
+    `;
+    const exited = await new Promise((resolve) => {
+      const child = execFile(process.execPath, ['-e', script], { timeout: 15000 },
+        (err) => resolve(!err));
+      child.on('error', () => resolve(false));
+    });
+    assert.ok(exited, 'a process that used the scanner and never shut it down must still exit');
+  });
+
   test('shutdown kills the child and refuses further work', async () => {
     const scanner = dirScanner.createScanner();
     await scanner.request('ping');
@@ -504,10 +527,25 @@ describe('lib/dir-scanner-child — serialisation helpers', () => {
 
   test('_plainError keeps the code, which callers branch on', () => {
     const err = Object.assign(new Error('nope'), { code: 'ENOENT' });
-    assert.deepEqual(_plainError(err), { message: 'nope', code: 'ENOENT' });
+    assert.deepEqual(_plainError(err),
+      { message: 'nope', code: 'ENOENT', tcTruncated: undefined });
+  });
+
+  test('_plainError carries tcTruncated but never lets the child claim tcTimedOut', () => {
+    // The distinction is the difference between "your folder is big and your
+    // disk is slow" and "grant Full Disk Access". A walk that ran out of budget
+    // may say the first; only the supervisor's own deadline may say the second,
+    // so a child that sets `tcTimedOut` must not be believed.
+    const truncated = Object.assign(new Error('gave up'), { tcTruncated: true });
+    assert.equal(_plainError(truncated).tcTruncated, true);
+
+    const impostor = Object.assign(new Error('not yours to declare'), { tcTimedOut: true });
+    assert.equal(_plainError(impostor).tcTimedOut, undefined,
+      'only the supervisor may declare a path unresponsive');
   });
 
   test('_plainError survives something that is not an Error', () => {
-    assert.deepEqual(_plainError('just a string'), { message: 'just a string', code: undefined });
+    assert.deepEqual(_plainError('just a string'),
+      { message: 'just a string', code: undefined, tcTruncated: undefined });
   });
 });

--- a/test/dir-scanner.test.js
+++ b/test/dir-scanner.test.js
@@ -1,0 +1,381 @@
+'use strict';
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFile, execFileSync } = require('node:child_process');
+
+const dirScanner = require('../lib/dir-scanner');
+const { _plainDirent, _plainError } = require('../lib/dir-scanner-child');
+
+const HANG_CHILD = path.join(__dirname, '_dir-scanner-hang-child.js');
+const POOL_DEMO = path.join(__dirname, '_dir-scanner-pool-demo.js');
+
+let tmpRoot;
+
+before(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-dir-scanner-'));
+});
+
+after(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+/**
+ * A fresh scratch directory, so no test can see another's entries.
+ * @param {string} name - Distinguishing name.
+ * @returns {string} Absolute path.
+ */
+function scratch(name) {
+  const p = path.join(tmpRoot, name);
+  fs.mkdirSync(p, { recursive: true });
+  return p;
+}
+
+/**
+ * Is a process still in the process table?
+ *
+ * Signal 0 performs the permission and existence checks without delivering
+ * anything — the standard way to ask "is this pid alive" without disturbing it.
+ *
+ * @param {number} pid - Process to test.
+ * @returns {boolean}
+ */
+function alive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return err.code !== 'ESRCH';
+  }
+}
+
+/**
+ * Wait for a pid to leave the process table.
+ *
+ * Polled rather than awaited on an event: the pid belongs to a process this test
+ * did not spawn directly, so there is no exit event to listen for — only the
+ * table to ask.
+ *
+ * @param {number} pid - Process expected to die.
+ * @param {number} [timeoutMs] - How long to allow.
+ * @returns {Promise<boolean>} Whether it died in time.
+ */
+async function waitForDeath(pid, timeoutMs = 5000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!alive(pid)) return true;
+    await new Promise((res) => setTimeout(res, 20));
+  }
+  return !alive(pid);
+}
+
+/**
+ * Assert a promise rejects, and hand back the error for inspection.
+ *
+ * `assert.rejects` checks the shape but does not return the error, and every
+ * rejection in this module carries flags (`tcTimedOut`, `tcAborted`) that the
+ * assertions are actually about.
+ *
+ * @param {Promise<any>} promise - Work expected to fail.
+ * @returns {Promise<Error>}
+ */
+async function rejection(promise) {
+  try {
+    await promise;
+  } catch (err) {
+    return err;
+  }
+  assert.fail('expected the request to reject, but it resolved');
+}
+
+describe('lib/dir-scanner — the healthy round trip', () => {
+  test('answers, and reuses ONE child across requests', async () => {
+    const scanner = dirScanner.createScanner();
+    try {
+      const first = await scanner.request('ping');
+      const second = await scanner.request('ping');
+
+      assert.equal(typeof first.pid, 'number');
+      // The point of a supervised long-lived child: the dashboard polls this
+      // route every ten seconds, and forking a node process per poll would be a
+      // permanent cost paid to guard a failure almost no install hits.
+      assert.equal(second.pid, first.pid, 'consecutive requests should share one child');
+      assert.equal(scanner.childPid(), first.pid);
+    } finally {
+      await scanner.shutdown();
+    }
+  });
+
+  test('does not fork a child until the first request', () => {
+    const scanner = dirScanner.createScanner();
+    assert.equal(scanner.childPid(), null);
+  });
+
+  test('reads a directory and reports which entries are directories', async () => {
+    const dir = scratch('readdir');
+    fs.mkdirSync(path.join(dir, 'a-project'));
+    fs.writeFileSync(path.join(dir, 'a-file.txt'), 'x');
+
+    const scanner = dirScanner.createScanner();
+    try {
+      const { entries } = await scanner.request('readdir', { dir });
+      const byName = Object.fromEntries(entries.map((e) => [e.name, e]));
+
+      assert.deepEqual(Object.keys(byName).sort(), ['a-file.txt', 'a-project']);
+      // Flattened booleans, not Dirent methods: a method does not survive the
+      // IPC hop, and a caller reading `entry.isDirectory` on the far side would
+      // get `undefined` and silently classify every entry as a file.
+      assert.equal(byName['a-project'].isDirectory, true);
+      assert.equal(byName['a-file.txt'].isDirectory, false);
+      assert.equal(byName['a-file.txt'].isFile, true);
+    } finally {
+      await scanner.shutdown();
+    }
+  });
+});
+
+describe('lib/dir-scanner — failures that are not hangs', () => {
+  test('preserves the error code across the process boundary', async () => {
+    const scanner = dirScanner.createScanner();
+    try {
+      const err = await rejection(
+        scanner.request('readdir', { dir: path.join(tmpRoot, 'does-not-exist') })
+      );
+      // The wizard offers to CREATE a directory on ENOENT. If the condition did
+      // not survive IPC as a value, that button would depend on matching prose.
+      assert.equal(err.code, 'ENOENT');
+      assert.ok(!err.tcTimedOut, 'a missing directory is not an unresponsive one');
+    } finally {
+      await scanner.shutdown();
+    }
+  });
+
+  test('refuses an unknown operation instead of hanging on it', async () => {
+    const scanner = dirScanner.createScanner();
+    try {
+      const err = await rejection(scanner.request('rmdir-everything'));
+      assert.equal(err.code, 'ENOSYS');
+    } finally {
+      await scanner.shutdown();
+    }
+  });
+
+  test('a child that dies is replaced on the next request', async () => {
+    const scanner = dirScanner.createScanner({ childPath: HANG_CHILD });
+    try {
+      const before = await scanner.request('ping');
+      await rejection(scanner.request('crash'));
+
+      const after = await scanner.request('ping');
+      // A supervisor that gave up once would turn a single crash into a
+      // permanently broken route.
+      assert.notEqual(after.pid, before.pid, 'a replacement child should have been forked');
+      assert.ok(!alive(before.pid), 'the crashed child should be gone');
+    } finally {
+      await scanner.shutdown();
+    }
+  });
+});
+
+describe('lib/dir-scanner — the deadline kills, it does not merely give up', () => {
+  test('a request that never answers rejects as timed out AND kills the child', async () => {
+    const fifoDir = scratch('deadline');
+    const fifo = path.join(fifoDir, 'pipe');
+    execFileSync('mkfifo', [fifo]);
+
+    const scanner = dirScanner.createScanner({
+      childPath: HANG_CHILD,
+      timeoutMs: 300,
+      exitGraceMs: 0
+    });
+    try {
+      await scanner.request('ping');
+      const pid = scanner.childPid();
+      assert.ok(pid, 'a child should be running before the hang');
+
+      const err = await rejection(scanner.request('hang', { fifo }, { what: `reading ${fifo}` }));
+
+      // `tcTimedOut` is what earns the Full Disk Access hint. It belongs to the
+      // request whose own deadline expired and to nothing else.
+      assert.ok(err.tcTimedOut, 'the hung request should be reported as unresponsive');
+      assert.match(err.message, /reading /);
+
+      // The whole reason this module exists. Abandoning the promise would leave
+      // the blocked thread in place; only the death of the process that owns it
+      // returns the resource.
+      assert.ok(await waitForDeath(pid), 'the hung child should have been killed');
+      assert.equal(scanner.childPid(), null);
+    } finally {
+      await scanner.shutdown();
+    }
+  });
+
+  test('collateral requests are abandoned, NOT reported as timed out', async () => {
+    const fifoDir = scratch('collateral');
+    const slow = path.join(fifoDir, 'slow');
+    const healthy = path.join(fifoDir, 'healthy');
+    execFileSync('mkfifo', [slow]);
+    execFileSync('mkfifo', [healthy]);
+
+    const scanner = dirScanner.createScanner({
+      childPath: HANG_CHILD,
+      timeoutMs: 400,
+      exitGraceMs: 0
+    });
+    try {
+      // Both hang, but the first one's deadline expires first, and its kill is
+      // what ends the second.
+      const first = scanner.request('hang', { fifo: slow }, { timeoutMs: 300 });
+      const second = scanner.request('hang', { fifo: healthy }, { timeoutMs: 5000 });
+
+      const firstErr = await rejection(first);
+      const secondErr = await rejection(second);
+
+      assert.ok(firstErr.tcTimedOut, 'the request that owned the deadline timed out');
+      // This distinction is the point. The second request's path may be
+      // perfectly healthy — it died because a sibling forced a kill. Calling it
+      // timed out would resurrect exactly the misdiagnosis this change removes:
+      // the operator sent to grant Full Disk Access for a directory that was
+      // never protected.
+      assert.ok(secondErr.tcAborted, 'collateral work should be reported as abandoned');
+      assert.ok(!secondErr.tcTimedOut, 'collateral work must NOT claim the path was unresponsive');
+    } finally {
+      await scanner.shutdown();
+    }
+  });
+
+  test('a kill does not take the NEXT request down with it', async () => {
+    const fifoDir = scratch('successor');
+    const fifo = path.join(fifoDir, 'pipe');
+    execFileSync('mkfifo', [fifo]);
+
+    const scanner = dirScanner.createScanner({
+      childPath: HANG_CHILD,
+      timeoutMs: 300,
+      exitGraceMs: 0
+    });
+    try {
+      await rejection(scanner.request('hang', { fifo }));
+
+      // The killed child's `exit` event lands while this request is still in
+      // flight on its replacement — forking a node process takes longer than
+      // reaping a SIGKILLed one. A supervisor that failed everything pending on
+      // any child's exit, rather than only the current child's, would reject
+      // this healthy request and read as a flaky scanner.
+      const reply = await scanner.request('ping');
+      assert.equal(typeof reply.pid, 'number');
+    } finally {
+      await scanner.shutdown();
+    }
+  });
+
+  test('shutdown kills the child and refuses further work', async () => {
+    const scanner = dirScanner.createScanner();
+    await scanner.request('ping');
+    const pid = scanner.childPid();
+
+    await scanner.shutdown();
+
+    assert.ok(await waitForDeath(pid), 'shutdown should leave no child behind');
+    assert.equal(scanner.childPid(), null);
+    const err = await rejection(scanner.request('ping'));
+    assert.ok(err.tcAborted);
+  });
+});
+
+describe('lib/dir-scanner — the threadpool leak (#883)', () => {
+  /**
+   * Run the pool demo in one mode and read its verdict.
+   *
+   * SIGKILLed rather than awaited: in `leak` mode the demo has destroyed its own
+   * threadpool by design, and a process with threads blocked in the kernel does
+   * not finish exiting — `process.exit(0)` returns to a runtime that cannot
+   * tear libuv down. Measured, not assumed; it is the same property that makes
+   * the bug permanent in the server.
+   *
+   * @param {string} mode - `leak` or `scanner`.
+   * @param {string} fifoDir - Scratch directory for the FIFOs.
+   * @returns {Promise<{mode: string, rejections: number, readdirMs: number|null, readdirStuck: boolean}>}
+   */
+  function runDemo(mode, fifoDir) {
+    return new Promise((resolve, reject) => {
+      const child = execFile(
+        process.execPath,
+        [POOL_DEMO, mode, fifoDir],
+        // A deliberately tiny pool, so the cliff is crossed in three calls
+        // rather than five and the test stays fast. The demo reads the size
+        // from here rather than hard-coding one.
+        { env: { ...process.env, UV_THREADPOOL_SIZE: '2' }, timeout: 30000 },
+        () => {}
+      );
+
+      let out = '';
+      child.stdout.on('data', (chunk) => {
+        out += chunk;
+        const line = out.split('\n').find((l) => l.trim().startsWith('{'));
+        if (!line) return;
+        child.kill('SIGKILL');
+        try {
+          resolve(JSON.parse(line));
+        } catch (err) {
+          reject(err);
+        }
+      });
+      child.on('error', reject);
+      child.on('exit', () => {
+        if (!out.includes('{')) reject(new Error(`demo produced no verdict: ${out}`));
+      });
+    });
+  }
+
+  test('the shipped in-process deadline DOES exhaust the pool — the defect, reproduced', async () => {
+    const verdict = await runDemo('leak', path.join(tmpRoot, 'demo-leak'));
+
+    // Every call rejected on time. That is exactly what made this invisible:
+    // `_withTimeout` did its job, the request was answered, and the resource was
+    // gone anyway.
+    assert.equal(verdict.rejections, 3, 'all three bounded calls should have rejected on time');
+
+    // And yet an ordinary directory read, on a path that has nothing to do with
+    // the blocked ones, never completes again for the life of the process. This
+    // is the assertion that must fail if the leak is ever really fixed
+    // in-process; it passes today because abandoning a promise does not cancel
+    // a syscall.
+    assert.equal(verdict.readdirStuck, true,
+      'an unrelated readdir should be permanently stuck once the pool is gone');
+  });
+
+  test('the same workload through the scanner leaves this process untouched', async () => {
+    const verdict = await runDemo('scanner', path.join(tmpRoot, 'demo-scanner'));
+
+    assert.equal(verdict.rejections, 3, 'all three hung scans should have been reported');
+    assert.equal(verdict.readdirStuck, false,
+      'the parent threadpool should survive more hung scans than it has threads');
+    assert.ok(verdict.readdirMs < 1000,
+      `an ordinary readdir should still be prompt, took ${verdict.readdirMs}ms`);
+  });
+});
+
+describe('lib/dir-scanner-child — serialisation helpers', () => {
+  test('_plainDirent flattens the methods IPC would drop', () => {
+    const dir = scratch('dirent');
+    fs.mkdirSync(path.join(dir, 'sub'));
+    const [entry] = fs.readdirSync(dir, { withFileTypes: true });
+
+    assert.deepEqual(_plainDirent(entry), {
+      name: 'sub', isDirectory: true, isFile: false, isSymbolicLink: false
+    });
+  });
+
+  test('_plainError keeps the code, which callers branch on', () => {
+    const err = Object.assign(new Error('nope'), { code: 'ENOENT' });
+    assert.deepEqual(_plainError(err), { message: 'nope', code: 'ENOENT' });
+  });
+
+  test('_plainError survives something that is not an Error', () => {
+    assert.deepEqual(_plainError('just a string'), { message: 'just a string', code: undefined });
+  });
+});

--- a/test/projects.test.js
+++ b/test/projects.test.js
@@ -1182,12 +1182,15 @@ describe('projects', () => {
      * @returns {Promise<any>}
      */
     async function withScanner(fakeRequest, fn) {
-      const real = dirScanner.request;
-      dirScanner.request = fakeRequest;
+      // `interactiveRequest`, not `request`: this route runs on the scanner
+      // reserved for work an operator pressed a button for, so that a hung
+      // background poll cannot kill the child out from under it.
+      const real = dirScanner.interactiveRequest;
+      dirScanner.interactiveRequest = fakeRequest;
       try {
         return await fn();
       } finally {
-        dirScanner.request = real;
+        dirScanner.interactiveRequest = real;
       }
     }
 
@@ -1247,6 +1250,42 @@ describe('projects', () => {
       assert.ok(seen, 'the fixture must actually reach the scanner');
       assert.ok(seen.payload.budgetMs < seen.opts.timeoutMs,
         'the child must give up before the supervisor kills it, so a slow walk can report');
+    });
+
+    it('uses a scanner the background poll cannot kill underneath it', async () => {
+      // One shared child made every caller collateral for every other: a hung
+      // ten-second poll of the projects directory times out, the supervisor kills
+      // the child to reclaim its thread, and an operator's scan of a completely
+      // HEALTHY folder dies alongside it. Patching only the background entry
+      // point proves the separation — if this route still used it, the stub would
+      // be reached and the scan would fail.
+      const realBackground = dirScanner.request;
+      dirScanner.request = () => Promise.reject(new Error('the poll must not be consulted here'));
+      try {
+        const result = await projects.scanDirectoryForProjects(projectsDir);
+        assert.equal(result.ok, true, 'the wizard scan must be independent of the polled route');
+      } finally {
+        dirScanner.request = realBackground;
+      }
+    });
+
+    it('reports an interrupted scan as interrupted, never as a bad directory', async () => {
+      // Collateral says NOTHING about the folder the operator chose. Reporting it
+      // through the Full Disk Access hint would tell someone to change a system
+      // permission because an unrelated directory hung — the misdiagnosis this
+      // whole issue exists to remove, arriving by another door.
+      const result = await withScanner(
+        () => Promise.reject(Object.assign(
+          new Error('directory scan abandoned: the scanner process was killed'),
+          { tcAborted: true }
+        )),
+        () => projects.scanDirectoryForProjects(projectsDir)
+      );
+      assert.equal(result.ok, false);
+      assert.equal(result.code, 'SCAN_INTERRUPTED', 'its own code, not SCAN_FAILED');
+      assert.doesNotMatch(result.error, /Full Disk Access/,
+        'a folder that was never read must not be blamed');
+      assert.match(result.error, /try again/, 'and the operator must be told what to do');
     });
 
     it('does NOT opt an operator-pressed button into the failure backoff', async () => {

--- a/test/projects.test.js
+++ b/test/projects.test.js
@@ -817,51 +817,71 @@ describe('projects', () => {
   // launchd still reporting the process alive. The dashboard loads this route, so
   // it was the first thing a new operator hit.
   describe('listAllProjects — a directory that never answers must not take the server down (#859)', () => {
-    const fsp2 = require('node:fs').promises;
+    const dirScanner = require('../lib/dir-scanner');
 
-    it('returns the registered projects instead of hanging forever', async () => {
-      // Simulate the real failure precisely: readdir that never settles. A
-      // rejecting stub would NOT reproduce it — the bug is a call that neither
-      // resolves nor rejects, which is why it was invisible to every error path.
-      const realReaddir = fsp2.readdir;
-      fsp2.readdir = () => new Promise(() => {});
+    /**
+     * Run `fn` with the scanner replaced, then restore it.
+     *
+     * The hang used to be injected by stubbing `fsp.readdir` in this process.
+     * Since #883 the walk happens in a child process, where a stub in this one
+     * cannot reach it — so the seam moved to the scanner call itself. What is
+     * being pinned here is unchanged: how `listAllProjects` DEGRADES when the
+     * scan does not come back. Whether the scanner really kills a hung child is
+     * `test/dir-scanner.test.js`'s job, and it is asserted against a genuinely
+     * blocked syscall there rather than a stub.
+     *
+     * @param {Function} fakeRequest - Stand-in for dirScanner.request.
+     * @param {Function} fn - Test body.
+     * @returns {Promise<any>}
+     */
+    async function withScanner(fakeRequest, fn) {
+      const real = dirScanner.request;
+      dirScanner.request = fakeRequest;
       try {
-        const started = Date.now();
-        const list = await projects.listAllProjects();
-        const elapsed = Date.now() - started;
-        assert.ok(Array.isArray(list), 'must still answer with a list');
-        // Bounded tightly against the 5s deadline. A loose ceiling would pass
-        // even if the deadline stopped working and something else happened to
-        // end the wait.
-        assert.ok(elapsed >= 4500 && elapsed < 9000,
-          `must answer at the deadline, not before or long after (took ${elapsed}ms)`);
-        // Registered projects come from the database and are unaffected by a
-        // stuck filesystem; only discovery of unregistered folders is lost.
-        for (const p of list) {
-          assert.equal(p.registered, true, 'a degraded scan may only return registered projects');
-        }
+        return await fn();
       } finally {
-        fsp2.readdir = realReaddir;
+        dirScanner.request = real;
+      }
+    }
+
+    /**
+     * The rejection a scan produces when the path never answered.
+     * @returns {Error}
+     */
+    function timedOut() {
+      return Object.assign(new Error('timed out after 5000ms reading /nowhere'),
+        { tcTimedOut: true });
+    }
+
+    it('returns the registered projects instead of failing the request', async () => {
+      const list = await withScanner(
+        () => Promise.reject(timedOut()),
+        () => projects.listAllProjects()
+      );
+      assert.ok(Array.isArray(list), 'must still answer with a list');
+      // Registered projects come from the database and are unaffected by a
+      // stuck filesystem; only discovery of unregistered folders is lost.
+      assert.ok(list.length > 0, 'the fixture must actually have registered projects to degrade to');
+      for (const p of list) {
+        assert.equal(p.registered, true, 'a degraded scan may only return registered projects');
       }
     });
 
-    it('marks a deadline failure so the caller can name Full Disk Access', async () => {
-      // The hint is the whole operator-facing value of the degradation: without
-      // it the dashboard just shows fewer projects and nobody learns why. It is
-      // keyed on `tcTimedOut`, which distinguishes "this path never answered"
-      // from an ordinary filesystem error — so THAT is what gets pinned, on the
-      // real helper rather than on a mock. Delete the flag and this goes red.
-      const started = Date.now();
-      await assert.rejects(
-        () => projects._withTimeout(new Promise(() => {}), 60, 'reading /nowhere'),
-        (err) => {
-          assert.equal(err.tcTimedOut, true,
-            'a timeout must be distinguishable from a filesystem error');
-          assert.match(err.message, /timed out after 60ms reading \/nowhere/);
-          return true;
-        }
+    it('gives the scan a deadline SHORTER than the walk it asks for', async () => {
+      // The two bounds are not redundant and their order is the whole point: the
+      // child stops itself first and hands back what it found, leaving the
+      // supervisor's kill as the backstop for a walk that never returns at all.
+      // Equal values let the kill win the tie, which throws away a partial answer
+      // and reports a responsive directory as unresponsive.
+      let seen;
+      await withScanner(
+        (op, payload, opts) => { seen = { payload, opts }; return Promise.reject(timedOut()); },
+        () => projects.listAllProjects()
       );
-      assert.ok(Date.now() - started >= 55, 'must actually wait for the deadline');
+      assert.ok(seen, 'the fixture must actually reach the scanner');
+      assert.ok(seen.payload.budgetMs < seen.opts.timeoutMs,
+        `the walk budget (${seen.payload.budgetMs}ms) must be under the request deadline `
+        + `(${seen.opts.timeoutMs}ms)`);
     });
 
     it('names Full Disk Access and the safe directories when the path never answered', () => {
@@ -899,15 +919,16 @@ describe('projects', () => {
       const prevLevel = logger.getLevel();
       logger.setLevel('warn');
       logger.setConsoleStream({ write: (c) => { chunks.push(String(c)); return true; } });
-      const fsp4 = require('node:fs').promises;
-      const realReaddir = fsp4.readdir;
-      fsp4.readdir = () => Promise.reject(Object.assign(new Error('timed out'), { tcTimedOut: true }));
+      const real = dirScanner.request;
+      dirScanner.request = () => Promise.reject(
+        Object.assign(new Error('timed out'), { tcTimedOut: true })
+      );
       return projects.listAllProjects().then(() => {
         const out = chunks.join('');
         assert.match(out, /Full Disk Access/,
           'the remedy must reach the log, not just exist in a helper');
       }).finally(() => {
-        fsp4.readdir = realReaddir;
+        dirScanner.request = real;
         logger.setConsoleStream(null);
         logger.setLevel(prevLevel);
       });
@@ -921,18 +942,20 @@ describe('projects', () => {
       assert.equal(projects._scanFailureHint(null), undefined);
     });
 
-    it('resolves normally when the work beats the deadline', async () => {
-      assert.equal(await projects._withTimeout(Promise.resolve('ok'), 5000, 'x'), 'ok');
-    });
+    // `_withTimeout`'s own two unit tests (the deadline fires and carries
+    // `tcTimedOut`; it resolves when the work wins) are gone with the helper.
+    // #883 moved every operator-path read into the scanner child, leaving the
+    // helper with no production caller, and keeping dead code alive to be a
+    // fixture misrepresents the module. Both contracts are asserted against the
+    // code that now owns them, in test/dir-scanner.test.js — and against a real
+    // blocked syscall rather than a never-settling stub.
 
     it('still answers when the directory read fails outright', async () => {
-      const realReaddir = fsp2.readdir;
-      fsp2.readdir = () => Promise.reject(Object.assign(new Error('boom'), { code: 'EACCES' }));
-      try {
-        assert.ok(Array.isArray(await projects.listAllProjects()));
-      } finally {
-        fsp2.readdir = realReaddir;
-      }
+      const list = await withScanner(
+        () => Promise.reject(Object.assign(new Error('boom'), { code: 'EACCES' })),
+        () => projects.listAllProjects()
+      );
+      assert.ok(Array.isArray(list));
     });
 
     it('keeps the directories it found when the walk runs out of time', async () => {
@@ -944,44 +967,57 @@ describe('projects', () => {
       // per directory, cached two minutes) — so a cold-cache load over a few
       // dozen unregistered folders would show NONE of them, with a log line as
       // the only trace. A discovery walk that ran out of budget still
-      // discovered what it got to. Mutation: throw instead of breaking, and
-      // unregistered.length goes to zero.
-      const realReaddir = fsp2.readdir;
-      const realAccess = fsp2.access;
-      const dir = projects.resolveProjectsDir(store.config.load().projectsDir);
-      const ENTRY_COUNT = 200;
-      const dirents = Array.from({ length: ENTRY_COUNT }, (_, i) => ({
-        name: `slow-proj-${i}`, isDirectory: () => true
-      }));
+      // discovered what it got to.
+      //
+      // The walk now truncates inside the scanner child, so THAT half is pinned
+      // in test/dir-scanner-child.test.js. What remains this file's job — and it
+      // is the half that regressed before — is that `listAllProjects` RENDERS a
+      // truncated result instead of treating it as a failure. Mutation: make the
+      // truncated branch degrade to the registered list and `found` goes to zero.
+      const partial = [
+        { id: null, name: 'walked-1', path: '/x/walked-1', registered: false, git: null },
+        { id: null, name: 'walked-2', path: '/x/walked-2', registered: false, git: null }
+      ];
+      const all = await withScanner(
+        () => Promise.resolve({ unregistered: partial, truncated: true }),
+        () => projects.listAllProjects()
+      );
+      const found = all.filter(p => p.registered === false);
+      assert.deepEqual(found.map(p => p.name).sort(), ['walked-1', 'walked-2'],
+        'the directories walked before the deadline must survive, not be discarded');
+    });
 
-      fsp2.readdir = (p, ...rest) => (String(p) === dir
-        ? Promise.resolve(dirents)
-        : realReaddir(p, ...rest));
-      // 200 × 60ms is twelve seconds of work against a five-second budget, so
-      // the walk must stop partway however fast the machine running this is.
-      fsp2.access = (p, ...rest) => (String(p).includes('slow-proj-')
-        ? new Promise((resolve) => setTimeout(resolve, 60))
-        : realAccess(p, ...rest));
-
+    it('says the list is SHORT rather than letting a truncated walk look complete', async () => {
+      // A silently-short list reads as "those directories are not there". The
+      // log line is the only place that distinction exists, so it is wiring
+      // worth pinning: delete the `truncated` branch and this goes red while
+      // the test above still passes.
+      const logger = require('../lib/logger');
+      const chunks = [];
+      const prevLevel = logger.getLevel();
+      logger.setLevel('warn');
+      logger.setConsoleStream({ write: (c) => { chunks.push(String(c)); return true; } });
       try {
-        const all = await projects.listAllProjects();
-        const found = all.filter(p => p.registered === false);
-        assert.ok(found.length > 0,
-          'the directories walked before the deadline must survive, not be discarded');
-        assert.ok(found.length < ENTRY_COUNT,
-          `must have stopped at the deadline (${found.length} of ${ENTRY_COUNT})`);
+        await withScanner(
+          () => Promise.resolve({ unregistered: [], truncated: true }),
+          () => projects.listAllProjects()
+        );
+        assert.match(chunks.join(''), /SHORT, not empty/);
       } finally {
-        fsp2.readdir = realReaddir;
-        fsp2.access = realAccess;
+        logger.setConsoleStream(null);
+        logger.setLevel(prevLevel);
       }
     });
 
-    it('reports an unregistered directory\'s TangleClaw config without a synchronous probe', async () => {
-      // The per-entry marker check here was still fs.existsSync — a bounded
-      // readdir followed by unbounded synchronous probes of what it returned is
-      // not a bounded scan, and it reads the same protected tree. Pinning the
-      // ANSWER, since the answer is what the sweep to fs.promises must not
-      // change: nothing else asserted this field for this function.
+    it('reports an unregistered directory\'s TangleClaw config, end to end', async () => {
+      // Pins the ANSWER, because the answer is what two successive rewrites of
+      // the mechanism underneath it must not change: this field was a synchronous
+      // `fs.existsSync`, then an awaited `fsp.access`, and is now an `access` in
+      // the scanner child, and nothing else asserts it for this function.
+      //
+      // Deliberately end-to-end against real directories through the real
+      // scanner — no stub anywhere — so it also proves the walk's result actually
+      // survives the process hop with this field intact.
       fs.mkdirSync(path.join(projectsDir, 'has-tc-config', '.tangleclaw'), { recursive: true });
       fs.writeFileSync(path.join(projectsDir, 'has-tc-config', '.tangleclaw', 'project.json'), '{}');
       fs.mkdirSync(path.join(projectsDir, 'no-tc-config'), { recursive: true });
@@ -1090,40 +1126,87 @@ describe('projects', () => {
   });
 
   describe('scanDirectoryForProjects — the wizard scan must answer, not hang', () => {
-    const fsp3 = require('node:fs').promises;
+    const dirScanner = require('../lib/dir-scanner');
 
-    it('answers at the deadline when the directory never responds', async () => {
-      // A never-settling readdir is the real shape: TCC does not deny the read,
-      // it declines to complete it. A rejecting stub would exercise an error
-      // path that this failure never reaches.
-      const realReaddir = fsp3.readdir;
-      fsp3.readdir = () => new Promise(() => {});
+    /**
+     * Run `fn` with the scanner replaced, then restore it.
+     *
+     * Same seam, and same reason, as the `listAllProjects` block above: since
+     * #883 the read happens in a child process, so a `fsp` stub in this one
+     * cannot reach it. These tests pin how the WIZARD reports a scan that did
+     * not come back; that the scanner really kills a hung child is asserted
+     * against a genuinely blocked syscall in test/dir-scanner.test.js.
+     *
+     * @param {Function} fakeRequest - Stand-in for dirScanner.request.
+     * @param {Function} fn - Test body.
+     * @returns {Promise<any>}
+     */
+    async function withScanner(fakeRequest, fn) {
+      const real = dirScanner.request;
+      dirScanner.request = fakeRequest;
       try {
-        const started = Date.now();
-        const result = await projects.scanDirectoryForProjects(projectsDir);
-        const elapsed = Date.now() - started;
-        assert.equal(result.ok, false, 'must report the failure, not pretend the directory was empty');
-        assert.ok(elapsed >= 4500 && elapsed < 9000,
-          `must answer at the deadline, not before or long after (took ${elapsed}ms)`);
+        return await fn();
       } finally {
-        fsp3.readdir = realReaddir;
+        dirScanner.request = real;
       }
+    }
+
+    it('reports the failure instead of pretending the directory was empty', async () => {
+      // The dangerous wrong answer here is not an error, it is `ok: true` with
+      // an empty list — the operator ticks nothing, imports nothing, and
+      // concludes they have no projects.
+      const result = await withScanner(
+        () => Promise.reject(Object.assign(new Error('timed out after 5000ms'),
+          { tcTimedOut: true })),
+        () => projects.scanDirectoryForProjects(projectsDir)
+      );
+      assert.equal(result.ok, false);
+      assert.equal(result.code, 'SCAN_FAILED');
     });
 
     it('names Full Disk Access in the error the operator will read', async () => {
       // The wizard renders this string verbatim. Without the remedy in it, the
       // operator sees a directory they can open in Finder being refused for no
       // stated reason — the state this whole change exists to prevent.
-      const realReaddir = fsp3.readdir;
-      fsp3.readdir = () => new Promise(() => {});
-      try {
-        const result = await projects.scanDirectoryForProjects(projectsDir);
-        assert.equal(result.code, 'SCAN_FAILED');
-        assert.match(result.error, /Full Disk Access/);
-        assert.match(result.error, /~\/Documents/);
-      } finally {
-        fsp3.readdir = realReaddir;
-      }
+      const result = await withScanner(
+        () => Promise.reject(Object.assign(new Error('timed out after 5000ms'),
+          { tcTimedOut: true })),
+        () => projects.scanDirectoryForProjects(projectsDir)
+      );
+      assert.equal(result.code, 'SCAN_FAILED');
+      assert.match(result.error, /Full Disk Access/);
+      assert.match(result.error, /~\/Documents/);
+    });
+
+    it('words a TRUNCATED walk differently, and does not blame Full Disk Access', async () => {
+      // A walk that ran out of budget is the one failure a perfectly healthy
+      // machine produces — a very large directory, a slow disk. Offering Full
+      // Disk Access as the remedy sends the operator to change a setting that
+      // was never the problem. The flag has to survive the process hop for this
+      // sentence to be reachable at all.
+      const result = await withScanner(
+        () => Promise.reject(Object.assign(
+          new Error('checked 12 of 200 subdirectories in 4750ms and gave up'),
+          { tcTruncated: true }
+        )),
+        () => projects.scanDirectoryForProjects(projectsDir)
+      );
+      assert.equal(result.code, 'SCAN_FAILED');
+      assert.match(result.error, /checked 12 of 200 subdirectories/,
+        'must say how far it got, so the operator can tell slow from blocked');
+      assert.doesNotMatch(result.error, /Full Disk Access — grant it/,
+        'a slow directory must not be diagnosed as a protected one');
+    });
+
+    it('gives the scan a deadline SHORTER than the walk it asks for', async () => {
+      let seen;
+      await withScanner(
+        (op, payload, opts) => { seen = { payload, opts }; return Promise.resolve({ projects: [] }); },
+        () => projects.scanDirectoryForProjects(projectsDir)
+      );
+      assert.ok(seen, 'the fixture must actually reach the scanner');
+      assert.ok(seen.payload.budgetMs < seen.opts.timeoutMs,
+        'the child must give up before the supervisor kills it, so a slow walk can report');
     });
 
     it('reports a missing directory under its OWN code, not a generic bad request', async () => {
@@ -1145,104 +1228,12 @@ describe('projects', () => {
       assert.match(result.error, /not a directory/);
     });
 
-    it('stops probing markers once one has answered', async () => {
-      // Twelve concurrent probes to settle a question the first hit answers is
-      // twelve threadpool slots against a filesystem that may not return any of
-      // them. The short-circuit is the difference between costing one stuck
-      // slot per directory and costing twelve.
-      const scanRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-scan-'));
-      fs.mkdirSync(path.join(scanRoot, 'js-project'));
-      fs.writeFileSync(path.join(scanRoot, 'js-project', 'package.json'), '{}');
-
-      const realAccess = fsp3.access;
-      const probed = [];
-      fsp3.access = (p, ...rest) => {
-        if (String(p).startsWith(scanRoot)) probed.push(path.basename(String(p)));
-        return realAccess(p, ...rest);
-      };
-      try {
-        const result = await projects.scanDirectoryForProjects(scanRoot);
-        assert.equal(result.projects[0].detected, true);
-        // The TangleClaw config probe, then package.json — first in the marker
-        // list, and the last thing that should have been looked at.
-        assert.deepEqual(probed, ['project.json', 'package.json'],
-          'must stop at the first marker that answers');
-      } finally {
-        fsp3.access = realAccess;
-        fs.rmSync(scanRoot, { recursive: true, force: true });
-      }
-    });
-
-    it('abandons the walk at the deadline instead of running it to the end', async () => {
-      // The deadline answers the REQUEST; it cannot cancel the walk it raced.
-      // Left running, the walk keeps issuing filesystem calls into a path
-      // already known not to answer, and each one holds a libuv threadpool slot
-      // (four by default) until the kernel returns — which for the failure this
-      // guards is never. A few retries and every async filesystem call in the
-      // process is queued behind them, which is the wedge again by another
-      // route. Mutation: delete the per-entry deadline check and the walk runs
-      // every entry, well past the point anyone is waiting.
-      const realReaddir = fsp3.readdir;
-      const realAccess = fsp3.access;
-      const realStat = fsp3.stat;
-      let accessCalls = 0;
-      let entriesWalked = 0;
-      const fakeDir = '/tc-fake-scan-root';
-      const ENTRY_COUNT = 200;
-      const dirents = Array.from({ length: ENTRY_COUNT }, (_, i) => ({
-        name: `proj-${i}`, isDirectory: () => true
-      }));
-
-      fsp3.stat = (p, ...rest) => (p === fakeDir
-        ? Promise.resolve({ isDirectory: () => true })
-        : realStat(p, ...rest));
-      fsp3.readdir = (p, ...rest) => (p === fakeDir
-        ? Promise.resolve(dirents)
-        : realReaddir(p, ...rest));
-      fsp3.access = (p, ...rest) => {
-        if (String(p).startsWith(fakeDir)) {
-          accessCalls++;
-          // One TangleClaw-config probe per entry, so this counts entries.
-          if (path.basename(String(p)) === 'project.json') entriesWalked++;
-          // Slow, but finite — the shape the deadline race alone cannot catch,
-          // because every individual call does eventually return.
-          return new Promise((resolve) => setTimeout(resolve, 20));
-        }
-        return realAccess(p, ...rest);
-      };
-
-      try {
-        const result = await projects.scanDirectoryForProjects(fakeDir);
-        assert.equal(result.ok, false, 'a walk that cannot finish in budget must be reported');
-        // Without this the test passes vacuously: every other assertion here
-        // also holds if the stubs were never reached and the path simply 404'd.
-        assert.ok(entriesWalked > 0, 'the fixture must actually reach the walk');
-        assert.ok(entriesWalked < ENTRY_COUNT,
-          `must not have walked every entry (${entriesWalked} of ${ENTRY_COUNT})`);
-        // A walk that was being answered, just slowly, is not a Full Disk Access
-        // problem — and telling a healthy machine to change a privacy setting
-        // sends the operator to fix something that was never wrong.
-        assert.doesNotMatch(result.error, /Full Disk Access — grant it/,
-          'a slow directory must not be diagnosed as a TCC block');
-        assert.match(result.error, /checked \d+ of 200 subdirectories/,
-          'must say how far it got, so the operator can tell slow from blocked');
-
-        // Sample after a grace longer than one entry's worth of probes, so the
-        // entry that was in flight at the deadline has had time to finish and
-        // the next check to fire.
-        await new Promise((resolve) => setTimeout(resolve, 600));
-        const settled = accessCalls;
-        await new Promise((resolve) => setTimeout(resolve, 600));
-        assert.equal(accessCalls, settled,
-          `the walk must stop when the deadline passes (kept going: ${settled} → ${accessCalls})`);
-      } finally {
-        fsp3.stat = realStat;
-        fsp3.readdir = realReaddir;
-        fsp3.access = realAccess;
-      }
-    });
-
-    it('classifies a marker-bearing directory as detected and a bare one as not', async () => {
+    it('classifies real directories end to end, through the real scanner', async () => {
+      // The classification RULES are pinned in test/dir-scanner-child.test.js,
+      // where `fs` can be stubbed. This is the same question asked with no stub
+      // anywhere — real directories, real child process — so the two together
+      // catch both a wrong rule and a correct rule whose answer does not survive
+      // the hop. Deliberate duplication at two levels, not an oversight.
       const scanRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-scan-'));
       fs.mkdirSync(path.join(scanRoot, 'with-marker'));
       fs.writeFileSync(path.join(scanRoot, 'with-marker', 'go.mod'), 'module example.com/x\n');

--- a/test/projects.test.js
+++ b/test/projects.test.js
@@ -1163,6 +1163,50 @@ describe('projects', () => {
       assert.match(result.error, /folder above it/);
       assert.equal(fs.existsSync(path.join(home, 'a')), false);
     });
+
+    it('reports an interrupted create as interrupted, never as a bad directory', async () => {
+      // The SECOND of the two doors this fix opened, and it shipped without this
+      // test while the scan side had one. Collateral means a concurrent request
+      // in the same scanner stopped responding and the process had to be killed —
+      // this create never ran, so it says nothing about the folder. Handing the
+      // operator the Full Disk Access hint for a path that was never touched is
+      // the misdiagnosis #883 exists to remove. Delete the tcAborted branch in
+      // createProjectsDir and this goes red; without it, the suite stayed green.
+      const dirScanner = require('../lib/dir-scanner');
+      const real = dirScanner.interactiveRequest;
+      dirScanner.interactiveRequest = () => Promise.reject(Object.assign(
+        new Error('directory scan abandoned: the scanner process was killed'),
+        { tcAborted: true }
+      ));
+      try {
+        const result = await projects.createProjectsDir(path.join(home, 'Projects'));
+        assert.equal(result.ok, false);
+        assert.equal(result.code, 'CREATE_INTERRUPTED', 'its own code, not CREATE_FAILED');
+        assert.doesNotMatch(result.error, /Full Disk Access/,
+          'a folder that was never touched must not be blamed');
+        assert.match(result.error, /Nothing was created/,
+          'and the operator must be told the retry is safe');
+        assert.match(result.error, /try again/);
+      } finally {
+        dirScanner.interactiveRequest = real;
+      }
+    });
+
+    it('runs on the scanner the background poll cannot kill underneath it', async () => {
+      // Same separation the scan route has. Patching only the background entry
+      // point proves it: if create still used it, the stub would be reached and
+      // the folder would not appear.
+      const dirScanner = require('../lib/dir-scanner');
+      const realBackground = dirScanner.request;
+      dirScanner.request = () => Promise.reject(new Error('the poll must not be consulted here'));
+      try {
+        const result = await projects.createProjectsDir(path.join(home, 'Projects'));
+        assert.equal(result.ok, true, 'create must be independent of the polled route');
+        assert.equal(result.created, true);
+      } finally {
+        dirScanner.request = realBackground;
+      }
+    });
   });
 
   describe('scanDirectoryForProjects — the wizard scan must answer, not hang', () => {

--- a/test/projects.test.js
+++ b/test/projects.test.js
@@ -884,6 +884,46 @@ describe('projects', () => {
         + `(${seen.opts.timeoutMs}ms)`);
     });
 
+    it('opts the POLLED route into the failure backoff', async () => {
+      // This route is polled every ten seconds for as long as a dashboard tab is
+      // open. Without opting in, an unreadable projects directory costs a killed
+      // child on every tick forever — and a child blocked in the kernel may never
+      // leave the process table. Drop the pathKey and that returns silently:
+      // everything still works, it just costs a process every ten seconds.
+      let seen;
+      await withScanner(
+        (op, payload, opts) => { seen = opts; return Promise.reject(timedOut()); },
+        () => projects.listAllProjects()
+      );
+      assert.ok(seen, 'the fixture must actually reach the scanner');
+      assert.equal(seen.pathKey, projects.resolveProjectsDir(store.config.load().projectsDir),
+        'the backoff must be keyed on the directory actually read');
+    });
+
+    it('logs a remembered refusal quietly, so one bad directory is not a log flood', async () => {
+      // Same condition, same degradation — but the scanner already warned when it
+      // really failed, and warns again on each escalation. Repeating that per poll
+      // would bury those lines behind six identical ones a minute.
+      const logger = require('../lib/logger');
+      const chunks = [];
+      const prevLevel = logger.getLevel();
+      logger.setLevel('warn');
+      logger.setConsoleStream({ write: (c) => { chunks.push(String(c)); return true; } });
+      try {
+        const cached = Object.assign(new Error('remembered'),
+          { tcTimedOut: true, tcCached: true });
+        await withScanner(() => Promise.reject(cached), () => projects.listAllProjects());
+        assert.equal(chunks.join(''), '', 'a remembered refusal must not warn again');
+
+        // ...but a NEW failure still must, or a stuck directory goes unreported.
+        await withScanner(() => Promise.reject(timedOut()), () => projects.listAllProjects());
+        assert.match(chunks.join(''), /Full Disk Access/);
+      } finally {
+        logger.setConsoleStream(null);
+        logger.setLevel(prevLevel);
+      }
+    });
+
     it('names Full Disk Access and the safe directories when the path never answered', () => {
       // This string is the entire operator-facing value of degrading instead of
       // hanging: without it the dashboard just shows fewer projects and nobody
@@ -1207,6 +1247,21 @@ describe('projects', () => {
       assert.ok(seen, 'the fixture must actually reach the scanner');
       assert.ok(seen.payload.budgetMs < seen.opts.timeoutMs,
         'the child must give up before the supervisor kills it, so a slow walk can report');
+    });
+
+    it('does NOT opt an operator-pressed button into the failure backoff', async () => {
+      // The polled route opts in; this one must not. Someone who has just granted
+      // Full Disk Access and pressed Scan again is entitled to a real answer — a
+      // remembered refusal would tell them their fix did not work, which is a
+      // worse version of the misdiagnosis this whole issue is about. The cost of
+      // leaving it out is bounded by how fast a person can click.
+      let seen;
+      await withScanner(
+        (op, payload, opts) => { seen = opts; return Promise.resolve({ projects: [] }); },
+        () => projects.scanDirectoryForProjects(projectsDir)
+      );
+      assert.ok(seen, 'the fixture must actually reach the scanner');
+      assert.equal(seen.pathKey, undefined);
     });
 
     it('reports a missing directory under its OWN code, not a generic bad request', async () => {

--- a/test/setup-wizard.test.js
+++ b/test/setup-wizard.test.js
@@ -516,8 +516,10 @@ describe('Setup Wizard', () => {
         timeoutMs: 1500,
         exitGraceMs: 0
       });
-      const real = dirScanner.request;
-      dirScanner.request = () => hungScanner.request('hang', { fifo });
+      // The wizard's scan runs on the interactive scanner, kept separate from the
+      // dashboard poll so a hung projects directory cannot kill this one's child.
+      const real = dirScanner.interactiveRequest;
+      dirScanner.interactiveRequest = () => hungScanner.request('hang', { fifo });
 
       try {
         const scan = request(server, 'POST', '/api/setup/scan', { directory: blocked });
@@ -537,7 +539,7 @@ describe('Setup Wizard', () => {
         assert.match(data.error, /Full Disk Access/,
           'the operator must be told the remedy, not just that it failed');
       } finally {
-        dirScanner.request = real;
+        dirScanner.interactiveRequest = real;
         await hungScanner.shutdown();
       }
     });

--- a/test/setup-wizard.test.js
+++ b/test/setup-wizard.test.js
@@ -499,25 +499,25 @@ describe('Setup Wizard', () => {
     it('keeps the event loop free and answers when the directory never responds', async () => {
       const blocked = path.join(tmpDir, 'blocked-projects');
       fs.mkdirSync(blocked, { recursive: true });
+      const fifo = path.join(blocked, 'pipe');
+      require('node:child_process').execFileSync('mkfifo', [fifo]);
 
-      const fsp = require('node:fs').promises;
-      const realAsync = fsp.readdir;
-      const realSync = fs.readdirSync;
-
-      // Both shapes are stubbed on purpose. The async stub reproduces the real
-      // failure (a read that neither resolves nor rejects); the SYNCHRONOUS one
-      // is the mutation guard — revert this route to fs.readdirSync and the
-      // spin below stalls the loop, which is what the assertions catch. Without
-      // it, restoring the defect would leave this test green.
-      fs.readdirSync = (p, o) => {
-        if (String(p) === blocked) {
-          const until = Date.now() + 3000;
-          while (Date.now() < until) { /* the kernel, not returning */ }
-          return [];
-        }
-        return realSync(p, o);
-      };
-      fsp.readdir = (p, o) => (String(p) === blocked ? new Promise(() => {}) : realAsync(p, o));
+      // NO STUB. The read this route performs happens in the scanner child since
+      // #883, so a stubbed `fs` in this process could not reach it — and a test
+      // whose fixture cannot reach its subject passes forever. Instead the child
+      // is made to block for real, on a reader-less FIFO, which occupies a
+      // genuine libuv thread in a genuine blocked syscall. That is a stronger
+      // fixture than the one it replaces: the loop-free assertion below is now
+      // measured against work that really is stuck rather than a promise that
+      // simply never settles.
+      const dirScanner = require('../lib/dir-scanner');
+      const hungScanner = dirScanner.createScanner({
+        childPath: path.join(__dirname, '_dir-scanner-hang-child.js'),
+        timeoutMs: 1500,
+        exitGraceMs: 0
+      });
+      const real = dirScanner.request;
+      dirScanner.request = () => hungScanner.request('hang', { fifo });
 
       try {
         const scan = request(server, 'POST', '/api/setup/scan', { directory: blocked });
@@ -537,8 +537,8 @@ describe('Setup Wizard', () => {
         assert.match(data.error, /Full Disk Access/,
           'the operator must be told the remedy, not just that it failed');
       } finally {
-        fs.readdirSync = realSync;
-        fsp.readdir = realAsync;
+        dirScanner.request = real;
+        await hungScanner.shutdown();
       }
     });
 


### PR DESCRIPTION
## What

Every read of an operator-chosen directory now happens in a forked child process that a
deadline can kill, instead of on the server's event loop or its libuv threadpool.

- **`lib/dir-scanner.js`** — a supervised, long-lived child: correlation ids, per-request child
  ownership, `SIGKILL` on the deadline, lazy respawn, and a per-path failure backoff.
- **`lib/dir-scanner-child.js`** — the walks themselves (`listUnregistered`, `scanEntries`,
  `createDir`), plus `git.getInfo`, which shells out with `execSync` from inside the loop.
- **`lib/projects.js`** — `listAllProjects`, `scanDirectoryForProjects` and `createProjectsDir`
  route through it. No `fsp.*` call on an operator-supplied path remains in the server process.

Two scanners, not one: a background one for the polled route, an interactive one for the
wizard's buttons, so a hung poll cannot kill a child out from under an operator's click.

Fixes #883.

## Why

The #859 fix bounded the **response**, not the **operation**. `fs.promises` performs a read on
libuv's threadpool — four threads shared by the whole process — and a deadline abandons the
promise without cancelling the syscall. On a TCC-protected macOS path the read never returns at
all, so each one cost a thread permanently. **Four of them and the server could no longer touch
the filesystem on any path, permanently**, while `/api/health` kept answering `200`.

Worse than the outage was the diagnosis. With the pool gone every operation timed out, and
`tcTimedOut` was the only signal — so the product told operators that healthy directories were
protected and sent them to grant Full Disk Access for a problem that had nothing to do with
permissions. That is how the bug was found: an operator reported "it's not working", and the
on-screen message was wrong.

Only killing the process that owns a thread blocked in the kernel reclaims it. `worker_threads`
cannot substitute — workers share the process-wide pool, and `terminate()` does not interrupt a
blocked syscall.

### The rejection vocabulary is the load-bearing design

One flag decides whether an operator is told to change a system permission, so nothing else may
borrow it:

| Flag | Means | Earns the Full Disk Access hint? |
|---|---|---|
| `tcTimedOut` | the path did not answer | **yes** — the only one |
| `tcCached` | remembered refusal of a path that recently did not answer | yes (same condition, no cost) |
| `tcAborted` | killed as collateral for a *sibling* request | no — says nothing about the path |
| `tcTruncated` | the walk *was* answered, but ran out of budget | no — a big folder on a slow disk |
| errno | the filesystem replied | no |

Every one of those used to arrive wearing `tcTimedOut`.

## Test plan

- **Full suite green**: 5754 tests, 0 failures (baseline before this branch: 5708).
- **The defect is reproduced, not described.** `test/_dir-scanner-pool-demo.js` drives
  `UV_THREADPOOL_SIZE + 1` blocking reads through the deadline-race shape that shipped before
  this branch, then times an ordinary `readdir` on an unrelated path: every call rejects on
  schedule and the readdir never completes again. The same workload through the scanner leaves
  it at ~35ms.
- **End-to-end through the real HTTP route**: `test/api-projects.test.js` issues
  `UV_THREADPOOL_SIZE + 1` hung scans at one running server, then asserts the server's own
  filesystem still works. Verified by mutation — putting the hang back in-process makes that
  readdir never complete.
- **Mutation-verified** on every load-bearing guard: the `SIGKILL`, the exit-identity check, the
  collateral labelling, the single-flight door, the forget-on-answer path, and the `tcTruncated`
  rehydration each turn a specific test red when removed.

### What the tests do NOT prove, stated plainly

A real hung `readdir` is not reproducible in CI. A FIFO — the one portable way to block a
filesystem call — answers `readdir` with `ENOTDIR` in 0ms (measured); only `open`/`readFile`
blocks. The hang is therefore produced with the operation that does block, in a fixture child.
That covers the supervisor's contract against a genuinely blocked syscall holding a genuine pool
thread, and nothing specific to `readdir`.

## Known limit, and what it costs

`SIGKILL` does not unwind a thread already blocked in an uninterruptible kernel call, so a killed
child can sit in the process table until the server exits and reaps it — the same ceiling ttyd's
wedged children hit. Unmitigated that was ~6 processes/minute under the dashboard's ten-second
poll; the per-path backoff (30s, doubling to a 5-minute cap) bounds the **rate**. Nothing bounds
the total. `docs/user-guide.md` gains a Troubleshooting entry — how to count them, how to find the
unresponsive folder in the log, that the fix is the folder rather than the processes, and the one
command that clears the ones already there.

## Not fixed here — filed instead

- **#884** — `enrichProject` still calls `fs.existsSync(project.path)` **synchronously for every
  registered project**, and `listAllProjects` calls it on its first line. A *registered* project
  on a protected path therefore still blocks the event loop: the #859 wedge, live, on the route
  this PR fixes the other half of. Scoped to the whole family (32 sites in `lib/projects.js`, 7
  in `lib/uploads.js`).
- **#885** — the degradation is still silent in the product: a shorter project list with nothing
  saying a scan failed.

The `listAllProjects` comment used to claim the registered list "cannot be affected by a stuck
filesystem". The rows come from SQLite; the enrichment does not. That comment now says otherwise.

## Governance

Three chunks, each Critic-reviewed, plus a final cumulative review: **0 blocking**, all findings
dispositioned. The cumulative review caught a defect no chunk review could — one shared scanner
child making every caller collateral for every other — which is why there are now two.

## Two things in this PR that are not about #883

1. **One commit flips eight legacy change-log entries to `status=shipped`** (`c907245`). Not
   smuggled — its own commit, its own reason: `regen-views` was exiting **2 (nothing written)**
   because those entries carried `status=` with no value, which on a trunk repo withholds *every*
   derived view, including the one backing this branch's own plan boxes. No gate this PR must pass
   could run until it was fixed. All eight are already on `main` and every issue they cite is
   closed, so `shipped` is accurate rather than convenient.

2. **`docs/user-guide.md` gains a Troubleshooting entry** for accumulating scanner children. The
   independent PR review caught that the entry written earlier went into
   `.prawduct/artifacts/operational-spec.md` — gitignored, and therefore shipped to nobody.

## Review

- **Critic:** three chunk reviews + a final cumulative + two `verify-resolutions` rounds.
  **0 unresolved blocking**, all findings dispositioned. The cumulative review caught a defect no
  chunk review could — one shared scanner child making every caller collateral for every other —
  which is why there are now two. A later round caught a `tcAborted` branch that had shipped
  without a test, which is why `CREATE_INTERRUPTED` now has one.
- **Independent PR review:** 0 blocking, 0 warnings, 2 notes (both addressed above).
