### PR TITLE
Bound git's total work with one budget, so a slow repo is not killed and misdiagnosed (#891)

### DIFF
--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -3810,6 +3810,13 @@ inside loops that already carry their own deadline — a deadline checked *betwe
 cannot interrupt a synchronous 35s spawn inside one. Bounding the handler would have fixed one call
 site and left the two that document a bound they could not honour.
 
+**That was necessary and not sufficient, which the Critic caught and the first implementation did
+not.** A budget inside `_fetchInfo` still let each walk candidate take a fresh FULL budget, because
+`_gitInfo` passed no options — so the overrun fell from ~35s to ~4s rather than going away, while
+this entry's first draft and the commit message both claimed all three sites were fixed. The walk
+call sites now forward `deadlineAt - Date.now()`. The claim is true because the code changed, not
+because the sentence was softened.
+
 **Exhaustion degrades to a labelled partial, never to `null` and never to a default.** Both rules came
 from grepping consumers, not from taste. `lib/dir-scanner-child.js` derives `detected` from
 `gitInfo && gitInfo.branch`, so returning `null` would make a real git-only project *vanish* from the

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -3848,7 +3848,7 @@ one, several times a minute per project. It is now loud once per directory and d
 process rather than per interval, because this runs in a child the supervisor recreates so the set
 dies with it and a genuinely new incident is loud again with no timer to get wrong. Both failure
 directions are guarded: warning every time and going silent after the first each fail. Separately,
-`detectProjects` projects only `branch` and `dirty` out of the git object and was dropping
+the wizard walk (`scanEntries`) projects only `branch` and `dirty` out of the git object and was dropping
 `incomplete` — so a `dirty: null` the walk never checked was indistinguishable THERE from a clean
 repository, the same false fact the other path carries it to prevent.
 

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -3788,6 +3788,62 @@ route this fixed the other half of. The family is 32 synchronous reads in `lib/p
 
 **Classification:** fix
 
+## 2026-08-09: git's total work is bounded once, so the scan deadline can only expire on a path that never answers (#891)
+
+<!-- prawduct: type=fix | chunks=01 | scope=fix-891-git-budget | status=shipped -->
+
+**Why:** `PROJECT_FACTS_TIMEOUT_MS` was 5000ms and bounded one round trip to the scanner child.
+`git.getInfo` behind it issued **seven** `execSync` spawns, each independently capped at 5000ms — an
+honest worst case near 35s against a 5s deadline. A repository whose git work merely stalled was
+SIGKILLed with the child and reported to the operator as a Full Disk Access problem it did not have,
+and because the kill discards git's in-process cache the retry after the backoff was equally cold and
+did it again.
+
+**Measured before it was tuned.** All seven spawns against this repository (949 commits, 400 tracked
+files, warm) cost **85ms together**, no single command over 20ms. So the failure is a *stall* case —
+a very large repository with a cold cache, or a filesystem that will not answer — not the "any large
+repo" case the issue's wording implied. The plan says so rather than inheriting the issue's framing.
+
+**The budget went into `lib/git.js`, not the handler the issue named.** `_gitInfo` is called from
+three places in `lib/dir-scanner-child.js`, and two of them call it once per candidate subdirectory
+inside loops that already carry their own deadline — a deadline checked *between* iterations, which
+cannot interrupt a synchronous 35s spawn inside one. Bounding the handler would have fixed one call
+site and left the two that document a bound they could not honour.
+
+**Exhaustion degrades to a labelled partial, never to `null` and never to a default.** Both rules came
+from grepping consumers, not from taste. `lib/dir-scanner-child.js` derives `detected` from
+`gitInfo && gitInfo.branch`, so returning `null` would make a real git-only project *vanish* from the
+detected list; `public/ui.js:248` would additionally print "Not a git repo", which is false. And
+`_isDirty`'s catch returns `false` while `public/ui.js` renders `dirty` as a dot — so a check the
+budget cut short would draw a dirty repository as clean, an unknown falling through to a definite
+(#861's shape). `dirty` is now `null` when unestablished, and a new `incomplete: string[]` names every
+field the read could not answer. No consumer reads it yet: it is the seam #885 renders, exactly as
+#884 left `unreadable` behind.
+
+**The deadline is computed from the budget rather than set beside it**, so the two cannot drift; the
+budget was sized to leave `PROJECT_FACTS_TIMEOUT_MS` at 5000 **unchanged**, because the poll issues
+these one at a time and a larger per-project deadline multiplies across every registered project.
+Partial readings are deliberately not cached — freezing one bad reading for the two-minute TTL would
+repeat it across twelve polls of a repository that may be fine now.
+
+**A REAL SLOW `git` ON PATH CAUGHT A BUG A STUB WOULD HAVE HIDDEN.** The first implementation
+detected "our own cap killed this spawn" with `if (err.killed)` — which never fires: `execSync` sets
+`killed` on `spawnSync`'s *result*, not on the error it *throws*, where a timeout arrives as
+`code: 'ETIMEDOUT'` / `signal: 'SIGTERM'`. The branch compiled, read correctly, and was dead, so every
+budget-truncated field silently reported its fallback as an answer — the exact false fact the change
+exists to prevent. Reverting to `err.killed` now fails four tests. `lib/tmux.js:53` carries the
+identical dead check and has therefore never once logged a tmux timeout; filed as #894 rather than
+widened into here.
+
+**One guard was tautological and was rewritten.** `PROJECT_FACTS_TIMEOUT_MS > GIT_INFO_BUDGET_MS`
+holds for *every* budget once the deadline is derived from it, so the assertion could not fail — it
+passed against the hardcoded value it was meant to forbid. It now asserts against the source that the
+deadline is computed from the budget, which goes red when a literal is restored. Found by planting the
+mutation and watching it *not* fail; #893 exists because that is the sixth time this has been the
+difference between a guard and a decoration.
+
+**Classification:** fix
+
 ## 2026-08-09: A registered project's directory is read in the killable child, not on the event loop (#884)
 
 <!-- prawduct: type=fix | chunks=01,02a,02b | scope=fix-884-sync-reads | status=shipped -->

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -3842,6 +3842,16 @@ exists to prevent. Reverting to `err.killed` now fails four tests. `lib/tmux.js:
 identical dead check and has therefore never once logged a tmux timeout; filed as #894 rather than
 widened into here.
 
+**Two smaller things the records did not originally mention.** A partial is not cached, so a
+repository that stays slow re-reads on every ten-second poll — and the new diagnostic fired on each
+one, several times a minute per project. It is now loud once per directory and debug thereafter, per
+process rather than per interval, because this runs in a child the supervisor recreates so the set
+dies with it and a genuinely new incident is loud again with no timer to get wrong. Both failure
+directions are guarded: warning every time and going silent after the first each fail. Separately,
+`detectProjects` projects only `branch` and `dirty` out of the git object and was dropping
+`incomplete` — so a `dirty: null` the walk never checked was indistinguishable THERE from a clean
+repository, the same false fact the other path carries it to prevent.
+
 **One guard was tautological and was rewritten.** `PROJECT_FACTS_TIMEOUT_MS > GIT_INFO_BUDGET_MS`
 holds for *every* budget once the deadline is derived from it, so the assertion could not fail — it
 passed against the hardcoded value it was meant to forbid. It now asserts against the source that the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -463,6 +463,27 @@ All notable changes to TangleClaw are documented in this file.
 
 ### Fixed
 
