### PR TITLE
Tell the operator a wrap command was stopped, not that it failed

### DIFF
--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -28,7 +28,7 @@ Tag-line conventions (ART-4K9M, ratified 2026-07-17):
 
 ## 2026-08-10: a killed wrap command stops reading as a failed one, on the steps that actually run (#897)
 
-<!-- prawduct: type=fix | scope=killed-vs-failed-897 | chunks=A,B,C | status=shipped -->
+<!-- prawduct: type=fix | scope=killed-vs-failed-897 | chunks=A,B,C,D | status=shipped -->
 
 **Why:** #894 fixed this distinction in `test` and `lint` — two handlers the shipped fourteen-step
 pipeline never runs. #897 is the reachable half. Seven sites (not the eight the issue names —

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -26,6 +26,42 @@ Tag-line conventions (ART-4K9M, ratified 2026-07-17):
 -->
 
 
+## 2026-08-10: a killed wrap command stops reading as a failed one, on the steps that actually run (#897)
+
+<!-- prawduct: type=fix | scope=killed-vs-failed-897 | chunks=A,B,C | status=shipped -->
+
+**Why:** #894 fixed this distinction in `test` and `lint` — two handlers the shipped fourteen-step
+pipeline never runs. #897 is the reachable half. Seven sites (not the eight the issue names —
+`version-bump.js` spawns no child process at all, and the written reason is now in its header) had
+their own copy of a child-process wrapper, and every copy flattened a command we killed at our own
+timeout into `exit 1` with empty output — byte-identical to a command that ran and refused.
+
+**What changed:** all five async wrappers delegate to `lib/wrap-steps/_exec-shell.js`, which grows an
+argv-style `execFileArgs` beside the shell-form `execShell`. Every site that surfaces a failure
+branches on `timedOut`, and where a kill leaves ambiguous state — a commit that may have landed, a
+push that may have been received, a PR request that may have reached GitHub — the remediation names
+the check that resolves it instead of asserting an outcome. The three synchronous sites distinguish a
+killed probe from a real negative answer, so a stopped `merge-base --is-ancestor` no longer silently
+widens the session range and a stopped `git log` no longer blocks a compliant wrap with
+"CHANGELOG.md is unchanged" from a predicate that never ran.
+
+**What the review caught:** two blocking findings, both self-inflicted by the fix. A brand-new false
+operator string on the very path built to remove them ("your working tree is exactly as you left it"
+— staged writes land before that probe), and a mutation-check claim that did not hold: eleven
+mutations had been run, which is not eleven branches covered. Twenty branches now carry a guard, each
+mutated away and confirmed red. Two design findings, each raised independently by more than one
+reviewer, were fixed in the same pass: `commit.js`'s branch probe was the one site where a kill
+changed BEHAVIOUR — a killed `git rev-parse --abbrev-ref HEAD` switched off the #264 auto-branch
+guard and committed straight to `main` — and `resolveSessionRange().stopped` had no production
+reader, which is the same unconsumed-field anti-pattern this branch cites when deleting `lint.js`'s
+`output.timedOut`.
+
+**Also:** the wrap-step child-process contract is now written into `boundary-patterns.md`, because
+seven hand-rolled copies is how this defect class was born twice.
+
+**Classification:** fix
+
+
 ## 2026-08-07: first run stops dead-ending — the wedge, the PATH, and three screens with no way forward (#859, #346)
 
 <!-- prawduct: type=fix | scope=first-run-859 | status=shipped -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -491,6 +491,32 @@ All notable changes to TangleClaw are documented in this file.
   resolves it instead of picking an outcome. The wording for a command that really did fail is
   unchanged.
 
