### PR TITLE
Log the #884 build plan, and correct what #884 says is broken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1597,6 +1597,32 @@ All notable changes to TangleClaw are documented in this file.
 
 ### Internal
 
+- **Build plan for #884, and a correction to what #884 says is broken.** The issue scopes the
+  remaining event-loop hazard as "32 `existsSync` sites". Reading `enrichProject`
+  (`lib/projects.js`) rather than the issue shows it performs **five** distinct synchronous
+  filesystem operations per registered project per ten-second poll, and only one is an
+  `existsSync`: `git.getInfo` shells out through `execSync` (`lib/git.js`), `_detectProjectVersion`
+  and `store.projectConfig.load` are `readFileSync` chains, and `engines.governanceState` is called
+  twice — once here and once via `actions.availableActions` (`lib/actions.js`). **This matters
+  because the project's own learning tells future sweeps to grep
+  `readdirSync|existsSync|statSync`, and that grep matches none of the other four.** The plan
+  therefore moves every per-project read into the `#883` scanner child rather than the existence
+  checks, which makes it correct whether or not macOS TCC blocks at `stat` — a question this
+  machine cannot answer, because a shell that has Full Disk Access returns instantly on every
+  protected path and proves nothing about the failing case.
+
+  Cheap where it was expected to be expensive: `listAllProjects` is already `async` and its only
+  caller already awaits it, so `enrichProject` and `listProjects` can go async without touching a
+  route signature. Plan at `.prawduct/artifacts/build-plan-884-sync-reads.md`, three chunks, with
+  Chunk 02 marked as the honest stopping point if the work has to be cut short.
+
+  Reconciling the plan against its governing norms also turned up a description that stopped
+  tracking: `architecture.md`'s degradation norm claims a missing project directory already
+  surfaces as a per-card error badge, while #885 exists because it does not. The norm is right and
+  the plan conforms; the retroactivity evidence overstated what was checked — the same failure that
+  artifact's observability sibling already recorded against itself. Correcting it belongs to #885,
+  where the claim becomes true.
+
 - **A killable scanner process, so a hung directory can no longer take the server's filesystem with
   it.** (#883, chunk 1 — the mechanism only; nothing routes through it yet, so no behavior changes
   in this entry.) A read of a TCC-protected macOS path does not fail, it never returns, and


### PR DESCRIPTION
## What

Records the build plan for #884 in the CHANGELOG, along with a correction to the issue's own scoping.

The plan itself lives at `.prawduct/artifacts/build-plan-884-sync-reads.md`. As with every other build plan in this repo, that path is gitignored — so this changelog entry and the hosted copy are the durable record.

## Why

#884 scopes the remaining event-loop hazard as "32 `existsSync` sites". Reading `enrichProject` rather than the issue shows it performs **five** distinct synchronous filesystem operations per registered project per ten-second poll, and only one is an `existsSync`:

| Call | What it does on disk |
|---|---|
| `fs.existsSync(project.path)` | `stat` — guards the git read |
| `git.getInfo(project.path)` | **`execSync`** — spawns git subprocesses (`lib/git.js`) |
| `_detectProjectVersion(project.path)` | `readFileSync` chain |
| `store.projectConfig.load(project.path)` | `readFileSync` |
| `engines.governanceState(project.path)` | called **twice** — here and via `actions.availableActions` |

This matters because the project's recorded learning tells future sweeps to grep `readdirSync|existsSync|statSync` — which matches none of the other four. The plan moves every per-project read into the #883 scanner child rather than the existence checks, so it is correct whether or not macOS TCC blocks at `stat`. That question could not be answered from this machine: a shell with Full Disk Access returns instantly on every protected path and proves nothing about the failing case.

Reconciling the plan against its governing norms also surfaced a description that stopped tracking: `architecture.md`'s degradation norm claims a missing project directory already surfaces as a per-card error badge, while #885 exists because it does not. The norm is right and the plan conforms; the retroactivity evidence overstated what was checked. Correcting it belongs to #885.

## Test plan

Doc-only — no code changed. `test/contracts.test.js` passes (18/18); the full suite ran green on `main` earlier this session (5753 pass, 0 fail).

Refs #884, #885, #883.