+- **A big or slow repository is no longer killed and blamed on Full Disk Access (#891).** Reading one
+  project's git state costs seven `git` invocations, and each was capped separately at five seconds —
+  behind a single five-second deadline that kills the process doing the work. The arithmetic never
+  worked: an honest worst case near 35 seconds against a 5-second limit. A repository whose git work
+  stalled was killed and the dashboard told the operator to grant Full Disk Access, for a permission
+  that was never the problem. It also repeated forever, because the kill throws away git's cache, so
+  the next attempt starts just as cold.
+
+  All seven invocations now share **one** budget. A repository that outruns it comes back with what
+  was established and an explicit list of what was not, instead of being killed.
+
+  **What it does not do is guess.** A field the budget could not check is reported as unknown, never
+  as a default — "we did not look" and "we looked and it is clean" are different answers, and a
+  dashboard that renders the first as the second is lying about the repository. A slow repository
+  loses a badge; it does not lose its dirty marker, and it does not stop being a project.
+
+  The deadline is now computed from the budget rather than written next to it, so the two cannot
+  drift apart again. It works out to the same five seconds it already was — deliberately, since the
+  server reads projects one at a time and a longer per-project deadline would multiply across every
+  project on the dashboard's ten-second poll. Nothing gets slower.
+
 - **A registered project's version is now detected in the scanner child, and `enrichProject`
   opens nothing under a project's own path (#884).** This was the last of the
   five per-project reads the dashboard poll ran on the server's event loop. It read up to four

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -474,10 +474,15 @@ All notable changes to TangleClaw are documented in this file.
   All seven invocations now share **one** budget. A repository that outruns it comes back with what
   was established and an explicit list of what was not, instead of being killed.
 
-  **What it does not do is guess.** A field the budget could not check is reported as unknown, never
-  as a default — "we did not look" and "we looked and it is clean" are different answers, and a
-  dashboard that renders the first as the second is lying about the repository. A slow repository
-  loses a badge; it does not lose its dirty marker, and it does not stop being a project.
+  **What it does not do is guess.** A field the budget could not check is recorded as unknown, never
+  as a default — "we did not look" and "we looked and it is clean" are different answers, and
+  treating the first as the second is a lie about the repository. A slow repository also does not
+  stop being a project: it still appears, still detected, rather than vanishing from the list.
+
+  **Being straight about how far that goes today:** the *data* now distinguishes unknown from clean,
+  and nothing in the interface reads that distinction yet, so an unchecked repository currently shows
+  no dirty marker — the same as a clean one. What has been removed is the false record underneath;
+  showing it is #885's job.
 
   The deadline is now computed from the budget rather than written next to it, so the two cannot
   drift apart again. It works out to the same five seconds it already was — deliberately, since the

--- a/lib/dir-scanner-child.js
+++ b/lib/dir-scanner-child.js
@@ -97,24 +97,36 @@ async function _probe(p) {
  * Git branch/dirty info for `dir`, or null when it is not a repo.
  *
  * WHY THIS RUNS HERE AND NOT IN THE SERVER. `git.getInfo` shells out with
- * `execSync`, and `lib/git`'s 5s cap is per command while reading a repo takes
- * several — so a directory whose git calls all stall blocks the calling process's
- * event loop for far longer than any scan deadline, which cannot fire while a
- * synchronous call is running. In the server that was a second way to wedge the
- * same request. Here the caller is a process that exists to be killed, so a
- * stalled `git` costs the same as a stalled `readdir` and no more.
+ * `execSync`, several times per repository, and a synchronous call cannot be
+ * interrupted by any deadline — a timer does not fire while it runs. In the
+ * server that was a second way to wedge the same request. Here the caller is a
+ * process that exists to be killed, so a stalled `git` costs the same as a
+ * stalled `readdir` and no more.
+ *
+ * `lib/git` now bounds all of one repository's invocations under a single budget
+ * rather than capping each separately, so the overrun a stall can produce is
+ * bounded by that budget instead of by the number of commands times the cap.
  *
  * One consequence worth knowing: `git.getInfo`'s two-minute cache now lives in
  * this process, so a child killed for a hang starts cold. That trades a few
  * repeated `git` calls after a kill for never blocking the server, which is the
  * right way round.
  *
+ * CALLERS INSIDE A DEADLINED WALK MUST PASS WHAT IS LEFT OF IT. `git.getInfo`
+ * bounds one repository's total git work, but its own default budget knows
+ * nothing about the walk containing it — so a per-directory call that took the
+ * default would let a single stalled repository overrun a walk deadline the loop
+ * can only check BETWEEN iterations, never inside a synchronous spawn. Passing
+ * the remainder is what makes the walk's own bound true rather than aspirational.
+ *
  * @param {string} dir - Directory to inspect.
+ * @param {number} [budgetMs] - Wall clock this read may take. Omit only outside
+ *   a deadlined loop, where `git.getInfo`'s own budget is the bound.
  * @returns {object|null}
  */
-function _gitInfo(dir) {
+function _gitInfo(dir, budgetMs) {
   try {
-    return git.getInfo(dir);
+    return git.getInfo(dir, Number.isFinite(budgetMs) ? { budgetMs } : {});
   } catch {
     // Not a git repo, or git is not installed. Either way there is no branch to
     // report and the directory is still worth listing.
@@ -285,7 +297,7 @@ const HANDLERS = {
         tags: [],
         ports: {},
         session: null,
-        git: _gitInfo(dirPath),
+        git: _gitInfo(dirPath, deadlineAt - Date.now()),
         status: null,
         hasTangleclawConfig: await _exists(path.join(dirPath, '.tangleclaw', 'project.json')),
         createdAt: null,
@@ -339,7 +351,7 @@ const HANDLERS = {
       }
 
       const dirPath = path.join(dir, entry.name);
-      const gitInfo = _gitInfo(dirPath);
+      const gitInfo = _gitInfo(dirPath, deadlineAt - Date.now());
       const hasTangleclawConfig = await _exists(path.join(dirPath, '.tangleclaw', 'project.json'));
 
       // Sequential and short-circuiting, deliberately. Probing all twelve markers
@@ -358,7 +370,13 @@ const HANDLERS = {
         name: entry.name,
         path: dirPath,
         hasTangleclawConfig,
-        git: gitInfo ? { branch: gitInfo.branch, dirty: gitInfo.dirty } : null,
+        // `incomplete` travels with the two fields it qualifies. Without it a
+        // `dirty: null` this walk never got to check is indistinguishable here
+        // from a repository that is genuinely clean — the same false fact the
+        // projectFacts path carries it to prevent.
+        git: gitInfo
+          ? { branch: gitInfo.branch, dirty: gitInfo.dirty, incomplete: gitInfo.incomplete }
+          : null,
         detected: !!((gitInfo && gitInfo.branch) || hasTangleclawConfig || hasProjectMarker)
       });
     }

--- a/lib/dir-scanner-child.js
+++ b/lib/dir-scanner-child.js
@@ -96,6 +96,11 @@ async function _probe(p) {
 /**
  * Git branch/dirty info for `dir`, or null when it is not a repo.
  *
+ * `null` means EXACTLY that and nothing else. A repository whose read ran out of
+ * budget comes back as an object carrying `incomplete` — the names of the fields
+ * that were never established — because a slow repository is still a repository
+ * and the caller below derives project detection from `branch` being present.
+ *
  * WHY THIS RUNS HERE AND NOT IN THE SERVER. `git.getInfo` shells out with
  * `execSync`, several times per repository, and a synchronous call cannot be
  * interrupted by any deadline — a timer does not fire while it runs. In the
@@ -122,7 +127,11 @@ async function _probe(p) {
  * @param {string} dir - Directory to inspect.
  * @param {number} [budgetMs] - Wall clock this read may take. Omit only outside
  *   a deadlined loop, where `git.getInfo`'s own budget is the bound.
- * @returns {object|null}
+ * @returns {{branch: string, dirty: boolean|null, lastCommit: string,
+ *   lastCommitAge: string, latestTag: string|null, incomplete: string[]}|null}
+ *   `null` only for a directory that is not a repository. A field named in
+ *   `incomplete` has no value rather than a default — `dirty` is `null`, not
+ *   `false`.
  */
 function _gitInfo(dir, budgetMs) {
   try {

--- a/lib/git.js
+++ b/lib/git.js
@@ -164,68 +164,83 @@ function _fetchInfo(dir, options = {}) {
    * @param {string} field - Field name to record when this cannot be answered.
    * @param {*} fallback - Value to use when it cannot be answered.
    * @param {(timeout: number) => *} run - Runs the step under the given cap.
-   * @returns {*}
+   * @param {boolean} [errorIsAnswer=false] - Whether a git-side failure IS the
+   *   answer. True for the three probes whose failure is informative — not a
+   *   repository, no commits, no tags — where the fallback stands as fact. False
+   *   everywhere else, because "git errored" tells us nothing about the value.
+   * @returns {{ok: boolean, value: *}} `ok` is the single source of truth for
+   *   whether this field was established; every caller branches on it and none
+   *   re-derives it from the value, the array, or a length snapshot.
    */
-  const step = (field, fallback, run) => {
+  const step = (field, fallback, run, errorIsAnswer = false) => {
     const remaining = endsAt - Date.now();
     if (remaining <= 0) {
       incomplete.push(field);
-      return fallback;
+      return { ok: false, value: fallback };
     }
     try {
-      return run(Math.min(PER_CALL_CAP_MS, remaining));
+      return { ok: true, value: run(Math.min(PER_CALL_CAP_MS, remaining)) };
     } catch (err) {
-      if (_wasTimedOut(err)) incomplete.push(field);
-      return fallback;
+      if (errorIsAnswer && !_wasTimedOut(err)) return { ok: true, value: fallback };
+      incomplete.push(field);
+      return { ok: false, value: fallback };
     }
   };
 
   // Whether this is a repository at all is answered first and separately: every
   // field below is meaningless without it, and it is the cheapest of the seven.
-  const repoCheck = step('branch', null, (t) => {
+  // A git-side failure here IS the answer — this is not a repository.
+  const repo = step('branch', false, (t) => {
     _exec('git rev-parse --is-inside-work-tree', dir, t);
     return true;
-  });
-  if (repoCheck === null) {
-    // Distinguish "we could not look" from "not a repository". Only the latter
-    // is an answer; the former must not be cached as one, and `incomplete`
-    // carrying `branch` is what tells `getInfo` to leave it out of the cache.
-    if (incomplete.length === 0) return null;
+  }, true);
+  if (!repo.ok) {
+    // We could not look. That is NOT "not a repository", and it must not be
+    // cached as one — `incomplete` is what tells `getInfo` to leave it out.
     return {
       branch: 'unknown', dirty: null, lastCommit: '', lastCommitAge: '', latestTag: null,
       incomplete: ['branch', 'dirty', 'lastCommit', 'lastCommitAge', 'latestTag']
     };
   }
+  if (repo.value !== true) return null;
 
+  // A git-side failure IS an answer here, and `'unknown'` is the honest one:
+  // `rev-parse --abbrev-ref HEAD` cannot name a branch over an unborn HEAD, so a
+  // freshly-initialised repository fails it as a matter of course. Marking that
+  // unestablished would leave every brand-new project permanently partial —
+  // never cached, re-spawning git on every poll, for a state that is normal.
+  //
+  // `'unknown'` is safe to treat this way because it SAYS it is unknown. That is
+  // exactly what separates it from `dirty` below, where the only available
+  // fallback is a plausible lie.
   const branch = step('branch', 'unknown',
-    (t) => _exec('git rev-parse --abbrev-ref HEAD', dir, t));
+    (t) => _exec('git rev-parse --abbrev-ref HEAD', dir, t), true);
+  // Any failure at all leaves us not knowing, so no `errorIsAnswer` here: a
+  // `git status` that errors for its own reasons still must not render as clean.
   const dirty = step('dirty', null,
     (t) => _exec('git status --porcelain', dir, t).length > 0);
 
   // Whether the repository has any commits at all, before asking log/describe
-  // about them.
-  //
-  // A repository with NO commits is a real answer — `git rev-parse HEAD` fails
-  // there, and empty message/age/tag are the truth about it. A probe the budget
-  // cut short is NOT an answer, and it fails the same way. The two are told
-  // apart by whether the step recorded the field, never by the return value,
-  // which is identical in both cases; reading the value alone reported every
-  // freshly-initialised repository as unestablished.
-  const beforeProbe = incomplete.length;
-  const hasCommits = step('lastCommit', false, (t) => {
+  // about them. A repository with NO commits is a real answer — `git rev-parse
+  // HEAD` fails there and empty message/age/tag are the truth about it — while a
+  // probe the budget cut short is not, and it fails the same way. `ok` separates
+  // them; reading the returned value alone reported every freshly-initialised
+  // repository as unestablished.
+  const head = step('lastCommit', false, (t) => {
     _exec('git rev-parse HEAD', dir, t);
     return true;
-  });
-  const probeAnswered = incomplete.length === beforeProbe;
+  }, true);
 
   let lastCommit = '';
   let lastCommitAge = '';
   let latestTag = null;
-  if (hasCommits) {
-    lastCommit = step('lastCommit', '', (t) => _exec('git log -1 --format=%s', dir, t));
-    lastCommitAge = step('lastCommitAge', '', (t) => _exec('git log -1 --format=%cr', dir, t));
-    latestTag = step('latestTag', null, (t) => _exec('git describe --tags --abbrev=0', dir, t));
-  } else if (!probeAnswered) {
+  if (head.ok && head.value === true) {
+    lastCommit = step('lastCommit', '', (t) => _exec('git log -1 --format=%s', dir, t)).value;
+    lastCommitAge = step('lastCommitAge', '', (t) => _exec('git log -1 --format=%cr', dir, t)).value;
+    // No tags is an answer, not a gap.
+    latestTag = step('latestTag', null,
+      (t) => _exec('git describe --tags --abbrev=0', dir, t), true).value;
+  } else if (!head.ok) {
     // The probe was skipped or killed, so nothing downstream of it was even
     // attempted. Say so for each field rather than letting three empty values
     // pass for "this repository has no commits".
@@ -250,7 +265,11 @@ function _fetchInfo(dir, options = {}) {
   }
 
   return {
-    branch, dirty, lastCommit, lastCommitAge, latestTag,
+    branch: branch.value,
+    dirty: dirty.value,
+    lastCommit,
+    lastCommitAge,
+    latestTag,
     // De-duplicated: the has-commits probe and the message read share a field
     // name, so a budget that dies on the probe would otherwise name it twice.
     incomplete: [...new Set(incomplete)]
@@ -324,7 +343,6 @@ module.exports = {
   clearCache,
   clearCacheFor,
   GIT_INFO_BUDGET_MS,
-  PER_CALL_CAP_MS,
   _exec,
   _fetchInfo
 };

--- a/lib/git.js
+++ b/lib/git.js
@@ -82,6 +82,34 @@ function _wasTimedOut(err) {
 }
 
 /**
+ * Report the fields a read could not establish — loud once, quiet after.
+ *
+ * A partial is deliberately not cached, so a repository that stays slow re-reads
+ * on every ten-second poll; warning each time would emit this several times a
+ * minute per project and bury the warning it is meant to be. The same call
+ * `lib/project-facts.js` makes for a remembered refusal.
+ *
+ * Per process rather than per interval: this runs in a child the supervisor
+ * recreates, so the set dies with it and a genuinely new incident is loud again
+ * without a timer to get wrong.
+ *
+ * @param {string} dir - Directory the read was for.
+ * @param {number} budgetMs - Budget the read was given.
+ * @param {string[]} fields - Field names that were not established.
+ * @returns {void}
+ */
+function _reportIncomplete(dir, budgetMs, fields) {
+  const key = cacheKeyFor(dir);
+  const level = _warnedIncomplete.has(key) ? 'debug' : 'warn';
+  _warnedIncomplete.add(key);
+  // Says what is true of every case: these fields were not established. The
+  // budget is the usual cause but not the only one — a `git status` that fails
+  // for its own reasons lands here too, and naming the budget would report a
+  // cause that did not happen.
+  log[level]('Git info incomplete — fields not established', { dir, budgetMs, fields });
+}
+
+/**
  * Check if a directory is a git repository.
  * @param {string} dir - Directory path
  * @returns {boolean}
@@ -197,9 +225,15 @@ function _fetchInfo(dir, options = {}) {
   if (!repo.ok) {
     // We could not look. That is NOT "not a repository", and it must not be
     // cached as one — `incomplete` is what tells `getInfo` to leave it out.
+    //
+    // This exit establishes NOTHING, which makes it the one that most needs to
+    // say so: it returns early, so it has to report on its own way out rather
+    // than falling through to the shared report below.
+    const nothing = ['branch', 'dirty', 'lastCommit', 'lastCommitAge', 'latestTag'];
+    _reportIncomplete(dir, budgetMs, nothing);
     return {
       branch: 'unknown', dirty: null, lastCommit: '', lastCommitAge: '', latestTag: null,
-      incomplete: ['branch', 'dirty', 'lastCommit', 'lastCommitAge', 'latestTag']
+      incomplete: nothing
     };
   }
   if (repo.value !== true) return null;
@@ -259,13 +293,7 @@ function _fetchInfo(dir, options = {}) {
     // Per process rather than per interval: this runs in a child the supervisor
     // recreates, so the set dies with it and a genuinely new incident is loud
     // again without a timer to get wrong.
-    const level = _warnedIncomplete.has(cacheKeyFor(dir)) ? 'debug' : 'warn';
-    _warnedIncomplete.add(cacheKeyFor(dir));
-    // Says what is true of every case: these fields were not established. The
-    // budget is the usual cause but not the only one — a `git status` that fails
-    // for its own reasons lands here too, and naming the budget would report a
-    // cause that did not happen.
-    log[level]('Git info incomplete — fields not established', { dir, budgetMs, fields: incomplete });
+    _reportIncomplete(dir, budgetMs, incomplete);
   }
 
   return {

--- a/lib/git.js
+++ b/lib/git.js
@@ -191,21 +191,29 @@ function _fetchInfo(dir, options = {}) {
     (t) => _exec('git status --porcelain', dir, t).length > 0);
 
   // Whether the repository has any commits at all, before asking log/describe
-  // about them. `null` means the probe itself did not answer, which is not the
-  // same as an empty repository and must not silently read as one.
-  const hasCommits = step('lastCommit', null, (t) => {
+  // about them.
+  //
+  // A repository with NO commits is a real answer — `git rev-parse HEAD` fails
+  // there, and empty message/age/tag are the truth about it. A probe the budget
+  // cut short is NOT an answer, and it fails the same way. The two are told
+  // apart by whether the step recorded the field, never by the return value,
+  // which is identical in both cases; reading the value alone reported every
+  // freshly-initialised repository as unestablished.
+  const beforeProbe = incomplete.length;
+  const hasCommits = step('lastCommit', false, (t) => {
     _exec('git rev-parse HEAD', dir, t);
     return true;
   });
+  const probeAnswered = incomplete.length === beforeProbe;
 
   let lastCommit = '';
   let lastCommitAge = '';
   let latestTag = null;
-  if (hasCommits === true) {
+  if (hasCommits) {
     lastCommit = step('lastCommit', '', (t) => _exec('git log -1 --format=%s', dir, t));
     lastCommitAge = step('lastCommitAge', '', (t) => _exec('git log -1 --format=%cr', dir, t));
     latestTag = step('latestTag', null, (t) => _exec('git describe --tags --abbrev=0', dir, t));
-  } else if (hasCommits === null) {
+  } else if (!probeAnswered) {
     // The probe was skipped or killed, so nothing downstream of it was even
     // attempted. Say so for each field rather than letting three empty values
     // pass for "this repository has no commits".

--- a/lib/git.js
+++ b/lib/git.js
@@ -156,10 +156,10 @@ function _fetchInfo(dir, options = {}) {
    * becomes UNBOUNDED the instant the budget reaches zero — the very inversion
    * this budget exists to remove. An exhausted budget must skip, never spawn.
    *
-   * A spawn our own cap KILLED is unestablished too, not answered: the caller's
+   * A spawn our own cap KILLED is unestablished, not answered: the caller's
    * documented fallback would otherwise present "we stopped looking" as a fact.
-   * Any other failure means git itself answered (or is absent), and there the
-   * fallback is the honest result.
+   * Whether any OTHER failure counts as an answer is the caller's call, because
+   * it differs per field — see `errorIsAnswer`.
    *
    * @param {string} field - Field name to record when this cannot be answered.
    * @param {*} fallback - Value to use when it cannot be answered.
@@ -261,7 +261,11 @@ function _fetchInfo(dir, options = {}) {
     // again without a timer to get wrong.
     const level = _warnedIncomplete.has(cacheKeyFor(dir)) ? 'debug' : 'warn';
     _warnedIncomplete.add(cacheKeyFor(dir));
-    log[level]('Git info incomplete — ran out of budget', { dir, budgetMs, fields: incomplete });
+    // Says what is true of every case: these fields were not established. The
+    // budget is the usual cause but not the only one — a `git status` that fails
+    // for its own reasons lands here too, and naming the budget would report a
+    // cause that did not happen.
+    log[level]('Git info incomplete — fields not established', { dir, budgetMs, fields: incomplete });
   }
 
   return {

--- a/lib/git.js
+++ b/lib/git.js
@@ -9,20 +9,64 @@ const log = createLogger('git');
 const CACHE_TTL = 120000; // 2 minutes — short TTLs cause frequent event-loop blocking
 const _cache = new Map();
 
+/** Longest any single `git` invocation may run, regardless of budget left. */
+const PER_CALL_CAP_MS = 5000;
+
+/**
+ * How long ALL of one directory's git work gets, in total.
+ *
+ * Reading a repository takes seven `git` invocations (see `_fetchInfo`). Capping
+ * each of them separately meant the honest worst case was seven times the cap —
+ * ~35s — while the scan deadline that kills the child process sits at 5s. A
+ * repository whose git work merely stalled was therefore killed and reported to
+ * the operator as a Full Disk Access problem, which it was not; and because the
+ * kill discards this module's cache, the retry after the backoff was equally
+ * cold and did it again.
+ *
+ * 4000ms is not a guess at how slow git can be. It is chosen so that this budget
+ * plus the small root-level file reads that share the same deadline still fits
+ * INSIDE that deadline (`lib/project-facts.js` derives the deadline from this
+ * constant, so the two cannot drift apart). Measured against this repository —
+ * 949 commits, 400 tracked files, warm — all seven invocations cost 85ms
+ * together, so the budget carries roughly a 47x margin over a healthy read.
+ *
+ * A repository that genuinely needs longer returns a PARTIAL reading naming what
+ * it could not establish, which is the point: a slow repository should cost a
+ * missing badge, not a kill and a misdiagnosis.
+ */
+const GIT_INFO_BUDGET_MS = 4000;
+
 /**
  * Execute a git command in a directory with timeout.
  * @param {string} command - Git command to run
  * @param {string} cwd - Working directory
- * @param {number} [timeout=5000] - Timeout in ms
+ * @param {number} [timeout=PER_CALL_CAP_MS] - Timeout in ms
  * @returns {string} - stdout output
  */
-function _exec(command, cwd, timeout = 5000) {
+function _exec(command, cwd, timeout = PER_CALL_CAP_MS) {
   return execSync(command, {
     cwd,
     timeout,
     encoding: 'utf8',
     stdio: ['pipe', 'pipe', 'pipe']
   }).trim();
+}
+
+/**
+ * Whether OUR OWN cap killed this spawn, rather than git answering.
+ *
+ * `execSync` does NOT set `killed` on the error it throws — that flag belongs to
+ * `spawnSync`'s result object. A timeout arrives as `code: 'ETIMEDOUT'` with
+ * `signal: 'SIGTERM'`, so a `killed` check compiles, reads plausibly, and never
+ * fires; every budget-truncated read would fall through to its documented
+ * fallback and be reported as an answer. Both properties are checked because
+ * they come from different layers and a Node change to either is survivable.
+ *
+ * @param {Error} err - Error thrown by `execSync`.
+ * @returns {boolean}
+ */
+function _wasTimedOut(err) {
+  return !!err && (err.code === 'ETIMEDOUT' || err.signal === 'SIGTERM');
 }
 
 /**
@@ -41,67 +85,154 @@ function isGitRepo(dir) {
 
 /**
  * Get git info for a project directory. Results are cached with a 2-minute TTL.
+ *
+ * A PARTIAL reading — one whose `incomplete` names fields the budget could not
+ * establish — is deliberately NOT cached. It records that the budget ran out
+ * once, not that this repository is slow, and freezing it for the TTL would
+ * repeat one bad reading across twelve polls of a repository that may be
+ * answering fine by now.
+ *
  * @param {string} dir - Project directory path
- * @returns {{ branch: string, dirty: boolean, lastCommit: string, lastCommitAge: string, latestTag: string|null }|null}
+ * @param {object} [options] - Read options.
+ * @param {number} [options.budgetMs] - Total wall clock for all git work here.
+ * @returns {{ branch: string, dirty: boolean|null, lastCommit: string, lastCommitAge: string, latestTag: string|null, incomplete: string[] }|null}
  */
-function getInfo(dir) {
+function getInfo(dir, options = {}) {
   const cacheKey = path.resolve(dir);
   const cached = _cache.get(cacheKey);
   if (cached && Date.now() - cached.time < CACHE_TTL) {
     return cached.data;
   }
 
-  const data = _fetchInfo(dir);
-  _cache.set(cacheKey, { data, time: Date.now() });
+  const data = _fetchInfo(dir, options);
+  if (!data || data.incomplete.length === 0) {
+    _cache.set(cacheKey, { data, time: Date.now() });
+  }
   return data;
 }
 
 /**
- * Fetch git info without caching.
+ * Fetch git info without caching, bounded by ONE budget across every spawn.
+ *
+ * Returns `null` only when the directory is genuinely not a repository. A
+ * repository this ran out of budget on comes back as an object whose
+ * `incomplete` names the fields it could not establish — never `null`, because
+ * `lib/dir-scanner-child.js` derives whether a directory IS a project from
+ * `gitInfo && gitInfo.branch`, and a slow repository must lose a badge rather
+ * than stop being a project.
+ *
+ * An unestablished field is never given a plausible default. `dirty` in
+ * particular becomes `null` and not `false`: the dashboard renders it as a dot,
+ * so `false` would draw a dirty repository as clean — an unknown presented as a
+ * definite answer.
+ *
  * @param {string} dir - Project directory path
- * @returns {{ branch: string, dirty: boolean, lastCommit: string, lastCommitAge: string, latestTag: string|null }|null}
+ * @param {object} [options] - Read options.
+ * @param {number} [options.budgetMs] - Total wall clock for all git work here.
+ * @returns {{ branch: string, dirty: boolean|null, lastCommit: string, lastCommitAge: string, latestTag: string|null, incomplete: string[] }|null}
  */
-function _fetchInfo(dir) {
-  if (!isGitRepo(dir)) return null;
+function _fetchInfo(dir, options = {}) {
+  const budgetMs = Number.isFinite(options.budgetMs) ? options.budgetMs : GIT_INFO_BUDGET_MS;
+  const endsAt = Date.now() + budgetMs;
+  const incomplete = [];
 
-  try {
-    const branch = _getBranch(dir);
-    const dirty = _isDirty(dir);
-
-    // Check if the repo has any commits before running log/describe
-    let hasCommits = true;
-    try {
-      _exec('git rev-parse HEAD', dir);
-    } catch {
-      hasCommits = false;
+  /**
+   * Run one git step if budget remains, else record the field as unestablished.
+   *
+   * The zero check is load-bearing rather than defensive: `execSync` treats
+   * `timeout: 0` as NO timeout, so a cap computed as min(perCall, remaining)
+   * becomes UNBOUNDED the instant the budget reaches zero — the very inversion
+   * this budget exists to remove. An exhausted budget must skip, never spawn.
+   *
+   * A spawn our own cap KILLED is unestablished too, not answered: the caller's
+   * documented fallback would otherwise present "we stopped looking" as a fact.
+   * Any other failure means git itself answered (or is absent), and there the
+   * fallback is the honest result.
+   *
+   * @param {string} field - Field name to record when this cannot be answered.
+   * @param {*} fallback - Value to use when it cannot be answered.
+   * @param {(timeout: number) => *} run - Runs the step under the given cap.
+   * @returns {*}
+   */
+  const step = (field, fallback, run) => {
+    const remaining = endsAt - Date.now();
+    if (remaining <= 0) {
+      incomplete.push(field);
+      return fallback;
     }
+    try {
+      return run(Math.min(PER_CALL_CAP_MS, remaining));
+    } catch (err) {
+      if (_wasTimedOut(err)) incomplete.push(field);
+      return fallback;
+    }
+  };
 
-    const lastCommit = hasCommits ? _getLastCommitMessage(dir) : '';
-    const lastCommitAge = hasCommits ? _getLastCommitAge(dir) : '';
-    const latestTag = hasCommits ? _getLatestTag(dir) : null;
-
-    return { branch, dirty, lastCommit, lastCommitAge, latestTag };
-  } catch (err) {
-    log.warn('Failed to get git info', { dir, error: err.message });
-    return null;
+  // Whether this is a repository at all is answered first and separately: every
+  // field below is meaningless without it, and it is the cheapest of the seven.
+  const repoCheck = step('branch', null, (t) => {
+    _exec('git rev-parse --is-inside-work-tree', dir, t);
+    return true;
+  });
+  if (repoCheck === null) {
+    // Distinguish "we could not look" from "not a repository". Only the latter
+    // is an answer; the former must not be cached as one, and `incomplete`
+    // carrying `branch` is what tells `getInfo` to leave it out of the cache.
+    if (incomplete.length === 0) return null;
+    return {
+      branch: 'unknown', dirty: null, lastCommit: '', lastCommitAge: '', latestTag: null,
+      incomplete: ['branch', 'dirty', 'lastCommit', 'lastCommitAge', 'latestTag']
+    };
   }
-}
 
-/**
- * Get the current branch name.
- * @param {string} dir - Repository directory
- * @returns {string}
- */
-function _getBranch(dir) {
-  try {
-    return _exec('git rev-parse --abbrev-ref HEAD', dir);
-  } catch {
-    return 'unknown';
+  const branch = step('branch', 'unknown',
+    (t) => _exec('git rev-parse --abbrev-ref HEAD', dir, t));
+  const dirty = step('dirty', null,
+    (t) => _exec('git status --porcelain', dir, t).length > 0);
+
+  // Whether the repository has any commits at all, before asking log/describe
+  // about them. `null` means the probe itself did not answer, which is not the
+  // same as an empty repository and must not silently read as one.
+  const hasCommits = step('lastCommit', null, (t) => {
+    _exec('git rev-parse HEAD', dir, t);
+    return true;
+  });
+
+  let lastCommit = '';
+  let lastCommitAge = '';
+  let latestTag = null;
+  if (hasCommits === true) {
+    lastCommit = step('lastCommit', '', (t) => _exec('git log -1 --format=%s', dir, t));
+    lastCommitAge = step('lastCommitAge', '', (t) => _exec('git log -1 --format=%cr', dir, t));
+    latestTag = step('latestTag', null, (t) => _exec('git describe --tags --abbrev=0', dir, t));
+  } else if (hasCommits === null) {
+    // The probe was skipped or killed, so nothing downstream of it was even
+    // attempted. Say so for each field rather than letting three empty values
+    // pass for "this repository has no commits".
+    for (const field of ['lastCommitAge', 'latestTag']) {
+      if (!incomplete.includes(field)) incomplete.push(field);
+    }
   }
+
+  if (incomplete.length > 0) {
+    log.warn('Git info incomplete — ran out of budget', { dir, budgetMs, fields: incomplete });
+  }
+
+  return {
+    branch, dirty, lastCommit, lastCommitAge, latestTag,
+    // De-duplicated: the has-commits probe and the message read share a field
+    // name, so a budget that dies on the probe would otherwise name it twice.
+    incomplete: [...new Set(incomplete)]
+  };
 }
 
 /**
  * Check if the working directory has uncommitted changes.
+ *
+ * Kept separate from `_fetchInfo`'s budgeted read because `commit` needs a
+ * straight yes/no under the ordinary per-call cap, with no partial answer to
+ * interpret.
+ *
  * @param {string} dir - Repository directory
  * @returns {boolean}
  */
@@ -111,45 +242,6 @@ function _isDirty(dir) {
     return output.length > 0;
   } catch {
     return false;
-  }
-}
-
-/**
- * Get the latest reachable tag (e.g. "v3.0.0").
- * @param {string} dir - Repository directory
- * @returns {string|null}
- */
-function _getLatestTag(dir) {
-  try {
-    return _exec('git describe --tags --abbrev=0', dir);
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Get the last commit message (first line).
- * @param {string} dir - Repository directory
- * @returns {string}
- */
-function _getLastCommitMessage(dir) {
-  try {
-    return _exec('git log -1 --format=%s', dir);
-  } catch {
-    return '';
-  }
-}
-
-/**
- * Get the relative age of the last commit.
- * @param {string} dir - Repository directory
- * @returns {string}
- */
-function _getLastCommitAge(dir) {
-  try {
-    return _exec('git log -1 --format=%cr', dir);
-  } catch {
-    return '';
   }
 }
 
@@ -198,6 +290,8 @@ module.exports = {
   getInfo,
   clearCache,
   clearCacheFor,
+  GIT_INFO_BUDGET_MS,
+  PER_CALL_CAP_MS,
   _exec,
   _fetchInfo
 };

--- a/lib/git.js
+++ b/lib/git.js
@@ -9,6 +9,18 @@ const log = createLogger('git');
 const CACHE_TTL = 120000; // 2 minutes — short TTLs cause frequent event-loop blocking
 const _cache = new Map();
 
+/** Directories already warned about a truncated read; see `_fetchInfo`. */
+const _warnedIncomplete = new Set();
+
+/**
+ * The identity a directory is cached and de-duplicated under.
+ * @param {string} dir - Directory path
+ * @returns {string}
+ */
+function cacheKeyFor(dir) {
+  return path.resolve(dir);
+}
+
 /** Longest any single `git` invocation may run, regardless of budget left. */
 const PER_CALL_CAP_MS = 5000;
 
@@ -98,7 +110,7 @@ function isGitRepo(dir) {
  * @returns {{ branch: string, dirty: boolean|null, lastCommit: string, lastCommitAge: string, latestTag: string|null, incomplete: string[] }|null}
  */
 function getInfo(dir, options = {}) {
-  const cacheKey = path.resolve(dir);
+  const cacheKey = cacheKeyFor(dir);
   const cached = _cache.get(cacheKey);
   if (cached && Date.now() - cached.time < CACHE_TTL) {
     return cached.data;
@@ -223,7 +235,18 @@ function _fetchInfo(dir, options = {}) {
   }
 
   if (incomplete.length > 0) {
-    log.warn('Git info incomplete — ran out of budget', { dir, budgetMs, fields: incomplete });
+    // Loud ONCE per directory, quiet afterwards. A partial is deliberately not
+    // cached, so a persistently slow repository re-reads on every ten-second
+    // poll — warning each time would emit this several times a minute and bury
+    // the warning it is meant to be. The same call is made one layer up for a
+    // remembered refusal, and for the same reason.
+    //
+    // Per process rather than per interval: this runs in a child the supervisor
+    // recreates, so the set dies with it and a genuinely new incident is loud
+    // again without a timer to get wrong.
+    const level = _warnedIncomplete.has(cacheKeyFor(dir)) ? 'debug' : 'warn';
+    _warnedIncomplete.add(cacheKeyFor(dir));
+    log[level]('Git info incomplete — ran out of budget', { dir, budgetMs, fields: incomplete });
   }
 
   return {
@@ -282,6 +305,7 @@ function commit(dir, message) {
  */
 function clearCache() {
   _cache.clear();
+  _warnedIncomplete.clear();
 }
 
 /**
@@ -289,7 +313,8 @@ function clearCache() {
  * @param {string} dir - Directory path to clear
  */
 function clearCacheFor(dir) {
-  _cache.delete(path.resolve(dir));
+  _cache.delete(cacheKeyFor(dir));
+  _warnedIncomplete.delete(cacheKeyFor(dir));
 }
 
 module.exports = {

--- a/lib/project-facts.js
+++ b/lib/project-facts.js
@@ -25,48 +25,45 @@
  */
 
 const dirScanner = require('./dir-scanner');
+const git = require('./git');
 const { createLogger } = require('./logger');
 
 const log = createLogger('project-facts');
 
 /**
+ * Everything the handler does BESIDES git, plus slack for the round trip.
+ *
+ * The governance read, the project-config parse, and the version chain's
+ * up-to-four reads are all small files at the project root — hundreds of
+ * microseconds warm. The margin is dominated by the fork/IPC round trip, not by
+ * the reads.
+ */
+const FILE_WORK_MARGIN_MS = 1000;
+
+/**
  * How long one project's directory gets to answer before we give up on it.
  *
- * Sized against the work actually behind it, which is no longer a single
- * existence probe: the handler runs `git.getInfo` — roughly six `execSync`
- * spawns, each capped at five seconds by `lib/git.js` — plus a governance read,
- * a config parse, and the version chain's up-to-four file reads and occasional
- * cache write. 2000ms was right when this only had to cover an `fs.access`, and
- * a cold `git.getInfo` on a large repository can legitimately exceed it. A
- * deadline shorter than the honest work is not a safety margin; it manufactures
- * the failure it is meant to detect, and does so on the path where the answer is
- * "grant Full Disk Access".
+ * DERIVED, NOT CHOSEN. The handler's dominant cost is `git.getInfo`, and this
+ * deadline used to be a literal 5000 sitting beside a git read whose honest
+ * worst case was ~35s — seven `execSync` spawns each independently capped at
+ * five seconds. A repository that merely stalled was therefore killed and
+ * reported to the operator as a Full Disk Access problem it did not have, and
+ * the kill discarded git's cache so the retry was equally cold (#891).
  *
- * THE DEADLINE IS NEVERTHELESS SMALLER THAN THE WORST CASE IT BOUNDS, and saying
- * otherwise would make this comment agree with itself at the cost of agreeing
- * with the code. `git.getInfo` issues roughly seven `execSync` calls, each capped
- * at 5000ms by `lib/git.js` — an honest worst case near 35s against one deadline
- * of 5s. A large or cold repository that is answering perfectly well can
- * therefore be killed and reported as unresponsive, complete with a Full Disk
- * Access hint aimed at a permission that was never the problem. It then
- * self-sustains: the kill discards `git.getInfo`'s in-child cache, so the retry
- * after the backoff is equally cold.
+ * Two numbers that must agree and are maintained separately drift, so this one
+ * is computed from the budget it contains. Raising `GIT_INFO_BUDGET_MS` moves
+ * this deadline with it, and the git read can no longer outlive the deadline
+ * that kills the process performing it. What remains is the property this was
+ * always meant to have: expiry means the path did not answer, never that the
+ * repository was slow.
  *
- * Raising this number is NOT the fix — it would trade a spurious timeout for a
- * genuinely wedged directory holding the poll open five times longer. The fix is
- * to bound git's total work inside the handler and derive this from that budget,
- * so the deadline can only expire on work that never answers. Tracked rather than
- * done here because it is a change to `lib/git.js`'s contract, not to this
- * constant. The version chain added by #884 chunk 02b is not a factor either way:
- * it reads small files at the project root.
- *
- * Matched to the projects-directory walk's deadline rather than derived
- * separately, because both now bound the same thing: one round trip to a child
- * doing real filesystem and subprocess work. Callers issue these ONE AT A TIME
- * (see `listProjects`), so this bounds the work itself, not the queue in front
- * of it.
+ * Callers issue these ONE AT A TIME (see `listProjects`), so this bounds the
+ * work itself, not the queue in front of it — which is also why the budget was
+ * sized to leave this deadline where it already was rather than raise it: a
+ * larger per-project deadline multiplies across every registered project on a
+ * ten-second poll.
  */
-const PROJECT_FACTS_TIMEOUT_MS = 5000;
+const PROJECT_FACTS_TIMEOUT_MS = git.GIT_INFO_BUDGET_MS + FILE_WORK_MARGIN_MS;
 
 /**
  * What the degraded answer looks like. Identical in shape to a genuinely missing

--- a/lib/projects.js
+++ b/lib/projects.js
@@ -925,8 +925,8 @@ async function listProjects(options = {}) {
   //
   // ISSUED ONE AT A TIME, and that is a correctness requirement rather than a
   // throttle. The child is single-threaded and each `projectFacts` now performs
-  // `git.getInfo` — around six `execSync` spawns — plus a governance read and a
-  // config parse, all synchronous in that process. Firing N requests in one tick
+  // `git.getInfo` — seven `execSync` spawns under one shared budget — plus a
+  // governance read and a config parse, all synchronous in that process. Firing N requests in one tick
   // put N deadlines on a SERIAL queue, and `dir-scanner.js` starts each timer
   // when the request is ISSUED, not when the child picks it up. The tail of a
   // large fleet therefore spent its whole deadline waiting its turn, and when it

--- a/test/dir-scanner-child.test.js
+++ b/test/dir-scanner-child.test.js
@@ -22,6 +22,7 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const fsp = require('node:fs').promises;
+const { execFileSync } = require('node:child_process');
 
 const { HANDLERS, PROJECT_MARKERS } = require('../lib/dir-scanner-child');
 
@@ -62,6 +63,30 @@ describe('dir-scanner child — scanEntries (the wizard walk)', () => {
       'hidden directories and loose files are not candidate projects');
     assert.equal(projects.find(p => p.name === 'with-marker').detected, true);
     assert.equal(projects.find(p => p.name === 'bare').detected, false);
+  });
+
+  test('forwards `incomplete` alongside the git fields it qualifies', async () => {
+    // This payload projects only `branch` and `dirty` out of the git object, so
+    // it has to carry `incomplete` with them: a `dirty: null` the walk never got
+    // to check is otherwise indistinguishable HERE from a repository that is
+    // genuinely clean, which is the same false fact the projectFacts path
+    // carries it to prevent. Without this the projection can be quietly dropped
+    // again and nothing fails (#891).
+    const root = scratch('incomplete-projection');
+    const repo = path.join(root, 'a-repo');
+    fs.mkdirSync(repo);
+    // Empty --template: a bare `git init` inherits the live global template dir,
+    // which TangleClaw rewrites, and that flakes (#831).
+    execFileSync('git', ['init', '--template=', '-q'], { cwd: repo });
+
+    const { projects } = await HANDLERS.scanEntries({ dir: root, budgetMs: 5000 });
+    const found = projects.find(p => p.name === 'a-repo');
+
+    assert.ok(found.git, 'a git directory reports a git object');
+    assert.ok(Array.isArray(found.git.incomplete),
+      'the projection must keep `incomplete`, or `dirty: null` reads as clean here');
+    assert.deepEqual(found.git.incomplete, [],
+      'a healthy repository establishes every field');
   });
 
   test('stops probing markers once one has answered', async () => {
@@ -342,7 +367,6 @@ describe('dir-scanner child — projectFacts (#884)', () => {
     // supervisor kills mid-syscall an open handle on the SQLite database the
     // server depends on. Asserted on a FRESH child process because this suite's
     // own requires have long since loaded `store` into this one.
-    const { execFileSync } = require('node:child_process');
     const probe = 'require("./lib/dir-scanner-child.js");'
       + 'process.stdout.write(String(Object.keys(require.cache).some(k => k.endsWith("/lib/store.js"))))';
     const loaded = execFileSync(process.execPath, ['-e', probe], {

--- a/test/git-budget.test.js
+++ b/test/git-budget.test.js
@@ -234,6 +234,31 @@ describe('git info budget (#891)', () => {
     });
   });
 
+  describe('the read that establishes nothing is the one that must say so', () => {
+    it('reports when even the is-a-repo probe never answered', () => {
+      // That probe failing takes an early return with a hand-built
+      // all-incomplete object, which bypassed the shared report below it — so
+      // the ONE path that established nothing at all was also the one path that
+      // logged nothing at all. Silent-failure shape, and this file family has
+      // been bitten by it twice (PRJ-2F8W, #884).
+      const lines = [];
+      setConsoleStream({ write: (s) => lines.push(s) });
+      setLevel('debug');
+      try {
+        shadowGit(null);
+        const info = git._fetchInfo(REPO_ROOT, { budgetMs: 800 });
+
+        assert.equal(info.incomplete.length, 5, 'precondition: nothing was established');
+        const reported = lines.filter((l) => l.includes('Git info incomplete'));
+        assert.equal(reported.length, 1, 'the emptiest read must not be the quietest one');
+        assert.match(reported[0], /WARN/);
+      } finally {
+        setConsoleStream(null);
+        setLevel(priorLogLevel);
+      }
+    });
+  });
+
   describe('a deadlined walk passes its remainder down, not the default budget', () => {
     it('reads each directory under what is LEFT of the walk, never a fresh full budget', () => {
       // The walk loops in `lib/dir-scanner-child.js` check their deadline

--- a/test/git-budget.test.js
+++ b/test/git-budget.test.js
@@ -27,11 +27,14 @@ const path = require('node:path');
 const { execFileSync } = require('node:child_process');
 
 const git = require('../lib/git');
+const { setConsoleStream, setLevel, getLevel } = require('../lib/logger');
 const { PROJECT_FACTS_TIMEOUT_MS } = require('../lib/project-facts');
 
 const REPO_ROOT = path.join(__dirname, '..');
 /** Long enough that a cap always wins the race, never the sleep. */
 const STALL_SECONDS = 30;
+/** Restored after the one test that turns the log level down. */
+const priorLogLevel = getLevel();
 
 /** Directory holding the fake `git`, prepended to PATH while a test runs. */
 let fakeBinDir = null;
@@ -177,6 +180,31 @@ describe('git info budget (#891)', () => {
       const first = git.getInfo(REPO_ROOT);
       const second = git.getInfo(REPO_ROOT);
       assert.equal(first, second);
+    });
+  });
+
+  describe('a persistently slow repository is reported once, not once per poll', () => {
+    it('warns the first time and drops to debug for the same directory', () => {
+      // A partial is deliberately not cached, so a repository that stays slow
+      // re-reads on every ten-second poll. Warning each time would emit this
+      // several times a minute and bury the warning it is meant to be — the
+      // same call `lib/project-facts.js` makes for a remembered refusal.
+      const lines = [];
+      setConsoleStream({ write: (s) => lines.push(s) });
+      setLevel('debug');
+      try {
+        shadowGit(['status']);
+        git._fetchInfo(REPO_ROOT, { budgetMs: 2000 });
+        git._fetchInfo(REPO_ROOT, { budgetMs: 2000 });
+
+        const budgetLines = lines.filter((l) => l.includes('ran out of budget'));
+        assert.equal(budgetLines.length, 2, 'both reads must reach the log — neither is silent');
+        assert.match(budgetLines[0], /WARN/);
+        assert.match(budgetLines[1], /DEBUG/);
+      } finally {
+        setConsoleStream(null);
+        setLevel(priorLogLevel);
+      }
     });
   });
 

--- a/test/git-budget.test.js
+++ b/test/git-budget.test.js
@@ -226,6 +226,27 @@ describe('git info budget — an empty budget never becomes an unbounded spawn (
     git.clearCache();
   });
 
+  it('calls a repository with no commits answered, not unestablished', () => {
+    // `git rev-parse HEAD` fails in a freshly-initialised repository, and it
+    // fails the same way a spawn the budget killed does. Distinguishing them by
+    // return value alone reported EVERY empty repository as incomplete — an
+    // answer misfiled as a failure, which is the mirror of the false fact this
+    // whole change exists to prevent.
+    const empty = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-git-nocommit-'));
+    try {
+      execFileSync('git', ['init', '--template=', '-q'], { cwd: empty });
+      const info = git._fetchInfo(empty);
+
+      assert.ok(info !== null, 'an initialised repository is a repository');
+      assert.deepEqual(info.incomplete, [],
+        'no commits is a fact about the repository, not a field we failed to read');
+      assert.equal(info.lastCommit, '');
+      assert.equal(info.latestTag, null);
+    } finally {
+      fs.rmSync(empty, { recursive: true, force: true });
+    }
+  });
+
   it('skips every step rather than spawning git with no timeout', () => {
     // `execSync` treats `timeout: 0` as NO timeout. A cap computed as
     // min(perCall, remaining) therefore becomes UNBOUNDED the moment the budget

--- a/test/git-budget.test.js
+++ b/test/git-budget.test.js
@@ -223,7 +223,7 @@ describe('git info budget (#891)', () => {
         git._fetchInfo(REPO_ROOT, { budgetMs: 2000 });
         git._fetchInfo(REPO_ROOT, { budgetMs: 2000 });
 
-        const budgetLines = lines.filter((l) => l.includes('ran out of budget'));
+        const budgetLines = lines.filter((l) => l.includes('Git info incomplete'));
         assert.equal(budgetLines.length, 2, 'both reads must reach the log — neither is silent');
         assert.match(budgetLines[0], /WARN/);
         assert.match(budgetLines[1], /DEBUG/);

--- a/test/git-budget.test.js
+++ b/test/git-budget.test.js
@@ -48,14 +48,21 @@ let realPath = null;
  * WHICH fields the budget establishes and how long the whole read takes, never
  * on git's output.
  *
- * @param {string[]|null} stallOn - Subcommands to stall on (`null` = all of them).
+ * Patterns are shell globs matched against the WHOLE argument list, not just the
+ * subcommand, because the two `rev-parse` calls have to be told apart: the
+ * is-a-repo probe and the has-commits probe share `$1`.
+ *
+ * @param {string[]|null} stallOn - Globs to stall on (`null` = every invocation).
  * @returns {void}
  */
 function shadowGit(stallOn) {
   fakeBinDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-slow-git-'));
+  // Spaces escaped rather than quoted: a quoted case pattern is literal, and
+  // these need to stay globs so `status*` matches its flags.
+  const patterns = stallOn && stallOn.map((g) => g.replace(/ /g, '\\ ')).join('|');
   const body = stallOn === null
     ? `sleep ${STALL_SECONDS}\n`
-    : `case "$1" in\n  ${stallOn.join('|')}) sleep ${STALL_SECONDS} ;;\nesac\n`;
+    : `case "$*" in\n  ${patterns}) sleep ${STALL_SECONDS} ;;\nesac\n`;
   fs.writeFileSync(path.join(fakeBinDir, 'git'), `#!/bin/sh\n${body}exit 0\n`, { mode: 0o755 });
   realPath = process.env.PATH;
   process.env.PATH = `${fakeBinDir}:${realPath}`;
@@ -92,7 +99,7 @@ describe('git info budget (#891)', () => {
     });
 
     it('names every field it did not establish', () => {
-      shadowGit(['status', 'log', 'describe']);
+      shadowGit(['status*', 'log*', 'describe*']);
       const info = git._fetchInfo(REPO_ROOT, { budgetMs: 2000 });
 
       assert.ok(Array.isArray(info.incomplete));
@@ -112,17 +119,36 @@ describe('git info budget (#891)', () => {
       // budget still stops the read, but the killed field is silently reported
       // as its fallback instead of as unestablished. Only `status` stalls here,
       // so `dirty` is cut short mid-call rather than skipped for want of budget.
-      shadowGit(['status']);
+      shadowGit(['status*']);
       const info = git._fetchInfo(REPO_ROOT, { budgetMs: 2000 });
 
       assert.ok(info.incomplete.includes('dirty'),
         'a field whose spawn was killed by the cap must be named unestablished');
     });
+
+    it('marks everything downstream of a killed has-commits probe, not just the probe', () => {
+      // `git rev-parse HEAD` failing means "no commits" — a real answer, whose
+      // empty message/age/tag are the truth. The same call being KILLED means we
+      // never found out, and it fails identically. Only the step's `ok` separates
+      // them; inferring from the returned value silently let a killed probe pass
+      // for an empty repository, leaving lastCommitAge and latestTag reported as
+      // established when nothing had looked at them.
+      //
+      // Stalls on the has-commits probe alone — matched on the full argument list
+      // because it shares `$1` with the is-a-repo probe that must stay fast.
+      shadowGit(['rev-parse HEAD']);
+      const info = git._fetchInfo(REPO_ROOT, { budgetMs: 3000 });
+
+      for (const field of ['lastCommit', 'lastCommitAge', 'latestTag']) {
+        assert.ok(info.incomplete.includes(field),
+          `${field} sits downstream of a probe that was killed, so it was never established`);
+      }
+    });
   });
 
   describe('an unestablished field never reads as a definite answer', () => {
     it('reports dirty as null rather than false when it could not look', () => {
-      shadowGit(['status']);
+      shadowGit(['status*']);
       const info = git._fetchInfo(REPO_ROOT, { budgetMs: 2000 });
 
       // THE GUARD THIS FILE EXISTS FOR. `_isDirty`'s catch returns `false`, and
@@ -165,7 +191,7 @@ describe('git info budget (#891)', () => {
 
   describe('a truncated reading is not frozen in the cache', () => {
     it('re-reads after a partial instead of serving it for the whole TTL', () => {
-      shadowGit(['status']);
+      shadowGit(['status*']);
       const first = git.getInfo(REPO_ROOT, { budgetMs: 2000 });
       assert.ok(first.incomplete.length > 0, 'precondition: the first read was partial');
 
@@ -193,7 +219,7 @@ describe('git info budget (#891)', () => {
       setConsoleStream({ write: (s) => lines.push(s) });
       setLevel('debug');
       try {
-        shadowGit(['status']);
+        shadowGit(['status*']);
         git._fetchInfo(REPO_ROOT, { budgetMs: 2000 });
         git._fetchInfo(REPO_ROOT, { budgetMs: 2000 });
 
@@ -204,6 +230,31 @@ describe('git info budget (#891)', () => {
       } finally {
         setConsoleStream(null);
         setLevel(priorLogLevel);
+      }
+    });
+  });
+
+  describe('a deadlined walk passes its remainder down, not the default budget', () => {
+    it('reads each directory under what is LEFT of the walk, never a fresh full budget', () => {
+      // The walk loops in `lib/dir-scanner-child.js` check their deadline
+      // BETWEEN iterations, and a synchronous git spawn inside one cannot be
+      // interrupted. So a per-directory read that took `git.getInfo`'s own
+      // default would overrun the walk's bound by a whole budget no matter how
+      // little of the walk was left — the walk's deadline would be documented
+      // rather than enforced. Asserted against the source because the overrun is
+      // a property of what the call site passes, not of anything git returns.
+      const source = fs.readFileSync(
+        path.join(REPO_ROOT, 'lib', 'dir-scanner-child.js'), 'utf8');
+
+      const perDirectoryCalls = [...source.matchAll(/_gitInfo\(([^)]*)\)/g)]
+        .map((m) => m[1])
+        .filter((args) => args.includes('dirPath'));
+
+      assert.ok(perDirectoryCalls.length >= 2,
+        'expected the walk call sites to still exist');
+      for (const args of perDirectoryCalls) {
+        assert.match(args, /deadlineAt/,
+          `a per-directory git read must be given the walk's remaining budget, got _gitInfo(${args})`);
       }
     });
   });

--- a/test/git-budget.test.js
+++ b/test/git-budget.test.js
@@ -1,0 +1,243 @@
+'use strict';
+
+/**
+ * One budget across all of `_fetchInfo`'s spawns (#891).
+ *
+ * `lib/git.js` capped each `git` invocation at 5s and issued seven of them, so
+ * the honest worst case was ~35s behind a 5s scan deadline: a repository whose
+ * git work stalled was SIGKILLed with the child and reported to the operator as
+ * a Full Disk Access problem it did not have.
+ *
+ * THE SLOW `git` HERE IS A REAL EXECUTABLE ON PATH, not a stubbed `_exec`. That
+ * is what caught the bug this file's first draft missed: `execSync` does not set
+ * `killed` on a timeout error, so the code's kill detection never fired and every
+ * truncated read quietly reported its fallback as an answer. A stub resolving on
+ * a timer would have asserted the arithmetic and reproduced none of it.
+ *
+ * Sleeps are 30s against sub-second budgets so a kill is never a race. The fake
+ * git carries a few hundred ms of shell-spawn overhead, which is why budgets
+ * here are seconds rather than the tens of ms a real git costs.
+ */
+
+const { describe, it, afterEach, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const git = require('../lib/git');
+const { PROJECT_FACTS_TIMEOUT_MS } = require('../lib/project-facts');
+
+const REPO_ROOT = path.join(__dirname, '..');
+/** Long enough that a cap always wins the race, never the sleep. */
+const STALL_SECONDS = 30;
+
+/** Directory holding the fake `git`, prepended to PATH while a test runs. */
+let fakeBinDir = null;
+/** PATH as it was before a test shadowed `git`, restored afterwards. */
+let realPath = null;
+
+/**
+ * Put a `git` that stalls on chosen subcommands at the front of PATH.
+ *
+ * It exits 0 with empty stdout otherwise, which is enough: these tests assert on
+ * WHICH fields the budget establishes and how long the whole read takes, never
+ * on git's output.
+ *
+ * @param {string[]|null} stallOn - Subcommands to stall on (`null` = all of them).
+ * @returns {void}
+ */
+function shadowGit(stallOn) {
+  fakeBinDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-slow-git-'));
+  const body = stallOn === null
+    ? `sleep ${STALL_SECONDS}\n`
+    : `case "$1" in\n  ${stallOn.join('|')}) sleep ${STALL_SECONDS} ;;\nesac\n`;
+  fs.writeFileSync(path.join(fakeBinDir, 'git'), `#!/bin/sh\n${body}exit 0\n`, { mode: 0o755 });
+  realPath = process.env.PATH;
+  process.env.PATH = `${fakeBinDir}:${realPath}`;
+}
+
+/**
+ * Undo `shadowGit`. Safe to call when it never ran.
+ * @returns {void}
+ */
+function restoreGit() {
+  if (realPath !== null) process.env.PATH = realPath;
+  if (fakeBinDir) fs.rmSync(fakeBinDir, { recursive: true, force: true });
+  fakeBinDir = null;
+  realPath = null;
+}
+
+describe('git info budget (#891)', () => {
+  afterEach(() => {
+    restoreGit();
+    git.clearCache();
+  });
+
+  describe('the budget bounds the whole read, not each spawn', () => {
+    it('stops near its budget instead of paying the per-call cap seven times', () => {
+      shadowGit(null);
+      const startedAt = Date.now();
+      const info = git._fetchInfo(REPO_ROOT, { budgetMs: 1000 });
+      const elapsed = Date.now() - startedAt;
+
+      assert.ok(info !== null, 'a repository whose git work stalls is still a repository');
+      // The assertion that matters is "nowhere near seven caps" (35s), not a
+      // precise number — a loaded CI box is allowed to be late.
+      assert.ok(elapsed < 5000, `expected the read to stop near its budget, took ${elapsed}ms`);
+    });
+
+    it('names every field it did not establish', () => {
+      shadowGit(['status', 'log', 'describe']);
+      const info = git._fetchInfo(REPO_ROOT, { budgetMs: 2000 });
+
+      assert.ok(Array.isArray(info.incomplete));
+      assert.ok(info.incomplete.length > 0, 'a truncated read must say what it could not answer');
+      for (const field of info.incomplete) {
+        assert.ok(
+          ['branch', 'dirty', 'lastCommit', 'lastCommitAge', 'latestTag'].includes(field),
+          `incomplete named an unknown field: ${field}`
+        );
+      }
+    });
+
+    it('records a spawn the cap KILLED, not only one it skipped', () => {
+      // The regression guard for the bug that shipped in this file's first
+      // draft. `execSync` reports a timeout as code ETIMEDOUT / signal SIGTERM
+      // and leaves `killed` undefined, so a `killed` check never fires: the
+      // budget still stops the read, but the killed field is silently reported
+      // as its fallback instead of as unestablished. Only `status` stalls here,
+      // so `dirty` is cut short mid-call rather than skipped for want of budget.
+      shadowGit(['status']);
+      const info = git._fetchInfo(REPO_ROOT, { budgetMs: 2000 });
+
+      assert.ok(info.incomplete.includes('dirty'),
+        'a field whose spawn was killed by the cap must be named unestablished');
+    });
+  });
+
+  describe('an unestablished field never reads as a definite answer', () => {
+    it('reports dirty as null rather than false when it could not look', () => {
+      shadowGit(['status']);
+      const info = git._fetchInfo(REPO_ROOT, { budgetMs: 2000 });
+
+      // THE GUARD THIS FILE EXISTS FOR. `_isDirty`'s catch returns `false`, and
+      // `public/ui.js` renders `dirty` as a dot — so a check the budget cut
+      // short would draw a dirty repository as clean. `false` here is a false
+      // fact, not a default.
+      assert.ok(info.incomplete.includes('dirty'), 'precondition: dirty was not established');
+      assert.equal(info.dirty, null);
+      assert.notEqual(info.dirty, false);
+    });
+
+    it('stays a non-null object so a stalled repository is still detected as a project', () => {
+      // `lib/dir-scanner-child.js` derives `detected` from `gitInfo && gitInfo.branch`.
+      // Returning null on exhaustion would make a real git-only project vanish
+      // from the detected list rather than merely lose its badge.
+      shadowGit(null);
+      const info = git._fetchInfo(REPO_ROOT, { budgetMs: 1000 });
+
+      assert.ok(info !== null);
+      assert.ok(info.branch, 'branch must stay truthy so the detection predicate still fires');
+    });
+  });
+
+  describe('a healthy repository is unaffected', () => {
+    it('establishes every field and reports nothing incomplete', () => {
+      const info = git._fetchInfo(REPO_ROOT);
+
+      assert.ok(info !== null);
+      assert.deepEqual(info.incomplete, []);
+      assert.equal(typeof info.branch, 'string');
+      assert.equal(typeof info.dirty, 'boolean');
+      assert.equal(typeof info.lastCommit, 'string');
+      assert.equal(typeof info.lastCommitAge, 'string');
+    });
+
+    it('still returns null for a directory that is not a repository', () => {
+      assert.equal(git._fetchInfo(os.tmpdir()), null);
+    });
+  });
+
+  describe('a truncated reading is not frozen in the cache', () => {
+    it('re-reads after a partial instead of serving it for the whole TTL', () => {
+      shadowGit(['status']);
+      const first = git.getInfo(REPO_ROOT, { budgetMs: 2000 });
+      assert.ok(first.incomplete.length > 0, 'precondition: the first read was partial');
+
+      const second = git.getInfo(REPO_ROOT, { budgetMs: 2000 });
+      // Identity, not contents: a cached answer is the SAME object. Caching a
+      // partial would repeat one bad reading across twelve polls of a
+      // repository that may be answering fine by now.
+      assert.notEqual(first, second);
+    });
+
+    it('caches a complete reading as before', () => {
+      const first = git.getInfo(REPO_ROOT);
+      const second = git.getInfo(REPO_ROOT);
+      assert.equal(first, second);
+    });
+  });
+
+  describe('the scan deadline is derived from the budget, not set beside it', () => {
+    it('computes the deadline from the budget rather than restating a number', () => {
+      // ASSERTED AGAINST THE SOURCE, DELIBERATELY. The obvious runtime check —
+      // `PROJECT_FACTS_TIMEOUT_MS > GIT_INFO_BUDGET_MS` — is tautological: the
+      // deadline IS the budget plus a margin, so that comparison holds for every
+      // possible budget and cannot fail. It was written first and passed while
+      // the value was hardcoded, which is the whole failure mode this guards.
+      //
+      // What can actually go wrong is someone restoring a literal here. Then the
+      // two numbers drift again and git's work outlives the deadline that kills
+      // the process performing it — the #891 defect, returned.
+      const source = fs.readFileSync(path.join(REPO_ROOT, 'lib', 'project-facts.js'), 'utf8');
+      const assignment = source.match(/const PROJECT_FACTS_TIMEOUT_MS\s*=\s*([^;]+);/);
+
+      assert.ok(assignment, 'PROJECT_FACTS_TIMEOUT_MS assignment not found');
+      assert.match(
+        assignment[1], /GIT_INFO_BUDGET_MS/,
+        'the scan deadline must be computed from the git budget it contains, not restated as a literal'
+      );
+    });
+
+    it('leaves the deadline above the budget it contains', () => {
+      assert.ok(git.GIT_INFO_BUDGET_MS > 0);
+      assert.ok(PROJECT_FACTS_TIMEOUT_MS > git.GIT_INFO_BUDGET_MS);
+    });
+  });
+});
+
+describe('git info budget — an empty budget never becomes an unbounded spawn (#891)', () => {
+  let repo = null;
+
+  before(() => {
+    repo = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-git-budget-'));
+    // Empty --template deliberately: a bare `git init` inherits the live global
+    // template dir, which TangleClaw rewrites, and that flakes (#831).
+    execFileSync('git', ['init', '--template=', '-q'], { cwd: repo });
+    execFileSync('git', ['config', 'user.email', 't@example.com'], { cwd: repo });
+    execFileSync('git', ['config', 'user.name', 'Test'], { cwd: repo });
+    execFileSync('git', ['commit', '--allow-empty', '-q', '-m', 'init'], { cwd: repo });
+  });
+
+  after(() => {
+    if (repo) fs.rmSync(repo, { recursive: true, force: true });
+    git.clearCache();
+  });
+
+  it('skips every step rather than spawning git with no timeout', () => {
+    // `execSync` treats `timeout: 0` as NO timeout. A cap computed as
+    // min(perCall, remaining) therefore becomes UNBOUNDED the moment the budget
+    // reaches zero — the exact inversion this fix exists to remove. A zero
+    // budget must skip, never spawn.
+    const startedAt = Date.now();
+    const info = git._fetchInfo(repo, { budgetMs: 0 });
+    const elapsed = Date.now() - startedAt;
+
+    assert.ok(elapsed < 1000, `a zero budget must not spawn anything, took ${elapsed}ms`);
+    assert.ok(info !== null, 'an unread repository is unknown, not absent');
+    assert.ok(info.incomplete.includes('dirty'));
+    assert.equal(info.dirty, null);
+  });
+});


### PR DESCRIPTION
## What

All of one repository's git work now shares **one budget** instead of seven independent per-command
caps, and the scan deadline is **computed from** that budget rather than written beside it.

A repository that outruns the budget returns what was established plus `incomplete: string[]` naming
what was not — it is no longer killed, and it is no longer told it has a permissions problem.

## Why

Fixes #891. `_fetchInfo` issues seven `execSync` spawns, each capped at 5000ms, behind a **single**
5000ms deadline that SIGKILLs the process doing the work:

| # | command | via |
|---|---|---|
| 1 | `rev-parse --is-inside-work-tree` | `isGitRepo` |
| 2 | `rev-parse --abbrev-ref HEAD` | branch |
| 3 | `status --porcelain` | dirty |
| 4 | `rev-parse HEAD` | has-commits probe |
| 5 | `log -1 --format=%s` | subject |
| 6 | `log -1 --format=%cr` | age |
| 7 | `describe --tags --abbrev=0` | tag |

An honest worst case near **35s against a 5s limit**. The dashboard then handed the operator a Full
Disk Access remedy for a permission that was never the problem — and it self-sustained, because the
kill discards git's in-process cache so the retry was equally cold.

**Measured before tuning:** all seven against this repository (949 commits, 400 tracked files), warm,
cost **84.5ms together**, none above 20ms. So this is a *stall* case — a very large repository with a
cold cache, or a filesystem that will not answer — not the "any large repo" case #891's wording
implied. The plan says so rather than inheriting the issue's framing.

## Key decisions

**The budget went into `lib/git.js`, not the handler the issue named.** `_gitInfo` has three call
sites, and two call it per candidate subdirectory inside loops carrying their own `deadlineAt` — a
deadline checked *between* iterations, which cannot interrupt a synchronous spawn inside one.
Bounding only the handler would have fixed one site and left two documenting a bound they could not
honour.

**That was necessary and not sufficient — the Critic caught the gap.** A budget in `_fetchInfo` still
let each walk candidate take a fresh *full* budget, because `_gitInfo` passed no options: the overrun
fell from ~35s to ~4s rather than going away, while the plan and commit message both claimed all
three sites were fixed. The walk sites now forward `deadlineAt - Date.now()`. **The claim is true
because the code changed, not because the sentence was softened.**

**Exhaustion degrades to a labelled partial, never `null` and never a default.** Both rules came from
grepping consumers, not from taste:

- `lib/dir-scanner-child.js` derives `detected` from `gitInfo && gitInfo.branch`, so `null` would make
  a real git-only project **vanish** from the detected list; `public/ui.js:248` would additionally
  print "Not a git repo", which is false.
- `_isDirty`'s catch returned `false` while `public/ui.js` renders `dirty` as a dot — so a check the
  budget cut short would draw a **dirty repository as clean**. `dirty` is now `null` when
  unestablished. Same shape as #861: an unknown falling through to a definite.

**The deadline is derived, so the two cannot drift** — and the budget was sized to leave
`PROJECT_FACTS_TIMEOUT_MS` at **5000, unchanged**, because the poll reads projects one at a time and a
larger per-project deadline multiplies across every registered project. **Nothing gets slower.**

**Partials are not cached.** Freezing one truncated reading for the 2-minute TTL would repeat it
across twelve polls of a repository that may be answering fine.

## The two bugs worth reading about

**1. A real slow `git` on PATH caught what a stub would have hidden.** The first implementation
detected "our own cap killed this spawn" with `if (err.killed)`. That branch never fires: `execSync`
sets `killed` on `spawnSync`'s *result*, not on the error it *throws*, where a timeout arrives as
`code: 'ETIMEDOUT'` / `signal: 'SIGTERM'`. It compiled, read correctly, and was dead — so every
budget-truncated field silently reported its fallback as an answer, **the exact false fact this change
exists to prevent**. Reverting it now fails four tests. `lib/tmux.js:53` carries the identical dead
check and has therefore never once logged a tmux timeout — filed as **#894** rather than widened in.

**2. One of my own guards was tautological.** `PROJECT_FACTS_TIMEOUT_MS > GIT_INFO_BUDGET_MS` holds
for *every* budget once the deadline is derived from it — it cannot fail, and it passed against the
hardcoded literal it was written to forbid. Raising the budget to 9000 produced zero red tests. It now
asserts against the source that the deadline is computed. Found by planting the mutation and watching
it *not* fail; sixth occurrence of the pattern behind **#893**.

## Test plan

- **5799 passed / 0 failed / 1 skipped.** JUnit evidence recorded.
- **Fourteen mutations confirmed red**, each planted and watched: budget removed; `dirty` → `false`;
  kill detection → `err.killed`; exhaustion → `null`; partials cached; deadline as a literal;
  zero-budget guard removed; empty repo conflated with a cut-short probe; warn every time; silent
  after the first; walk sites reverted to the default budget; branch failure marked unestablished;
  `step`'s `ok` replaced by value inspection; the all-incomplete early return going silent.
- **Three mutations initially did *not* fail** and each exposed a real gap — the tautological guard,
  the unguarded has-commits path, and a mutation batch run against a baseline that was itself red
  because the fixture raced the fake git's spawn overhead. All three closed.
- **Live:** `readProjectFacts` through the real forked child against this repository — **139ms**,
  `incomplete: []`, `dirty: true`, `version: 4.38.0`, no `unreadable`; a missing directory returned in
  0ms with no spurious remedy. Deadline printed 5000, derived from budget 4000.

**Not verified, and stated as such:** the actual stall case needs a repository whose git work genuinely
exceeds 4s. The unrun TCC probe — `stat` vs `open` from a launchd process *without* Full Disk Access —
remains the honest gap under this whole family, since a session shell inherits FDA and proves nothing.

## Review

**Critic** (`cumulative`, three-reviewer roster; `lib/project-facts.js` is a declared risk surface):
1 blocking, 8 warnings, 14 notes — **14 fixed, 7 accepted with recorded reasons, 2 filed** (#885,
#895). The blocking finding was an empty repository reported as unestablished, which self-scrub had
already fixed while the review ran; the review's more valuable contribution was R-7, which showed
*why* it happened — six per-field conditions reconstructing "did this answer?" from array membership,
a length snapshot and fallback identity. `step` now returns `{ok, value}`. Three `verify-resolutions`
rounds followed, each clean.

**PR reviewer** (independent, opus): 0 blocking, 1 warning, 3 notes. The warning and two notes were
contract/record citations and are fixed. The third it offered to let me accept, and I did not: the
one code path that established *nothing* was also the only one that logged nothing — `_fetchInfo`'s
early return bypassed the warn entirely. That is the silent-failure class this file family has been
burned by twice, so both exits now report through one helper, guarded by a mutation.

**An honest note on process cost:** this branch spent four review rounds. Each surfaced something
real, and each fix bought the next round. The doc-only fixes composed for free; the code ones did
not. Worth knowing before assuming a clean verify means the branch is finished.

## Follow-ups filed

- **#894** — `lib/tmux.js`'s timeout branch is dead code for the same `err.killed` reason.
- **#895** — collapse the seven spawns into three; the measured 84.5ms is nearly all spawn overhead,
  and this runs per project per ten-second poll.
