### PR TITLE
Make the timeout branches fire, so a hang stops reading as a failure (#894)

### DIFF
--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -3832,6 +3832,26 @@ also never fired for a non-numeric code, so a suite chatty enough to exceed the 
 reported a bare `exit 1` with no error at all. Now `typeof err.code !== 'number'`, and the operator
 sees *"stdout maxBuffer length exceeded"*.
 
+**The Critic then found the fix had the same duplication problem as the bug.** `defaultExecShell`
+existed byte-identically in both wrap steps — which is *why* one dead branch was two — and the fix
+had been pasted into both copies rather than removing the copies. It now lives once, in
+`lib/wrap-steps/_exec-shell.js`, with `timedOut` named in the returned contract rather than left as
+an undocumented key that six existing test doubles omit. Extracting it immediately caught a second
+`exec` consumer in `lint.js` that the naive extraction broke, which is the argument for the tests
+being there.
+
+Three more from the same review. **The blocked half of lint had no guard at all** — the
+informational branch got one and the blocking branch, which is lint's canonical mode, did not, so
+reverting it left the suite green. **A killed non-blocking lint was invisible to the operator**: it
+wrote `output.warnings`, and `public/wrap-drawer.js` renders `output.warning` and
+`output.remediation`, so the row showed plain green. And **neither wrap step logged anything** —
+`lib/tmux.js` got a log line, the half that actually misleads an operator got none.
+
+**One finding was widened into its own issue rather than the chunk.** The acceptance criterion
+grepped the symbol `err.killed`, not the pattern behind it; eight more wrap steps still map a killed
+command to a plain exit 1, several of them taking outward actions like `commit` and `pr-merge`.
+Filed as #897.
+
 **Guards driven by real stalling executables, not stubbed errors** — the #891 rule applied
 deliberately, since this entire issue is three hand-written models of an error shape being wrong. A
 stalling `tmux` on PATH, a real `sleep` under a 300ms cap through the production `defaultExecShell`,

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -3788,6 +3788,50 @@ route this fixed the other half of. The family is 32 synchronous reads in `lib/p
 
 **Classification:** fix
 
+## 2026-08-09: the timeout branches actually fire, so a hang stops reading as a failure (#894)
+
+<!-- prawduct: type=fix | chunks=01 | scope=fix-894-timeout-detection | status=shipped -->
+
+**Why:** #894 was filed naming one dead branch in `lib/tmux.js`. A sweep found **three**, dead for
+**two different reasons**, and the second is materially worse than the one that was filed.
+
+| site | API | error on timeout | its check | fired? |
+|---|---|---|---|---|
+| `lib/tmux.js` | `execSync` | `killed: undefined`, `code: 'ETIMEDOUT'` | `err.killed` | never |
+| `lib/wrap-steps/test.js` | async `exec` | `killed: true`, `code: null` | `err.code === undefined && err.killed` | never |
+| `lib/wrap-steps/lint.js` | async `exec` | same | same | never |
+
+`execSync` puts `killed` on `spawnSync`'s *result*, never on the error it *throws*. Async `exec`
+does set it — but its `code` is `null`, not `undefined`, so the compound check died on its first
+clause. Two wrong models of one API family, both compiling, both reading correctly, neither ever
+true. Every shape here was probed against a live process before a line changed.
+
+**The wrap-step consequence was the serious one.** A test command that hung and was killed at ten
+minutes fell through to `exitCode: 1, error: null` — indistinguishable from a suite that ran and
+failed. The operator was then handed `Tests failed (exit 1)` and *"Run the suite locally, fix the
+failing test(s) shown above"*, for tests that had never produced a result. That is the same shape as
+#891: the product naming a cause that did not happen, and charging a debugging session for it.
+Correcting the exit code alone would have shipped a right number under wrong advice, so a timed-out
+step now gets its own blocker and its own remediation, which says plainly that nothing failed.
+
+**The predicate now lives in one place.** `lib/git.js` had a fourth copy, written for #891 — a
+fourth hand-rolled version is how this family produced three wrong answers, so `lib/exec-timeout.js`
+owns it and all four call sites consume it. Its `ETIMEDOUT` clause is deliberately redundant with
+the `SIGTERM` fallback and the module says so: deleting it breaks no test, and that overlap is
+recorded rather than left for an auditor to mistake for an untested branch.
+
+**One adjacent instance of the same class went with it.** `error: err.code === undefined ? … : null`
+also never fired for a non-numeric code, so a suite chatty enough to exceed the 10 MiB buffer
+reported a bare `exit 1` with no error at all. Now `typeof err.code !== 'number'`, and the operator
+sees *"stdout maxBuffer length exceeded"*.
+
+**Guards driven by real stalling executables, not stubbed errors** — the #891 rule applied
+deliberately, since this entire issue is three hand-written models of an error shape being wrong. A
+stalling `tmux` on PATH, a real `sleep` under a 300ms cap through the production `defaultExecShell`,
+a real buffer overflow. Both historical bugs were replanted and both go red.
+
+**Classification:** fix
+
 ## 2026-08-09: git's total work is bounded once, so the scan deadline can only expire on a path that never answers (#891)
 
 <!-- prawduct: type=fix | chunks=01 | scope=fix-891-git-budget | status=shipped -->

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -3820,6 +3820,13 @@ owns it and all four call sites consume it. Its `ETIMEDOUT` clause is deliberate
 the `SIGTERM` fallback and the module says so: deleting it breaks no test, and that overlap is
 recorded rather than left for an auditor to mistake for an untested branch.
 
+**The lint step's informational mode had the same hole one branch over**, found by scrubbing the
+diff rather than by the review. With `blocker: false` a non-zero exit returns `ok: true, status:
+'done'` carrying the output tail — and a killed command has no output, so a lint that never ran was
+reported as one that ran and found nothing to say. Not blocking is the configured behaviour; being
+silent about why is not, and the fix had been placed after that branch rather than before it. It now
+names the timeout there too. *One call site is not the family*, again.
+
 **One adjacent instance of the same class went with it.** `error: err.code === undefined ? … : null`
 also never fired for a non-numeric code, so a suite chatty enough to exceed the 10 MiB buffer
 reported a bare `exit 1` with no error at all. Now `typeof err.code !== 'number'`, and the operator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -463,22 +463,26 @@ All notable changes to TangleClaw are documented in this file.
 
 ### Fixed
 
-- **A wrap step that hangs no longer reports itself as a failing test suite (#894).** If your test
-  command hung and was stopped at the ten-minute limit, the wrap said *"Tests failed (exit 1)"* and
-  told you to *"fix the failing test(s) shown above"*. There were none — nothing had finished. The
-  advice sent you looking for a failure that never happened.
+- **Three checks for "did our own timeout kill this?" were dead code — none had ever run once
+  (#894).** They failed for two different reasons: `execSync` puts `killed` on a different object
+  than the error it throws, and async `exec` does set it but reports a `code` the check compared
+  wrongly. Every one compiled, read correctly, and was never true.
 
-  A stopped command now says so: its own blocker, its own exit code, and remediation that points at
-  where the command hangs — a watch mode left on, a prompt waiting for input, a suite that genuinely
-  needs longer — and states plainly that nothing failed. An ordinary failing suite is unaffected and
-  still reads exactly as before.
+  **What changes for you today** is the tmux diagnostic. A tmux command that hangs and is stopped now
+  says so in the log; that line existed and had never been emitted, so a wedged tmux server left no
+  trace at all.
 
-  Same fix for the lint step. And a test suite noisy enough to overflow the 10 MiB output buffer now
-  tells you that is what happened, instead of failing with no explanation.
+  **What is fixed but not yet reachable from a wrap:** the `test` and `lint` step handlers. A command
+  they stopped for hanging was reported as *"Tests failed (exit 1)"* with advice to *"fix the failing
+  test(s) shown above"* — for tests that had never finished. Both now name the timeout instead, with
+  their own remediation and a log line, and an output overflow reports itself rather than arriving as
+  a bare exit 1. **Neither handler is in the shipped wrap pipeline**, which is fixed to fourteen
+  steps, so no wrap runs them today — they are opt-in primitives, and this makes them correct before
+  they are used rather than after.
 
-  Underneath, three separate checks for "did our own timeout kill this?" were all dead code — none
-  had ever run once, for two different reasons. They now share one implementation, and the
-  `tmux command timed out` diagnostic fires for the first time since it was written.
+  The steps that *are* in the pipeline — `commit`, `pr-merge` and six others — still map a stopped
+  command to a plain failure. That is the reachable half of the same defect and it is tracked
+  separately as #897.
 
 - **A big or slow repository is no longer killed and blamed on Full Disk Access (#891).** Reading one
   project's git state costs seven `git` invocations, and each was capped separately at five seconds —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -463,6 +463,23 @@ All notable changes to TangleClaw are documented in this file.
 
 ### Fixed
 
+- **A wrap step that hangs no longer reports itself as a failing test suite (#894).** If your test
+  command hung and was stopped at the ten-minute limit, the wrap said *"Tests failed (exit 1)"* and
+  told you to *"fix the failing test(s) shown above"*. There were none — nothing had finished. The
+  advice sent you looking for a failure that never happened.
+
+  A stopped command now says so: its own blocker, its own exit code, and remediation that points at
+  where the command hangs — a watch mode left on, a prompt waiting for input, a suite that genuinely
+  needs longer — and states plainly that nothing failed. An ordinary failing suite is unaffected and
+  still reads exactly as before.
+
+  Same fix for the lint step. And a test suite noisy enough to overflow the 10 MiB output buffer now
+  tells you that is what happened, instead of failing with no explanation.
+
+  Underneath, three separate checks for "did our own timeout kill this?" were all dead code — none
+  had ever run once, for two different reasons. They now share one implementation, and the
+  `tmux command timed out` diagnostic fires for the first time since it was written.
+
 - **A big or slow repository is no longer killed and blamed on Full Disk Access (#891).** Reading one
   project's git state costs seven `git` invocations, and each was capped separately at five seconds —
   behind a single five-second deadline that kills the process doing the work. The arithmetic never

--- a/lib/exec-timeout.js
+++ b/lib/exec-timeout.js
@@ -1,0 +1,52 @@
+'use strict';
+
+/**
+ * Whether a child-process error means OUR OWN timeout killed the command.
+ *
+ * This exists as a shared module rather than a local helper because the repo had
+ * THREE hand-written versions of it and all three were dead code (#894). Node
+ * reports the same event two different ways depending on which API ran, and each
+ * author modelled one of them wrongly:
+ *
+ *   `execSync` / `execFileSync` — throws with `code: 'ETIMEDOUT'`,
+ *     `signal: 'SIGTERM'`, and **no `killed`**. That flag belongs to
+ *     `spawnSync`'s RESULT object, not to the error being thrown. `lib/tmux.js`
+ *     read `err.killed`, so its "tmux command timed out" branch had never once
+ *     executed.
+ *
+ *   `exec` / `execFile` (async) — the callback error DOES carry `killed: true`,
+ *     but its `code` is **`null`, not `undefined`**. Both wrap steps tested
+ *     `err.code === undefined && err.killed` and died on the first clause, so a
+ *     hung test run was reported as an ordinary test failure and the operator was
+ *     told to go fix tests that had never run.
+ *
+ * The lesson worth keeping: both branches read correctly, compiled, and were
+ * never once true. Drive any change here with a REAL stalling process — a stub
+ * asserts your model of these shapes, which is exactly what was broken.
+ *
+ * @param {Error|null|undefined} err - Error thrown by, or handed to, a
+ *   `child_process` call.
+ * @returns {boolean} True when a timeout we set killed the command.
+ */
+function wasTimedOut(err) {
+  if (!err) return false;
+  // The synchronous throw. DELIBERATELY REDUNDANT: `execSync` sets both this and
+  // `signal: 'SIGTERM'`, so the fallback below already covers it and deleting
+  // this line breaks no test. Kept because the two come from different layers —
+  // this is the documented contract, the signal is an artifact of how the kill
+  // is delivered — and a predicate this repo got wrong three times should state
+  // what it means rather than rely on a side effect. Anyone auditing coverage:
+  // the overlap is known, not an untested branch.
+  if (err.code === 'ETIMEDOUT') return true;
+  // The asynchronous callback. Strict `true`: an ordinary non-zero exit sets
+  // `killed: false`, which must not read as a timeout.
+  if (err.killed === true) return true;
+  // Shared fallback for shapes neither clause names, and the only clause that
+  // can be wrong: a human `kill` mid-command would land here. Accepted, because
+  // at every call site the sole sender of these signals is our own timeout, and
+  // calling a manual kill a timeout is far better than the behaviour this
+  // replaces — calling a timeout an ordinary failure and remediating it as one.
+  return err.signal === 'SIGTERM' || err.signal === 'SIGKILL';
+}
+
+module.exports = { wasTimedOut };

--- a/lib/git.js
+++ b/lib/git.js
@@ -3,6 +3,7 @@
 const { execSync } = require('node:child_process');
 const path = require('node:path');
 const { createLogger } = require('./logger');
+const { wasTimedOut } = require('./exec-timeout');
 
 const log = createLogger('git');
 
@@ -62,23 +63,6 @@ function _exec(command, cwd, timeout = PER_CALL_CAP_MS) {
     encoding: 'utf8',
     stdio: ['pipe', 'pipe', 'pipe']
   }).trim();
-}
-
-/**
- * Whether OUR OWN cap killed this spawn, rather than git answering.
- *
- * `execSync` does NOT set `killed` on the error it throws — that flag belongs to
- * `spawnSync`'s result object. A timeout arrives as `code: 'ETIMEDOUT'` with
- * `signal: 'SIGTERM'`, so a `killed` check compiles, reads plausibly, and never
- * fires; every budget-truncated read would fall through to its documented
- * fallback and be reported as an answer. Both properties are checked because
- * they come from different layers and a Node change to either is survivable.
- *
- * @param {Error} err - Error thrown by `execSync`.
- * @returns {boolean}
- */
-function _wasTimedOut(err) {
-  return !!err && (err.code === 'ETIMEDOUT' || err.signal === 'SIGTERM');
 }
 
 /**
@@ -209,7 +193,7 @@ function _fetchInfo(dir, options = {}) {
     try {
       return { ok: true, value: run(Math.min(PER_CALL_CAP_MS, remaining)) };
     } catch (err) {
-      if (errorIsAnswer && !_wasTimedOut(err)) return { ok: true, value: fallback };
+      if (errorIsAnswer && !wasTimedOut(err)) return { ok: true, value: fallback };
       incomplete.push(field);
       return { ok: false, value: fallback };
     }

--- a/lib/tmux.js
+++ b/lib/tmux.js
@@ -5,6 +5,7 @@ const os = require('node:os');
 const path = require('node:path');
 const { execSync } = require('node:child_process');
 const { createLogger } = require('./logger');
+const { wasTimedOut } = require('./exec-timeout');
 const serverInfo = require('./server-info');
 
 const log = createLogger('tmux');
@@ -50,7 +51,10 @@ function _exec(command, options = {}) {
   try {
     return execSync(command, { timeout, encoding: 'utf8' }).trim();
   } catch (err) {
-    if (err.killed) {
+    // `wasTimedOut`, not `err.killed`: `execSync` never sets that flag on the
+    // error it throws, so this branch existed and had never once run — a wedged
+    // tmux server produced no timeout log at all (#894).
+    if (wasTimedOut(err)) {
       log.error('tmux command timed out', { command, timeout });
       throw new Error(`tmux command timed out after ${timeout}ms`);
     }

--- a/lib/wrap-steps/_exec-shell.js
+++ b/lib/wrap-steps/_exec-shell.js
@@ -1,0 +1,81 @@
+'use strict';
+
+/**
+ * The shell runner shared by the wrap steps that execute a project command.
+ *
+ * It lived as a byte-identical copy in `test.js` and `lint.js`. Both copies
+ * carried the same dead timeout branch (#894) and both had to be fixed
+ * separately, which is the argument for one copy — a defect in a duplicated
+ * function is a defect per duplicate, and the one that gets missed is the one
+ * nobody was looking at.
+ *
+ * Conventional shell exit code for a command killed by a timeout, so the caller
+ * can tell it apart from any code the command itself could have produced.
+ */
+const TIMEOUT_EXIT_CODE = 124;
+
+const { exec } = require('node:child_process');
+const { wasTimedOut } = require('../exec-timeout');
+
+/**
+ * Run a shell command and resolve to a structured result.
+ *
+ * Never throws, and never rejects: a non-zero exit is an ordinary outcome here
+ * (it is the whole point of a test or lint step), so the exit code is data
+ * rather than an error.
+ *
+ * @param {string} command - Shell command string (e.g. `"npm test"`).
+ * @param {object} options - Run options.
+ * @param {string} options.cwd - Working directory.
+ * @param {number} options.timeoutMs - Wall clock before the command is killed.
+ * @param {number} options.maxBufferBytes - Output cap before the child is killed.
+ * @returns {Promise<{exitCode: number, stdout: string, stderr: string,
+ *   error: string|null, timedOut: boolean}>} `timedOut` distinguishes a command
+ *   that was KILLED from one that ran and failed — callers branch on it to pick
+ *   what they tell the operator, so it is part of the contract, not a hint.
+ *   Anything constructing this shape by hand (a test double, say) must set it.
+ */
+function execShell(command, options) {
+  return new Promise((resolve) => {
+    exec(command, {
+      cwd: options.cwd,
+      timeout: options.timeoutMs,
+      maxBuffer: options.maxBufferBytes,
+      env: process.env
+    }, (err, stdout, stderr) => {
+      // `wasTimedOut`, not `err.code === undefined && err.killed`: async `exec`
+      // DOES set `killed`, but its `code` is `null` rather than `undefined`, so
+      // that branch died on its first clause and a killed command fell through
+      // as an ordinary non-zero exit — reported to the operator as a failure
+      // that never happened (#894).
+      if (wasTimedOut(err)) {
+        resolve({
+          exitCode: TIMEOUT_EXIT_CODE,
+          stdout: stdout || '',
+          stderr: stderr || '',
+          error: `timed out after ${options.timeoutMs}ms`,
+          timedOut: true
+        });
+        return;
+      }
+      const exitCode = err ? (typeof err.code === 'number' ? err.code : 1) : 0;
+      resolve({
+        exitCode,
+        stdout: stdout || '',
+        stderr: stderr || '',
+        // A NUMERIC code means the command ran and exited, and that code IS the
+        // answer. Anything else is the run itself failing, and the old
+        // `=== undefined` test caught none of them — most reachably an output
+        // overflow (`ERR_CHILD_PROCESS_STDIO_MAXBUFFER`), which arrived as a
+        // bare exit 1 with no explanation for a suite that simply printed too
+        // much. (A command that does not EXIST is not one of these: `exec` runs
+        // through a shell, so that is the shell exiting 127 — numeric, and
+        // already reported correctly.)
+        error: err && typeof err.code !== 'number' ? err.message : null,
+        timedOut: false
+      });
+    });
+  });
+}
+
+module.exports = { execShell, TIMEOUT_EXIT_CODE };

--- a/lib/wrap-steps/lint.js
+++ b/lib/wrap-steps/lint.js
@@ -226,11 +226,21 @@ async function run(context) {
 
   // exit ≠ 0 — diverge by blocker mode
   if (blocker === false) {
-    // Informational; never blocks.
+    // Informational; never blocks. It still has to be HONEST: a killed command
+    // produces no output, so reporting it here as a plain non-zero exit with an
+    // empty warnings field says the lint ran and found nothing to say. Not
+    // blocking is the configured behaviour; staying silent about why is not.
     return {
       ok: true,
       status: 'done',
-      output: { exitCode: execResult.exitCode, filesLinted: files.length, warnings: tail },
+      output: {
+        exitCode: execResult.exitCode,
+        filesLinted: files.length,
+        warnings: execResult.timedOut
+          ? `Lint command timed out after ${EXEC_TIMEOUT_MS / 60000} minutes and was stopped — it reported nothing.`
+          : tail,
+        timedOut: !!execResult.timedOut
+      },
       blockers: []
     };
   }

--- a/lib/wrap-steps/lint.js
+++ b/lib/wrap-steps/lint.js
@@ -30,10 +30,13 @@
 const { exec } = require('node:child_process');
 const { createLogger } = require('../logger');
 const store = require('../store');
+const { wasTimedOut } = require('../exec-timeout');
 
 const log = createLogger('wrap-step-lint');
 
 const EXEC_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes — lint should be faster than test
+/** Conventional shell exit code for a command killed by a timeout. */
+const TIMEOUT_EXIT_CODE = 124;
 const MAX_BUFFER_BYTES = 10 * 1024 * 1024;
 const OUTPUT_TAIL_LINES = 50;
 
@@ -44,18 +47,39 @@ const OUTPUT_TAIL_LINES = 50;
  * @param {string} command
  * @param {object} options
  * @param {string} options.cwd
+ * @param {number} [options.timeoutMs] - Test seam; defaults to EXEC_TIMEOUT_MS.
+ * @param {number} [options.maxBufferBytes] - Test seam; defaults to MAX_BUFFER_BYTES.
  * @returns {Promise<{exitCode:number, stdout:string, stderr:string, error:string|null}>}
  */
 function defaultExecShell(command, options) {
+  // The cap is overridable ONLY so a guard can drive the timeout path in
+  // milliseconds instead of waiting out the real one. Production callers pass
+  // nothing and get EXEC_TIMEOUT_MS; without this seam the mapping from a real
+  // kill to `timedOut` is the one thing no test could reach — which is where
+  // this defect lived undetected (#894).
+  const timeoutMs = Number.isFinite(options.timeoutMs) ? options.timeoutMs : EXEC_TIMEOUT_MS;
+  const maxBuffer = Number.isFinite(options.maxBufferBytes)
+    ? options.maxBufferBytes : MAX_BUFFER_BYTES;
   return new Promise((resolve) => {
     exec(command, {
       cwd: options.cwd,
-      timeout: EXEC_TIMEOUT_MS,
-      maxBuffer: MAX_BUFFER_BYTES,
+      timeout: timeoutMs,
+      maxBuffer,
       env: process.env
     }, (err, stdout, stderr) => {
-      if (err && err.code === undefined && err.killed) {
-        resolve({ exitCode: 124, stdout: stdout || '', stderr: stderr || '', error: 'timed out' });
+      // `wasTimedOut`, not `err.code === undefined && err.killed`: async `exec`
+      // DOES set `killed`, but its `code` is `null` rather than `undefined`, so
+      // this branch died on its first clause and a killed command fell through
+      // as an ordinary non-zero exit — reported to the operator as a failure
+      // that never happened (#894).
+      if (wasTimedOut(err)) {
+        resolve({
+          exitCode: TIMEOUT_EXIT_CODE,
+          stdout: stdout || '',
+          stderr: stderr || '',
+          error: `timed out after ${timeoutMs}ms`,
+          timedOut: true
+        });
         return;
       }
       const exitCode = err ? (typeof err.code === 'number' ? err.code : 1) : 0;
@@ -63,7 +87,12 @@ function defaultExecShell(command, options) {
         exitCode,
         stdout: stdout || '',
         stderr: stderr || '',
-        error: err && err.code === undefined ? err.message : null
+        // A NUMERIC code means the command ran and exited; anything else is a
+        // spawn-level failure (`ENOENT` for a command that is not installed),
+        // which the old `=== undefined` test also never caught — so a mistyped
+        // command reported as a plain failure with no error either.
+        error: err && typeof err.code !== 'number' ? err.message : null,
+        timedOut: false
       });
     });
   });
@@ -203,6 +232,25 @@ async function run(context) {
       status: 'done',
       output: { exitCode: execResult.exitCode, filesLinted: files.length, warnings: tail },
       blockers: []
+    };
+  }
+
+  // A KILLED command and a FAILING lint need different words. "Fix the lint
+  // errors shown above" is wrong advice when nothing finished and there are no
+  // errors to show (#894).
+  if (execResult.timedOut) {
+    return {
+      ok: false,
+      status: 'blocked',
+      output: {
+        exitCode: execResult.exitCode,
+        filesLinted: files.length,
+        remediation: `The lint command did not finish within ${EXEC_TIMEOUT_MS / 60000} minutes and was stopped, so it reported nothing. Run it locally to see where it hangs. Nothing here says a file failed lint.`
+      },
+      blockers: [
+        `Lint command timed out after ${EXEC_TIMEOUT_MS / 60000} minutes (exit ${execResult.exitCode})`,
+        ...(tail ? [tail] : [])
+      ]
     };
   }
 

--- a/lib/wrap-steps/lint.js
+++ b/lib/wrap-steps/lint.js
@@ -27,76 +27,43 @@
  * file-name injection (spaces, semicolons, backticks).
  */
 
-const { exec } = require('node:child_process');
 const { createLogger } = require('../logger');
 const store = require('../store');
-const { wasTimedOut } = require('../exec-timeout');
+const { exec } = require('node:child_process');
+const { execShell } = require('./_exec-shell');
 
 const log = createLogger('wrap-step-lint');
 
 const EXEC_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes — lint should be faster than test
-/** Conventional shell exit code for a command killed by a timeout. */
-const TIMEOUT_EXIT_CODE = 124;
 const MAX_BUFFER_BYTES = 10 * 1024 * 1024;
 const OUTPUT_TAIL_LINES = 50;
 
 /**
- * Default shell exec — same shape as `test.js#defaultExecShell`. Exposed
- * via `_internal` so tests can inject without spawning real processes.
+ * This step's shell runner: the shared runner plus this step's own caps.
  *
- * @param {string} command
- * @param {object} options
- * @param {string} options.cwd
+ * The caps are overridable ONLY so a guard can drive the timeout and overflow
+ * paths in milliseconds instead of waiting out the real ones. Production callers
+ * pass neither. Without that seam the mapping from a real kill to `timedOut` is
+ * the one thing no test could reach — which is exactly where this defect lived
+ * undetected (#894).
+ *
+ * @param {string} command - Shell command string.
+ * @param {object} options - Run options.
+ * @param {string} options.cwd - Working directory.
  * @param {number} [options.timeoutMs] - Test seam; defaults to EXEC_TIMEOUT_MS.
  * @param {number} [options.maxBufferBytes] - Test seam; defaults to MAX_BUFFER_BYTES.
- * @returns {Promise<{exitCode:number, stdout:string, stderr:string, error:string|null}>}
+ * @returns {Promise<{exitCode: number, stdout: string, stderr: string,
+ *   error: string|null, timedOut: boolean}>}
  */
 function defaultExecShell(command, options) {
-  // The cap is overridable ONLY so a guard can drive the timeout path in
-  // milliseconds instead of waiting out the real one. Production callers pass
-  // nothing and get EXEC_TIMEOUT_MS; without this seam the mapping from a real
-  // kill to `timedOut` is the one thing no test could reach — which is where
-  // this defect lived undetected (#894).
-  const timeoutMs = Number.isFinite(options.timeoutMs) ? options.timeoutMs : EXEC_TIMEOUT_MS;
-  const maxBuffer = Number.isFinite(options.maxBufferBytes)
-    ? options.maxBufferBytes : MAX_BUFFER_BYTES;
-  return new Promise((resolve) => {
-    exec(command, {
-      cwd: options.cwd,
-      timeout: timeoutMs,
-      maxBuffer,
-      env: process.env
-    }, (err, stdout, stderr) => {
-      // `wasTimedOut`, not `err.code === undefined && err.killed`: async `exec`
-      // DOES set `killed`, but its `code` is `null` rather than `undefined`, so
-      // this branch died on its first clause and a killed command fell through
-      // as an ordinary non-zero exit — reported to the operator as a failure
-      // that never happened (#894).
-      if (wasTimedOut(err)) {
-        resolve({
-          exitCode: TIMEOUT_EXIT_CODE,
-          stdout: stdout || '',
-          stderr: stderr || '',
-          error: `timed out after ${timeoutMs}ms`,
-          timedOut: true
-        });
-        return;
-      }
-      const exitCode = err ? (typeof err.code === 'number' ? err.code : 1) : 0;
-      resolve({
-        exitCode,
-        stdout: stdout || '',
-        stderr: stderr || '',
-        // A NUMERIC code means the command ran and exited; anything else is a
-        // spawn-level failure (`ENOENT` for a command that is not installed),
-        // which the old `=== undefined` test also never caught — so a mistyped
-        // command reported as a plain failure with no error either.
-        error: err && typeof err.code !== 'number' ? err.message : null,
-        timedOut: false
-      });
-    });
+  return execShell(command, {
+    cwd: options.cwd,
+    timeoutMs: Number.isFinite(options.timeoutMs) ? options.timeoutMs : EXEC_TIMEOUT_MS,
+    maxBufferBytes: Number.isFinite(options.maxBufferBytes)
+      ? options.maxBufferBytes : MAX_BUFFER_BYTES
   });
 }
+
 
 /**
  * Detect files changed in this session via `git status --porcelain`.
@@ -239,7 +206,16 @@ async function run(context) {
         warnings: execResult.timedOut
           ? `Lint command timed out after ${EXEC_TIMEOUT_MS / 60000} minutes and was stopped — it reported nothing.`
           : tail,
-        timedOut: !!execResult.timedOut
+        timedOut: !!execResult.timedOut,
+        // `warning`/`remediation` are the channels the drawer actually renders
+        // (`public/wrap-drawer.js#buildStepRow` reads `output.warning === true`
+        // and `output.remediation`). Writing only to `warnings` left a killed
+        // lint showing as a plain green row — honest in the payload, invisible
+        // to the person it was for.
+        ...(execResult.timedOut ? {
+          warning: true,
+          remediation: `The lint command did not finish within ${EXEC_TIMEOUT_MS / 60000} minutes and was stopped, so it checked nothing. This step is configured not to block, so the wrap continued. Run it locally to see where it hangs.`
+        } : {})
       },
       blockers: []
     };
@@ -249,6 +225,9 @@ async function run(context) {
   // errors shown above" is wrong advice when nothing finished and there are no
   // errors to show (#894).
   if (execResult.timedOut) {
+    log.warn('Lint command timed out', {
+      project: project.name, timeoutMs: EXEC_TIMEOUT_MS, exitCode: execResult.exitCode
+    });
     return {
       ok: false,
       status: 'blocked',

--- a/lib/wrap-steps/test.js
+++ b/lib/wrap-steps/test.js
@@ -16,77 +16,42 @@
  * is allowed to opt out of tests, and a missing command must not block.
  */
 
-const { exec } = require('node:child_process');
 const { createLogger } = require('../logger');
 const store = require('../store');
-const { wasTimedOut } = require('../exec-timeout');
+const { execShell } = require('./_exec-shell');
 
 const log = createLogger('wrap-step-test');
 
 const EXEC_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes — long enough for real test suites; bounded so a hung process can't wedge the wrap UI forever
-/** Conventional shell exit code for a command killed by a timeout. */
-const TIMEOUT_EXIT_CODE = 124;
 const MAX_BUFFER_BYTES = 10 * 1024 * 1024; // 10 MiB — generous; truncated to a tail before surfacing
 const OUTPUT_TAIL_LINES = 50;
 
 /**
- * Default shell exec. Resolves to a structured result; never throws on
- * non-zero exit (that's the success path for "tests failed"). Exposed
- * via `_internal` so tests can inject without spawning real processes.
+ * This step's shell runner: the shared runner plus this step's own caps.
  *
- * @param {string} command - Shell command string (e.g. "npm test")
- * @param {object} options
- * @param {string} options.cwd - Working directory
+ * The caps are overridable ONLY so a guard can drive the timeout and overflow
+ * paths in milliseconds instead of waiting out the real ones. Production callers
+ * pass neither. Without that seam the mapping from a real kill to `timedOut` is
+ * the one thing no test could reach — which is exactly where this defect lived
+ * undetected (#894).
+ *
+ * @param {string} command - Shell command string.
+ * @param {object} options - Run options.
+ * @param {string} options.cwd - Working directory.
  * @param {number} [options.timeoutMs] - Test seam; defaults to EXEC_TIMEOUT_MS.
  * @param {number} [options.maxBufferBytes] - Test seam; defaults to MAX_BUFFER_BYTES.
- * @returns {Promise<{exitCode: number, stdout: string, stderr: string, error: string|null}>}
+ * @returns {Promise<{exitCode: number, stdout: string, stderr: string,
+ *   error: string|null, timedOut: boolean}>}
  */
 function defaultExecShell(command, options) {
-  // The cap is overridable ONLY so a guard can drive the timeout path in
-  // milliseconds instead of waiting out the real one. Production callers pass
-  // nothing and get EXEC_TIMEOUT_MS; without this seam the mapping from a real
-  // kill to `timedOut` is the one thing no test could reach — which is where
-  // this defect lived undetected (#894).
-  const timeoutMs = Number.isFinite(options.timeoutMs) ? options.timeoutMs : EXEC_TIMEOUT_MS;
-  const maxBuffer = Number.isFinite(options.maxBufferBytes)
-    ? options.maxBufferBytes : MAX_BUFFER_BYTES;
-  return new Promise((resolve) => {
-    exec(command, {
-      cwd: options.cwd,
-      timeout: timeoutMs,
-      maxBuffer,
-      env: process.env
-    }, (err, stdout, stderr) => {
-      // `wasTimedOut`, not `err.code === undefined && err.killed`: async `exec`
-      // DOES set `killed`, but its `code` is `null` rather than `undefined`, so
-      // this branch died on its first clause and a killed command fell through
-      // as an ordinary non-zero exit — reported to the operator as a failure
-      // that never happened (#894).
-      if (wasTimedOut(err)) {
-        resolve({
-          exitCode: TIMEOUT_EXIT_CODE,
-          stdout: stdout || '',
-          stderr: stderr || '',
-          error: `timed out after ${timeoutMs}ms`,
-          timedOut: true
-        });
-        return;
-      }
-      const exitCode = err ? (typeof err.code === 'number' ? err.code : 1) : 0;
-      resolve({
-        exitCode,
-        stdout: stdout || '',
-        stderr: stderr || '',
-        // A NUMERIC code means the command ran and exited; anything else is a
-        // spawn-level failure (`ENOENT` for a command that is not installed),
-        // which the old `=== undefined` test also never caught — so a mistyped
-        // command reported as a plain failure with no error either.
-        error: err && typeof err.code !== 'number' ? err.message : null,
-        timedOut: false
-      });
-    });
+  return execShell(command, {
+    cwd: options.cwd,
+    timeoutMs: Number.isFinite(options.timeoutMs) ? options.timeoutMs : EXEC_TIMEOUT_MS,
+    maxBufferBytes: Number.isFinite(options.maxBufferBytes)
+      ? options.maxBufferBytes : MAX_BUFFER_BYTES
   });
 }
+
 
 /**
  * Take the last N lines of a string for surfacing in blockers/output.
@@ -154,6 +119,12 @@ async function run(context) {
   // after a failure that never happened — there is no result to read, because
   // nothing finished (#894).
   if (execResult.timedOut) {
+    // The serious half of #894 left no trace anywhere an operator or a support
+    // question could find it: `lib/tmux.js` got a log line, this did not, and
+    // `wrap-pipeline.js` does not persist step results.
+    log.warn('Test command timed out', {
+      project: project.name, timeoutMs: EXEC_TIMEOUT_MS, exitCode: execResult.exitCode
+    });
     return {
       ok: false,
       status: 'blocked',

--- a/lib/wrap-steps/test.js
+++ b/lib/wrap-steps/test.js
@@ -19,10 +19,13 @@
 const { exec } = require('node:child_process');
 const { createLogger } = require('../logger');
 const store = require('../store');
+const { wasTimedOut } = require('../exec-timeout');
 
 const log = createLogger('wrap-step-test');
 
 const EXEC_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes — long enough for real test suites; bounded so a hung process can't wedge the wrap UI forever
+/** Conventional shell exit code for a command killed by a timeout. */
+const TIMEOUT_EXIT_CODE = 124;
 const MAX_BUFFER_BYTES = 10 * 1024 * 1024; // 10 MiB — generous; truncated to a tail before surfacing
 const OUTPUT_TAIL_LINES = 50;
 
@@ -34,19 +37,39 @@ const OUTPUT_TAIL_LINES = 50;
  * @param {string} command - Shell command string (e.g. "npm test")
  * @param {object} options
  * @param {string} options.cwd - Working directory
+ * @param {number} [options.timeoutMs] - Test seam; defaults to EXEC_TIMEOUT_MS.
+ * @param {number} [options.maxBufferBytes] - Test seam; defaults to MAX_BUFFER_BYTES.
  * @returns {Promise<{exitCode: number, stdout: string, stderr: string, error: string|null}>}
  */
 function defaultExecShell(command, options) {
+  // The cap is overridable ONLY so a guard can drive the timeout path in
+  // milliseconds instead of waiting out the real one. Production callers pass
+  // nothing and get EXEC_TIMEOUT_MS; without this seam the mapping from a real
+  // kill to `timedOut` is the one thing no test could reach — which is where
+  // this defect lived undetected (#894).
+  const timeoutMs = Number.isFinite(options.timeoutMs) ? options.timeoutMs : EXEC_TIMEOUT_MS;
+  const maxBuffer = Number.isFinite(options.maxBufferBytes)
+    ? options.maxBufferBytes : MAX_BUFFER_BYTES;
   return new Promise((resolve) => {
     exec(command, {
       cwd: options.cwd,
-      timeout: EXEC_TIMEOUT_MS,
-      maxBuffer: MAX_BUFFER_BYTES,
+      timeout: timeoutMs,
+      maxBuffer,
       env: process.env
     }, (err, stdout, stderr) => {
-      if (err && err.code === undefined && err.killed) {
-        // Killed by timeout — surface as a synthetic non-zero exit
-        resolve({ exitCode: 124, stdout: stdout || '', stderr: stderr || '', error: 'timed out' });
+      // `wasTimedOut`, not `err.code === undefined && err.killed`: async `exec`
+      // DOES set `killed`, but its `code` is `null` rather than `undefined`, so
+      // this branch died on its first clause and a killed command fell through
+      // as an ordinary non-zero exit — reported to the operator as a failure
+      // that never happened (#894).
+      if (wasTimedOut(err)) {
+        resolve({
+          exitCode: TIMEOUT_EXIT_CODE,
+          stdout: stdout || '',
+          stderr: stderr || '',
+          error: `timed out after ${timeoutMs}ms`,
+          timedOut: true
+        });
         return;
       }
       const exitCode = err ? (typeof err.code === 'number' ? err.code : 1) : 0;
@@ -54,7 +77,12 @@ function defaultExecShell(command, options) {
         exitCode,
         stdout: stdout || '',
         stderr: stderr || '',
-        error: err && err.code === undefined ? err.message : null
+        // A NUMERIC code means the command ran and exited; anything else is a
+        // spawn-level failure (`ENOENT` for a command that is not installed),
+        // which the old `=== undefined` test also never caught — so a mistyped
+        // command reported as a plain failure with no error either.
+        error: err && typeof err.code !== 'number' ? err.message : null,
+        timedOut: false
       });
     });
   });
@@ -120,6 +148,26 @@ async function run(context) {
   }
 
   const tail = _tail(execResult.stderr || execResult.stdout, OUTPUT_TAIL_LINES);
+
+  // A KILLED command and a FAILING suite need different words. Telling someone
+  // whose test command hung to "fix the failing test(s) shown above" sends them
+  // after a failure that never happened — there is no result to read, because
+  // nothing finished (#894).
+  if (execResult.timedOut) {
+    return {
+      ok: false,
+      status: 'blocked',
+      output: {
+        exitCode: execResult.exitCode,
+        remediation: `The test command did not finish within ${EXEC_TIMEOUT_MS / 60000} minutes and was stopped, so there is no pass/fail result to read. Run it locally to see where it hangs — a watch mode left on, a prompt waiting for input, or a suite that genuinely needs longer are the usual causes. Nothing here says a test failed.`
+      },
+      blockers: [
+        `Test command timed out after ${EXEC_TIMEOUT_MS / 60000} minutes (exit ${execResult.exitCode})`,
+        ...(tail ? [tail] : [])
+      ]
+    };
+  }
+
   const blockers = [`Tests failed (exit ${execResult.exitCode})`];
   if (tail) blockers.push(tail);
   if (execResult.error) blockers.push(`exec error: ${execResult.error}`);

--- a/test/exec-timeout.test.js
+++ b/test/exec-timeout.test.js
@@ -1,0 +1,103 @@
+'use strict';
+
+/**
+ * One predicate for "our own timeout killed this" (#894).
+ *
+ * Three hand-rolled versions of this check lived in the repo and ALL THREE were
+ * dead code, for two different reasons:
+ *
+ *   `execSync`     throws with code 'ETIMEDOUT', signal 'SIGTERM', and NO
+ *                  `killed` — that flag belongs to `spawnSync`'s RESULT object,
+ *                  never to the error. `lib/tmux.js` tested `err.killed`.
+ *   async `exec`   DOES set `killed: true` on the callback error, but its `code`
+ *                  is `null`, not `undefined`. Both wrap steps tested
+ *                  `err.code === undefined && err.killed`, failing on clause one.
+ *
+ * EVERY CASE HERE RUNS A REAL PROCESS. A stubbed error object would assert the
+ * author's model of these shapes, and this issue exists precisely because three
+ * such models were wrong.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { execSync, exec } = require('node:child_process');
+
+const { wasTimedOut } = require('../lib/exec-timeout');
+
+/**
+ * Run a command under `execSync` with a timeout and hand back what it threw.
+ * @param {string} command - Command to run.
+ * @param {number} timeout - Milliseconds before the kill.
+ * @returns {Error|null} The thrown error, or null when it did not throw.
+ */
+function syncFailure(command, timeout) {
+  try {
+    execSync(command, { timeout, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] });
+    return null;
+  } catch (err) {
+    return err;
+  }
+}
+
+/**
+ * Run a command under async `exec` and hand back the callback's error.
+ * @param {string} command - Command to run.
+ * @param {number} [timeout] - Milliseconds before the kill; omit for no timeout.
+ * @returns {Promise<Error|null>}
+ */
+function asyncFailure(command, timeout) {
+  return new Promise((resolve) => {
+    exec(command, timeout ? { timeout } : {}, (err) => resolve(err || null));
+  });
+}
+
+describe('wasTimedOut (#894)', () => {
+  describe('says yes to a kill we caused', () => {
+    it('recognises a real execSync timeout', () => {
+      const err = syncFailure('sleep 5', 200);
+
+      assert.ok(err, 'precondition: the command was killed');
+      // Pinned because it is the whole bug: `killed` is NOT on this error, so a
+      // check that reads it compiles, looks right, and never fires.
+      assert.equal(err.killed, undefined,
+        'execSync leaves `killed` unset — this is why the old tmux check was dead');
+      assert.equal(err.code, 'ETIMEDOUT');
+      assert.equal(wasTimedOut(err), true);
+    });
+
+    it('recognises a real async exec timeout', async () => {
+      const err = await asyncFailure('sleep 5', 200);
+
+      assert.ok(err, 'precondition: the command was killed');
+      // The mirror-image trap: `killed` IS set here, but `code` is null rather
+      // than undefined, so the wrap steps' compound check died on its first
+      // clause while looking like it handled exactly this case.
+      assert.equal(err.killed, true);
+      assert.equal(err.code, null, 'null, NOT undefined — this is why the wrap-step check was dead');
+      assert.equal(wasTimedOut(err), true);
+    });
+  });
+
+  describe('says no to a failure that is the command answering', () => {
+    it('rejects an ordinary non-zero exit', async () => {
+      const err = await asyncFailure('exit 3');
+
+      assert.ok(err, 'precondition: the command failed');
+      assert.equal(err.code, 3);
+      assert.equal(wasTimedOut(err), false,
+        'a test suite that legitimately failed must never be reported as a timeout');
+    });
+
+    it('rejects a command that does not exist', async () => {
+      const err = await asyncFailure('tc-no-such-command-894');
+
+      assert.ok(err, 'precondition: the command failed');
+      assert.equal(wasTimedOut(err), false);
+    });
+
+    it('rejects a null or undefined error', () => {
+      assert.equal(wasTimedOut(null), false);
+      assert.equal(wasTimedOut(undefined), false);
+    });
+  });
+});

--- a/test/tmux.test.js
+++ b/test/tmux.test.js
@@ -17,7 +17,6 @@ describe('tmux — a timed-out command says so (#894)', () => {
     // Driven by a REAL stalling `tmux` on PATH: a stubbed error would assert the
     // very model that was wrong.
     const os = require('node:os');
-    const { execSync } = require('node:child_process');
     const binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-slow-tmux-'));
     fs.writeFileSync(path.join(binDir, 'tmux'), '#!/bin/sh\nsleep 30\n', { mode: 0o755 });
     const realPath = process.env.PATH;
@@ -31,7 +30,6 @@ describe('tmux — a timed-out command says so (#894)', () => {
     } finally {
       process.env.PATH = realPath;
       fs.rmSync(binDir, { recursive: true, force: true });
-      void execSync;
     }
   });
 });

--- a/test/tmux.test.js
+++ b/test/tmux.test.js
@@ -6,6 +6,36 @@ const fs = require('node:fs');
 const path = require('node:path');
 const tmux = require('../lib/tmux');
 
+describe('tmux — a timed-out command says so (#894)', () => {
+  it('raises the timeout error instead of the raw exec failure', () => {
+    // `lib/tmux.js` tested `err.killed` to spot its own timeout. `execSync` never
+    // sets that on the error it throws — it throws code 'ETIMEDOUT' — so the
+    // branch, and the 'tmux command timed out' log line inside it, had NEVER
+    // executed. A wedged tmux server (a state #94/#144/#380 record this install
+    // reaching) produced no timeout diagnostic at all.
+    //
+    // Driven by a REAL stalling `tmux` on PATH: a stubbed error would assert the
+    // very model that was wrong.
+    const os = require('node:os');
+    const { execSync } = require('node:child_process');
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-slow-tmux-'));
+    fs.writeFileSync(path.join(binDir, 'tmux'), '#!/bin/sh\nsleep 30\n', { mode: 0o755 });
+    const realPath = process.env.PATH;
+    process.env.PATH = `${binDir}:${realPath}`;
+    try {
+      assert.throws(
+        () => tmux._exec('tmux list-sessions', { timeout: 300 }),
+        /tmux command timed out after 300ms/,
+        'a killed tmux command must be reported as timed out, not as a bare exec failure'
+      );
+    } finally {
+      process.env.PATH = realPath;
+      fs.rmSync(binDir, { recursive: true, force: true });
+      void execSync;
+    }
+  });
+});
+
 describe('tmux', () => {
   describe('toSessionName', () => {
     it('should pass through valid names unchanged', () => {

--- a/test/wrap-pipeline.test.js
+++ b/test/wrap-pipeline.test.js
@@ -733,6 +733,24 @@ describe('wrap-step lint (#139 Chunk 4)', () => {
     assert.match(result.output.warnings, /error/);
   });
 
+  it('with blocker:false, a timeout still says it timed out', async () => {
+    // Not blocking is the configured behaviour; staying silent about WHY is a
+    // different thing. A killed lint produces no output, so the informational
+    // branch would otherwise report a bare non-zero exit with empty warnings —
+    // a step that never ran, presented as one that ran and had nothing to say.
+    writeConfig({ lintCommand: 'eslint' });
+    lintStep._internal.detectChangedFiles = async () => ['src/foo.js'];
+    lintStep._internal.execShell = async () => ({
+      exitCode: 124, stdout: '', stderr: '', error: 'timed out after 300000ms', timedOut: true
+    });
+    const result = await lintStep.run(buildContext({ id: 'lint', blocker: false }));
+
+    assert.equal(result.ok, true, 'blocker:false still must not block');
+    assert.equal(result.output.timedOut, true);
+    assert.match(result.output.warnings, /timed out/i,
+      'an informational step that was killed must still say so');
+  });
+
   it('shell-quotes file paths containing spaces and single quotes', async () => {
     // Direct unit test of the quoting helper — visible from public API
     // so the test pins the contract.

--- a/test/wrap-pipeline.test.js
+++ b/test/wrap-pipeline.test.js
@@ -733,6 +733,46 @@ describe('wrap-step lint (#139 Chunk 4)', () => {
     assert.match(result.output.warnings, /error/);
   });
 
+  it('names a timeout as a timeout in its BLOCKING mode too', async () => {
+    // R-1 from the #894 review, and the acceptance criterion this chunk set for
+    // itself: every timeout branch needs a guard that fails when reverted. The
+    // informational branch had one and the blocked branch did not — and blocked
+    // is lint's canonical mode (`docs/adr/0002` configures it "errors-only"), so
+    // the guarded half was the half that matters less.
+    writeConfig({ lintCommand: 'eslint' });
+    lintStep._internal.detectChangedFiles = async () => ['src/foo.js'];
+    lintStep._internal.execShell = async () => ({
+      exitCode: 124, stdout: '', stderr: '', error: 'timed out after 300000ms', timedOut: true
+    });
+    const result = await lintStep.run(buildContext({ id: 'lint', blocker: true }));
+
+    assert.equal(result.ok, false);
+    assert.equal(result.status, 'blocked');
+    assert.equal(result.output.exitCode, 124);
+    assert.ok(result.blockers.some((b) => /timed out/i.test(b)),
+      'the blocker must name the timeout');
+    assert.ok(!result.blockers.some((b) => /^Lint failed/.test(b)),
+      'nothing was linted — saying it failed sends the operator after errors that do not exist');
+    assert.doesNotMatch(result.output.remediation, /fix the lint errors/i);
+  });
+
+  it('routes a non-blocking timeout through the channel the drawer renders', async () => {
+    // `public/wrap-drawer.js#buildStepRow` reads `output.warning === true` and
+    // `output.remediation`. Writing only to `output.warnings` left a killed lint
+    // rendering as a plain green row — correct in the payload, invisible to the
+    // person it was written for.
+    writeConfig({ lintCommand: 'eslint' });
+    lintStep._internal.detectChangedFiles = async () => ['src/foo.js'];
+    lintStep._internal.execShell = async () => ({
+      exitCode: 124, stdout: '', stderr: '', error: 'timed out after 300000ms', timedOut: true
+    });
+    const result = await lintStep.run(buildContext({ id: 'lint', blocker: false }));
+
+    assert.equal(result.ok, true, 'blocker:false still must not block');
+    assert.equal(result.output.warning, true, 'the drawer keys off `warning`, not `warnings`');
+    assert.match(result.output.remediation, /did not finish|hangs/i);
+  });
+
   it('with blocker:false, a timeout still says it timed out', async () => {
     // Not blocking is the configured behaviour; staying silent about WHY is a
     // different thing. A killed lint produces no output, so the informational

--- a/test/wrap-pipeline.test.js
+++ b/test/wrap-pipeline.test.js
@@ -538,6 +538,42 @@ describe('wrap-step test (#139 Chunk 4)', () => {
       'test remediation must mention the skip-tests override');
   });
 
+  it('names a timeout as a timeout instead of as a failing suite', async () => {
+    // The whole point of #894. Before the fix a killed command arrived here as
+    // exitCode 1 / error null — indistinguishable from a suite that ran and
+    // failed — so the operator was handed "fix the failing test(s) shown above"
+    // for tests that had never produced a result.
+    writeConfig({ testCommand: 'npm test' });
+    testStep._internal.execShell = async () => ({
+      exitCode: 124, stdout: '', stderr: '', error: 'timed out after 600000ms', timedOut: true
+    });
+    const result = await testStep.run(buildContext({ id: 'test', blocker: true }));
+
+    assert.equal(result.ok, false);
+    assert.equal(result.status, 'blocked');
+    assert.equal(result.output.exitCode, 124);
+    assert.ok(result.blockers.some((b) => /timed out/i.test(b)),
+      'the blocker must name the timeout');
+    assert.ok(!result.blockers.some((b) => b.startsWith('Tests failed')),
+      'nothing failed — saying so sends the operator after a failure that never happened');
+    assert.doesNotMatch(result.output.remediation, /fix the failing test/i);
+    assert.match(result.output.remediation, /did not finish|hangs/i);
+  });
+
+  it('keeps the failing-suite remediation for an ordinary non-zero exit', async () => {
+    // The other half of the same predicate: correcting the timeout path must not
+    // reclassify a genuine failure as a hang.
+    writeConfig({ testCommand: 'npm test' });
+    testStep._internal.execShell = async () => ({
+      exitCode: 1, stdout: '', stderr: '1 failing\n', error: null, timedOut: false
+    });
+    const result = await testStep.run(buildContext({ id: 'test', blocker: true }));
+
+    assert.equal(result.ok, false);
+    assert.ok(result.blockers[0].includes('Tests failed (exit 1)'));
+    assert.match(result.output.remediation, /fix the failing test/i);
+  });
+
   it('honors allowOverride+skipTests by reporting skipped with override flag', async () => {
     writeConfig({ testCommand: 'npm test' });
     let execCalled = false;

--- a/test/wrap-step-exec-timeout.test.js
+++ b/test/wrap-step-exec-timeout.test.js
@@ -1,0 +1,73 @@
+'use strict';
+
+/**
+ * A wrap step that was KILLED must not be reported as one that FAILED (#894).
+ *
+ * `defaultExecShell` tested `err.code === undefined && err.killed` for its
+ * timeout. Async `exec` does set `killed: true`, but its `code` is `null` rather
+ * than `undefined`, so the branch died on its first clause and every killed
+ * command fell through to the ordinary path as `exitCode: 1, error: null` —
+ * byte-identical to a suite that ran and failed. The operator was then handed
+ * "fix the failing test(s) shown above" for tests that had never run.
+ *
+ * The timeout cases here run a REAL process against a REAL kill, through the
+ * production `defaultExecShell`. That mapping is precisely where the defect
+ * lived, and an injected error object would have asserted the broken model.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const os = require('node:os');
+
+const testStep = require('../lib/wrap-steps/test');
+const lintStep = require('../lib/wrap-steps/lint');
+
+/** Short enough to keep the suite fast, long enough not to race the spawn. */
+const SHORT_TIMEOUT_MS = 300;
+
+describe('wrap exec shell — a killed command is named as killed (#894)', () => {
+  for (const [label, step] of [['test', testStep], ['lint', lintStep]]) {
+    describe(`${label} step`, () => {
+      it('maps a real timeout to exit 124 and timedOut', async () => {
+        const result = await step._internal.execShell('sleep 30', {
+          cwd: os.tmpdir(), timeoutMs: SHORT_TIMEOUT_MS
+        });
+
+        assert.equal(result.timedOut, true, 'a killed command must be flagged as killed');
+        assert.equal(result.exitCode, 124);
+        assert.match(result.error, /timed out/);
+        // The pre-fix behaviour, pinned so a regression is unmistakable: it
+        // resolved exitCode 1 with error null, which no caller could tell apart
+        // from an ordinary failing run.
+        assert.notEqual(result.exitCode, 1);
+        assert.notEqual(result.error, null);
+      });
+
+      it('leaves an ordinary non-zero exit alone', async () => {
+        const result = await step._internal.execShell('exit 3', { cwd: os.tmpdir() });
+
+        assert.equal(result.timedOut, false, 'a command that answered is not a timeout');
+        assert.equal(result.exitCode, 3);
+        assert.equal(result.error, null, 'an exit code IS the answer — there is no exec error');
+      });
+
+      it('names an output overflow instead of reporting a silent failure', async () => {
+        // The reachable non-numeric code, and why `typeof err.code !== 'number'`
+        // replaced `err.code === undefined`: a suite chatty enough to exceed
+        // maxBuffer fails with code 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER', which
+        // the old test missed — so it arrived as a bare exit 1 with no error.
+        //
+        // It is also the near-miss for the timeout predicate: the child IS
+        // killed here, but `killed` is left unset and no signal is reported, so
+        // this must NOT be reported as a timeout.
+        const result = await step._internal.execShell('yes hello | head -c 200000', {
+          cwd: os.tmpdir(), maxBufferBytes: 1024
+        });
+
+        assert.equal(result.timedOut, false, 'an overflow is not a timeout');
+        assert.notEqual(result.exitCode, 0);
+        assert.match(result.error, /maxBuffer/, 'the operator must be told what actually happened');
+      });
+    });
+  }
+});


### PR DESCRIPTION
## What

`lib/exec-timeout.js` becomes the single `wasTimedOut` predicate, consumed by `lib/git.js`,
`lib/tmux.js`, and the new shared `lib/wrap-steps/_exec-shell.js` — which replaces the
byte-identical `defaultExecShell` that existed in both wrap steps.

## Why

Fixes #894. The issue named **one** dead timeout branch. A sweep found **three**, dead for **two
different reasons** — every one compiling, reading correctly, and never once true:

| site | API | error on timeout | its check | fired? |
|---|---|---|---|---|
| `lib/tmux.js` | `execSync` | `killed: undefined`, `code: 'ETIMEDOUT'` | `err.killed` | **no** |
| `lib/wrap-steps/test.js` | async `exec` | `killed: true`, `code: null` | `err.code === undefined && err.killed` | **no** |
| `lib/wrap-steps/lint.js` | async `exec` | same | same | **no** |

`execSync` puts `killed` on `spawnSync`'s *result*, never on the error it throws. Async `exec` does
set it — but reports `code: null`, not `undefined`, so the compound check died on its first clause.
Every shape was probed against a live process before a line changed.

## Be precise about what this delivers

**Live today:** the `tmux command timed out` diagnostic, which had never been emitted in the life of
the code. A wedged tmux server — a state #94/#144/#380 record this install reaching — left no trace.

**Fixed but not yet reachable:** the `test` and `lint` handlers. A command they stopped for hanging
was reported as `Tests failed (exit 1)` with advice to *"fix the failing test(s) shown above"*, for
tests that never finished. Both now name the timeout, with their own blocker, remediation, log line
and drawer-visible warning. **But neither handler is in the shipped pipeline** — enumerated at
runtime, it is fourteen steps and includes neither, and projects may not add steps. They are opt-in
primitives, so this makes them correct before use rather than after.

**Still broken, deliberately:** `commit`, `pr-merge` and six other steps that *are* in the pipeline
still map a killed command to a plain exit 1. That is the reachable half of the same defect class and
it is **#897**, split out rather than expanded into this chunk.

The first draft of the CHANGELOG entry claimed the wrap behaviour change as a live operator-facing
fix. It is not, and the entry now says so — caught by the PR reviewer, verified by enumerating the
pipeline rather than by taking the claim.

## Also fixed, same class

`error: err.code === undefined ? … : null` never fired for a non-numeric code either, so a suite
chatty enough to exceed the 10 MiB buffer reported a bare `exit 1` with no explanation. Now
`typeof err.code !== \'number\'`, and the operator sees the overflow named. (The first draft claimed
this was the `ENOENT` case; the tests disproved it — `exec` runs through a shell, so a missing
command is the shell exiting 127, numeric and already handled.)

## Test plan

- **5816 passed / 0 failed / 1 skipped.** JUnit evidence recorded.
- **Seven mutations confirmed red**, baseline green at both ends, including **both historical bugs
  replanted verbatim**: `err.killed` alone (2 red) and `err.code === undefined && err.killed`
  (5 red); plus the timeout remediation removed, the overflow silenced, the informational-mode
  timeout silenced, the blocked-lint branch deleted, and the drawer channel not written.
- **Guards run real stalling executables** — a stalling `tmux` on PATH, a real `sleep` under a 300ms
  cap through the production exec shell, a real buffer overflow. A stub asserts the author\'s model of
  the error shape, and three such models being wrong is the entire issue.
- One mutation did **not** go red and that was informative: the predicate is over-determined
  (`execSync` sets both `ETIMEDOUT` and `SIGTERM`), so the overlap is now recorded in the module
  rather than left looking like an untested branch.

## Review

**Critic** (`cumulative`, three-reviewer roster, tier `escalate`): 1 blocking, 7 warnings, 7 notes →
**6 fixed, 8 accepted with recorded reasons, 1 filed (#897)**. The blocking finding was that lint\'s
*blocked* timeout path had no guard while the informational one did — and blocked is lint\'s canonical
mode, so the guarded half was the half that mattered less. Its most useful warning was that the fix
had been pasted into both copies of a duplicated function rather than removing the duplication that
made one dead branch into two. `verify-resolutions` returned 0 findings.

**PR reviewer** (independent, opus): 0 blocking, 1 warning, 1 note. The warning is the pipeline-
reachability point above, and it changed what this PR claims. The note (an unused export, two stray
blank lines) rides #897, which touches these files.

## Follow-up

- **#897** — the eight pipeline steps still mapping a killed command to exit 1, several taking
  outward actions.