+- **A killed git probe no longer silently changes what your wrap measures — or blocks on (#897).**
+  The same defect in the wrap's synchronous git calls, where it was quieter and in one case worse.
+
+  Every probe behind the session range answers its question by catching a non-zero exit, so a probe
+  stopped at its ten-second timeout was read as a confident *no*:
+
+  - a stopped `git merge-base --is-ancestor` read as *"the recorded wrap SHA is orphaned"* and
+    abandoned this session's range for the whole trunk divergence — sweeping in many sessions of
+    already-released work, with nothing anywhere saying why;
+  - a stopped `git rev-parse --verify main` read as *"this repo has no main or master"*, which the
+    Feature Index step then reported to the operator as a fact;
+  - a stopped `git log` made the changelog-coverage predicate return *unavailable*, and an
+    unavailable verdict falls back to the mutation check — so a wrap whose CHANGELOG **was**
+    maintained got blocked with *"CHANGELOG.md is unchanged"* by a check that never ran. This is the
+    one an operator hits on an ordinary wrap.
+
+  Each of these now says the probe was stopped and the answer is unknown. The fallback behaviour is
+  unchanged — falling back is still right when you cannot know — but it is now recorded rather than
+  indistinguishable from a real negative answer, in the step output and in the server log.
+
+  Also in this sweep: a non-blocking lint step that was killed now leaves a line in the server log
+  (previously the one configuration that deliberately does not stop the wrap was also the only one
+  leaving no trace it was killed), and a comment in `lint.js` describing which `blocker` values fall
+  through to the informational branch has been corrected — only strict `false` does; every other
+  value blocks.
+
 - **Three checks for "did our own timeout kill this?" were dead code — none had ever run once
   (#894).** They failed for two different reasons: `execSync` puts `killed` on a different object
   than the error it throws, and async `exec` does set it but reports a `code` the check compared

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -511,6 +511,24 @@ All notable changes to TangleClaw are documented in this file.
   unchanged — falling back is still right when you cannot know — but it is now recorded rather than
   indistinguishable from a real negative answer, in the step output and in the server log.
 
+- **A wrap can no longer commit straight to `main` because a git probe hung (#897).** The same
+  defect, at the one place it changed what the wrap *did* rather than what it said.
+
+  The commit step reads your current branch to decide whether to auto-create a `wrap/…` branch
+  instead of committing to a protected one. When that read was killed at its timeout, the branch came
+  back empty — which the step took to mean "not on a protected branch", switched the guard off, and
+  committed directly to `main`. Silently, and with nothing in the log. That guard exists because
+  exactly that happened once before.
+
+  An unanswered branch probe now halts the wrap and says why, instead of guessing. Nothing is staged
+  and nothing is committed. If you genuinely want to commit wherever HEAD is, the direct-to-main
+  option in the wrap drawer still bypasses it, as before.
+
+- **When a stopped probe widens the range a wrap judges you on, it now says so (#897).** A killed
+  ancestry check falls back to comparing against the whole trunk, which can reach back past your
+  session — so the changelog block would list commits that shipped weeks ago and ask you to write
+  entries for them. That block now carries the caveat, and the Feature Index skip reason does too.
+
   Also in this sweep: a non-blocking lint step that was killed now leaves a line in the server log
   (previously the one configuration that deliberately does not stop the wrap was also the only one
   leaving no trace it was killed), and a comment in `lint.js` describing which `blocker` values fall

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -463,6 +463,34 @@ All notable changes to TangleClaw are documented in this file.
 
 ### Fixed
 
+- **The wrap steps you actually run no longer report a hung command as a failed one (#897).** #894
+  fixed that distinction in `test` and `lint` — two handlers the shipped fourteen-step pipeline
+  never runs. The steps fixed here run on every wrap: `open-pr-check`, `commit`, `continuity-write`
+  and `apply-pr-resolutions`.
+
+  A command TangleClaw kills at its own timeout prints nothing and reports no exit code, so every
+  one of these arrived as a plain `exit 1` with empty output — byte-identical to a command that ran
+  and refused. What an operator was then told:
+
+  - a `git commit` stopped at sixty seconds: *"The commit was rejected — most often by a pre-commit
+    hook. Read the hook output above."* There is no hook output, and — because a slow pre-commit
+    hook is the likeliest way to reach that timeout, and such a hook can finish after TangleClaw
+    stops waiting — **the commit may have landed**. It now says the outcome is unknown and to check
+    `git log -1` before doing anything else.
+  - a `gh pr merge --auto` stopped mid-request: *"auto-merge could not be armed"*, asserting an
+    outcome nobody observed. The request may have reached GitHub. It now says so, and points at the
+    PR before suggesting a manual merge.
+  - a `gh pr list` stopped mid-request rendered as a bare `exit 1`, which reads as gh not being
+    authenticated. It now names the stop and says the PR list is unknown, not empty.
+  - a stopped `git remote get-url origin` reported *"no origin remote"*, and a stopped
+    `gh --version` reported *"gh CLI not available"* — both sending the operator to fix something
+    they already have.
+
+  Where a kill leaves genuinely ambiguous state — the commit, the push, the PR creation, the
+  auto-merge, and a partially-staged `git add -A` — the remediation now names the check that
+  resolves it instead of picking an outcome. The wording for a command that really did fail is
+  unchanged.
+
 - **Three checks for "did our own timeout kill this?" were dead code — none had ever run once
   (#894).** They failed for two different reasons: `execSync` puts `killed` on a different object
   than the error it throws, and async `exec` does set it but reports a `code` the check compared

--- a/lib/wrap-steps/_exec-shell.js
+++ b/lib/wrap-steps/_exec-shell.js
@@ -1,21 +1,71 @@
 'use strict';
 
 /**
- * The shell runner shared by the wrap steps that execute a project command.
+ * The child-process runners shared by every wrap step that executes a command.
  *
- * It lived as a byte-identical copy in `test.js` and `lint.js`. Both copies
- * carried the same dead timeout branch (#894) and both had to be fixed
+ * The shell form lived as a byte-identical copy in `test.js` and `lint.js`. Both
+ * copies carried the same dead timeout branch (#894) and both had to be fixed
  * separately, which is the argument for one copy — a defect in a duplicated
  * function is a defect per duplicate, and the one that gets missed is the one
- * nobody was looking at.
+ * nobody was looking at. Five more copies then turned up in `commit.js`,
+ * `pr-merge.js`, `pr-check.js` and `continuity-write.js`, each with the same
+ * missing distinction, which is why both forms now live here.
  *
  * Conventional shell exit code for a command killed by a timeout, so the caller
  * can tell it apart from any code the command itself could have produced.
  */
 const TIMEOUT_EXIT_CODE = 124;
 
-const { exec } = require('node:child_process');
+const { exec, execFile } = require('node:child_process');
 const { wasTimedOut } = require('../exec-timeout');
+
+/**
+ * Turn one `child_process` callback into the structured result both runners
+ * resolve to. Shared so the killed-vs-failed distinction is decided in exactly
+ * one place: the whole of #894 and #897 is that distinction having been made
+ * independently — and wrongly — at each site.
+ *
+ * @param {Error|null} err - Callback error.
+ * @param {string|Buffer} stdout
+ * @param {string|Buffer} stderr
+ * @param {number} timeoutMs - The wall clock that was set, for the message.
+ * @returns {{exitCode:number, stdout:string, stderr:string, error:string|null,
+ *   timedOut:boolean}}
+ */
+function _toResult(err, stdout, stderr, timeoutMs) {
+  const out = (stdout || '').toString();
+  const errOut = (stderr || '').toString();
+  // `wasTimedOut`, not `err.code === undefined && err.killed`: async `exec` and
+  // `execFile` DO set `killed`, but their `code` is `null` rather than
+  // `undefined`, so that branch died on its first clause and a killed command
+  // fell through as an ordinary non-zero exit — reported to the operator as a
+  // failure that never happened (#894).
+  if (wasTimedOut(err)) {
+    return {
+      exitCode: TIMEOUT_EXIT_CODE,
+      stdout: out,
+      stderr: errOut,
+      error: `timed out after ${timeoutMs}ms`,
+      timedOut: true
+    };
+  }
+  return {
+    exitCode: err ? (typeof err.code === 'number' ? err.code : 1) : 0,
+    stdout: out,
+    stderr: errOut,
+    // A NUMERIC code means the command ran and exited, and that code IS the
+    // answer. Anything else is the run itself failing, and the old
+    // `=== undefined` test caught none of them — most reachably an output
+    // overflow (`ERR_CHILD_PROCESS_STDIO_MAXBUFFER`), which arrived as a bare
+    // exit 1 with no explanation for a suite that simply printed too much.
+    // A MISSING executable differs by form: through a shell it is the shell
+    // exiting 127 (numeric, already reported correctly), while argv-style it is
+    // `ENOENT` — non-numeric, so it lands here and is named rather than
+    // flattened into "exit 1".
+    error: err && typeof err.code !== 'number' ? err.message : null,
+    timedOut: false
+  };
+}
 
 /**
  * Run a shell command and resolve to a structured result.
@@ -43,39 +93,42 @@ function execShell(command, options) {
       maxBuffer: options.maxBufferBytes,
       env: process.env
     }, (err, stdout, stderr) => {
-      // `wasTimedOut`, not `err.code === undefined && err.killed`: async `exec`
-      // DOES set `killed`, but its `code` is `null` rather than `undefined`, so
-      // that branch died on its first clause and a killed command fell through
-      // as an ordinary non-zero exit — reported to the operator as a failure
-      // that never happened (#894).
-      if (wasTimedOut(err)) {
-        resolve({
-          exitCode: TIMEOUT_EXIT_CODE,
-          stdout: stdout || '',
-          stderr: stderr || '',
-          error: `timed out after ${options.timeoutMs}ms`,
-          timedOut: true
-        });
-        return;
-      }
-      const exitCode = err ? (typeof err.code === 'number' ? err.code : 1) : 0;
-      resolve({
-        exitCode,
-        stdout: stdout || '',
-        stderr: stderr || '',
-        // A NUMERIC code means the command ran and exited, and that code IS the
-        // answer. Anything else is the run itself failing, and the old
-        // `=== undefined` test caught none of them — most reachably an output
-        // overflow (`ERR_CHILD_PROCESS_STDIO_MAXBUFFER`), which arrived as a
-        // bare exit 1 with no explanation for a suite that simply printed too
-        // much. (A command that does not EXIST is not one of these: `exec` runs
-        // through a shell, so that is the shell exiting 127 — numeric, and
-        // already reported correctly.)
-        error: err && typeof err.code !== 'number' ? err.message : null,
-        timedOut: false
-      });
+      resolve(_toResult(err, stdout, stderr, options.timeoutMs));
     });
   });
 }
 
-module.exports = { execShell, TIMEOUT_EXIT_CODE };
+/**
+ * Run a command argv-style — no shell — and resolve to the same structured
+ * result as {@link execShell}.
+ *
+ * This is a separate entry point rather than a flag because the absence of a
+ * shell is the reason callers pick it: `commit.js` passes a multi-line commit
+ * message to `git commit -m`, where every quote, newline and backtick must reach
+ * the child's `argv[]` byte-intact. Routing that through a shell to save one
+ * function would reintroduce the quoting bug the argv form exists to avoid.
+ *
+ * @param {string} file - Executable name (e.g. `'git'`).
+ * @param {string[]} args - Arguments, each passed as its own `argv[]` entry.
+ * @param {object} options - Run options.
+ * @param {string} options.cwd - Working directory.
+ * @param {number} options.timeoutMs - Wall clock before the command is killed.
+ * @param {number} options.maxBufferBytes - Output cap before the child is killed.
+ * @returns {Promise<{exitCode: number, stdout: string, stderr: string,
+ *   error: string|null, timedOut: boolean}>} Same contract as {@link execShell},
+ *   `timedOut` included — a hand-built double must set it.
+ */
+function execFileArgs(file, args, options) {
+  return new Promise((resolve) => {
+    execFile(file, args, {
+      cwd: options.cwd,
+      timeout: options.timeoutMs,
+      maxBuffer: options.maxBufferBytes,
+      env: process.env
+    }, (err, stdout, stderr) => {
+      resolve(_toResult(err, stdout, stderr, options.timeoutMs));
+    });
+  });
+}
+
+module.exports = { execShell, execFileArgs, TIMEOUT_EXIT_CODE };

--- a/lib/wrap-steps/_git-range.js
+++ b/lib/wrap-steps/_git-range.js
@@ -14,6 +14,10 @@
  */
 
 const { execSync } = require('node:child_process');
+const { wasTimedOut } = require('../exec-timeout');
+const { createLogger } = require('../logger');
+
+const log = createLogger('wrap-step-git-range');
 
 /** Bound on every git call made here. */
 const GIT_EXEC_TIMEOUT_MS = 10 * 1000;
@@ -27,6 +31,33 @@ const SHA_RE = /^[0-9a-f]{7,64}$/i;
 
 /** Trunk branch candidates, in preference order, for the first-wrap fallback. */
 const BASE_BRANCH_CANDIDATES = ['main', 'master'];
+
+/**
+ * Note that a probe was STOPPED by our own timeout rather than answering.
+ *
+ * Every probe here answers a yes/no question by catching a non-zero exit, which
+ * makes a killed command indistinguishable from a confident "no" — and each of
+ * those "no"s widens the session range. A stopped `merge-base --is-ancestor`
+ * reads as "the recorded SHA is orphaned" and silently falls back to the whole
+ * trunk divergence, which is the range-ballooning shape that made a wrap sweep
+ * up sessions of already-released work. The fallback is still the right move on
+ * an unknown answer; what was missing was any record that the answer was
+ * unknown rather than negative (#897).
+ *
+ * @param {Error} err - The error `execSync` threw.
+ * @param {string} command - The git command, for the log line.
+ * @param {string} cwd - Where it ran.
+ * @param {((command: string) => void)|null} onStopped - Optional collector so a
+ *   caller can report the degraded answer alongside the range it returns.
+ * @returns {void}
+ */
+function _noteIfStopped(err, command, cwd, onStopped) {
+  if (!wasTimedOut(err)) return;
+  log.warn('git probe was stopped before it answered; treating it as a negative answer', {
+    command, cwd, timeoutMs: GIT_EXEC_TIMEOUT_MS
+  });
+  if (onStopped) onStopped(command);
+}
 
 /**
  * Resolve the range of commits belonging to the current session.
@@ -48,11 +79,24 @@ const BASE_BRANCH_CANDIDATES = ['main', 'master'];
  * @param {object} [options] - Resolution options.
  * @param {'two'|'three'} [options.dots='three'] - Range form for the base-branch fallback.
  * @param {Function} [options.exec] - `execSync` replacement, for tests.
- * @returns {{range:string, kind:'session'|'branch', baseBranch:(string|null)}|null}
- *   Null when neither a session SHA nor a base branch resolves.
+ * @param {(command: string) => void} [options.onStopped] - Called with each
+ *   probe our own timeout killed. Needed as well as the returned `stopped`
+ *   because the NULL return — "no range resolves" — is exactly the case a
+ *   killed `rev-parse` can manufacture, and a null carries no field to say so.
+ * @returns {{range:string, kind:'session'|'branch', baseBranch:(string|null),
+ *   stopped:string[]}|null} Null when neither a session SHA nor a base branch
+ *   resolves. `stopped` names any probe our own timeout killed rather than let
+ *   answer — non-empty means the range is a fallback taken on an UNKNOWN answer,
+ *   not a negative one, and callers that tell an operator why they got the range
+ *   they did must say so (#897).
  */
 function resolveSessionRange(cwd, lastWrapSha, options = {}) {
-  const { dots = 'three', exec = execSync } = options;
+  const { dots = 'three', exec = execSync, onStopped = null } = options;
+  const stopped = [];
+  const note = (command) => {
+    stopped.push(command);
+    if (onStopped) onStopped(command);
+  };
   // The recorded SHA must be an ANCESTOR of HEAD, not merely resolvable. A wrap
   // stamps its base and the wrap squash-merges onto the trunk; an older stamp made
   // before #664 recorded the wrap BRANCH commit, which squash-merge orphans. An
@@ -61,14 +105,14 @@ function resolveSessionRange(cwd, lastWrapSha, options = {}) {
   // already-released work. Falling back to the trunk range keeps a stale or
   // orphaned stamp from ballooning the session (#664).
   if (lastWrapSha && SHA_RE.test(lastWrapSha)
-    && isResolvableCommit(cwd, lastWrapSha, exec)
-    && isAncestorOfHead(cwd, lastWrapSha, exec)) {
-    return { range: `${lastWrapSha}..HEAD`, kind: 'session', baseBranch: null };
+    && isResolvableCommit(cwd, lastWrapSha, exec, note)
+    && isAncestorOfHead(cwd, lastWrapSha, exec, note)) {
+    return { range: `${lastWrapSha}..HEAD`, kind: 'session', baseBranch: null, stopped };
   }
-  const baseBranch = resolveBaseBranch(cwd, exec);
+  const baseBranch = resolveBaseBranch(cwd, exec, note);
   if (baseBranch) {
     const sep = dots === 'two' ? '..' : '...';
-    return { range: `${baseBranch}${sep}HEAD`, kind: 'branch', baseBranch };
+    return { range: `${baseBranch}${sep}HEAD`, kind: 'branch', baseBranch, stopped };
   }
   return null;
 }
@@ -80,22 +124,30 @@ function resolveSessionRange(cwd, lastWrapSha, options = {}) {
  * @param {string} cwd - Absolute path to run git in.
  * @param {string} ref - A git ref or SHA.
  * @param {Function} [exec=execSync] - `execSync` replacement, for tests.
+ * @param {((command: string) => void)|null} [onStopped] - Notified when our own
+ *   timeout killed the probe rather than letting it answer.
  * @returns {boolean}
  */
-function isResolvableCommit(cwd, ref, exec = execSync) {
+function isResolvableCommit(cwd, ref, exec = execSync, onStopped = null) {
+  const command = `git rev-parse --verify --quiet ${ref}^{commit}`;
   try {
-    exec(`git rev-parse --verify --quiet ${ref}^{commit}`, {
+    exec(command, {
       cwd,
       timeout: GIT_EXEC_TIMEOUT_MS,
       stdio: ['ignore', 'pipe', 'ignore']
     });
     return true;
-  } catch {
+  } catch (err) {
     // `rev-parse --verify` exits non-zero for "no such ref", which is the answer
     // this function exists to give. It also exits non-zero when git is missing or
     // the directory is not a repo — indistinguishable here, and deliberately so:
     // every caller's next move on false is the same fallback. Callers that must
     // tell the two apart should probe the repo separately.
+    //
+    // A KILL is the one shape that must not vanish into that set: it is not an
+    // answer at all, and returning `false` for it silently changes which range
+    // the wrap measures.
+    _noteIfStopped(err, command, cwd, onStopped);
     return false;
   }
 }
@@ -108,20 +160,29 @@ function isResolvableCommit(cwd, ref, exec = execSync) {
  * @param {string} cwd - Absolute path to run git in.
  * @param {string} ref - A git ref or SHA already known to resolve.
  * @param {Function} [exec=execSync] - `execSync` replacement, for tests.
+ * @param {((command: string) => void)|null} [onStopped] - Notified when our own
+ *   timeout killed the probe rather than letting it answer.
  * @returns {boolean}
  */
-function isAncestorOfHead(cwd, ref, exec = execSync) {
+function isAncestorOfHead(cwd, ref, exec = execSync, onStopped = null) {
+  const command = `git merge-base --is-ancestor ${ref} HEAD`;
   try {
-    exec(`git merge-base --is-ancestor ${ref} HEAD`, {
+    exec(command, {
       cwd,
       timeout: GIT_EXEC_TIMEOUT_MS,
       stdio: ['ignore', 'pipe', 'ignore']
     });
     return true;
-  } catch {
+  } catch (err) {
     // Exit 1 = resolves but is not an ancestor (the orphaned-stamp case). Any
     // other non-zero (bad repo, missing git) lands here too, and the caller's
     // move is the same either way: fall back to the trunk range.
+    //
+    // This is the costliest probe to answer wrongly. A `false` here abandons a
+    // perfectly good `<sha>..HEAD` range for the whole trunk divergence — many
+    // sessions of already-released work — so a kill reported as "not an
+    // ancestor" balloons the range with nothing anywhere saying why.
+    _noteIfStopped(err, command, cwd, onStopped);
     return false;
   }
 }
@@ -132,19 +193,26 @@ function isAncestorOfHead(cwd, ref, exec = execSync) {
  *
  * @param {string} cwd - Absolute path to run git in.
  * @param {Function} [exec=execSync] - `execSync` replacement, for tests.
+ * @param {((command: string) => void)|null} [onStopped] - Notified when our own
+ *   timeout killed a probe rather than letting it answer.
  * @returns {string|null}
  */
-function resolveBaseBranch(cwd, exec = execSync) {
+function resolveBaseBranch(cwd, exec = execSync, onStopped = null) {
   for (const candidate of BASE_BRANCH_CANDIDATES) {
+    const command = `git rev-parse --verify --quiet ${candidate}`;
     try {
-      exec(`git rev-parse --verify --quiet ${candidate}`, {
+      exec(command, {
         cwd,
         timeout: GIT_EXEC_TIMEOUT_MS,
         stdio: ['ignore', 'pipe', 'ignore']
       });
       return candidate;
-    } catch {
-      // Ref does not exist locally — try the next candidate.
+    } catch (err) {
+      // Ref does not exist locally — try the next candidate. Trying the next
+      // one is right for a kill too, but the null this can produce is reported
+      // upstream as "this repo has no main/master", which a stopped probe is
+      // no evidence for.
+      _noteIfStopped(err, command, cwd, onStopped);
     }
   }
   return null;

--- a/lib/wrap-steps/ai-content.js
+++ b/lib/wrap-steps/ai-content.js
@@ -1013,6 +1013,15 @@ function _satisfactionPredicateGate(projectPath, step, paths) {
     // the gate never looked at would send the operator to the wrong place.
     const names = paths.join(', ');
 
+    // A non-null `reason` on an UNCOVERED verdict means the range this verdict
+    // was computed over was widened by a git probe our own timeout killed. The
+    // block still stands — the changelog genuinely was not maintained over that
+    // range — but the operator is about to be handed a commit list that may
+    // reach back past their own session, so the caveat rides with it.
+    const degraded = typeof result.reason === 'string' && result.reason.trim()
+      ? `\n\nNote: ${result.reason.trim()}. Check the listed commits belong to this session before writing entries for them.`
+      : '';
+
     // #659: an `uncovered` verdict has two shapes and they render differently. When
     // it names uncommitted work (files that `git add -A` will sweep into this wrap's
     // own commit with no entry) the rows are paths, not commits — the commit
@@ -1024,7 +1033,7 @@ function _satisfactionPredicateGate(projectPath, step, paths) {
         ok: false,
         block: {
           blocker: `${step.id}: ${names} is unchanged, and ${uncommittedWork.length} uncommitted work file(s) will ship in this wrap's commit with no entry`,
-          remediation: `These uncommitted files will be committed by this wrap with no ${names} entry:\n  - ${listed}\nWrite the entry into ${names} (an uncommitted entry counts, so it does not matter whether you write it now or the session writes it on retry), then Retry. If that work genuinely warrants no entry, tick "Skip & note" to record that decision.`
+          remediation: `These uncommitted files will be committed by this wrap with no ${names} entry:\n  - ${listed}\nWrite the entry into ${names} (an uncommitted entry counts, so it does not matter whether you write it now or the session writes it on retry), then Retry. If that work genuinely warrants no entry, tick "Skip & note" to record that decision.${degraded}`
         }
       };
     }
@@ -1041,7 +1050,7 @@ function _satisfactionPredicateGate(projectPath, step, paths) {
         // made before it leaves the file dirty, which the predicate itself accepts.
         // Both are covered, so this text can promise a retry works — unlike the
         // mutation blocker below, where a retry genuinely cannot clear.
-        remediation: `These commits shipped without a ${names} entry:\n  - ${listed}\nWrite the missing entries into ${names}, then Retry — an uncommitted entry counts, so it does not matter whether you write it now or the session writes it on retry. If that work genuinely warrants no entry, tick "Skip & note" to record that decision.`
+        remediation: `These commits shipped without a ${names} entry:\n  - ${listed}\nWrite the missing entries into ${names}, then Retry — an uncommitted entry counts, so it does not matter whether you write it now or the session writes it on retry. If that work genuinely warrants no entry, tick "Skip & note" to record that decision.${degraded}`
       }
     };
   }

--- a/lib/wrap-steps/changelog-coverage.js
+++ b/lib/wrap-steps/changelog-coverage.js
@@ -151,7 +151,13 @@ const VERDICTS = Object.freeze({
  *   changelog) OR `uncommittedWork` lists the dirty source files that will ship in
  *   the wrap's own commit with no entry (#659) — never both; the other is empty.
  *   Both are empty when covered. `checkedCount` is how many commits the verdict was
- *   computed over. `reason` explains an `unavailable` verdict and is null otherwise.
+ *   computed over. `reason` explains an `unavailable` verdict; on an `uncovered`
+ *   verdict it is non-null ONLY when a git probe our own timeout killed forced the
+ *   range to a fallback, because then the commit list this verdict blocks on was
+ *   computed over a range nobody could confirm — a stopped `merge-base
+ *   --is-ancestor` widens `<sha>..HEAD` to the whole trunk divergence, so the
+ *   operator would otherwise be told to write entries for already-released work.
+ *   Null in every other case, including a clean `covered`.
  */
 function evaluate(projectPath, paths, coveragePaths) {
   const wanted = (Array.isArray(paths) ? paths : []).filter((p) => typeof p === 'string' && p.trim());
@@ -258,7 +264,7 @@ function evaluate(projectPath, paths, coveragePaths) {
       uncommittedWork: dirtyWork,
       checkedCount: 0,
       range,
-      reason: null
+      reason: _degradedRangeReason(stoppedProbes)
     };
   }
 
@@ -309,7 +315,28 @@ function evaluate(projectPath, paths, coveragePaths) {
     checkedCount,
     coveragePaths: globSources
   });
-  return { verdict: VERDICTS.UNCOVERED, uncovered, uncommittedWork: [], checkedCount, range, reason: null };
+  return {
+    verdict: VERDICTS.UNCOVERED, uncovered, uncommittedWork: [], checkedCount, range,
+    reason: _degradedRangeReason(stoppedProbes)
+  };
+}
+
+/**
+ * Explain that this verdict was computed over a range taken on an UNKNOWN answer.
+ *
+ * The range resolver answers every question by catching a non-zero exit, so a
+ * probe we killed reads as a confident "no" and silently falls back to the trunk
+ * range. That fallback still resolves, so the verdict looks entirely ordinary —
+ * which makes this the one case where a blocked operator has no way to tell that
+ * the commit list they are being asked to write entries for may reach back past
+ * their own session.
+ *
+ * @param {string[]} stoppedProbes - Probes our own timeout killed, if any.
+ * @returns {string|null} Null when every probe answered.
+ */
+function _degradedRangeReason(stoppedProbes) {
+  if (!stoppedProbes || stoppedProbes.length === 0) return null;
+  return `${stoppedProbes.length} git probe(s) were stopped before answering (${stoppedProbes[0]}), so this range is a fallback taken on an unknown answer and may reach further back than this session`;
 }
 
 /**

--- a/lib/wrap-steps/changelog-coverage.js
+++ b/lib/wrap-steps/changelog-coverage.js
@@ -80,6 +80,7 @@
  */
 
 const { execSync } = require('node:child_process');
+const { wasTimedOut } = require('../exec-timeout');
 const { createLogger } = require('../logger');
 const store = require('../store');
 const gitRange = require('./_git-range');
@@ -177,16 +178,26 @@ function evaluate(projectPath, paths, coveragePaths) {
     log.info('Could not load project config; using the trunk range', { error: err.message });
   }
 
-  const range = _resolveLogRange(projectPath, lastWrapSha);
+  // An `unavailable` verdict is not inert: the caller maps it to "the predicate
+  // could not judge" and falls back to the mutation check, which blocks a wrap
+  // whose CHANGELOG is untouched this turn. So every reason string here is text
+  // an operator may read while being blocked, and a reason that names a cause
+  // nobody observed sends them to fix the wrong thing (#897).
+  const stoppedProbes = [];
+  const range = _resolveLogRange(projectPath, lastWrapSha, stoppedProbes);
   if (!range) {
-    return _unavailable('no session range resolves (no lastWrapSha and no main/master base branch)', null);
+    return _unavailable(stoppedProbes.length > 0
+      ? `could not resolve a session range — ${stoppedProbes.length} git probe(s) were stopped before answering (${stoppedProbes[0]})`
+      : 'no session range resolves (no lastWrapSha and no main/master base branch)', null);
   }
 
   let commits;
   try {
     commits = _listCommits(projectPath, range);
   } catch (err) {
-    return _unavailable(`could not list commits in ${range}: ${err.message}`, range);
+    return _unavailable(wasTimedOut(err)
+      ? `git log did not finish within ${GIT_EXEC_TIMEOUT_MS / 1000}s and was stopped, so the commits in ${range} are unknown`
+      : `could not list commits in ${range}: ${err.message}`, range);
   }
 
   const wantedSet = new Set(wanted);
@@ -207,7 +218,9 @@ function evaluate(projectPath, paths, coveragePaths) {
   try {
     dirty = _dirtyPaths(projectPath);
   } catch (err) {
-    return _unavailable(`could not read the working tree: ${err.message}`, range);
+    return _unavailable(wasTimedOut(err)
+      ? `reading the working tree did not finish within ${GIT_EXEC_TIMEOUT_MS / 1000}s and was stopped, so the uncommitted files are unknown`
+      : `could not read the working tree: ${err.message}`, range);
   }
   const declaredDirty = dirty.filter(isCovered);
 
@@ -325,12 +338,17 @@ function _unavailable(reason, range) {
  *
  * @param {string} cwd - Absolute project root.
  * @param {string|null} lastWrapSha - `projConfig.lastWrapSha`, or null.
+ * @param {string[]} [stoppedProbes] - Collector for probes our own timeout
+ *   killed. The resolver answers every question by catching a non-zero exit, so
+ *   a stopped probe returns the same null as a repo with no trunk branch — and
+ *   that null becomes an `unavailable` verdict the caller must explain (#897).
  * @returns {string|null} A git revision range, or null when none resolves.
  */
-function _resolveLogRange(cwd, lastWrapSha) {
+function _resolveLogRange(cwd, lastWrapSha, stoppedProbes = null) {
   const resolved = gitRange.resolveSessionRange(cwd, lastWrapSha, {
     dots: 'two',
-    exec: _internal.execSync
+    exec: _internal.execSync,
+    onStopped: stoppedProbes ? (command) => stoppedProbes.push(command) : undefined
   });
   return resolved ? resolved.range : null;
 }

--- a/lib/wrap-steps/changelog-coverage.js
+++ b/lib/wrap-steps/changelog-coverage.js
@@ -152,9 +152,11 @@ const VERDICTS = Object.freeze({
  *   the wrap's own commit with no entry (#659) — never both; the other is empty.
  *   Both are empty when covered. `checkedCount` is how many commits the verdict was
  *   computed over. `reason` explains an `unavailable` verdict; on an `uncovered`
- *   verdict it is non-null ONLY when a git probe our own timeout killed forced the
- *   range to a fallback, because then the commit list this verdict blocks on was
- *   computed over a range nobody could confirm — a stopped `merge-base
+ *   verdict it is non-null ONLY on the COMMIT-LIST form (`uncovered` non-empty),
+ *   and only when a git probe our own timeout killed forced the range to a
+ *   fallback — because then the commit list this verdict blocks on was computed
+ *   over a range nobody could confirm. The uncommitted-work form is read from the
+ *   working tree with no range involved, so it never carries the caveat — a stopped `merge-base
  *   --is-ancestor` widens `<sha>..HEAD` to the whole trunk divergence, so the
  *   operator would otherwise be told to write entries for already-released work.
  *   Null in every other case, including a clean `covered`.
@@ -264,7 +266,13 @@ function evaluate(projectPath, paths, coveragePaths) {
       uncommittedWork: dirtyWork,
       checkedCount: 0,
       range,
-      reason: _degradedRangeReason(stoppedProbes)
+      // NOT the degraded-range caveat. This verdict is computed entirely from
+      // the working tree — `uncovered` is empty and `checkedCount` is 0, so the
+      // range played no part in reaching it and cannot have widened it. The
+      // caveat belongs only to the commit-list verdict below, whose rows ARE
+      // range-derived. Attaching it here would tell the operator to check
+      // whether a list of FILE PATHS belongs to this session.
+      reason: null
     };
   }
 

--- a/lib/wrap-steps/commit.js
+++ b/lib/wrap-steps/commit.js
@@ -621,6 +621,14 @@ async function _autoPrCloseLoop({ cwd, branch, originalBranch, staged }) {
   // checkout onto the current branch exits 0, so this is idempotent.
   const coRes = await _internal.exec('git', ['checkout', originalBranch], { cwd });
   result.returnedToBranch = coRes.exitCode === 0;
+  if (!result.returnedToBranch && coRes.timedOut) {
+    // `returnedToBranch: false` asserts HEAD is NOT on the original branch. A
+    // stopped checkout does not establish that — it may have completed after we
+    // stopped waiting — so the flag is a guess here and the log says so.
+    log.warn('checkout back to the original branch was stopped before it answered; HEAD position is unknown', {
+      project: project.name, originalBranch, error: coRes.error
+    });
+  }
 
   return result;
 }
@@ -707,7 +715,11 @@ async function run(context) {
       ok: false,
       status: 'blocked',
       output: statusRes.timedOut ? {
-        remediation: 'Nothing was committed — the wrap stopped before it staged anything, so your working tree is exactly as you left it. `git status` is normally instant, so a repo where it hangs usually has an index lock left behind by another git process, or a very large untracked tree. Check the repo, then re-run the wrap.'
+        // NOT "your working tree is untouched": step 1 above already flushed
+        // the staged writes to disk (see `_flushStagedWrites`, and the same
+        // caveat spelled out at the auto-branch failure below). Session
+        // artifacts from earlier steps are already there.
+        remediation: 'Nothing was committed. Session artifacts staged by earlier wrap steps are already written to disk, so run `git status` to see what is there. `git status` itself is normally instant, so a repo where it hangs usually has an index lock left behind by another git process, or a very large untracked tree. Check the repo, then re-run the wrap.'
       } : null,
       blockers: [`${_describeOutcome(statusRes, 'git status')}${detail ? `: ${detail}` : ''}`]
     };
@@ -732,11 +744,23 @@ async function run(context) {
   //    failure must NOT block the commit — the commit itself is what
   //    matters.
   let branch = null;
+  let branchProbeStopped = false;
   try {
     const br = await _internal.exec('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd });
     if (br.exitCode === 0) {
       const name = br.stdout.trim();
       if (name && name !== 'HEAD') branch = name;
+    } else if (br.timedOut) {
+      // This is the ONE probe in this step where reading a stop as a negative
+      // answer changes what the wrap DOES rather than what it says. A null
+      // branch makes `onProtectedBranch` false below, which turns the
+      // auto-branch guard off — so a wrap fired on `main` would commit
+      // straight to `main`, which is precisely the outcome that guard was
+      // added to prevent. Recorded here and acted on in step 3a.
+      branchProbeStopped = true;
+      log.warn('branch probe was stopped before it answered; the protected-branch check cannot be made', {
+        project: project.name, error: br.error
+      });
     }
   } catch (_) { /* branch stays null */ }
 
@@ -750,14 +774,41 @@ async function run(context) {
   //     bypasses entirely — for trivial doc fixes or hot-fixes where
   //     the operator explicitly opts in via the wrap drawer UI.
   //
-  //     Branch detection failures (branch === null) are NOT auto-
-  //     branched — we can't know what we're protecting against.
+  //     Branch detection FAILURES (branch === null because git answered
+  //     and the answer was "detached" or "not a repo") are NOT auto-
+  //     branched — we can't know what we're protecting against, and git
+  //     has told us we are not sitting on a named branch.
+  //
+  //     A branch probe we KILLED is a different thing and is handled
+  //     separately below. It produces the same null, but it is not an
+  //     answer: the wrap may well be on `main`, and letting the null
+  //     switch the guard off would commit straight to the branch the
+  //     guard exists to protect — silently, which is the failure mode
+  //     the guard was added for in the first place. So an unanswered
+  //     probe halts instead, and says why.
   //
   //     A failed `git checkout -b` is a blocker — the operator's
   //     intent ("safely wrap to a branch") was clear; silently
   //     committing to main against that intent would be worse than
   //     halting.
   const directToMainAllowed = !!(context.options && context.options.allowDirectToMain === true);
+  // An unanswered branch probe halts rather than committing to a branch nobody
+  // identified. `allowDirectToMain` still bypasses: an operator who has already
+  // said "commit wherever I am" is not protected by this check and should not be
+  // stopped by it.
+  if (branchProbeStopped && !directToMainAllowed) {
+    return {
+      ok: false,
+      status: 'blocked',
+      output: {
+        branch: null,
+        remediation: 'Nothing was committed. The wrap could not read which branch you are on — `git rev-parse --abbrev-ref HEAD` was stopped before it answered — so it cannot tell whether committing here would land directly on a protected branch. Check the repo (`git status`), then re-run the wrap. If you know you want to commit wherever HEAD currently is, tick the direct-to-main option in the wrap drawer.'
+      },
+      blockers: [
+        'Branch detection was stopped before it answered, so the protected-branch check could not be made.'
+      ]
+    };
+  }
   const onProtectedBranch = branch === 'main' || branch === 'master';
   const shouldAutoBranch = onProtectedBranch && !directToMainAllowed;
   let originalBranch = branch;

--- a/lib/wrap-steps/commit.js
+++ b/lib/wrap-steps/commit.js
@@ -47,46 +47,68 @@
  * commit file list so the user can cancel before this step runs.
  */
 
-const { execFile } = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
 const { createLogger } = require('../logger');
 const store = require('../store');
 const secretScan = require('../secret-scan');
+const { execFileArgs } = require('./_exec-shell');
 
 const log = createLogger('wrap-step-commit');
 
 const EXEC_TIMEOUT_MS = 60 * 1000;
+const MAX_BUFFER_BYTES = 5 * 1024 * 1024;
 const MAX_SUBJECT_LEN = 72;
 
 /**
- * Thin `execFile` wrapper — resolves to a structured result; never
- * throws on non-zero exit so the caller decides what each non-zero
- * means. Mirrors the shape used by `pr-check.js` so the test harness
- * pattern carries over.
+ * This step's git runner: the shared argv-style runner plus this step's caps.
+ *
+ * Argv-style, not shell — `git commit -m` receives a multi-line message whose
+ * quotes, newlines and backticks must reach the child's `argv[]` byte-intact.
+ *
+ * The caps are overridable ONLY so a guard can drive the timeout path in
+ * milliseconds instead of waiting out the real minute. Production callers pass
+ * neither. Without that seam the mapping from a real kill to `timedOut` is the
+ * one thing no test could reach — which is exactly where this defect lived
+ * undetected (#897).
  *
  * @param {string} file - Command name (e.g. `'git'`)
  * @param {string[]} args - Args (each passed argv-style — no shell quoting needed)
  * @param {object} options
  * @param {string} options.cwd
- * @returns {Promise<{exitCode:number, stdout:string, stderr:string}>}
+ * @param {number} [options.timeoutMs] - Test seam; defaults to EXEC_TIMEOUT_MS.
+ * @param {number} [options.maxBufferBytes] - Test seam; defaults to MAX_BUFFER_BYTES.
+ * @returns {Promise<{exitCode:number, stdout:string, stderr:string,
+ *   error:string|null, timedOut:boolean}>}
  */
 function defaultExec(file, args, options) {
-  return new Promise((resolve) => {
-    execFile(file, args, {
-      cwd: options.cwd,
-      timeout: EXEC_TIMEOUT_MS,
-      maxBuffer: 5 * 1024 * 1024,
-      env: process.env
-    }, (err, stdout, stderr) => {
-      const exitCode = err ? (typeof err.code === 'number' ? err.code : 1) : 0;
-      resolve({
-        exitCode,
-        stdout: (stdout || '').toString(),
-        stderr: (stderr || '').toString()
-      });
-    });
+  return execFileArgs(file, args, {
+    cwd: options.cwd,
+    timeoutMs: Number.isFinite(options.timeoutMs) ? options.timeoutMs : EXEC_TIMEOUT_MS,
+    maxBufferBytes: Number.isFinite(options.maxBufferBytes)
+      ? options.maxBufferBytes : MAX_BUFFER_BYTES
   });
+}
+
+/**
+ * Name what happened to a git command, in words the operator can act on.
+ *
+ * A command this step KILLED and a command that ran and REPORTED A PROBLEM need
+ * different sentences: "git commit failed" is a false statement about a commit
+ * that was stopped at sixty seconds, and every remediation downstream of it
+ * then explains a cause nobody observed (#897, and #894 before it).
+ *
+ * The timeout wording quotes the runner's own `error` rather than restating
+ * `EXEC_TIMEOUT_MS`, so the number the operator reads is the wall clock that
+ * actually applied and cannot drift from it.
+ *
+ * @param {{exitCode:number, timedOut:boolean, error:(string|null)}} res - An exec result.
+ * @param {string} what - The command, as the operator would name it.
+ * @returns {string} A clause suitable as the head of a blocker line.
+ */
+function _describeOutcome(res, what) {
+  if (!res.timedOut) return `${what} failed (exit ${res.exitCode})`;
+  return `${what} did not finish and was stopped (${res.error || 'timed out'})`;
 }
 
 /**
@@ -512,7 +534,12 @@ async function _autoPrCloseLoop({ cwd, branch, originalBranch, staged }) {
 
   const remoteRes = await _internal.exec('git', ['remote', 'get-url', 'origin'], { cwd });
   if (remoteRes.exitCode !== 0) {
-    result.skippedReason = 'no origin remote — nowhere to land the wrap branch';
+    // A stopped probe says nothing about whether the remote exists. Reporting
+    // "no origin remote" for a command that never answered sends the operator
+    // to configure a remote they may already have.
+    result.skippedReason = remoteRes.timedOut
+      ? 'could not tell whether an origin remote exists — the probe was stopped before it answered'
+      : 'no origin remote — nowhere to land the wrap branch';
     return result;
   }
 
@@ -521,15 +548,26 @@ async function _autoPrCloseLoop({ cwd, branch, originalBranch, staged }) {
   const pushRes = await _internal.exec('git', ['push', '-u', 'origin', branch], { cwd });
   if (pushRes.exitCode !== 0) {
     const detail = pushRes.stderr.trim() || pushRes.stdout.trim();
-    result.error = `git push failed (exit ${pushRes.exitCode}): ${detail}`;
-    result.remediation = `The wrap commit is safe on local branch ${branch}. Push it and open a PR manually: git push -u origin ${branch} && gh pr create --base ${originalBranch} --head ${branch}`;
+    result.error = `${_describeOutcome(pushRes, 'git push')}${detail ? `: ${detail}` : ''}`;
+    // A stopped push may have completed server-side — git can finish receiving
+    // the pack after we stop waiting for the client. The safe instruction is
+    // the same either way (re-push; it is idempotent), but the operator must
+    // not be told the push "failed" when the branch may be on the remote.
+    result.remediation = pushRes.timedOut
+      ? `The wrap commit is safe on local branch ${branch}. The push was stopped before it answered, so the branch may or may not have reached origin — a slow network or a large first push is the usual cause. Re-running it is harmless either way: git push -u origin ${branch} && gh pr create --base ${originalBranch} --head ${branch}`
+      : `The wrap commit is safe on local branch ${branch}. Push it and open a PR manually: git push -u origin ${branch} && gh pr create --base ${originalBranch} --head ${branch}`;
     return result;
   }
   result.pushed = true;
 
   const ghRes = await _internal.exec('gh', ['--version'], { cwd });
   if (ghRes.exitCode !== 0) {
-    result.skippedReason = 'gh CLI not available — branch pushed, PR not opened';
+    // Same rule as the remote probe: `gh --version` being stopped is not
+    // evidence that `gh` is missing, and telling the operator it is sends them
+    // to install a CLI they already have.
+    result.skippedReason = ghRes.timedOut
+      ? 'could not tell whether the gh CLI is available — the probe was stopped before it answered; branch pushed, PR not opened'
+      : 'gh CLI not available — branch pushed, PR not opened';
     result.remediation = `Open the PR manually: gh pr create --base ${originalBranch} --head ${branch} (or use the GitHub web UI — the branch is pushed).`;
     return result;
   }
@@ -542,8 +580,14 @@ async function _autoPrCloseLoop({ cwd, branch, originalBranch, staged }) {
   ], { cwd });
   if (createRes.exitCode !== 0) {
     const detail = createRes.stderr.trim() || createRes.stdout.trim();
-    result.error = `gh pr create failed (exit ${createRes.exitCode}): ${detail}`;
-    result.remediation = `The wrap branch is pushed. Open the PR manually: gh pr create --base ${originalBranch} --head ${branch}`;
+    result.error = `${_describeOutcome(createRes, 'gh pr create')}${detail ? `: ${detail}` : ''}`;
+    // The request may have reached GitHub before we stopped waiting, so the PR
+    // may already exist. Sending the operator straight to `gh pr create` would
+    // then hand them a duplicate-PR error with no idea where the first came
+    // from; check first.
+    result.remediation = createRes.timedOut
+      ? `The wrap branch is pushed. The PR request was stopped before it answered, so a PR may already have been opened — check with \`gh pr list --head ${branch}\` before opening one: gh pr create --base ${originalBranch} --head ${branch}`
+      : `The wrap branch is pushed. Open the PR manually: gh pr create --base ${originalBranch} --head ${branch}`;
     return result;
   }
   const urlMatch = createRes.stdout.match(/https:\/\/\S+\/pull\/\d+/);
@@ -560,8 +604,13 @@ async function _autoPrCloseLoop({ cwd, branch, originalBranch, staged }) {
   ], { cwd });
   if (mergeRes.exitCode !== 0) {
     const detail = mergeRes.stderr.trim() || mergeRes.stdout.trim();
-    result.error = `gh pr merge --auto failed (exit ${mergeRes.exitCode}): ${detail}`;
-    result.remediation = 'The PR is open but auto-merge could not be armed. Enable auto-merge in the repo (Settings → General → Pull Requests) or merge the PR manually once checks pass.';
+    result.error = `${_describeOutcome(mergeRes, 'gh pr merge --auto')}${detail ? `: ${detail}` : ''}`;
+    // "Auto-merge could not be armed" asserts an outcome we did not observe: a
+    // stopped request may have armed it, in which case following the old
+    // advice means merging by hand a PR that GitHub was already going to land.
+    result.remediation = mergeRes.timedOut
+      ? 'The PR is open. The auto-merge request was stopped before it answered, so it is unknown whether auto-merge was armed — check the PR page before acting. If it was not, enable auto-merge in the repo (Settings → General → Pull Requests) or merge the PR manually once checks pass.'
+      : 'The PR is open but auto-merge could not be armed. Enable auto-merge in the repo (Settings → General → Pull Requests) or merge the PR manually once checks pass.';
     return result;
   }
   result.autoMergeArmed = true;
@@ -653,11 +702,14 @@ async function run(context) {
   //    Empty output = working tree clean + index empty.
   const statusRes = await _internal.exec('git', ['status', '--porcelain'], { cwd });
   if (statusRes.exitCode !== 0) {
+    const detail = statusRes.stderr.trim() || statusRes.stdout.trim();
     return {
       ok: false,
       status: 'blocked',
-      output: null,
-      blockers: [`git status failed (exit ${statusRes.exitCode}): ${statusRes.stderr.trim() || statusRes.stdout.trim()}`]
+      output: statusRes.timedOut ? {
+        remediation: 'Nothing was committed — the wrap stopped before it staged anything, so your working tree is exactly as you left it. `git status` is normally instant, so a repo where it hangs usually has an index lock left behind by another git process, or a very large untracked tree. Check the repo, then re-run the wrap.'
+      } : null,
+      blockers: [`${_describeOutcome(statusRes, 'git status')}${detail ? `: ${detail}` : ''}`]
     };
   }
   const statusOutput = statusRes.stdout;
@@ -741,9 +793,19 @@ async function run(context) {
       return {
         ok: false,
         status: 'blocked',
-        output: { branch: originalBranch, attemptedWrapBranch: wrapBranchName },
+        output: {
+          branch: originalBranch,
+          attemptedWrapBranch: wrapBranchName,
+          // A killed `git checkout -b` leaves the branch's existence unknown:
+          // the ref may have been written before the kill even though HEAD did
+          // not move. Say so rather than let a retry hit "branch already
+          // exists" with no explanation for where it came from.
+          ...(checkoutRes.timedOut ? {
+            remediation: `Nothing was committed. The wrap was creating ${wrapBranchName} when the command was stopped, so that branch may or may not exist — check with \`git branch --list ${wrapBranchName}\` and delete it if it was left behind, then re-run the wrap.`
+          } : {})
+        },
         blockers: [
-          `Auto-branch failed (exit ${checkoutRes.exitCode}): ${detail}`,
+          `${_describeOutcome(checkoutRes, 'Auto-branch')}${detail ? `: ${detail}` : ''}`,
           'Set context.options.allowDirectToMain to bypass auto-branching.'
         ]
       };
@@ -766,11 +828,18 @@ async function run(context) {
   //    user can cancel before this step runs.
   const addRes = await _internal.exec('git', ['add', '-A'], { cwd });
   if (addRes.exitCode !== 0) {
+    const addDetail = addRes.stderr.trim() || addRes.stdout.trim();
     return {
       ok: false,
       status: 'blocked',
-      output: null,
-      blockers: [`git add -A failed (exit ${addRes.exitCode}): ${addRes.stderr.trim() || addRes.stdout.trim()}`]
+      output: addRes.timedOut ? {
+        // `git add -A` stages incrementally, so a kill can leave the index
+        // PARTIALLY staged — no commit was made, but the index is not
+        // necessarily as it was. Naming that is the difference between a
+        // recoverable state and a confusing one.
+        remediation: 'Nothing was committed, but `git add -A` was stopped partway, so some paths may already be staged. Run `git status` to see where it got to (`git reset` unstages without touching your files), then re-run the wrap.'
+      } : null,
+      blockers: [`${_describeOutcome(addRes, 'git add -A')}${addDetail ? `: ${addDetail}` : ''}`]
     };
   }
 
@@ -792,9 +861,18 @@ async function run(context) {
         flushed,
         message,
         branch,
-        remediation: 'The commit was rejected — most often by a pre-commit hook (e.g. husky running tests or lint). Read the hook output above, fix what it flagged, then re-run the wrap. The wrap pipeline never passes `--no-verify`; the hook is your intentional gate.'
+        // A KILLED commit and a REJECTED one need different instructions, and
+        // this is the site where getting it wrong costs the most. "The commit
+        // was rejected — read the hook output above" is false twice over when
+        // the command was stopped: there is no hook output, and the commit may
+        // have LANDED. A long-running pre-commit hook is the likeliest way to
+        // reach the kill, and such a hook can still finish — letting git write
+        // the commit — after we have stopped waiting for it.
+        remediation: commitRes.timedOut
+          ? 'The commit command was stopped before it answered, so it is unknown whether the commit landed. A pre-commit hook that outran the wrap is the usual cause, and such a hook can still complete after we stop waiting. Run `git log -1` first: if your wrap commit is there, the commit succeeded and only the wrap was cut short; if it is not, nothing was committed. Re-running the wrap is safe once you know which.'
+          : 'The commit was rejected — most often by a pre-commit hook (e.g. husky running tests or lint). Read the hook output above, fix what it flagged, then re-run the wrap. The wrap pipeline never passes `--no-verify`; the hook is your intentional gate.'
       },
-      blockers: [`git commit failed (exit ${commitRes.exitCode}): ${detail}`]
+      blockers: [`${_describeOutcome(commitRes, 'git commit')}${detail ? `: ${detail}` : ''}`]
     };
   }
 
@@ -810,9 +888,13 @@ async function run(context) {
   // capture the SHA. Log it; don't block. Downstream consumers
   // (Chunk 10 UI, lastWrapSha stamping) handle null gracefully.
   if (commitSha === null) {
-    log.warn('git rev-parse HEAD failed after commit landed', {
+    log.warn('git rev-parse HEAD did not return a SHA after the commit landed', {
       project: project.name,
       exitCode: shaRes.exitCode,
+      // Whether the probe was STOPPED or answered non-zero points at different
+      // causes (a wedged repo vs a broken git), and this log line is the only
+      // record either way.
+      timedOut: !!shaRes.timedOut,
       stderr: shaRes.stderr.trim().slice(0, 200)
     });
   }
@@ -837,7 +919,7 @@ async function run(context) {
     // non-root failure (a broken git that also failed the step-7 HEAD capture) is
     // visible when someone asks why the range base looks wrong.
     log.info('git rev-parse HEAD~1 found no parent; stamping the wrap commit as the range base', {
-      project: project.name, exitCode: parentRes.exitCode
+      project: project.name, exitCode: parentRes.exitCode, timedOut: !!parentRes.timedOut
     });
   }
   // A wrap commit with no parent (a repo whose first-ever commit is a wrap) has no

--- a/lib/wrap-steps/commit.js
+++ b/lib/wrap-steps/commit.js
@@ -625,8 +625,14 @@ async function _autoPrCloseLoop({ cwd, branch, originalBranch, staged }) {
     // `returnedToBranch: false` asserts HEAD is NOT on the original branch. A
     // stopped checkout does not establish that — it may have completed after we
     // stopped waiting — so the flag is a guess here and the log says so.
+    // No `project` here: this function takes `{cwd, branch, originalBranch,
+    // staged}`, and reaching for a name bound in `run()`'s scope throws a
+    // ReferenceError that the call site's catch turns into a WORSE lie than the
+    // one this log exists to prevent — the catch synthesises
+    // `pushed:false, prUrl:null` for a branch that by this line is already
+    // pushed, with its PR open and auto-merge armed.
     log.warn('checkout back to the original branch was stopped before it answered; HEAD position is unknown', {
-      project: project.name, originalBranch, error: coRes.error
+      cwd, branch, originalBranch, error: coRes.error
     });
   }
 

--- a/lib/wrap-steps/continuity-write.js
+++ b/lib/wrap-steps/continuity-write.js
@@ -32,39 +32,44 @@
  * after `commit` without needing a second commit.
  */
 
-const { execFile } = require('node:child_process');
 const continuity = require('../continuity');
 const transcript = require('../transcript');
 const featuresToc = require('./features-toc');
 const engines = require('../engines');
 const store = require('../store');
 const { createLogger } = require('../logger');
+const { execFileArgs } = require('./_exec-shell');
 
 const log = createLogger('wrap-step-continuity-write');
 
 const EXEC_TIMEOUT_MS = 30 * 1000;
+const MAX_BUFFER_BYTES = 1024 * 1024;
 
 /**
- * Thin `execFile` wrapper mirroring `commit.js:defaultExec` — resolves to
- * a structured result, never throws on non-zero exit. Overridable via
- * `_internal` so tests can stub git without a real repo.
+ * This step's git runner: the shared argv-style runner plus this step's caps.
+ * Overridable via `_internal` so tests can stub git without a real repo.
+ *
+ * The caps are overridable ONLY so a guard can drive the timeout path in
+ * milliseconds instead of waiting out the real thirty seconds; production
+ * callers pass neither. Without that seam the mapping from a real kill to
+ * `timedOut` is unreachable by any test, which is where this defect lived
+ * (#897).
+ *
  * @param {string} file
  * @param {string[]} args
  * @param {object} options
  * @param {string} options.cwd
- * @returns {Promise<{exitCode:number, stdout:string, stderr:string}>}
+ * @param {number} [options.timeoutMs] - Test seam; defaults to EXEC_TIMEOUT_MS.
+ * @param {number} [options.maxBufferBytes] - Test seam; defaults to MAX_BUFFER_BYTES.
+ * @returns {Promise<{exitCode:number, stdout:string, stderr:string,
+ *   error:string|null, timedOut:boolean}>}
  */
 function defaultExec(file, args, options) {
-  return new Promise((resolve) => {
-    execFile(file, args, {
-      cwd: options.cwd,
-      timeout: EXEC_TIMEOUT_MS,
-      maxBuffer: 1024 * 1024,
-      env: process.env
-    }, (err, stdout, stderr) => {
-      const exitCode = err ? (typeof err.code === 'number' ? err.code : 1) : 0;
-      resolve({ exitCode, stdout: (stdout || '').toString(), stderr: (stderr || '').toString() });
-    });
+  return execFileArgs(file, args, {
+    cwd: options.cwd,
+    timeoutMs: Number.isFinite(options.timeoutMs) ? options.timeoutMs : EXEC_TIMEOUT_MS,
+    maxBufferBytes: Number.isFinite(options.maxBufferBytes)
+      ? options.maxBufferBytes : MAX_BUFFER_BYTES
   });
 }
 
@@ -119,6 +124,26 @@ function _resolveCommitAnchor(previousResults) {
 }
 
 /**
+ * Record that a git probe was STOPPED rather than that it answered badly.
+ *
+ * This step is best-effort by contract: every git failure degrades to an empty
+ * value and the wrap continues, which is right. But that makes it the step
+ * where a kill is most completely invisible — a stamp reading `unknown` and a
+ * Map left untouched look identical whether git said "no" or never answered at
+ * all. This log line is the only place that distinction survives (#897).
+ *
+ * @param {string} what - The command, as an operator would name it.
+ * @param {string} cwd - Project root the probe ran in.
+ * @param {{error:(string|null)}} res - The exec result that timed out.
+ * @returns {void}
+ */
+function _warnStopped(what, cwd, res) {
+  log.warn('git probe was stopped before it answered; continuity data degrades to unknown', {
+    command: what, cwd, error: res.error
+  });
+}
+
+/**
  * Read short sha + branch for the freshness stamp. Anchored to the wrap
  * commit when `anchor` is provided (see `_resolveCommitAnchor`); falls
  * back to HEAD reads otherwise. Best-effort: a non-repo or git failure
@@ -134,11 +159,13 @@ async function _gitFacts(cwd, anchor = null) {
     const shaRef = anchor && anchor.sha ? anchor.sha : 'HEAD';
     const sha = await _internal.exec('git', ['rev-parse', '--short', shaRef], { cwd });
     if (sha.exitCode === 0) facts.sha = sha.stdout.trim();
+    else if (sha.timedOut) _warnStopped('git rev-parse --short', cwd, sha);
     if (anchor && anchor.branch) {
       facts.branch = anchor.branch;
     } else {
       const branch = await _internal.exec('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd });
       if (branch.exitCode === 0) facts.branch = branch.stdout.trim();
+      else if (branch.timedOut) _warnStopped('git rev-parse --abbrev-ref HEAD', cwd, branch);
     }
   } catch (err) {
     log.debug('git facts unavailable for continuity stamp', { cwd, error: err.message });
@@ -157,6 +184,10 @@ async function _resolveBase(cwd) {
     try {
       const r = await _internal.exec('git', ['rev-parse', '--verify', '--quiet', candidate], { cwd });
       if (r.exitCode === 0 && r.stdout.trim()) return candidate;
+      // A stopped probe is not "this ref does not exist" — trying the next
+      // candidate is still the right move, but the null this may produce must
+      // not read as a repo with no trunk branch.
+      if (r.timedOut) _warnStopped(`git rev-parse --verify ${candidate}`, cwd, r);
     } catch { /* try next */ }
   }
   return null;
@@ -191,7 +222,13 @@ async function _mapDelta(cwd, anchor = null) {
   } catch {
     return empty;
   }
-  if (!out || out.exitCode !== 0) return empty;
+  if (!out || out.exitCode !== 0) {
+    // Empty lists leave the prior Map untouched — the safe degrade. Naming a
+    // kill here is what tells the next reader the Map is stale because git was
+    // stopped, not because the session touched nothing.
+    if (out && out.timedOut) _warnStopped(`git diff --name-status ${base}...${tip}`, cwd, out);
+    return empty;
+  }
 
   const touched = [];
   const deleted = [];

--- a/lib/wrap-steps/continuity-write.js
+++ b/lib/wrap-steps/continuity-write.js
@@ -502,4 +502,4 @@ const _internal = {
   today: () => new Date().toISOString().slice(0, 10)
 };
 
-module.exports = { run, _internal, _resolveCapturedFields, _resolveBase, _resolveCommitAnchor, _mapDelta, _branchType, _deriveTier, _deriveUncapturedReason };
+module.exports = { run, _internal, _resolveCapturedFields, _resolveBase, _resolveCommitAnchor, _mapDelta, _gitFacts, _branchType, _deriveTier, _deriveUncapturedReason };

--- a/lib/wrap-steps/features-toc.js
+++ b/lib/wrap-steps/features-toc.js
@@ -367,7 +367,15 @@ function _finalize(a) {
     return _skipped(diffError);
   }
   if (touchedCount === 0) {
-    return _skipped(`no files touched in ${sessionRange.range}`);
+    // The costliest stopped-probe case reaches HERE, not the no-range branch
+    // above: a killed `merge-base --is-ancestor` still resolves a range — the
+    // trunk fallback — so the step reports a perfectly normal outcome computed
+    // over a range that was widened by a probe nobody could answer. Naming it
+    // is what stops "no files touched" reading as a fact about the session.
+    const degraded = sessionRange.stopped && sessionRange.stopped.length > 0;
+    return _skipped(degraded
+      ? `no files touched in ${sessionRange.range} — but ${sessionRange.stopped.length} git probe(s) were stopped before answering (${sessionRange.stopped[0]}), so that range is a fallback taken on an unknown answer`
+      : `no files touched in ${sessionRange.range}`);
   }
   if (candidateCount === 0) {
     // Distinguish the two empty-candidate causes rather than reporting the

--- a/lib/wrap-steps/features-toc.js
+++ b/lib/wrap-steps/features-toc.js
@@ -104,6 +104,7 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const { execSync } = require('node:child_process');
+const { wasTimedOut } = require('../exec-timeout');
 const { todayIsoLocal } = require('./_date');
 const { createLogger } = require('../logger');
 const store = require('../store');
@@ -227,13 +228,19 @@ async function run(context) {
   let candidateCount = null;
   let diffError = null;
 
-  const sessionRange = _resolveSessionRange(project.path, projConfig.lastWrapSha);
+  const stoppedProbes = [];
+  const sessionRange = _resolveSessionRange(project.path, projConfig.lastWrapSha, stoppedProbes);
   if (sessionRange) {
     let touchedFiles = null;
     try {
       touchedFiles = _diffNameOnly(project.path, sessionRange.range);
     } catch (err) {
-      diffError = err.message;
+      // "git diff failed" is the wrong word for a command we killed: it says the
+      // diff was attempted and refused, when in fact it never answered, and it
+      // does not even mention the timeout that stopped it (#897).
+      diffError = wasTimedOut(err)
+        ? `git diff did not finish within ${GIT_EXEC_TIMEOUT_MS / 1000}s and was stopped, so this session's changed files are unknown`
+        : `git diff failed: ${err.message}`;
     }
     if (touchedFiles) {
       touchedCount = touchedFiles.length;
@@ -254,7 +261,7 @@ async function run(context) {
   return _finalize({
     staged, featuresPath, indexContent, workingContent, created, drifted,
     todoDate, prunedPaths, danglingHandwritten, project, sessionRange,
-    touchedCount, indexableCount, candidateCount, diffError
+    touchedCount, indexableCount, candidateCount, diffError, stoppedProbes
   });
 }
 
@@ -272,7 +279,7 @@ function _finalize(a) {
   const {
     staged, featuresPath, indexContent, workingContent, created, drifted,
     todoDate, prunedPaths, danglingHandwritten, project, sessionRange,
-    touchedCount, indexableCount, candidateCount, diffError
+    touchedCount, indexableCount, candidateCount, diffError, stoppedProbes
   } = a;
 
   const contentChanged = created || workingContent !== indexContent;
@@ -347,10 +354,17 @@ function _finalize(a) {
   // Existing skip taxonomy — reached only when nothing changed and nothing is
   // reported. Order and wording preserved from the pre-#640 handler.
   if (!sessionRange) {
-    return _skipped('no session range resolves (no lastWrapSha and no main/master base branch)');
+    // Every probe behind this answer returns "no" by catching a non-zero exit,
+    // so a probe our own timeout killed produces the same null as a repo that
+    // genuinely has no trunk branch. Naming the stopped probe is the difference
+    // between "your repo has no main" — which is actionable and wrong — and
+    // "we could not find out" (#897).
+    return _skipped(stoppedProbes.length > 0
+      ? `could not resolve a session range — ${stoppedProbes.length} git probe(s) were stopped before answering (${stoppedProbes[0]})`
+      : 'no session range resolves (no lastWrapSha and no main/master base branch)');
   }
   if (diffError !== null) {
-    return _skipped(`git diff failed: ${diffError}`);
+    return _skipped(diffError);
   }
   if (touchedCount === 0) {
     return _skipped(`no files touched in ${sessionRange.range}`);
@@ -542,15 +556,21 @@ const SHA_RE = gitRange.SHA_RE;
  *
  * @param {string} cwd
  * @param {string|null} [lastWrapSha] - `projConfig.lastWrapSha`, or null/undefined.
- * @returns {{range:string, kind:'session'|'branch', baseBranch:(string|null)}|null}
+ * @param {string[]} [stoppedProbes] - Collector for probes our own timeout
+ *   killed. A stopped probe reads as a definite "no" to the resolver, so this
+ *   is the only way the caller can tell a resolved-negative from an unanswered
+ *   one when reporting why it got the range it did (#897).
+ * @returns {{range:string, kind:'session'|'branch', baseBranch:(string|null),
+ *   stopped:string[]}|null}
  */
-function _resolveSessionRange(cwd, lastWrapSha) {
+function _resolveSessionRange(cwd, lastWrapSha, stoppedProbes = null) {
   // Three-dot: this range feeds `git diff`, where it means "since the merge base".
   // `changelog-coverage` asks the same resolver for the two-dot form because it
   // feeds `git log`, where three-dot would mean the symmetric difference instead.
   return gitRange.resolveSessionRange(cwd, lastWrapSha, {
     dots: 'three',
-    exec: _internal.execSync
+    exec: _internal.execSync,
+    onStopped: stoppedProbes ? (command) => stoppedProbes.push(command) : undefined
   });
 }
 

--- a/lib/wrap-steps/lint.js
+++ b/lib/wrap-steps/lint.js
@@ -64,7 +64,6 @@ function defaultExecShell(command, options) {
   });
 }
 
-
 /**
  * Detect files changed in this session via `git status --porcelain`.
  * Returns repo-relative paths for tracked-modified, staged, and
@@ -197,6 +196,15 @@ async function run(context) {
     // produces no output, so reporting it here as a plain non-zero exit with an
     // empty warnings field says the lint ran and found nothing to say. Not
     // blocking is the configured behaviour; staying silent about why is not.
+    if (execResult.timedOut) {
+      // The two BLOCKING timeout paths both log; this one did not, which made
+      // the one configuration that deliberately lets the wrap continue also the
+      // one leaving no record it was killed — the worse pairing of the two,
+      // since nobody is stopped to notice.
+      log.warn('Lint command timed out (informational — this step is configured not to block)', {
+        project: project.name, timeoutMs: EXEC_TIMEOUT_MS, exitCode: execResult.exitCode
+      });
+    }
     return {
       ok: true,
       status: 'done',
@@ -206,12 +214,14 @@ async function run(context) {
         warnings: execResult.timedOut
           ? `Lint command timed out after ${EXEC_TIMEOUT_MS / 60000} minutes and was stopped — it reported nothing.`
           : tail,
-        timedOut: !!execResult.timedOut,
         // `warning`/`remediation` are the channels the drawer actually renders
         // (`public/wrap-drawer.js#buildStepRow` reads `output.warning === true`
         // and `output.remediation`). Writing only to `warnings` left a killed
         // lint showing as a plain green row — honest in the payload, invisible
-        // to the person it was for.
+        // to the person it was for. There is deliberately no separate
+        // `timedOut` flag on this output: nothing renders one, and an
+        // unconsumed field on a payload contract is the kind of thing a later
+        // change treats as load-bearing by accident.
         ...(execResult.timedOut ? {
           warning: true,
           remediation: `The lint command did not finish within ${EXEC_TIMEOUT_MS / 60000} minutes and was stopped, so it checked nothing. This step is configured not to block, so the wrap continued. Run it locally to see where it hangs.`
@@ -245,8 +255,9 @@ async function run(context) {
 
   // blocker === true OR blocker === "errors-only": exit ≠ 0 → block.
   // The runner halts on either case (see `lib/wrap-pipeline.js` blocker
-  // semantics). Any other blocker value falls through to the `false`
-  // branch above (informational only).
+  // semantics). So does every OTHER value, including undefined: the branch
+  // above tests strict `false`, so blocking is what a step gets unless it
+  // explicitly opts out.
   const blockers = [`Lint failed (exit ${execResult.exitCode}) on ${files.length} file(s)`];
   if (tail) blockers.push(tail);
   if (execResult.error) blockers.push(`exec error: ${execResult.error}`);

--- a/lib/wrap-steps/pr-check.js
+++ b/lib/wrap-steps/pr-check.js
@@ -51,12 +51,13 @@
  * action in this pair, enqueueing auto-merge, lives in `pr-merge.js`.
  */
 
-const { exec } = require('node:child_process');
 const { createLogger } = require('../logger');
+const { execShell } = require('./_exec-shell');
 
 const log = createLogger('wrap-step-pr-check');
 
 const EXEC_TIMEOUT_MS = 30 * 1000; // 30s — gh API calls should be fast over a healthy net
+const MAX_BUFFER_BYTES = 5 * 1024 * 1024;
 const VALID_HANDLINGS = new Set(['merge', 'defer', 'ignore']);
 // JSON fields requested from `gh pr list`. Kept narrow on purpose: the
 // commit-step + UI need just enough to identify and link the PR.
@@ -64,33 +65,32 @@ const VALID_HANDLINGS = new Set(['merge', 'defer', 'ignore']);
 const GH_PR_JSON_FIELDS = 'number,title,headRefName,baseRefName,url,createdAt,isDraft,author';
 
 /**
- * Default thin exec wrapper — resolves to a structured result; never
- * throws on non-zero exit (caller decides what non-zero means). gh
- * exits non-zero on the no-auth path, no-repo path, and many other
- * recoverable cases, so blanket-rethrow would defeat the never-blocks
- * contract.
+ * This step's shell runner: the shared runner plus this step's caps.
+ *
+ * Never throws on non-zero exit (the caller decides what non-zero means). gh
+ * exits non-zero on the no-auth path, no-repo path, and many other recoverable
+ * cases, so blanket-rethrow would defeat the never-blocks contract.
+ *
+ * The caps are overridable ONLY so a guard can drive the timeout path in
+ * milliseconds instead of waiting out the real thirty seconds; production
+ * callers pass neither. Without that seam the mapping from a real kill to
+ * `timedOut` is unreachable by any test, which is where this defect lived
+ * (#897).
  *
  * @param {string} command
  * @param {object} options
  * @param {string} options.cwd
- * @returns {Promise<{exitCode:number, stdout:string, stderr:string, error:string|null}>}
+ * @param {number} [options.timeoutMs] - Test seam; defaults to EXEC_TIMEOUT_MS.
+ * @param {number} [options.maxBufferBytes] - Test seam; defaults to MAX_BUFFER_BYTES.
+ * @returns {Promise<{exitCode:number, stdout:string, stderr:string,
+ *   error:string|null, timedOut:boolean}>}
  */
 function defaultExec(command, options) {
-  return new Promise((resolve) => {
-    exec(command, {
-      cwd: options.cwd,
-      timeout: EXEC_TIMEOUT_MS,
-      maxBuffer: 5 * 1024 * 1024,
-      env: process.env
-    }, (err, stdout, stderr) => {
-      const exitCode = err ? (typeof err.code === 'number' ? err.code : 1) : 0;
-      resolve({
-        exitCode,
-        stdout: (stdout || '').toString(),
-        stderr: (stderr || '').toString(),
-        error: err && typeof err.code !== 'number' ? err.message : null
-      });
-    });
+  return execShell(command, {
+    cwd: options.cwd,
+    timeoutMs: Number.isFinite(options.timeoutMs) ? options.timeoutMs : EXEC_TIMEOUT_MS,
+    maxBufferBytes: Number.isFinite(options.maxBufferBytes)
+      ? options.maxBufferBytes : MAX_BUFFER_BYTES
   });
 }
 
@@ -106,6 +106,15 @@ function defaultExec(command, options) {
  */
 async function defaultIsGhAvailable(cwd) {
   const r = await _internal.exec('gh --version', { cwd });
+  if (r.exitCode !== 0 && r.timedOut) {
+    // Answering `false` is right — the step cannot proceed without gh — but a
+    // stopped probe is not evidence that gh is absent, and this log line is
+    // the only place that distinction survives (the caller's skip reason names
+    // the CLI as unavailable, which is all it can say). #897.
+    log.warn('gh availability probe was stopped before it answered; treating gh as unavailable', {
+      cwd, error: r.error
+    });
+  }
   return r.exitCode === 0;
 }
 
@@ -120,7 +129,17 @@ async function defaultIsGhAvailable(cwd) {
  */
 async function defaultGetCurrentBranch(cwd) {
   const r = await _internal.exec('git rev-parse --abbrev-ref HEAD', { cwd });
-  if (r.exitCode !== 0) return null;
+  if (r.exitCode !== 0) {
+    if (r.timedOut) {
+      // Null widens the step from "this session's PRs" to every open PR. That
+      // fallback is safe, but a stopped probe leaves no other trace of WHY the
+      // list suddenly got wider, so record it (#897).
+      log.warn('branch probe was stopped before it answered; PR list falls back to unscoped', {
+        cwd, error: r.error
+      });
+    }
+    return null;
+  }
   const name = r.stdout.trim();
   if (!name || name === 'HEAD') return null;
   return name;
@@ -139,6 +158,18 @@ async function defaultListOpenPrs(cwd) {
   const cmd = `gh pr list --state open --author @me --json ${GH_PR_JSON_FIELDS}`;
   const r = await _internal.exec(cmd, { cwd });
   if (r.exitCode !== 0) {
+    // A stopped `gh` prints nothing, so the raw fallback rendered as a bare
+    // "exit 1" — which reads as gh refusing (no auth, not a repo) and sends
+    // the operator to fix an auth problem they do not have. Name the stop
+    // instead; the honest answer is that the PR list is unknown (#897).
+    if (r.timedOut) {
+      return {
+        ok: false,
+        prs: [],
+        reason: `gh did not answer within ${EXEC_TIMEOUT_MS / 1000}s and was stopped — your open PRs could not be listed, so none are shown. This is usually a slow or blocked network rather than a problem with gh.`,
+        exitCode: r.exitCode
+      };
+    }
     // gh prints actionable text on stderr ("no auth", "not a repo", etc).
     // Surface the first ~200 chars so the UI can render the recovery
     // hint inline rather than just "gh failed." Append `…` when the

--- a/lib/wrap-steps/pr-merge.js
+++ b/lib/wrap-steps/pr-merge.js
@@ -40,58 +40,59 @@
  * gate step still feeds this one.
  */
 
-const { exec, execFile } = require('node:child_process');
 const { createLogger } = require('../logger');
+const { execShell, execFileArgs } = require('./_exec-shell');
 
 const log = createLogger('wrap-step-pr-merge');
 
 const EXEC_TIMEOUT_MS = 60 * 1000;
+const MAX_BUFFER_BYTES = 1024 * 1024;
 
 /**
- * Thin `execFile` wrapper mirroring `commit.js:defaultExec` — resolves to a
- * structured result, never throws on non-zero exit.
+ * This step's git runner: the shared argv-style runner plus this step's caps.
+ *
+ * The caps are overridable ONLY so a guard can drive the timeout path in
+ * milliseconds instead of waiting out the real minute; production callers pass
+ * neither. Without that seam the mapping from a real kill to `timedOut` is
+ * unreachable by any test, which is where this defect lived (#897).
  *
  * @param {string} file
  * @param {string[]} args
  * @param {object} options
  * @param {string} options.cwd
- * @returns {Promise<{exitCode:number, stdout:string, stderr:string}>}
+ * @param {number} [options.timeoutMs] - Test seam; defaults to EXEC_TIMEOUT_MS.
+ * @param {number} [options.maxBufferBytes] - Test seam; defaults to MAX_BUFFER_BYTES.
+ * @returns {Promise<{exitCode:number, stdout:string, stderr:string,
+ *   error:string|null, timedOut:boolean}>}
  */
 function defaultExec(file, args, options) {
-  return new Promise((resolve) => {
-    execFile(file, args, {
-      cwd: options.cwd,
-      timeout: EXEC_TIMEOUT_MS,
-      maxBuffer: 1024 * 1024,
-      env: process.env
-    }, (err, stdout, stderr) => {
-      const exitCode = err ? (typeof err.code === 'number' ? err.code : 1) : 0;
-      resolve({ exitCode, stdout: (stdout || '').toString(), stderr: (stderr || '').toString() });
-    });
+  return execFileArgs(file, args, {
+    cwd: options.cwd,
+    timeoutMs: Number.isFinite(options.timeoutMs) ? options.timeoutMs : EXEC_TIMEOUT_MS,
+    maxBufferBytes: Number.isFinite(options.maxBufferBytes)
+      ? options.maxBufferBytes : MAX_BUFFER_BYTES
   });
 }
 
 /**
- * Shell-form exec for the `gh` calls, which are composed as command strings.
+ * Shell-form runner for the `gh` calls, which are composed as command strings.
  * Same never-throw contract as `defaultExec`; separate because git is invoked
  * argv-style and gh is not.
  *
  * @param {string} command
  * @param {object} options
  * @param {string} options.cwd
- * @returns {Promise<{exitCode:number, stdout:string, stderr:string}>}
+ * @param {number} [options.timeoutMs] - Test seam; defaults to EXEC_TIMEOUT_MS.
+ * @param {number} [options.maxBufferBytes] - Test seam; defaults to MAX_BUFFER_BYTES.
+ * @returns {Promise<{exitCode:number, stdout:string, stderr:string,
+ *   error:string|null, timedOut:boolean}>}
  */
 function defaultExecShell(command, options) {
-  return new Promise((resolve) => {
-    exec(command, {
-      cwd: options.cwd,
-      timeout: EXEC_TIMEOUT_MS,
-      maxBuffer: 1024 * 1024,
-      env: process.env
-    }, (err, stdout, stderr) => {
-      const exitCode = err ? (typeof err.code === 'number' ? err.code : 1) : 0;
-      resolve({ exitCode, stdout: (stdout || '').toString(), stderr: (stderr || '').toString() });
-    });
+  return execShell(command, {
+    cwd: options.cwd,
+    timeoutMs: Number.isFinite(options.timeoutMs) ? options.timeoutMs : EXEC_TIMEOUT_MS,
+    maxBufferBytes: Number.isFinite(options.maxBufferBytes)
+      ? options.maxBufferBytes : MAX_BUFFER_BYTES
   });
 }
 
@@ -126,6 +127,17 @@ async function defaultEnqueueAutoMerge(cwd, prNumber) {
     { cwd }
   );
   if (r.exitCode === 0) return { ok: true, reason: null };
+  // A stopped request is not a refused one. `gh` prints nothing when we kill
+  // it, so the raw fallback here used to render as a bare "exit 1" — which
+  // reads as GitHub declining the request, when in fact the request may have
+  // reached GitHub and armed auto-merge. Say that it is unknown, and where to
+  // look (#897).
+  if (r.timedOut) {
+    return {
+      ok: false,
+      reason: `the request was stopped before it answered (${r.error || 'timed out'}) — auto-merge may or may not have been armed; check PR #${prNumber} before merging by hand`
+    };
+  }
   const raw = (r.stderr || r.stdout || `exit ${r.exitCode}`).trim();
   return { ok: false, reason: raw.length > 200 ? `${raw.slice(0, 200)}…` : raw };
 }
@@ -189,7 +201,16 @@ async function _ensurePushed(cwd) {
   const branchRes = await _internal.exec('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd });
   const branch = branchRes.exitCode === 0 ? branchRes.stdout.trim() : '';
   if (!branch || branch === 'HEAD') {
-    return { ok: false, pushed: false, reason: 'HEAD is detached — cannot identify the branch to push' };
+    // Declining is right either way, but the REASON must not claim a detached
+    // HEAD when the probe was simply stopped before it answered — that sends
+    // the operator to check out a branch they are probably already on (#897).
+    return {
+      ok: false,
+      pushed: false,
+      reason: branchRes.timedOut
+        ? 'could not identify the branch to push — `git rev-parse` was stopped before it answered'
+        : 'HEAD is detached — cannot identify the branch to push'
+    };
   }
 
   // Measured against `origin/<branch>` rather than the tracking ref `@{u}`:
@@ -204,9 +225,23 @@ async function _ensurePushed(cwd) {
 
   // Either the branch is ahead, or `origin/<branch>` does not exist yet (the
   // rev-list fails). Both want the same push; `-u` is harmless when an
-  // upstream already exists.
+  // upstream already exists. A STOPPED rev-list also lands here, and pushing
+  // is the safe response to not knowing — the push is idempotent when the
+  // remote was already current.
   const push = await _internal.exec('git', ['push', '-u', 'origin', branch], { cwd });
   if (push.exitCode !== 0) {
+    // git prints nothing when we kill it, so a stopped push used to surface as
+    // a bare "exit 1" — indistinguishable from a rejected push, and wrong: the
+    // remote may have received the pack after we stopped waiting. Declining to
+    // enqueue is still correct (this function refuses on any uncertainty); the
+    // reason just has to be true.
+    if (push.timedOut) {
+      return {
+        ok: false,
+        pushed: false,
+        reason: `the push was stopped before it answered (${push.error || 'timed out'}) — origin/${branch} may or may not have the wrap commit, so auto-merge was not enqueued`
+      };
+    }
     const raw = (push.stderr || push.stdout || `exit ${push.exitCode}`).trim();
     return { ok: false, pushed: false, reason: raw.length > 200 ? `${raw.slice(0, 200)}…` : raw };
   }

--- a/lib/wrap-steps/test.js
+++ b/lib/wrap-steps/test.js
@@ -52,7 +52,6 @@ function defaultExecShell(command, options) {
   });
 }
 
-
 /**
  * Take the last N lines of a string for surfacing in blockers/output.
  * Empty or null input returns an empty string.

--- a/lib/wrap-steps/version-bump.js
+++ b/lib/wrap-steps/version-bump.js
@@ -102,6 +102,15 @@
  * Acceptable for this project (already 2-space) — open follow-up if
  * a project adopts a different style and complains.
  *
+ * **This step runs no child process, and that is why it is absent from the
+ * killed-vs-failed sweep (#897).** It reads and writes files and parses text;
+ * its only requires are `fs`, `path`, `./_date`, `../logger`, `../store` and
+ * `../project-paths`, none of which reaches `child_process`. With nothing to
+ * kill, there is no timeout that could be mistaken for a failure. Recorded here
+ * because #897 listed this file among the offenders on the strength of its
+ * eleven `.exec(` matches — every one of them `RegExp.prototype.exec`. Anyone
+ * sweeping this family again should check the requires, not the symbol.
+ *
  * @module lib/wrap-steps/version-bump
  */
 

--- a/test/wrap-git-range.test.js
+++ b/test/wrap-git-range.test.js
@@ -30,7 +30,10 @@ function fakeExec(failing = null) {
 describe('_git-range — session range resolution', () => {
   it('prefers the recorded lastWrapSha over the trunk fallback', () => {
     const out = gitRange.resolveSessionRange('/p', 'c1f94ac', { exec: fakeExec() });
-    assert.deepEqual(out, { range: 'c1f94ac..HEAD', kind: 'session', baseBranch: null });
+    // `stopped` names any probe our own timeout killed rather than let answer, so
+    // a caller can tell a fallback taken on an UNKNOWN answer from one taken on a
+    // negative one. Asserted exhaustively here because it is part of the shape.
+    assert.deepEqual(out, { range: 'c1f94ac..HEAD', kind: 'session', baseBranch: null, stopped: [] });
   });
 
   it('emits three-dot for the diff caller and two-dot for the log caller', () => {

--- a/test/wrap-pipeline.test.js
+++ b/test/wrap-pipeline.test.js
@@ -5,7 +5,7 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
-const { setLevel } = require('../lib/logger');
+const { setLevel, getLevel, setConsoleStream } = require('../lib/logger');
 
 setLevel('error');
 
@@ -440,6 +440,10 @@ describe('wrap-pipeline step stubs (#139 Chunk 3) — all kinds now real', () =>
 
 describe('wrap-step test (#139 Chunk 4)', () => {
   const testStep = require('../lib/wrap-steps/test');
+  // The literal `124` these timeout cases assert on is the runner's own
+  // constant. Importing it means a change to the convention updates the guards
+  // rather than silently leaving them asserting a number nothing produces.
+  const { TIMEOUT_EXIT_CODE } = require('../lib/wrap-steps/_exec-shell');
   let tmpDir;
   let projectPath;
   let originalExec;
@@ -545,13 +549,13 @@ describe('wrap-step test (#139 Chunk 4)', () => {
     // for tests that had never produced a result.
     writeConfig({ testCommand: 'npm test' });
     testStep._internal.execShell = async () => ({
-      exitCode: 124, stdout: '', stderr: '', error: 'timed out after 600000ms', timedOut: true
+      exitCode: TIMEOUT_EXIT_CODE, stdout: '', stderr: '', error: 'timed out after 600000ms', timedOut: true
     });
     const result = await testStep.run(buildContext({ id: 'test', blocker: true }));
 
     assert.equal(result.ok, false);
     assert.equal(result.status, 'blocked');
-    assert.equal(result.output.exitCode, 124);
+    assert.equal(result.output.exitCode, TIMEOUT_EXIT_CODE);
     assert.ok(result.blockers.some((b) => /timed out/i.test(b)),
       'the blocker must name the timeout');
     assert.ok(!result.blockers.some((b) => b.startsWith('Tests failed')),
@@ -609,6 +613,7 @@ describe('wrap-step test (#139 Chunk 4)', () => {
 
 describe('wrap-step lint (#139 Chunk 4)', () => {
   const lintStep = require('../lib/wrap-steps/lint');
+  const { TIMEOUT_EXIT_CODE } = require('../lib/wrap-steps/_exec-shell');
   let tmpDir;
   let projectPath;
   let originalExec;
@@ -742,13 +747,13 @@ describe('wrap-step lint (#139 Chunk 4)', () => {
     writeConfig({ lintCommand: 'eslint' });
     lintStep._internal.detectChangedFiles = async () => ['src/foo.js'];
     lintStep._internal.execShell = async () => ({
-      exitCode: 124, stdout: '', stderr: '', error: 'timed out after 300000ms', timedOut: true
+      exitCode: TIMEOUT_EXIT_CODE, stdout: '', stderr: '', error: 'timed out after 300000ms', timedOut: true
     });
     const result = await lintStep.run(buildContext({ id: 'lint', blocker: true }));
 
     assert.equal(result.ok, false);
     assert.equal(result.status, 'blocked');
-    assert.equal(result.output.exitCode, 124);
+    assert.equal(result.output.exitCode, TIMEOUT_EXIT_CODE);
     assert.ok(result.blockers.some((b) => /timed out/i.test(b)),
       'the blocker must name the timeout');
     assert.ok(!result.blockers.some((b) => /^Lint failed/.test(b)),
@@ -764,7 +769,7 @@ describe('wrap-step lint (#139 Chunk 4)', () => {
     writeConfig({ lintCommand: 'eslint' });
     lintStep._internal.detectChangedFiles = async () => ['src/foo.js'];
     lintStep._internal.execShell = async () => ({
-      exitCode: 124, stdout: '', stderr: '', error: 'timed out after 300000ms', timedOut: true
+      exitCode: TIMEOUT_EXIT_CODE, stdout: '', stderr: '', error: 'timed out after 300000ms', timedOut: true
     });
     const result = await lintStep.run(buildContext({ id: 'lint', blocker: false }));
 
@@ -781,14 +786,47 @@ describe('wrap-step lint (#139 Chunk 4)', () => {
     writeConfig({ lintCommand: 'eslint' });
     lintStep._internal.detectChangedFiles = async () => ['src/foo.js'];
     lintStep._internal.execShell = async () => ({
-      exitCode: 124, stdout: '', stderr: '', error: 'timed out after 300000ms', timedOut: true
+      exitCode: TIMEOUT_EXIT_CODE, stdout: '', stderr: '', error: 'timed out after 300000ms', timedOut: true
     });
     const result = await lintStep.run(buildContext({ id: 'lint', blocker: false }));
 
     assert.equal(result.ok, true, 'blocker:false still must not block');
-    assert.equal(result.output.timedOut, true);
+    // Asserted on the fields the drawer renders, not on a bare `output.timedOut`
+    // flag: that flag had no production consumer at all, so a test reading it
+    // proved only that the handler set a field nobody displayed. `warning` and
+    // `remediation` are what `public/wrap-drawer.js#buildStepRow` reads, which
+    // makes this the assertion an operator's experience actually depends on.
+    assert.equal(result.output.warning, true);
+    assert.match(result.output.remediation, /did not finish/i);
     assert.match(result.output.warnings, /timed out/i,
       'an informational step that was killed must still say so');
+  });
+
+  it('with blocker:false, a timeout is written to the server log as well as the drawer', async () => {
+    // Both BLOCKING timeout paths log; this one did not. That made the single
+    // configuration that deliberately lets the wrap continue also the only one
+    // leaving no trace it was killed — the worse pairing of the two, because
+    // nobody is stopped to notice and the drawer row is gone by the next wrap.
+    writeConfig({ lintCommand: 'eslint' });
+    lintStep._internal.detectChangedFiles = async () => ['src/foo.js'];
+    lintStep._internal.execShell = async () => ({
+      exitCode: TIMEOUT_EXIT_CODE, stdout: '', stderr: '', error: 'timed out after 300000ms', timedOut: true
+    });
+
+    // The suite runs at level `error`, so raise it and pin the stream to capture.
+    const lines = [];
+    const priorLevel = getLevel();
+    setLevel('warn');
+    setConsoleStream({ write: (s) => lines.push(s) });
+    try {
+      await lintStep.run(buildContext({ id: 'lint', blocker: false }));
+    } finally {
+      setConsoleStream(null);
+      setLevel(priorLevel);
+    }
+
+    assert.ok(lines.some((l) => /Lint command timed out/.test(l)),
+      'a killed informational lint must leave a record in the server log');
   });
 
   it('shell-quotes file paths containing spaces and single quotes', async () => {

--- a/test/wrap-step-features-toc.test.js
+++ b/test/wrap-step-features-toc.test.js
@@ -622,7 +622,7 @@ describe('wrap-step features-toc (#207 Chunk 3)', () => {
       featuresToc._internal.execSync = (cmd) => { calls.push(cmd); return Buffer.from(''); };
       try {
         const r = featuresToc._resolveSessionRange('/repo', SHA);
-        assert.deepEqual(r, { range: `${SHA}..HEAD`, kind: 'session', baseBranch: null });
+        assert.deepEqual(r, { range: `${SHA}..HEAD`, kind: 'session', baseBranch: null, stopped: [] });
         // It verified the SHA peels to a commit; no base-branch resolution needed.
         assert.ok(calls.some((c) => c.includes(`${SHA}^{commit}`)));
         assert.ok(!calls.some((c) => c.includes('rev-parse --verify --quiet main')));
@@ -639,7 +639,7 @@ describe('wrap-step features-toc (#207 Chunk 3)', () => {
       };
       try {
         const r = featuresToc._resolveSessionRange('/repo', null);
-        assert.deepEqual(r, { range: 'main...HEAD', kind: 'branch', baseBranch: 'main' });
+        assert.deepEqual(r, { range: 'main...HEAD', kind: 'branch', baseBranch: 'main', stopped: [] });
       } finally {
         featuresToc._internal.execSync = orig;
       }

--- a/test/wrap-step-git-range-killed.test.js
+++ b/test/wrap-step-git-range-killed.test.js
@@ -481,3 +481,69 @@ describe('a widened range reaches the operator who is blocked by it (#897)', () 
     }
   });
 });
+
+describe('the degraded-range caveat goes only where the range was used (#897)', () => {
+  // The caveat exists because a widened range can put commits from OTHER
+  // sessions into the list an operator is told to write entries for. The
+  // uncommitted-work verdict has no such list: it is read from the working tree,
+  // `uncovered` is empty and `checkedCount` is 0, so the range played no part.
+  // Attaching the caveat there tells the operator to check whether a set of FILE
+  // PATHS belongs to their session, which is not a question, and invites
+  // tick-through of a correct block.
+
+  it('an uncommitted-work verdict carries no caveat even when a probe was stopped', () => {
+    const savedExec = changelogCoverage._internal.execSync;
+    const savedCfg = changelogCoverage._internal.loadProjectConfig;
+    try {
+      changelogCoverage._internal.loadProjectConfig = () => ({ lastWrapSha: 'abcdef1234567' });
+      changelogCoverage._internal.execSync = (command) => {
+        const cmd = String(command);
+        if (cmd.includes('merge-base --is-ancestor')) throw realTimeoutError();
+        if (cmd.startsWith('git log')) return Buffer.from('');
+        // Dirty source work, no changelog edit → the uncommitted-work verdict.
+        if (cmd.startsWith('git diff --name-only --relative HEAD')) return Buffer.from('lib/thing.js\n');
+        return Buffer.from('');
+      };
+
+      const r = changelogCoverage.evaluate('/tmp', ['CHANGELOG.md'], []);
+
+      assert.equal(r.verdict, changelogCoverage.VERDICTS.UNCOVERED);
+      assert.deepEqual(r.uncommittedWork, ['lib/thing.js'],
+        'this is the working-tree form of the verdict');
+      assert.equal(r.checkedCount, 0, 'no commits were judged, so no range was used');
+      assert.equal(r.reason, null,
+        'a verdict the range did not produce must not carry a range caveat');
+    } finally {
+      changelogCoverage._internal.execSync = savedExec;
+      changelogCoverage._internal.loadProjectConfig = savedCfg;
+    }
+  });
+
+  it('the ai-content gate renders no commit-checking advice onto a file-path block', () => {
+    const aiContent = require('../lib/wrap-steps/ai-content');
+    const saved = aiContent._internal.changelogCoverage;
+    try {
+      aiContent._internal.changelogCoverage = () => ({
+        verdict: 'uncovered',
+        uncovered: [],
+        uncommittedWork: ['lib/thing.js'],
+        checkedCount: 0,
+        range: 'main..HEAD',
+        reason: null
+      });
+
+      const block = aiContent._verifyChangedGate(
+        '/tmp',
+        { id: 'changelog-update', verifySatisfiedBy: 'changelog-coverage' },
+        { 'CHANGELOG.md': null }
+      );
+
+      assert.ok(block);
+      assert.match(block.remediation, /lib\/thing\.js/);
+      assert.doesNotMatch(block.remediation, /listed commits/,
+        'the rows here are file paths, not commits');
+    } finally {
+      aiContent._internal.changelogCoverage = saved;
+    }
+  });
+});

--- a/test/wrap-step-git-range-killed.test.js
+++ b/test/wrap-step-git-range-killed.test.js
@@ -26,7 +26,7 @@
  * actually killing a real process.
  */
 
-const { describe, it } = require('node:test');
+const { describe, it, before, after } = require('node:test');
 const assert = require('node:assert/strict');
 const { execSync } = require('node:child_process');
 const os = require('node:os');
@@ -246,6 +246,238 @@ describe('changelog-coverage explains an unavailable verdict honestly (#897)', (
     } finally {
       changelogCoverage._internal.execSync = savedExec;
       changelogCoverage._internal.loadProjectConfig = savedCfg;
+    }
+  });
+});
+
+describe('features-toc names a stopped probe rather than a fact (#897)', () => {
+  const featuresToc = require('../lib/wrap-steps/features-toc');
+  const store = require('../lib/store');
+  const fs = require('node:fs');
+  const path = require('node:path');
+
+  let tmpDir;
+  let projectPath;
+
+  before(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-897-features-toc-'));
+    projectPath = path.join(tmpDir, 'proj');
+    fs.mkdirSync(projectPath, { recursive: true });
+    fs.writeFileSync(path.join(projectPath, 'FEATURES.md'), '# Feature Index\n');
+  });
+
+  after(() => { fs.rmSync(tmpDir, { recursive: true, force: true }); });
+
+  /**
+   * Run the handler with the project config and `execSync` both scripted.
+   *
+   * @param {object} projConfig - What `store.projectConfig.load` returns.
+   * @param {(command:string) => Buffer} exec - The scripted `execSync`.
+   * @returns {Promise<object>} The step result.
+   */
+  async function runWith(projConfig, exec) {
+    const savedExec = featuresToc._internal.execSync;
+    const savedLoad = store.projectConfig.load;
+    try {
+      store.projectConfig.load = () => projConfig;
+      featuresToc._internal.execSync = exec;
+      return await featuresToc.run({
+        project: { name: 'p', path: projectPath },
+        step: { id: 'features-toc' },
+        staged: {}
+      });
+    } finally {
+      featuresToc._internal.execSync = savedExec;
+      store.projectConfig.load = savedLoad;
+    }
+  }
+
+  it('a killed `git diff` is not reported as a diff that failed', async () => {
+    const r = await runWith({ featureIndexEnabled: true, lastWrapSha: null }, (command) => {
+      if (String(command).startsWith('git diff')) throw realTimeoutError();
+      return Buffer.from('');
+    });
+
+    assert.equal(r.status, 'skipped');
+    assert.match(r.output.reason, /was stopped/);
+    assert.doesNotMatch(r.output.reason, /git diff failed/,
+      'the old wording said "failed" about a command that never answered');
+    assert.match(r.output.reason, /unknown/);
+  });
+
+  it('an ordinary `git diff` failure keeps its original wording', async () => {
+    const r = await runWith({ featureIndexEnabled: true, lastWrapSha: null }, (command) => {
+      if (String(command).startsWith('git diff')) {
+        const err = new Error('Command failed: git diff');
+        err.status = 128;
+        throw err;
+      }
+      return Buffer.from('');
+    });
+
+    assert.match(r.output.reason, /git diff failed/);
+  });
+
+  it('a killed range probe does not claim the repo has no main or master', async () => {
+    const r = await runWith(
+      { featureIndexEnabled: true, lastWrapSha: null },
+      () => { throw realTimeoutError(); }
+    );
+
+    assert.equal(r.status, 'skipped');
+    assert.match(r.output.reason, /stopped before answering/);
+    assert.doesNotMatch(r.output.reason, /no main\/master base branch/);
+  });
+
+  it('a genuinely trunk-less repo keeps its original skip reason', async () => {
+    const r = await runWith({ featureIndexEnabled: true, lastWrapSha: null }, () => {
+      const err = new Error('Command failed');
+      err.status = 1;
+      throw err;
+    });
+
+    assert.match(r.output.reason, /no main\/master base branch/);
+  });
+
+  it('a resolved-but-WIDENED range says so — the case with the highest cost', async () => {
+    // The costliest stopped-probe case does NOT reach the no-range branch: a
+    // killed `merge-base --is-ancestor` still resolves a range (the trunk
+    // fallback), so the step reports an entirely ordinary outcome computed over
+    // a range that was silently widened.
+    const SHA = 'abcdef1234567';
+    const r = await runWith({ featureIndexEnabled: true, lastWrapSha: SHA }, (command) => {
+      const cmd = String(command);
+      if (cmd.includes('merge-base --is-ancestor')) throw realTimeoutError();
+      // Everything else resolves; the diff is empty.
+      return Buffer.from('');
+    });
+
+    assert.equal(r.status, 'skipped');
+    assert.match(r.output.reason, /no files touched in main\.\.\.HEAD/,
+      'the fallback range is still used — that part is correct');
+    assert.match(r.output.reason, /stopped before answering/,
+      '"no files touched" must not read as a fact about the session');
+    assert.match(r.output.reason, /unknown answer/);
+  });
+
+  it('an undegraded empty range keeps the plain wording', async () => {
+    const SHA = 'abcdef1234567';
+    const r = await runWith(
+      { featureIndexEnabled: true, lastWrapSha: SHA },
+      () => Buffer.from('')
+    );
+
+    assert.match(r.output.reason, /^no files touched in abcdef1234567\.\.HEAD$/,
+      'no caveat when every probe answered');
+  });
+});
+
+describe('a widened range reaches the operator who is blocked by it (#897)', () => {
+  const aiContent = require('../lib/wrap-steps/ai-content');
+
+  it('changelog-coverage flags an uncovered verdict computed over a guessed range', () => {
+    const savedExec = changelogCoverage._internal.execSync;
+    const savedCfg = changelogCoverage._internal.loadProjectConfig;
+    try {
+      changelogCoverage._internal.loadProjectConfig = () => ({ lastWrapSha: 'abcdef1234567' });
+      changelogCoverage._internal.execSync = (command) => {
+        const cmd = String(command);
+        if (cmd.includes('merge-base --is-ancestor')) throw realTimeoutError();
+        if (cmd.startsWith('git log')) {
+          // One judged commit that never touched the changelog.
+          return Buffer.from('\x1eabc123\x1fp1\x1fAdd a thing\nlib/thing.js\n');
+        }
+        return Buffer.from('');
+      };
+
+      const r = changelogCoverage.evaluate('/tmp', ['CHANGELOG.md'], []);
+
+      assert.equal(r.verdict, changelogCoverage.VERDICTS.UNCOVERED);
+      assert.match(r.reason, /stopped before answering/,
+        'the commit list may reach past this session and the operator must be told');
+      assert.match(r.reason, /may reach further back than this session/);
+    } finally {
+      changelogCoverage._internal.execSync = savedExec;
+      changelogCoverage._internal.loadProjectConfig = savedCfg;
+    }
+  });
+
+  it('an uncovered verdict over a confirmed range carries no caveat', () => {
+    const savedExec = changelogCoverage._internal.execSync;
+    const savedCfg = changelogCoverage._internal.loadProjectConfig;
+    try {
+      changelogCoverage._internal.loadProjectConfig = () => ({ lastWrapSha: 'abcdef1234567' });
+      changelogCoverage._internal.execSync = (command) => {
+        if (String(command).startsWith('git log')) {
+          return Buffer.from('\x1eabc123\x1fp1\x1fAdd a thing\nlib/thing.js\n');
+        }
+        return Buffer.from('');
+      };
+
+      const r = changelogCoverage.evaluate('/tmp', ['CHANGELOG.md'], []);
+
+      assert.equal(r.verdict, changelogCoverage.VERDICTS.UNCOVERED);
+      assert.equal(r.reason, null, 'nothing to caveat when every probe answered');
+    } finally {
+      changelogCoverage._internal.execSync = savedExec;
+      changelogCoverage._internal.loadProjectConfig = savedCfg;
+    }
+  });
+
+  it('the ai-content gate renders the caveat into the block the operator reads', () => {
+    // Without this the field would be one more unconsumed payload key — the
+    // exact anti-pattern this branch cites when deleting lint's `output.timedOut`.
+    const saved = aiContent._internal.changelogCoverage;
+    try {
+      aiContent._internal.changelogCoverage = () => ({
+        verdict: 'uncovered',
+        uncovered: [{ sha: 'abc1234def', subject: 'Add a thing' }],
+        uncommittedWork: [],
+        checkedCount: 1,
+        range: 'main..HEAD',
+        reason: '1 git probe(s) were stopped before answering (git merge-base --is-ancestor abc HEAD), so this range is a fallback taken on an unknown answer and may reach further back than this session'
+      });
+
+      // Driven through the real gate rather than the private predicate: the
+      // snapshot is unchanged, which is exactly the condition that routes an
+      // ai-content step into the coverage predicate on a live wrap.
+      const block = aiContent._verifyChangedGate(
+        '/tmp',
+        { id: 'changelog-update', verifySatisfiedBy: 'changelog-coverage' },
+        { 'CHANGELOG.md': null }
+      );
+
+      assert.ok(block, 'the block still stands — the changelog was not maintained');
+      assert.match(block.remediation, /stopped before answering/);
+      assert.match(block.remediation, /belong to this session before writing entries/);
+    } finally {
+      aiContent._internal.changelogCoverage = saved;
+    }
+  });
+
+  it('an ordinary uncovered block is unchanged', () => {
+    const saved = aiContent._internal.changelogCoverage;
+    try {
+      aiContent._internal.changelogCoverage = () => ({
+        verdict: 'uncovered',
+        uncovered: [{ sha: 'abc1234def', subject: 'Add a thing' }],
+        uncommittedWork: [],
+        checkedCount: 1,
+        range: 'main..HEAD',
+        reason: null
+      });
+
+      const block = aiContent._verifyChangedGate(
+        '/tmp',
+        { id: 'changelog-update', verifySatisfiedBy: 'changelog-coverage' },
+        { 'CHANGELOG.md': null }
+      );
+
+      assert.ok(block);
+      assert.doesNotMatch(block.remediation, /Note:/,
+        'no caveat when the range was confirmed');
+    } finally {
+      aiContent._internal.changelogCoverage = saved;
     }
   });
 });

--- a/test/wrap-step-git-range-killed.test.js
+++ b/test/wrap-step-git-range-killed.test.js
@@ -1,0 +1,251 @@
+'use strict';
+
+/**
+ * The SYNCHRONOUS half of "a killed command is not a failed one" (#897).
+ *
+ * `_git-range`, `features-toc` and `changelog-coverage` all reach git through
+ * `execSync`, and all three answer their question by catching a non-zero exit.
+ * That makes a command our own timeout killed indistinguishable from a
+ * confident negative answer — and every negative answer here widens what the
+ * wrap measures or blocks on:
+ *
+ *   - a stopped `merge-base --is-ancestor` reads as "the recorded SHA is
+ *     orphaned" and abandons `<sha>..HEAD` for the whole trunk divergence;
+ *   - a stopped `rev-parse --verify main` reads as "this repo has no main",
+ *     which is reported to the operator as a fact;
+ *   - a stopped `git log` makes `changelog-coverage` return `unavailable`,
+ *     which the ai-content gate maps to the mutation-check fallback — so the
+ *     operator is blocked with "CHANGELOG.md is unchanged" by a predicate that
+ *     never ran.
+ *
+ * `execSync` reports a timeout as `code: 'ETIMEDOUT'` with `signal: 'SIGTERM'`
+ * and — unlike the async APIs — **no `killed` flag at all**, because that flag
+ * belongs to `spawnSync`'s result object rather than to the error it throws.
+ * Three authors modelled that wrongly in #894. So the errors driven through
+ * these seams are never hand-built: `realTimeoutError()` produces one by
+ * actually killing a real process.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { execSync } = require('node:child_process');
+const os = require('node:os');
+
+const { wasTimedOut } = require('../lib/exec-timeout');
+const gitRange = require('../lib/wrap-steps/_git-range');
+const changelogCoverage = require('../lib/wrap-steps/changelog-coverage');
+
+/**
+ * Produce a genuine `execSync` timeout error by killing a real process.
+ *
+ * The subject of these guards is a failure MODE, so it is spawned rather than
+ * described — a hand-written `{code: 'ETIMEDOUT'}` would assert this file's
+ * model of the shape, which is precisely what was broken. The one concession is
+ * that the error is then REUSED through the injected `exec` seam: these
+ * functions build their own git command strings, so a stalling command cannot
+ * be passed in from outside. The object is still one a real kill produced.
+ *
+ * @returns {Error} The error a real killed `execSync` threw.
+ */
+function realTimeoutError() {
+  try {
+    execSync('sleep 30', { timeout: 300, cwd: os.tmpdir(), stdio: ['ignore', 'pipe', 'ignore'] });
+  } catch (err) {
+    return err;
+  }
+  throw new Error('sleep 30 was not killed by a 300ms timeout — the fixture is not producing a kill');
+}
+
+describe('a real execSync kill is recognised as a kill (#897)', () => {
+  it('carries no `killed` flag, which is why three hand-written checks were dead', () => {
+    const err = realTimeoutError();
+
+    assert.equal(err.killed, undefined,
+      'if this ever becomes true, the shape changed and the comments explaining #894 are stale');
+    assert.equal(err.code, 'ETIMEDOUT');
+    assert.equal(wasTimedOut(err), true, 'the shared predicate must recognise the real shape');
+  });
+
+  it('an ordinary non-zero exit is not a timeout', () => {
+    let err;
+    try {
+      execSync('exit 3', { cwd: os.tmpdir(), stdio: ['ignore', 'pipe', 'ignore'] });
+    } catch (e) { err = e; }
+
+    assert.equal(wasTimedOut(err), false, 'exit 3 answered — it was not killed');
+  });
+});
+
+describe('_git-range reports a stopped probe instead of a negative answer (#897)', () => {
+  const killed = () => { throw realTimeoutError(); };
+  const succeeds = () => Buffer.from('');
+
+  it('isAncestorOfHead still answers false, but names the probe as stopped', () => {
+    const stopped = [];
+    const answer = gitRange.isAncestorOfHead('/tmp', 'abc1234', killed, (c) => stopped.push(c));
+
+    assert.equal(answer, false, 'falling back on an unknown answer is still the safe move');
+    assert.equal(stopped.length, 1, 'but the caller must be able to tell unknown from negative');
+    assert.match(stopped[0], /merge-base --is-ancestor/);
+  });
+
+  it('isResolvableCommit reports a stopped probe', () => {
+    const stopped = [];
+    const answer = gitRange.isResolvableCommit('/tmp', 'abc1234', killed, (c) => stopped.push(c));
+
+    assert.equal(answer, false);
+    assert.match(stopped[0], /rev-parse --verify/);
+  });
+
+  it('resolveBaseBranch reports a stopped probe per candidate it could not read', () => {
+    const stopped = [];
+    const answer = gitRange.resolveBaseBranch('/tmp', killed, (c) => stopped.push(c));
+
+    assert.equal(answer, null);
+    assert.equal(stopped.length, 2, 'both main and master were probed and neither answered');
+  });
+
+  it('a probe that genuinely says no is NOT reported as stopped', () => {
+    // The falsifying half: if `_noteIfStopped` fired on every catch, the field
+    // would be meaningless. An ordinary non-zero exit must leave it empty.
+    const stopped = [];
+    const refuses = () => {
+      const err = new Error('Command failed');
+      err.status = 1;
+      throw err;
+    };
+    const answer = gitRange.isAncestorOfHead('/tmp', 'abc1234', refuses, (c) => stopped.push(c));
+
+    assert.equal(answer, false);
+    assert.deepEqual(stopped, [], 'a real negative answer is not a stopped probe');
+  });
+
+  it('resolveSessionRange surfaces the stopped probes alongside the range it fell back to', () => {
+    // The costly case: the SHA is well-formed and resolvable, but the ancestry
+    // probe is killed — so the session range silently widens from
+    // `<sha>..HEAD` to the whole trunk divergence.
+    let call = 0;
+    const exec = (command) => {
+      call += 1;
+      // 1st: rev-parse --verify <sha>^{commit} → resolves.
+      if (call === 1) return Buffer.from('');
+      // 2nd: merge-base --is-ancestor → killed.
+      if (call === 2) throw realTimeoutError();
+      // 3rd: rev-parse --verify main → resolves, giving the fallback range.
+      return Buffer.from('');
+    };
+
+    const resolved = gitRange.resolveSessionRange('/tmp', 'abcdef1234567', { dots: 'two', exec });
+
+    assert.equal(resolved.kind, 'branch', 'it fell back, as it should on an unknown answer');
+    assert.equal(resolved.range, 'main..HEAD');
+    assert.equal(resolved.stopped.length, 1,
+      'the fallback was taken on an UNKNOWN answer and the result must say so');
+    assert.match(resolved.stopped[0], /merge-base --is-ancestor/);
+  });
+
+  it('a range resolved with no stopped probes reports an empty list', () => {
+    const resolved = gitRange.resolveSessionRange('/tmp', 'abcdef1234567', {
+      dots: 'two', exec: () => Buffer.from('')
+    });
+
+    assert.equal(resolved.kind, 'session');
+    assert.deepEqual(resolved.stopped, []);
+  });
+});
+
+describe('changelog-coverage explains an unavailable verdict honestly (#897)', () => {
+  // `unavailable` is not inert — `ai-content.js#_satisfactionPredicateGate` maps
+  // it to the mutation-check fallback, which BLOCKS a wrap whose changelog is
+  // untouched this turn. So these reason strings are read by a blocked operator.
+
+  it('a killed `git log` says the commits are unknown, not that the range failed', () => {
+    const savedExec = changelogCoverage._internal.execSync;
+    const savedCfg = changelogCoverage._internal.loadProjectConfig;
+    try {
+      changelogCoverage._internal.loadProjectConfig = () => ({ lastWrapSha: null });
+      let call = 0;
+      changelogCoverage._internal.execSync = (command) => {
+        call += 1;
+        // The range resolves off `main`; the `git log` that follows is killed.
+        if (String(command).startsWith('git log')) throw realTimeoutError();
+        return Buffer.from('');
+      };
+
+      const r = changelogCoverage.evaluate('/tmp', ['CHANGELOG.md'], []);
+
+      assert.equal(r.verdict, changelogCoverage.VERDICTS.UNAVAILABLE);
+      assert.match(r.reason, /was stopped/);
+      assert.match(r.reason, /unknown/,
+        'the operator must not read this as "there are no commits"');
+      assert.ok(call > 1, 'the git log call was actually reached');
+    } finally {
+      changelogCoverage._internal.execSync = savedExec;
+      changelogCoverage._internal.loadProjectConfig = savedCfg;
+    }
+  });
+
+  it('a killed working-tree read says the uncommitted files are unknown', () => {
+    const savedExec = changelogCoverage._internal.execSync;
+    const savedCfg = changelogCoverage._internal.loadProjectConfig;
+    try {
+      changelogCoverage._internal.loadProjectConfig = () => ({ lastWrapSha: null });
+      changelogCoverage._internal.execSync = (command) => {
+        const cmd = String(command);
+        if (cmd.startsWith('git diff --name-only --relative HEAD')) throw realTimeoutError();
+        if (cmd.startsWith('git log')) return Buffer.from('');
+        return Buffer.from('');
+      };
+
+      const r = changelogCoverage.evaluate('/tmp', ['CHANGELOG.md'], []);
+
+      assert.equal(r.verdict, changelogCoverage.VERDICTS.UNAVAILABLE);
+      assert.match(r.reason, /was stopped/);
+      assert.match(r.reason, /uncommitted files are unknown/);
+    } finally {
+      changelogCoverage._internal.execSync = savedExec;
+      changelogCoverage._internal.loadProjectConfig = savedCfg;
+    }
+  });
+
+  it('a killed range probe does not claim the repo has no main or master', () => {
+    const savedExec = changelogCoverage._internal.execSync;
+    const savedCfg = changelogCoverage._internal.loadProjectConfig;
+    try {
+      changelogCoverage._internal.loadProjectConfig = () => ({ lastWrapSha: null });
+      changelogCoverage._internal.execSync = () => { throw realTimeoutError(); };
+
+      const r = changelogCoverage.evaluate('/tmp', ['CHANGELOG.md'], []);
+
+      assert.equal(r.verdict, changelogCoverage.VERDICTS.UNAVAILABLE);
+      assert.match(r.reason, /stopped before answering/);
+      assert.doesNotMatch(r.reason, /no main\/master base branch/,
+        'a stopped probe is no evidence about which branches this repo has');
+    } finally {
+      changelogCoverage._internal.execSync = savedExec;
+      changelogCoverage._internal.loadProjectConfig = savedCfg;
+    }
+  });
+
+  it('a genuinely missing trunk branch keeps its original wording', () => {
+    // The other direction — the new message must not swallow the real case.
+    const savedExec = changelogCoverage._internal.execSync;
+    const savedCfg = changelogCoverage._internal.loadProjectConfig;
+    try {
+      changelogCoverage._internal.loadProjectConfig = () => ({ lastWrapSha: null });
+      changelogCoverage._internal.execSync = () => {
+        const err = new Error('Command failed');
+        err.status = 1;
+        throw err;
+      };
+
+      const r = changelogCoverage.evaluate('/tmp', ['CHANGELOG.md'], []);
+
+      assert.equal(r.verdict, changelogCoverage.VERDICTS.UNAVAILABLE);
+      assert.match(r.reason, /no main\/master base branch/);
+    } finally {
+      changelogCoverage._internal.execSync = savedExec;
+      changelogCoverage._internal.loadProjectConfig = savedCfg;
+    }
+  });
+});

--- a/test/wrap-step-killed-vs-failed.test.js
+++ b/test/wrap-step-killed-vs-failed.test.js
@@ -1,0 +1,249 @@
+'use strict';
+
+/**
+ * A wrap step that was KILLED must not be reported as one that FAILED (#897).
+ *
+ * #894 fixed that distinction in `test` and `lint` — two handlers the shipped
+ * fourteen-step pipeline never runs. The four steps covered here DO run on every
+ * wrap (`open-pr-check`, `commit`, `continuity-write`, `apply-pr-resolutions`),
+ * and two of them take outward actions: a `git commit` or a `gh pr merge` killed
+ * at its timeout used to arrive as a plain `exit 1` with empty output, so the
+ * operator was told the commit "was rejected — read the hook output above" for a
+ * commit that may in fact have landed.
+ *
+ * Every timeout case below runs a REAL process against a REAL kill, through the
+ * production wrapper. Three hand-written models of these error shapes were wrong
+ * in #894, which is the entire reason this file does not inject error objects.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const os = require('node:os');
+
+const { execShell, execFileArgs, TIMEOUT_EXIT_CODE } = require('../lib/wrap-steps/_exec-shell');
+const commitStep = require('../lib/wrap-steps/commit');
+const prMergeStep = require('../lib/wrap-steps/pr-merge');
+const prCheckStep = require('../lib/wrap-steps/pr-check');
+const continuityStep = require('../lib/wrap-steps/continuity-write');
+
+/** Short enough to keep the suite fast, long enough not to race the spawn. */
+const SHORT_TIMEOUT_MS = 300;
+
+describe('_exec-shell.execFileArgs — the argv-style runner (#897)', () => {
+  it('maps a real timeout to the timeout exit code and timedOut', async () => {
+    const result = await execFileArgs('sleep', ['30'], {
+      cwd: os.tmpdir(), timeoutMs: SHORT_TIMEOUT_MS, maxBufferBytes: 1024 * 1024
+    });
+
+    assert.equal(result.timedOut, true, 'a killed command must be flagged as killed');
+    assert.equal(result.exitCode, TIMEOUT_EXIT_CODE);
+    assert.match(result.error, /timed out/);
+    // The pre-fix behaviour, pinned so a regression is unmistakable: it resolved
+    // exitCode 1 with error null, which no caller could tell from a real failure.
+    assert.notEqual(result.exitCode, 1);
+    assert.notEqual(result.error, null);
+  });
+
+  it('leaves an ordinary non-zero exit alone', async () => {
+    const result = await execFileArgs('sh', ['-c', 'exit 3'], {
+      cwd: os.tmpdir(), timeoutMs: 30_000, maxBufferBytes: 1024 * 1024
+    });
+
+    assert.equal(result.timedOut, false, 'a command that answered is not a timeout');
+    assert.equal(result.exitCode, 3);
+    assert.equal(result.error, null, 'an exit code IS the answer — there is no exec error');
+  });
+
+  it('names a missing executable instead of flattening it to exit 1', async () => {
+    // The argv form has no shell to exit 127 on its behalf, so a missing binary
+    // arrives as a non-numeric `ENOENT` — the same slot as an output overflow.
+    // It must be named, and it must NOT be mistaken for a timeout: the child is
+    // never spawned, so nothing is killed.
+    const result = await execFileArgs('tangleclaw-no-such-binary', [], {
+      cwd: os.tmpdir(), timeoutMs: 30_000, maxBufferBytes: 1024 * 1024
+    });
+
+    assert.equal(result.timedOut, false, 'a binary that never spawned was not killed');
+    assert.match(result.error, /ENOENT/, 'the operator must be told what actually happened');
+  });
+
+  it('does not report an output overflow as a timeout', async () => {
+    // The near-miss for the timeout predicate: the child IS killed here, but
+    // `killed` is left unset and no signal is reported.
+    const result = await execShell('yes hello | head -c 200000', {
+      cwd: os.tmpdir(), timeoutMs: 30_000, maxBufferBytes: 1024
+    });
+
+    assert.equal(result.timedOut, false, 'an overflow is not a timeout');
+    assert.match(result.error, /maxBuffer/);
+  });
+});
+
+describe('the four pipeline steps whose runner could not tell killed from failed (#897)', () => {
+  // Each step's production wrapper, driven against a real stalling process. The
+  // test seam supplies only the caps — the wrapper, the predicate, and the
+  // mapping under test are all production code.
+  const argvRunners = [
+    ['commit', () => commitStep._internal.exec('sleep', ['30'], {
+      cwd: os.tmpdir(), timeoutMs: SHORT_TIMEOUT_MS
+    })],
+    ['pr-merge', () => prMergeStep._internal.exec('sleep', ['30'], {
+      cwd: os.tmpdir(), timeoutMs: SHORT_TIMEOUT_MS
+    })],
+    ['continuity-write', () => continuityStep._internal.exec('sleep', ['30'], {
+      cwd: os.tmpdir(), timeoutMs: SHORT_TIMEOUT_MS
+    })]
+  ];
+  const shellRunners = [
+    ['pr-check', () => prCheckStep._internal.exec('sleep 30', {
+      cwd: os.tmpdir(), timeoutMs: SHORT_TIMEOUT_MS
+    })],
+    ['pr-merge (shell form)', () => prMergeStep._internal.execShell('sleep 30', {
+      cwd: os.tmpdir(), timeoutMs: SHORT_TIMEOUT_MS
+    })]
+  ];
+
+  for (const [label, run] of [...argvRunners, ...shellRunners]) {
+    it(`${label}: a real kill resolves timedOut, not a bare exit 1`, async () => {
+      const result = await run();
+
+      assert.equal(result.timedOut, true, `${label} must flag a killed command as killed`);
+      assert.equal(result.exitCode, TIMEOUT_EXIT_CODE);
+      assert.notEqual(result.exitCode, 1, 'exit 1 is what a command that RAN and failed returns');
+    });
+  }
+
+  for (const [label, step, args] of [
+    ['commit', commitStep, ['sh', ['-c', 'exit 3']]],
+    ['pr-merge', prMergeStep, ['sh', ['-c', 'exit 3']]],
+    ['continuity-write', continuityStep, ['sh', ['-c', 'exit 3']]]
+  ]) {
+    it(`${label}: an ordinary non-zero exit is still an ordinary non-zero exit`, async () => {
+      const result = await step._internal.exec(args[0], args[1], { cwd: os.tmpdir() });
+
+      assert.equal(result.timedOut, false);
+      assert.equal(result.exitCode, 3);
+    });
+  }
+});
+
+describe('what the operator is told when a wrap command is killed (#897)', () => {
+  // Each case below scripts the step's git runner, but the KILLED result it
+  // returns is produced by a real `sleep` kill through the production wrapper —
+  // never a hand-built error object. That is the part three authors got wrong
+  // in #894, so it is the part no double is allowed to model.
+
+  /** An exec result for a command that RAN and succeeded. */
+  const ok = (stdout = '') => ({
+    exitCode: 0, stdout, stderr: '', error: null, timedOut: false
+  });
+
+  it('commit: a killed `git commit` is not called a rejection, and does not claim the commit failed', async () => {
+    const realKill = await execFileArgs('sleep', ['30'], {
+      cwd: os.tmpdir(), timeoutMs: SHORT_TIMEOUT_MS, maxBufferBytes: 1024
+    });
+    const saved = commitStep._internal.exec;
+    try {
+      commitStep._internal.exec = async (file, args) => {
+        const cmd = `${file} ${args.join(' ')}`;
+        if (cmd.startsWith('git commit')) return realKill;
+        if (cmd === 'git status --porcelain') return ok('M lib/thing.js\n');
+        if (cmd === 'git rev-parse --abbrev-ref HEAD') return ok('fix/some-branch\n');
+        if (cmd === 'git add -A') return ok();
+        return ok();
+      };
+
+      const result = await commitStep.run({
+        project: { name: 'p', path: os.tmpdir() },
+        step: { id: 'commit' },
+        staged: {},
+        options: {}
+      });
+
+      assert.equal(result.status, 'blocked');
+      // The blocker names a stop, not a failure.
+      assert.match(result.blockers[0], /was stopped/);
+      assert.doesNotMatch(result.blockers[0], /git commit failed/,
+        'a killed commit must not be reported as a failed one');
+      // And the remediation must not send the operator to read hook output that
+      // does not exist, nor assert that nothing was committed.
+      assert.match(result.output.remediation, /git log -1/,
+        'the operator must be told how to find out whether the commit landed');
+      assert.doesNotMatch(result.output.remediation, /was rejected/,
+        'nothing rejected this commit — it was stopped');
+    } finally {
+      commitStep._internal.exec = saved;
+    }
+  });
+
+  it('commit: an ordinary rejected commit keeps its pre-commit-hook remediation', async () => {
+    const saved = commitStep._internal.exec;
+    try {
+      commitStep._internal.exec = async (file, args) => {
+        const cmd = `${file} ${args.join(' ')}`;
+        if (cmd.startsWith('git commit')) {
+          return { exitCode: 1, stdout: '', stderr: 'husky: lint failed', error: null, timedOut: false };
+        }
+        if (cmd === 'git status --porcelain') return ok('M lib/thing.js\n');
+        if (cmd === 'git rev-parse --abbrev-ref HEAD') return ok('fix/some-branch\n');
+        return ok();
+      };
+
+      const result = await commitStep.run({
+        project: { name: 'p', path: os.tmpdir() },
+        step: { id: 'commit' },
+        staged: {},
+        options: {}
+      });
+
+      assert.equal(result.status, 'blocked');
+      assert.match(result.blockers[0], /git commit failed \(exit 1\)/,
+        'the non-timeout wording is a contract other tests and the drawer read');
+      assert.match(result.output.remediation, /was rejected/);
+      assert.doesNotMatch(result.output.remediation, /git log -1/,
+        'a rejected commit definitely did not land — do not muddy it with a check');
+    } finally {
+      commitStep._internal.exec = saved;
+    }
+  });
+
+  it('pr-merge: a killed `gh pr merge` says auto-merge state is unknown, not that it was refused', async () => {
+    const realKill = await execShell('sleep 30', {
+      cwd: os.tmpdir(), timeoutMs: SHORT_TIMEOUT_MS, maxBufferBytes: 1024
+    });
+    const saved = prMergeStep._internal.execShell;
+    try {
+      prMergeStep._internal.execShell = async () => realKill;
+
+      const r = await prMergeStep._internal.enqueueAutoMerge(os.tmpdir(), 42);
+
+      assert.equal(r.ok, false, 'a stopped request must not be reported as an armed merge');
+      assert.match(r.reason, /stopped before it answered/);
+      assert.match(r.reason, /may or may not have been armed/,
+        'the outward action leaves ambiguous state and the operator must be told');
+      assert.doesNotMatch(r.reason, /^exit 1$/,
+        'the pre-fix rendering, which read as GitHub refusing the request');
+    } finally {
+      prMergeStep._internal.execShell = saved;
+    }
+  });
+
+  it('pr-check: a killed `gh pr list` does not read as gh refusing', async () => {
+    const realKill = await execShell('sleep 30', {
+      cwd: os.tmpdir(), timeoutMs: SHORT_TIMEOUT_MS, maxBufferBytes: 1024
+    });
+    const saved = prCheckStep._internal.exec;
+    try {
+      prCheckStep._internal.exec = async () => realKill;
+
+      const r = await prCheckStep._internal.listOpenPrs(os.tmpdir());
+
+      assert.equal(r.ok, false);
+      assert.match(r.reason, /was stopped/);
+      assert.doesNotMatch(r.reason, /^exit 1$/,
+        'the pre-fix rendering — indistinguishable from "gh is not authenticated"');
+    } finally {
+      prCheckStep._internal.exec = saved;
+    }
+  });
+});

--- a/test/wrap-step-killed-vs-failed.test.js
+++ b/test/wrap-step-killed-vs-failed.test.js
@@ -665,3 +665,79 @@ describe('every operator-facing timeout branch in the swept steps (#897)', () =>
     });
   });
 });
+
+describe('the resolution pass must not introduce its own false report (#897)', () => {
+  /** An exec result for a command that RAN and succeeded. */
+  const ok = (stdout = '') => ({
+    exitCode: 0, stdout, stderr: '', error: null, timedOut: false
+  });
+
+  it('a killed final checkout does not destroy the auto-PR result that already succeeded', async () => {
+    // `_autoPrCloseLoop`'s last step is a courtesy checkout back to the original
+    // branch, reached only AFTER push + `gh pr create` + `gh pr merge --auto`
+    // have all succeeded. Anything that throws here is caught by the call site,
+    // which synthesises `pushed:false, prUrl:null, autoMergeArmed:false` and
+    // tells the operator to push a branch that is already pushed and open a PR
+    // that is already open — and nulls the prUrl in the activity_log row that
+    // exists so stranded wraps can be found by query. A `log.warn` reaching for
+    // a variable bound in a different function did exactly that.
+    const realKill = await execFileArgs('sleep', ['30'], {
+      cwd: os.tmpdir(), timeoutMs: SHORT_TIMEOUT_MS, maxBufferBytes: 1024
+    });
+    const saved = commitStep._internal.exec;
+    try {
+      commitStep._internal.exec = async (file, args) => {
+        const cmd = `${file} ${args.join(' ')}`;
+        if (cmd === 'git status --porcelain') return ok('M lib/thing.js\n');
+        if (cmd === 'git rev-parse --abbrev-ref HEAD') return ok('main\n');
+        if (cmd.startsWith('gh pr create')) return ok('https://github.com/o/r/pull/7\n');
+        // The courtesy checkout — and ONLY it — is killed.
+        if (cmd.startsWith('git checkout ') && !cmd.startsWith('git checkout -b')) return realKill;
+        return ok('deadbee\n');
+      };
+
+      const result = await commitStep.run({
+        project: { name: 'p', path: os.tmpdir() },
+        step: { id: 'commit' },
+        staged: {},
+        options: {}
+      });
+
+      const ap = result.output.autoPr;
+      assert.equal(ap.pushed, true, 'the push succeeded and must still be reported as such');
+      assert.equal(ap.prUrl, 'https://github.com/o/r/pull/7',
+        'the PR url must survive — the activity_log row is how a stranded wrap is found');
+      assert.equal(ap.autoMergeArmed, true, 'auto-merge was armed before this step ran');
+      assert.equal(ap.returnedToBranch, false, 'only the checkout is in doubt');
+      assert.ok(!ap.error || !/threw/.test(ap.error),
+        'a log line must not be able to convert a successful auto-PR into a thrown one');
+    } finally {
+      commitStep._internal.exec = saved;
+    }
+  });
+
+  it('continuity-write logs a stopped probe from _gitFacts too', async () => {
+    // The two `_gitFacts` sites funnel through the same helper as the two
+    // already covered, but "same helper" is an argument about the code, not a
+    // guard over these call sites.
+    const realKill = await execFileArgs('sleep', ['30'], {
+      cwd: os.tmpdir(), timeoutMs: SHORT_TIMEOUT_MS, maxBufferBytes: 1024
+    });
+    const lines = await captureWarnings(async () => {
+      const saved = continuityStep._internal.exec;
+      try {
+        continuityStep._internal.exec = async () => realKill;
+        const facts = await continuityStep._gitFacts(os.tmpdir());
+        assert.deepEqual(facts, { sha: '', branch: '' },
+          'the safe degrade is unchanged — renderIndex flags these unknown');
+      } finally {
+        continuityStep._internal.exec = saved;
+      }
+    });
+
+    assert.equal(
+      lines.filter((l) => /git probe was stopped/.test(l)).length, 2,
+      'both the sha and the branch probe were stopped and both must be recorded'
+    );
+  });
+});

--- a/test/wrap-step-killed-vs-failed.test.js
+++ b/test/wrap-step-killed-vs-failed.test.js
@@ -16,7 +16,7 @@
  * in #894, which is the entire reason this file does not inject error objects.
  */
 
-const { describe, it } = require('node:test');
+const { describe, it, before } = require('node:test');
 const assert = require('node:assert/strict');
 const os = require('node:os');
 
@@ -25,9 +25,35 @@ const commitStep = require('../lib/wrap-steps/commit');
 const prMergeStep = require('../lib/wrap-steps/pr-merge');
 const prCheckStep = require('../lib/wrap-steps/pr-check');
 const continuityStep = require('../lib/wrap-steps/continuity-write');
+const { setLevel, getLevel, setConsoleStream } = require('../lib/logger');
 
 /** Short enough to keep the suite fast, long enough not to race the spawn. */
 const SHORT_TIMEOUT_MS = 300;
+
+/**
+ * Run `fn` with the logger raised to `warn` and its console stream captured.
+ *
+ * Several sites in this sweep are best-effort by contract — they degrade to an
+ * empty value and let the wrap continue, which is correct. That makes the log
+ * line the ONLY place a kill is distinguishable from a definite negative
+ * answer, so it is the thing worth asserting on.
+ *
+ * @param {() => Promise<void>} fn - The work to run while capturing.
+ * @returns {Promise<string[]>} The captured log lines.
+ */
+async function captureWarnings(fn) {
+  const lines = [];
+  const priorLevel = getLevel();
+  setLevel('warn');
+  setConsoleStream({ write: (s) => lines.push(s) });
+  try {
+    await fn();
+  } finally {
+    setConsoleStream(null);
+    setLevel(priorLevel);
+  }
+  return lines;
+}
 
 describe('_exec-shell.execFileArgs — the argv-style runner (#897)', () => {
   it('maps a real timeout to the timeout exit code and timedOut', async () => {
@@ -245,5 +271,397 @@ describe('what the operator is told when a wrap command is killed (#897)', () =>
     } finally {
       prCheckStep._internal.exec = saved;
     }
+  });
+});
+
+describe('every operator-facing timeout branch in the swept steps (#897)', () => {
+  // The first pass of this branch guarded the shared runners and four handler
+  // messages, and the plan then claimed a mutation check "per new branch" —
+  // which was not true of the branches with no guard at all. These are those
+  // branches. Same discipline as above: the killed result each seam returns is
+  // produced by a real kill through the production wrapper, never hand-built.
+
+  /** A real killed argv-style result, reused across the cases below. */
+  let argvKill;
+  /** A real killed shell-form result. */
+  let shellKill;
+
+  before(async () => {
+    argvKill = await execFileArgs('sleep', ['30'], {
+      cwd: os.tmpdir(), timeoutMs: SHORT_TIMEOUT_MS, maxBufferBytes: 1024
+    });
+    shellKill = await execShell('sleep 30', {
+      cwd: os.tmpdir(), timeoutMs: SHORT_TIMEOUT_MS, maxBufferBytes: 1024
+    });
+    assert.equal(argvKill.timedOut, true, 'the fixture must actually be a kill');
+    assert.equal(shellKill.timedOut, true, 'the fixture must actually be a kill');
+  });
+
+  /** An exec result for a command that RAN and succeeded. */
+  const ok = (stdout = '') => ({
+    exitCode: 0, stdout, stderr: '', error: null, timedOut: false
+  });
+  /** An exec result for a command that RAN and refused. */
+  const refused = (code = 1, stderr = '') => ({
+    exitCode: code, stdout: '', stderr, error: null, timedOut: false
+  });
+
+  /**
+   * Run `commit.run` with `_internal.exec` scripted by a command-string matcher.
+   *
+   * @param {(cmd:string) => object|undefined} script - Returns a result, or
+   *   undefined to fall through to a generic success.
+   * @param {object} [options] - `context.options`.
+   * @returns {Promise<object>} The step result.
+   */
+  async function runCommit(script, options = {}) {
+    const saved = commitStep._internal.exec;
+    try {
+      commitStep._internal.exec = async (file, args) => {
+        const cmd = `${file} ${args.join(' ')}`;
+        const scripted = script(cmd);
+        if (scripted) return scripted;
+        if (cmd === 'git status --porcelain') return ok('M lib/thing.js\n');
+        if (cmd === 'git rev-parse --abbrev-ref HEAD') return ok('fix/some-branch\n');
+        return ok('deadbee\n');
+      };
+      return await commitStep.run({
+        project: { name: 'p', path: os.tmpdir() },
+        step: { id: 'commit' },
+        staged: {},
+        options
+      });
+    } finally {
+      commitStep._internal.exec = saved;
+    }
+  }
+
+  describe('commit — the blockers before anything is committed', () => {
+    it('a killed `git status` does not claim the working tree is untouched', async () => {
+      const r = await runCommit((cmd) => (cmd === 'git status --porcelain' ? argvKill : undefined));
+
+      assert.equal(r.status, 'blocked');
+      assert.match(r.blockers[0], /was stopped/);
+      assert.doesNotMatch(r.blockers[0], /git status failed/);
+      // The clause this replaced was flatly wrong: `_flushStagedWrites` runs
+      // BEFORE this probe, so earlier steps' artifacts are already on disk.
+      assert.doesNotMatch(r.output.remediation, /exactly as you left it/,
+        'staged writes from earlier steps have already landed by this point');
+      assert.match(r.output.remediation, /already written to disk/);
+    });
+
+    it('a killed `git add -A` says the index may be partly staged', async () => {
+      const r = await runCommit((cmd) => (cmd === 'git add -A' ? argvKill : undefined));
+
+      assert.equal(r.status, 'blocked');
+      assert.match(r.blockers[0], /was stopped/);
+      assert.match(r.output.remediation, /partway/);
+      assert.match(r.output.remediation, /git status/);
+    });
+
+    it('a killed auto-branch says the branch may or may not exist', async () => {
+      const r = await runCommit(
+        (cmd) => {
+          if (cmd === 'git rev-parse --abbrev-ref HEAD') return ok('main\n');
+          if (cmd.startsWith('git checkout -b')) return argvKill;
+          return undefined;
+        }
+      );
+
+      assert.equal(r.status, 'blocked');
+      assert.match(r.blockers[0], /Auto-branch did not finish/);
+      assert.match(r.output.remediation, /may or may not exist/);
+      assert.match(r.output.remediation, /git branch --list/);
+    });
+
+    it('an ordinary auto-branch failure keeps its pre-existing wording', async () => {
+      const r = await runCommit((cmd) => {
+        if (cmd === 'git rev-parse --abbrev-ref HEAD') return ok('main\n');
+        if (cmd.startsWith('git checkout -b')) return refused(128, 'fatal: already exists');
+        return undefined;
+      });
+
+      assert.match(r.blockers[0], /Auto-branch failed \(exit 128\)/,
+        'the non-timeout wording is what existing assertions pin');
+      assert.equal(r.output.remediation, undefined,
+        'a definite failure needs no ambiguity caveat');
+    });
+  });
+
+  describe('commit — the killed branch probe changes what the wrap DOES', () => {
+    // This is the one probe in the step where reading a stop as a negative
+    // answer alters behaviour rather than wording: a null branch switches the
+    // #264 auto-branch guard off, so a wrap fired on `main` would commit
+    // straight to `main` — silently, which is what that guard exists to stop.
+
+    it('halts rather than committing to a branch nobody identified', async () => {
+      const r = await runCommit(
+        (cmd) => (cmd === 'git rev-parse --abbrev-ref HEAD' ? argvKill : undefined)
+      );
+
+      assert.equal(r.status, 'blocked',
+        'an unanswered branch probe must not be read as "not on a protected branch"');
+      assert.match(r.blockers[0], /protected-branch check could not be made/);
+      assert.match(r.output.remediation, /direct-to-main/);
+    });
+
+    it('does not commit when the branch probe was killed', async () => {
+      // The behavioural half: the guard above is only worth anything if no
+      // commit is attempted. Asserted on the commands actually issued.
+      const issued = [];
+      const saved = commitStep._internal.exec;
+      try {
+        commitStep._internal.exec = async (file, args) => {
+          const cmd = `${file} ${args.join(' ')}`;
+          issued.push(cmd);
+          if (cmd === 'git status --porcelain') return ok('M lib/thing.js\n');
+          if (cmd === 'git rev-parse --abbrev-ref HEAD') return argvKill;
+          return ok();
+        };
+        await commitStep.run({
+          project: { name: 'p', path: os.tmpdir() },
+          step: { id: 'commit' },
+          staged: {},
+          options: {}
+        });
+      } finally {
+        commitStep._internal.exec = saved;
+      }
+
+      assert.ok(!issued.some((c) => c.startsWith('git commit')),
+        'nothing may be committed when we cannot tell which branch we are on');
+      assert.ok(!issued.some((c) => c === 'git add -A'),
+        'and nothing may be staged either');
+    });
+
+    it('still honours an explicit direct-to-main opt-in', async () => {
+      // An operator who has already said "commit wherever I am" is not
+      // protected by this check and must not be stopped by it.
+      const r = await runCommit(
+        (cmd) => (cmd === 'git rev-parse --abbrev-ref HEAD' ? argvKill : undefined),
+        { allowDirectToMain: true }
+      );
+
+      assert.notEqual(r.status, 'blocked',
+        'the escape hatch must still bypass');
+    });
+  });
+
+  describe('commit — the auto-PR loop, where the kill is outward-facing', () => {
+    /**
+     * Drive the auto-PR close-loop by wrapping the whole step: the loop runs
+     * after a successful commit on an auto-created wrap branch.
+     *
+     * @param {(cmd:string) => object|undefined} script
+     * @returns {Promise<object>} `output.autoPr`
+     */
+    async function runAutoPr(script) {
+      const r = await runCommit((cmd) => {
+        if (cmd === 'git rev-parse --abbrev-ref HEAD') return ok('main\n');
+        return script(cmd);
+      });
+      return r.output && r.output.autoPr;
+    }
+
+    it('a killed `git push` does not assert the push failed', async () => {
+      const ap = await runAutoPr((cmd) => (cmd.startsWith('git push') ? argvKill : undefined));
+
+      assert.match(ap.error, /was stopped/);
+      assert.doesNotMatch(ap.error, /git push failed/);
+      assert.match(ap.remediation, /may or may not have reached origin/);
+    });
+
+    it('a killed `gh pr create` says a PR may already exist', async () => {
+      const ap = await runAutoPr((cmd) => (cmd.startsWith('gh pr create') ? argvKill : undefined));
+
+      assert.match(ap.error, /was stopped/);
+      assert.match(ap.remediation, /gh pr list --head/,
+        'sending them straight to `gh pr create` would hand them a duplicate-PR error');
+    });
+
+    it('a killed `gh pr merge` does not assert auto-merge was not armed', async () => {
+      const ap = await runAutoPr((cmd) => (cmd.startsWith('gh pr merge') ? argvKill : undefined));
+
+      assert.match(ap.error, /was stopped/);
+      assert.doesNotMatch(ap.remediation, /^The PR is open but auto-merge could not be armed/);
+      assert.match(ap.remediation, /unknown whether auto-merge was armed/);
+    });
+
+    it('a killed origin probe does not claim there is no origin remote', async () => {
+      const ap = await runAutoPr((cmd) => (cmd === 'git remote get-url origin' ? argvKill : undefined));
+
+      assert.match(ap.skippedReason, /stopped before it answered/);
+      assert.doesNotMatch(ap.skippedReason, /^no origin remote/,
+        'that sends the operator to configure a remote they may already have');
+    });
+
+    it('a killed gh probe does not claim the gh CLI is missing', async () => {
+      const ap = await runAutoPr((cmd) => (cmd === 'gh --version' ? argvKill : undefined));
+
+      assert.match(ap.skippedReason, /stopped before it answered/);
+      assert.doesNotMatch(ap.skippedReason, /^gh CLI not available/);
+    });
+
+    it('a genuinely absent origin keeps its original wording', async () => {
+      const ap = await runAutoPr(
+        (cmd) => (cmd === 'git remote get-url origin' ? refused(128) : undefined)
+      );
+
+      assert.match(ap.skippedReason, /^no origin remote/);
+    });
+  });
+
+  describe('pr-merge — _ensurePushed', () => {
+    it('a killed branch probe does not claim HEAD is detached', async () => {
+      const saved = prMergeStep._internal.exec;
+      try {
+        prMergeStep._internal.exec = async () => argvKill;
+        const r = await prMergeStep._ensurePushed(os.tmpdir());
+
+        assert.equal(r.ok, false, 'declining on an uncertain answer is still right');
+        assert.match(r.reason, /stopped before it answered/);
+        assert.doesNotMatch(r.reason, /HEAD is detached/,
+          'that sends the operator to check out a branch they are probably on');
+      } finally {
+        prMergeStep._internal.exec = saved;
+      }
+    });
+
+    it('a killed push says origin may or may not have the wrap commit', async () => {
+      const saved = prMergeStep._internal.exec;
+      try {
+        prMergeStep._internal.exec = async (file, args) => {
+          const cmd = `${file} ${args.join(' ')}`;
+          if (cmd === 'git rev-parse --abbrev-ref HEAD') return ok('wrap/x\n');
+          if (cmd.startsWith('git rev-list')) return ok('2\n');
+          if (cmd.startsWith('git push')) return argvKill;
+          return ok();
+        };
+        const r = await prMergeStep._ensurePushed(os.tmpdir());
+
+        assert.equal(r.ok, false);
+        assert.match(r.reason, /stopped before it answered/);
+        assert.match(r.reason, /may or may not have the wrap commit/);
+        assert.doesNotMatch(r.reason, /^exit 1$/, 'the pre-fix rendering');
+      } finally {
+        prMergeStep._internal.exec = saved;
+      }
+    });
+
+    it('a genuinely detached HEAD keeps its original wording', async () => {
+      const saved = prMergeStep._internal.exec;
+      try {
+        prMergeStep._internal.exec = async () => ok('HEAD\n');
+        const r = await prMergeStep._ensurePushed(os.tmpdir());
+
+        assert.match(r.reason, /HEAD is detached/);
+      } finally {
+        prMergeStep._internal.exec = saved;
+      }
+    });
+  });
+
+  describe('pr-check — the two probes whose kill silently widens or empties the list', () => {
+    it('logs when the gh probe was stopped rather than answering', async () => {
+      const lines = await captureWarnings(async () => {
+        const saved = prCheckStep._internal.exec;
+        try {
+          prCheckStep._internal.exec = async () => shellKill;
+          const available = await prCheckStep._internal.isGhAvailable(os.tmpdir());
+          assert.equal(available, false, 'the step still cannot proceed without gh');
+        } finally {
+          prCheckStep._internal.exec = saved;
+        }
+      });
+
+      assert.ok(lines.some((l) => /gh availability probe was stopped/.test(l)),
+        'the skip reason can only say "unavailable" — the log is where the distinction survives');
+    });
+
+    it('logs when the branch probe was stopped, because the PR list silently widens', async () => {
+      const lines = await captureWarnings(async () => {
+        const saved = prCheckStep._internal.exec;
+        try {
+          prCheckStep._internal.exec = async () => shellKill;
+          const branch = await prCheckStep._internal.getCurrentBranch(os.tmpdir());
+          assert.equal(branch, null);
+        } finally {
+          prCheckStep._internal.exec = saved;
+        }
+      });
+
+      assert.ok(lines.some((l) => /branch probe was stopped/.test(l)),
+        'null widens the step from this session to every open PR — that needs a trace');
+    });
+
+    it('does NOT log for an ordinary non-zero exit', async () => {
+      // The falsifying half: if the log fired on every failure it would say
+      // nothing about whether the probe answered.
+      const lines = await captureWarnings(async () => {
+        const saved = prCheckStep._internal.exec;
+        try {
+          prCheckStep._internal.exec = async () => refused(1, 'not a git repository');
+          await prCheckStep._internal.getCurrentBranch(os.tmpdir());
+        } finally {
+          prCheckStep._internal.exec = saved;
+        }
+      });
+
+      assert.ok(!lines.some((l) => /was stopped/.test(l)),
+        'a command that answered is not a stopped probe');
+    });
+  });
+
+  describe('continuity-write — best-effort by contract, so the log is the only trace', () => {
+    it('logs when the map-delta diff was stopped', async () => {
+      const lines = await captureWarnings(async () => {
+        const saved = continuityStep._internal.exec;
+        try {
+          continuityStep._internal.exec = async (file, args) => {
+            const cmd = `${file} ${args.join(' ')}`;
+            if (cmd.startsWith('git rev-parse --verify --quiet main')) return ok('abc\n');
+            if (cmd.startsWith('git diff --name-status')) return argvKill;
+            return ok();
+          };
+          const delta = await continuityStep._mapDelta(os.tmpdir());
+          assert.deepEqual(delta, { touched: [], deleted: [] },
+            'the safe degrade is unchanged — the Map is left alone');
+        } finally {
+          continuityStep._internal.exec = saved;
+        }
+      });
+
+      assert.ok(lines.some((l) => /git probe was stopped/.test(l)),
+        'a Map left untouched must not look the same as a session that touched nothing');
+    });
+
+    it('logs when the base-branch probe was stopped', async () => {
+      const lines = await captureWarnings(async () => {
+        const saved = continuityStep._internal.exec;
+        try {
+          continuityStep._internal.exec = async () => argvKill;
+          const base = await continuityStep._resolveBase(os.tmpdir());
+          assert.equal(base, null);
+        } finally {
+          continuityStep._internal.exec = saved;
+        }
+      });
+
+      assert.ok(lines.some((l) => /git probe was stopped/.test(l)));
+    });
+
+    it('does NOT log when a probe genuinely answers no', async () => {
+      const lines = await captureWarnings(async () => {
+        const saved = continuityStep._internal.exec;
+        try {
+          continuityStep._internal.exec = async () => refused(1);
+          await continuityStep._resolveBase(os.tmpdir());
+        } finally {
+          continuityStep._internal.exec = saved;
+        }
+      });
+
+      assert.ok(!lines.some((l) => /was stopped/.test(l)));
+    });
   });
 });


### PR DESCRIPTION
## What

Seven wrap-step sites ran a child process under a timeout and could not tell a command **we killed** from one that **ran and refused**. A killed command prints nothing and reports no exit code, so every one of these flattened it to `exit 1` with empty output — byte-identical to a real failure, and then remediated as one.

#894 fixed this distinction in `test` and `lint` — two handlers the shipped fourteen-step pipeline never runs. **These run on every wrap**, and two of them take outward actions.

## Why it matters

What an operator was told before this:

- a `git commit` stopped at sixty seconds: *"The commit was rejected — most often by a pre-commit hook. Read the hook output above."* There is no hook output, and because a slow pre-commit hook is the likeliest way to reach that timeout — and such a hook can finish after we stop waiting — **the commit may have landed**.
- a `gh pr merge --auto` stopped mid-request: *"auto-merge could not be armed"*, asserting an outcome nobody observed.
- a stopped `git remote get-url origin` reported *"no origin remote"*; a stopped `gh --version` reported *"gh CLI not available"* — both sending the operator to fix something they already have.
- a killed `git rev-parse --abbrev-ref HEAD` left the branch unknown, which switched off the #264 auto-branch guard — so **a wrap fired on `main` committed straight to `main`**, silently. That guard exists because exactly that happened once before (631acb5).
- a killed `git log` made the changelog-coverage predicate return `unavailable`, which falls back to the mutation check — so a wrap whose CHANGELOG **was** maintained got blocked with *"CHANGELOG.md is unchanged"*, by a check that never ran.

## How

All five async wrappers now delegate to `lib/wrap-steps/_exec-shell.js`, which grows an argv-style `execFileArgs` beside the shell-form `execShell`. Argv style stays a separate entry point rather than a flag, because the absence of a shell is the reason `commit.js` picks it — a multi-line commit message must reach the child's `argv[]` byte-intact.

Every site that surfaces a failure branches on `timedOut`. Where a kill leaves genuinely ambiguous state, the remediation **names the check that resolves it** instead of picking an outcome. Wording for a command that really did fail is unchanged.

The three synchronous sites distinguish a killed probe from a real negative answer. Falling back is still right when you cannot know — what was missing was any record that the answer was unknown rather than negative, including where the fallback still resolves a range and everything looks normal.

**Correction to the issue:** `version-bump.js` runs no child process. Its eleven `.exec(` hits are all `RegExp.prototype.exec`. Seven sites, not eight; the written reason is now in that module's header so the next sweep checks requires rather than symbols.

## Test plan

- `node --test 'test/*.test.js'` — **5901 tests, 0 failing** (36 new across two suites).
- Every timeout guard drives a **real** `sleep` kill through the **production** wrapper. Three hand-written models of these error shapes were wrong in #894, which is the entire reason nothing here models one. One guard pins that a real `execSync` kill carries **no** `killed` flag — the fact three authors got wrong.
- **Twenty-two branches mutated away and confirmed red**, individually. Two of those mutations restore defects this branch introduced and then fixed.

## Review

Three rounds. Round 0: 2 blocking, 8 warning, 6 note. Round 1: both prior blockers verified fixed, 2 **new** blocking — both introduced by the resolution pass. Round 2: **0 blocking, 0 warning, 0 note**.

Worth stating plainly, because it is the pattern: every blocking finding after the first round was introduced by the fix for the previous round's findings. Notably a `log.warn` added to close a finding threw `ReferenceError` — caught by a call site, so it never crashed; it failed silently into a *worse* report than the one it existed to prevent.

Also added: the wrap-step child-process contract in `.prawduct/artifacts/boundary-patterns.md`. Seven hand-rolled copies of that wrapper is how this defect class was born twice.

Fixes #897
