### PR TITLE
Ask the machine once, not once per project, on the projects poll (#890)

### DIFF
--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -26,6 +26,48 @@ Tag-line conventions (ART-4K9M, ratified 2026-07-17):
 -->
 
 
+## 2026-08-11: the project poll stops asking every project a question about the machine (#890)
+
+<!-- prawduct: type=fix | scope=enrichproject-spawns-890 | chunks=01,02 | status=shipped -->
+
+**Why:** `enrichProject` ran two subprocesses per project, synchronously on the event loop, on the
+route the dashboard polls every ten seconds — `command -v <engine>` (2s cap) and `tmux has-session`
+(5s cap). Both answer a question about the MACHINE, identical for every project asking, so the honest
+worst case was the project count times those caps while the server answered nothing at all. Measured
+on the live 33-project fleet: **41 synchronous spawns per poll → 0** (5 asynchronous: one per distinct
+engine, one tmux), with the enriched payload identical before and after. #884 named both call sites
+and left them explicitly, so this closes its 02b criterion rather than rounding it up.
+
+**What changed:** session liveness comes from one `tmux list-sessions` snapshot shared across the
+list — lazy, so an idle fleet still spawns nothing, and memoised on the in-flight PROMISE rather than
+the settled value, because the callers run under `Promise.all` and caching the result lets every one
+of them miss before the first reply lands. Engine detection is cached 60s, keyed on what was probed
+rather than which engine asked, single-flight, with an async form for the poll. Neither went through
+the scanner child: that child survives operator-chosen paths, and these needed deduplication, not
+isolation. `hasSession` is untouched and still exact — its callers kill, adopt and type into the
+session they ask about.
+
+**What the review caught:** four rounds. The blocking finding, and the defect worth remembering, is
+that a cache changes what every EXISTING caller is told, not just the slow one — `detectEngine` is a
+launch gate in `sessions.js`, `master.js` and `engineReadiness`, where a stale "not installed"
+refuses to start a session for an engine just installed, with no retry that helps. All three now
+probe fresh; the tmux half of this same branch already stated that rule. Reviewers also found a
+failed SPAWN being cached as the answer "not installed" — on a machine whose recorded failure mode is
+process exhaustion (#94/#144/#380), where every spawn fails at once, one fork failure would have
+blanked every engine for a minute. Three outcomes are now never remembered: a killed probe, a probe
+that never started, and anything predating a cache clear (including a probe already running when
+"Check again" was pressed).
+
+**Two of the three blocking findings were introduced by the fix for the previous round** — an
+orphaned JSDoc block and a rule applied to two of three call sites, both mechanical consequences of
+inserting code, invisible in the hunk and obvious in the finished file.
+
+**Also:** the mutation discipline caught something new. One fix shipped with NO guard — discovered
+because reverting it left the suite green. A behaviour change whose own reversal leaves the suite
+green is untested, and "the suite still passes" reads identically to "the suite covers this".
+Seventeen guards, seventeen reds. #900 filed for the wedged-tmux server that reports every session as
+dead rather than unknown, preserved deliberately here rather than changed in passing.
+
 ## 2026-08-10: a killed wrap command stops reading as a failed one, on the steps that actually run (#897)
 
 <!-- prawduct: type=fix | scope=killed-vs-failed-897 | chunks=A,B,C,D | status=shipped -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -472,14 +472,26 @@ All notable changes to TangleClaw are documented in this file.
   Concurrent askers share a single probe rather than each starting their own, which is what makes
   the first poll after startup cheap and not just the ones after it.
 
-  Two things are deliberately **not** cached. A probe that our own timeout killed is not an answer —
-  it means we could not look — so it is never stored; storing it would report an engine you have
-  installed as missing for the next full minute. And pressing **Check again** in the setup wizard
-  drops everything remembered, so the one button whose purpose is "my engine really is installed"
-  cannot be answered out of the cache that hid it.
+  Three things are deliberately **not** cached, because none of them is an answer. A probe our own
+  timeout killed — that means we could not look, not that nothing is there. A probe that **could not
+  be started at all**, which is what happens when the machine is out of process slots; this install
+  reaches that state (#94/#144/#380), and every spawn fails at once when it does, so caching it would
+  report *every* engine as uninstalled simultaneously for a full minute, on the machine least able to
+  recover. And pressing **Check again** in the setup wizard drops everything remembered, so the one
+  button whose purpose is "my engine really is installed" cannot be answered out of the cache that hid
+  it — including by a probe that was already running when you pressed it.
+
+  A detection probe that times out or cannot start now says so in the log. Both of those branches
+  were previously silent, which is the same defect #894 fixed for tmux.
 
   An engine you install while the server is running is picked up within a minute — no restart, and
   no need to know the Check again button exists.
+
+  **Launching still looks rather than remembers.** Starting a session and starting the Project
+  Master both refuse when the engine's binary is not found, and a gate answering out of a
+  minute-old cache would tell an operator who had just installed it that it is not there — with no
+  way to retry into a different answer. Those two paths probe every time; the cache is for the poll
+  that asks thirty-three times a minute, not for a button someone presses.
 
 - **Asking whether your sessions are alive no longer costs one `tmux` call per project (#890).**
   Enriching the project list ran `tmux has-session` once per project, synchronously on the event

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -463,6 +463,24 @@ All notable changes to TangleClaw are documented in this file.
 
 ### Fixed
 
+- **Checking which engines are installed no longer costs one probe per project (#890).** Enriching
+  the project list ran `command -v claude` once per project, synchronously on the event loop, every
+  ten seconds — asking separately, for each project, a question about the *machine* whose answer is
+  the same for all of them. Ten projects on Claude Code meant ten identical probes per poll.
+
+  It is now asked once and remembered for a minute, and the poll awaits it instead of blocking.
+  Concurrent askers share a single probe rather than each starting their own, which is what makes
+  the first poll after startup cheap and not just the ones after it.
+
+  Two things are deliberately **not** cached. A probe that our own timeout killed is not an answer —
+  it means we could not look — so it is never stored; storing it would report an engine you have
+  installed as missing for the next full minute. And pressing **Check again** in the setup wizard
+  drops everything remembered, so the one button whose purpose is "my engine really is installed"
+  cannot be answered out of the cache that hid it.
+
+  An engine you install while the server is running is picked up within a minute — no restart, and
+  no need to know the Check again button exists.
+
 - **Asking whether your sessions are alive no longer costs one `tmux` call per project (#890).**
   Enriching the project list ran `tmux has-session` once per project, synchronously on the event
   loop, each with its own five-second cap — on the route the dashboard polls every ten seconds. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -463,6 +463,25 @@ All notable changes to TangleClaw are documented in this file.
 
 ### Fixed
 
+- **Asking whether your sessions are alive no longer costs one `tmux` call per project (#890).**
+  Enriching the project list ran `tmux has-session` once per project, synchronously on the event
+  loop, each with its own five-second cap — on the route the dashboard polls every ten seconds. The
+  answer is identical for every project asking, so the honest worst case scaled with the size of
+  your fleet for no reason: ten projects meant up to fifty seconds during which the server could not
+  answer anything at all, and #94/#144/#380 record this install's tmux server reaching exactly the
+  state that makes those calls slow.
+
+  One `tmux list-sessions` now answers the whole list, and it is awaited rather than blocking. It is
+  also lazy: a fleet with nothing running spawns nothing, so the quiet case did not get more
+  expensive to make the busy one cheaper.
+
+  `tmux.hasSession` is unchanged and still exact — its callers kill, adopt and type into the session
+  they are asking about, and for them a cached answer would be wrong in a way that destroys work.
+
+  Known and deliberately unchanged: a tmux server too wedged to answer still reports every session
+  as dead rather than as unknown, which is the same "unknown presented as a fact" #891 removed from
+  git reads. Filed as #900 rather than folded in here.
+
 - **The wrap steps you actually run no longer report a hung command as a failed one (#897).** #894
   fixed that distinction in `test` and `lint` — two handlers the shipped fourteen-step pipeline
   never runs. The steps fixed here run on every wrap: `open-pr-check`, `commit`, `continuity-write`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -490,8 +490,10 @@ All notable changes to TangleClaw are documented in this file.
   **Launching still looks rather than remembers.** Starting a session and starting the Project
   Master both refuse when the engine's binary is not found, and a gate answering out of a
   minute-old cache would tell an operator who had just installed it that it is not there — with no
-  way to retry into a different answer. Those two paths probe every time; the cache is for the poll
-  that asks thirty-three times a minute, not for a button someone presses.
+  way to retry into a different answer. The setup gate that decides whether you have any engine at
+  all works the same way. Those paths probe every time; the cache is for the poll that asked once
+  per project — on a 33-project fleet, about two hundred times a minute — not for a button someone
+  presses.
 
 - **Asking whether your sessions are alive no longer costs one `tmux` call per project (#890).**
   Enriching the project list ran `tmux has-session` once per project, synchronously on the event

--- a/docs/engine-guide.md
+++ b/docs/engine-guide.md
@@ -73,7 +73,9 @@ OpenClaw does **not** appear in the project engine dropdown (#459) — assigning
 
 ## Engine Detection
 
-TangleClaw checks if each engine is available by running `which <command>`. The landing page shows an availability badge on each engine option:
+TangleClaw checks if each engine is available by running `command -v <command>` on the PATH your
+login shell reports, not the narrower one the background service inherits. The landing page shows an
+availability badge on each engine option:
 
 - **Available** — the binary was found in PATH
 - **Not found** — the binary is not in PATH
@@ -154,8 +156,18 @@ The `configFormat` above is set to `null` because config file generation require
 
 | Strategy | Target | Description |
 |----------|--------|-------------|
-| `"which"` | binary name | Run `which <target>` to check PATH |
+| `"which"` | binary name | Run `command -v <target>` to check PATH |
+| `"path"` | absolute file path | Check whether that exact path exists |
 | `"custom"` | null | No auto-detection (persistent engines) |
+
+Results are cached for 60 seconds and shared by every caller asking about the
+same target, so a fleet of projects on one engine costs a single probe rather
+than one each. Two outcomes are never cached, because neither is an answer: a
+probe killed by its own 2-second cap, and a probe that could not be started at
+all (the machine was out of process slots). "Check again" in the setup wizard
+drops everything cached, and the paths that *gate* a launch — starting a session,
+starting the Project Master — probe fresh every time rather than reading the
+cache, so an engine you have just installed is never refused.
 
 ### Capabilities
 

--- a/lib/engines.js
+++ b/lib/engines.js
@@ -79,10 +79,11 @@ function detectEngine(profile, options = {}) {
  * cache with `detectEngine`, so whichever asks first pays and the other does not.
  *
  * The `path` strategy has no async form — see `_detectPath` for why making it
- * one would move a hang rather than remove it.
+ * one would move a hang rather than remove it. It still honours `fresh`; only
+ * `execFn` and `timeout`, which describe a subprocess, mean nothing to it.
  *
  * @param {object} profile - Engine profile object
- * @param {object} [options] - Options, forwarded to the `which` probe.
+ * @param {object} [options] - Options, forwarded to whichever probe runs.
  * @param {boolean} [options.fresh] - Probe now rather than trusting the cache.
  *   For gates; see `detectEngine` for why a gate must not remember.
  * @param {Function} [options.execFn] - Injected `execFile` (tests).
@@ -100,7 +101,12 @@ async function detectEngineAsync(profile, options = {}) {
     case 'which':
       return _detectWhichAsync(profile.id, target, options);
     case 'path':
-      return _detectPath(profile.id, target);
+      // `options` forwarded here too, even though this arm has no async form and
+      // ignores `execFn`/`timeout`: `fresh` is meaningful for it, and an option
+      // a function accepts and silently drops on ONE branch is worse than one it
+      // never took — the call site reads as asking for a fresh probe and gets a
+      // cached answer.
+      return _detectPath(profile.id, target, options);
     default:
       log.warn('Unknown detection strategy', { id: profile.id, strategy });
       return { id: profile.id, available: false, path: null };
@@ -585,6 +591,10 @@ function _detectPath(id, target, options = {}) {
  * for it, so this stays cheap enough to call from a request handler. Callers who
  * need a fresh answer await that function first.
  *
+ * @param {object} [options] - Options, forwarded to each engine's probe.
+ * @param {boolean} [options.fresh] - Probe now rather than trusting the detection
+ *   cache. For gates — `engineReadiness` is the caller that needs it, and
+ *   `detectEngine` explains why a gate must not remember.
  * @returns {object[]} - Engine profiles enriched with `available` and `detectedPath` fields
  */
 function listWithAvailability(options = {}) {

--- a/lib/engines.js
+++ b/lib/engines.js
@@ -18,13 +18,15 @@ const log = createLogger('engines');
  * Checks each engine profile's detection config.
  * Uses whatever PATH `refreshDetectionPath` last resolved; it does not resolve
  * one itself, so calling this never spawns a login shell.
+ * @param {object} [options] - Options, forwarded to each `detectEngine`.
+ * @param {boolean} [options.fresh] - Probe now rather than trusting the cache.
  * @returns {{ id: string, available: boolean, path: string|null }[]}
  */
-function detect() {
+function detect(options = {}) {
   const profiles = store.engines.list();
   const results = [];
   for (const profile of profiles) {
-    const result = detectEngine(profile);
+    const result = detectEngine(profile, options);
     results.push(result);
     if (result.available) {
       log.debug('Engine detected', { id: profile.id, path: result.path });
@@ -383,15 +385,6 @@ function _clearDetectionResults() {
 }
 
 /**
- * Detect engine using `command -v`, on the operator's PATH rather than the
- * server's.
- * @param {string} id - Engine id
- * @param {string} target - Binary name
- * @param {object} [options] - Options.
- * @param {boolean} [options.fresh] - Probe even if a cached answer is in date.
- * @returns {{ id: string, available: boolean, path: string|null }}
- */
-/**
  * Did the probe process actually run, or did it never start?
  *
  * The difference decides whether "not found" is a finding or a gap, and the two
@@ -454,6 +447,15 @@ function _settleWhichProbe(key, generation, err, stdout, context) {
   return _rememberDetection(key, { available: false, path: null }, generation);
 }
 
+/**
+ * Detect engine using `command -v`, on the operator's PATH rather than the
+ * server's.
+ * @param {string} id - Engine id
+ * @param {string} target - Binary name
+ * @param {object} [options] - Options.
+ * @param {boolean} [options.fresh] - Probe even if a cached answer is in date.
+ * @returns {{ id: string, available: boolean, path: string|null }}
+ */
 function _detectWhich(id, target, options = {}) {
   if (!DETECTION_TARGET_RE.test(String(target || ''))) {
     log.warn('Engine detection target is not a plain command name — refusing to probe it', { id });
@@ -585,9 +587,9 @@ function _detectPath(id, target, options = {}) {
  *
  * @returns {object[]} - Engine profiles enriched with `available` and `detectedPath` fields
  */
-function listWithAvailability() {
+function listWithAvailability(options = {}) {
   const profiles = store.engines.list().filter((p) => !p.pickerHidden);
-  const detection = detect();
+  const detection = detect(options);
   const detectionMap = new Map(detection.map((d) => [d.id, d]));
 
   return profiles.map((profile) => {
@@ -628,7 +630,14 @@ function listWithAvailability() {
  *   actually installed.
  */
 async function engineReadiness() {
-  if (listWithAvailability().some((e) => e && e.available)) {
+  // `fresh`: this is the third gate, and gates do not remember — the same rule
+  // the session and Project Master launches follow. The detection cache exists
+  // for a poll asking once per project every ten seconds; nothing about that
+  // economics applies to a wizard step a person is standing in front of. A
+  // remembered "yes" would let the setup gate open for up to a minute after the
+  // engine was removed, and a remembered "no" would spend a login-shell probe
+  // recovering from an answer it should not have trusted.
+  if (listWithAvailability({ fresh: true }).some((e) => e && e.available)) {
     return { installed: true, certain: true };
   }
 

--- a/lib/engines.js
+++ b/lib/engines.js
@@ -6,6 +6,7 @@ const os = require('node:os');
 const { execSync, execFile } = require('node:child_process');
 const store = require('./store');
 const { createLogger } = require('./logger');
+const { wasTimedOut } = require('./exec-timeout');
 const rulesChannel = require('./session-rules-channel');
 const { effectiveServerProtocol, effectiveServerPort } = require('./https-setup');
 const { tildeHomePath } = require('./project-paths');
@@ -48,6 +49,37 @@ function detectEngine(profile) {
   switch (strategy) {
     case 'which':
       return _detectWhich(profile.id, target);
+    case 'path':
+      return _detectPath(profile.id, target);
+    default:
+      log.warn('Unknown detection strategy', { id: profile.id, strategy });
+      return { id: profile.id, available: false, path: null };
+  }
+}
+
+/**
+ * Detect availability of a single engine without blocking the event loop.
+ *
+ * The form `enrichProject` uses: it runs per project on the ten-second poll, so
+ * a probe there stops every other route for as long as it takes. Shares one
+ * cache with `detectEngine`, so whichever asks first pays and the other does not.
+ *
+ * The `path` strategy has no async form — see `_detectPath` for why making it
+ * one would move a hang rather than remove it.
+ *
+ * @param {object} profile - Engine profile object
+ * @returns {Promise<{ id: string, available: boolean, path: string|null }>}
+ */
+async function detectEngineAsync(profile, options = {}) {
+  if (!profile || !profile.detection) {
+    return { id: profile ? profile.id : 'unknown', available: false, path: null };
+  }
+
+  const { strategy, target } = profile.detection;
+
+  switch (strategy) {
+    case 'which':
+      return _detectWhichAsync(profile.id, target, options);
     case 'path':
       return _detectPath(profile.id, target);
     default:
@@ -172,6 +204,10 @@ async function refreshDetectionPath() {
   _loginPathCache = merged.join(':');
   _loginProbeSucceeded = loginPath !== '';
   _loginProbeAttempted = true;
+  // A newly resolved PATH changes what is findable, and this is the path the
+  // wizard's "Check again" takes — so results probed against the OLD PATH must
+  // not survive it. See `_clearDetectionResults`.
+  _clearDetectionResults();
   if (!_loginProbeSucceeded) {
     log.warn('Could not read the login shell PATH — engine detection can only see the '
       + 'server\'s own PATH, so an installed engine may be reported as missing', {
@@ -215,6 +251,7 @@ function resetDetectionCache() {
   _loginPathCache = null;
   _loginProbeSucceeded = false;
   _loginProbeAttempted = false;
+  _clearDetectionResults();
 }
 
 // An engine profile's detection target is a command NAME, and it is interpolated
@@ -222,6 +259,96 @@ function resetDetectionCache() {
 // through the API, so the shape is enforced rather than trusted: anything with a
 // space, quote, slash or shell metacharacter is not a command name.
 const DETECTION_TARGET_RE = /^[A-Za-z0-9._-]+$/;
+
+/**
+ * How long a detection result stands before the target is probed again.
+ *
+ * Detection used to run once per project per poll: enriching a fleet asked
+ * `command -v claude` separately for every project using Claude, on the event
+ * loop, ten seconds apart, forever. The answer is a property of the MACHINE, not
+ * of the project asking.
+ *
+ * 60s rather than "until something clears it". A permanent cache is cheaper and
+ * would be correct for a machine nobody touches, but it makes an engine the
+ * operator installs mid-session invisible until they either restart the server
+ * or find the wizard's "Check again" button — and the operator most likely to
+ * have just installed one is the operator least likely to know that button
+ * exists. A minute bounds the staleness a person would notice while still
+ * collapsing six polls into one probe.
+ */
+const DETECTION_TTL_MS = 60000;
+
+/** Longest a single availability probe may run before it is killed. */
+const DETECTION_PROBE_TIMEOUT_MS = 2000;
+
+// Settled detection results, keyed on WHAT was probed rather than on which
+// engine asked: two profiles pointing at the same binary are one question, and
+// keying on the engine id would probe once per profile to learn the same fact.
+const _detectionResults = new Map();
+// Probes currently running, so concurrent askers share one. Enrichment runs
+// under `Promise.all`, so without this a cold cache still spawns once per
+// project — the exact multiplication the cache exists to remove, hidden behind a
+// cache that looks like it works when called sequentially.
+const _detectionInflight = new Map();
+
+/**
+ * The cache key for one detection question.
+ * @param {string} strategy - Detection strategy (`which` / `path`).
+ * @param {string} target - Command name or filesystem path probed.
+ * @returns {string}
+ */
+function _detectionKey(strategy, target) {
+  return `${strategy} ${target}`;
+}
+
+/**
+ * A detection result still within its TTL, or null.
+ * @param {string} key - Cache key from `_detectionKey`.
+ * @returns {{ available: boolean, path: string|null }|null}
+ */
+function _cachedDetection(key) {
+  const hit = _detectionResults.get(key);
+  if (!hit) return null;
+  if (Date.now() - hit.at >= DETECTION_TTL_MS) {
+    _detectionResults.delete(key);
+    return null;
+  }
+  return hit.result;
+}
+
+/**
+ * Remember a detection result, and return it.
+ *
+ * Only ever called with an ANSWER. A probe our own timeout killed is not one:
+ * it says we could not look, and storing it would publish "not installed" as a
+ * finding for the next full minute — for an engine that may well be installed.
+ *
+ * @param {string} key - Cache key from `_detectionKey`.
+ * @param {{ available: boolean, path: string|null }} result - The answer.
+ * @returns {{ available: boolean, path: string|null }} The same result.
+ */
+function _rememberDetection(key, result) {
+  _detectionResults.set(key, { at: Date.now(), result });
+  return result;
+}
+
+/**
+ * Drop every cached detection result.
+ *
+ * Called both by `resetDetectionCache` and by `refreshDetectionPath`. The second
+ * is the load-bearing one: `GET /api/engines?refresh=1` — the wizard's "Check
+ * again" — routes through `refreshDetectionPath` and does NOT call
+ * `resetDetectionCache`, so hooking only the latter would leave the one button
+ * whose entire purpose is "my engine IS installed" answering out of the stale
+ * cache that hid it. A newly resolved PATH also changes what is findable, which
+ * is the same reason stated a second way.
+ *
+ * @returns {void}
+ */
+function _clearDetectionResults() {
+  _detectionResults.clear();
+  _detectionInflight.clear();
+}
 
 /**
  * Detect engine using `command -v`, on the operator's PATH rather than the
@@ -235,19 +362,80 @@ function _detectWhich(id, target) {
     log.warn('Engine detection target is not a plain command name — refusing to probe it', { id });
     return { id, available: false, path: null };
   }
+  const key = _detectionKey('which', target);
+  const cached = _cachedDetection(key);
+  if (cached) return { id, ...cached };
   try {
     // `command -v` rather than `which`: it is a POSIX shell builtin, so it needs
     // nothing on the PATH it is searching — `which` is itself a binary, and on a
     // PATH that does not contain it the probe fails for the wrong reason.
     const binPath = execSync(`command -v ${target}`, {
-      timeout: 2000,
+      timeout: DETECTION_PROBE_TIMEOUT_MS,
       encoding: 'utf8',
       env: { ...process.env, PATH: _detectionPath() },
       stdio: ['ignore', 'pipe', 'ignore']
     }).trim();
-    return { id, available: !!binPath, path: binPath || null };
-  } catch {
+    return { id, ..._rememberDetection(key, { available: !!binPath, path: binPath || null }) };
+  } catch (err) {
+    // A non-zero exit from `command -v` IS the answer: the command is not on the
+    // PATH. Our own timeout killing the probe is NOT — see `_rememberDetection`.
+    // `wasTimedOut`, never `err.killed`: `execSync` sets that flag on
+    // `spawnSync`'s result and not on the error it throws, which is how three
+    // hand-written versions of this check ended up dead (#891, #894).
+    if (wasTimedOut(err)) return { id, available: false, path: null };
+    return { id, ..._rememberDetection(key, { available: false, path: null }) };
+  }
+}
+
+/**
+ * `_detectWhich` without blocking the event loop, and shared between callers.
+ *
+ * Exists for `enrichProject`, which runs this once per project on the route the
+ * dashboard polls every ten seconds. Same cache as the synchronous form, so a
+ * warm cache answers either with no subprocess and there is only one cache
+ * policy to keep right.
+ *
+ * @param {string} id - Engine id
+ * @param {string} target - Binary name
+ * @returns {Promise<{ id: string, available: boolean, path: string|null }>}
+ */
+async function _detectWhichAsync(id, target, options = {}) {
+  if (!DETECTION_TARGET_RE.test(String(target || ''))) {
+    log.warn('Engine detection target is not a plain command name — refusing to probe it', { id });
     return { id, available: false, path: null };
+  }
+  const key = _detectionKey('which', target);
+  const cached = _cachedDetection(key);
+  if (cached) return { id, ...cached };
+
+  const running = _detectionInflight.get(key);
+  if (running) return { id, ...(await running) };
+
+  const execFn = options.execFn || execFile;
+  const probe = new Promise((resolve) => {
+    execFn('/bin/sh', ['-c', `command -v ${target}`], {
+      timeout: options.timeout || DETECTION_PROBE_TIMEOUT_MS,
+      encoding: 'utf8',
+      env: { ...process.env, PATH: _detectionPath() }
+    }, (err, stdout) => {
+      if (err) {
+        if (wasTimedOut(err)) {
+          // Not an answer, so not remembered — the next caller probes again.
+          resolve({ available: false, path: null });
+          return;
+        }
+        resolve(_rememberDetection(key, { available: false, path: null }));
+        return;
+      }
+      const binPath = String(stdout || '').trim();
+      resolve(_rememberDetection(key, { available: !!binPath, path: binPath || null }));
+    });
+  });
+  _detectionInflight.set(key, probe);
+  try {
+    return { id, ...(await probe) };
+  } finally {
+    _detectionInflight.delete(key);
   }
 }
 
@@ -258,9 +446,20 @@ function _detectWhich(id, target) {
  * @returns {{ id: string, available: boolean, path: string|null }}
  */
 function _detectPath(id, target) {
+  const key = _detectionKey('path', target);
+  const cached = _cachedDetection(key);
+  if (cached) return { id, ...cached };
   const fs = require('node:fs');
+  // Still synchronous, and deliberately so. Making it `fs.promises` would not
+  // make it safe: an `open()` the kernel never returns from — what a
+  // TCC-protected path does on macOS — holds a libuv threadpool slot instead of
+  // the event loop, which is a different way to lose the process rather than a
+  // fix (#883, #884; only a killable child process bounds that). What actually
+  // protects this path is the cache above, which turns a per-project-per-poll
+  // call into at most one a minute, plus the fact that no shipped engine profile
+  // uses the `path` strategy — all four use `which`.
   const exists = fs.existsSync(target);
-  return { id, available: exists, path: exists ? target : null };
+  return { id, ..._rememberDetection(key, { available: exists, path: exists ? target : null }) };
 }
 
 /**
@@ -1689,7 +1888,15 @@ const _internal = {
   // The five wired call sites went untested for exactly this reason, and an
   // untested call site is where #707 actually lived — the resolver was never
   // the hard part.
-  listWithAvailability: (...args) => listWithAvailability(...args)
+  listWithAvailability: (...args) => listWithAvailability(...args),
+  // The settled detection cache, exposed so a test can age an entry and watch
+  // the real TTL comparison decide — rather than assert against a helper written
+  // to make the test pass.
+  detectionResults: _detectionResults,
+  // The in-flight probes. A test proves single-flight by firing concurrent asks
+  // and reading this before any of them settles; there is no way to observe "how
+  // many subprocesses were spawned" from outside, and the count is the claim.
+  detectionInflight: _detectionInflight
 };
 
 /**
@@ -1897,6 +2104,7 @@ module.exports = {
   TC_LEGACY_HOOK_MARKERS,
   detect,
   detectEngine,
+  detectEngineAsync,
   anyEngineInstalled,
   engineReadiness,
   // Exported so "Check again" can drop the cached login PATH, and so the merge

--- a/lib/engines.js
+++ b/lib/engines.js
@@ -36,10 +36,22 @@ function detect() {
 
 /**
  * Detect availability of a single engine.
+ *
+ * Answers from a short-lived cache by default (see `DETECTION_TTL_MS`), because
+ * the expensive caller is a poll asking the same question about the same machine
+ * once per project. `{ fresh: true }` is for the callers where a stale answer
+ * has a cost the poll does not have: a LAUNCH GATE refusing to start a session
+ * because a minute-old probe said the binary was missing tells an operator who
+ * just installed it that it is not there. A button press can afford a probe; a
+ * ten-second poll across a fleet cannot.
+ *
  * @param {object} profile - Engine profile object
+ * @param {object} [options] - Options.
+ * @param {boolean} [options.fresh] - Probe now rather than trusting the cache.
+ *   The answer is still cached for everyone else.
  * @returns {{ id: string, available: boolean, path: string|null }}
  */
-function detectEngine(profile) {
+function detectEngine(profile, options = {}) {
   if (!profile || !profile.detection) {
     return { id: profile ? profile.id : 'unknown', available: false, path: null };
   }
@@ -48,9 +60,9 @@ function detectEngine(profile) {
 
   switch (strategy) {
     case 'which':
-      return _detectWhich(profile.id, target);
+      return _detectWhich(profile.id, target, options);
     case 'path':
-      return _detectPath(profile.id, target);
+      return _detectPath(profile.id, target, options);
     default:
       log.warn('Unknown detection strategy', { id: profile.id, strategy });
       return { id: profile.id, available: false, path: null };
@@ -68,6 +80,11 @@ function detectEngine(profile) {
  * one would move a hang rather than remove it.
  *
  * @param {object} profile - Engine profile object
+ * @param {object} [options] - Options, forwarded to the `which` probe.
+ * @param {boolean} [options.fresh] - Probe now rather than trusting the cache.
+ *   For gates; see `detectEngine` for why a gate must not remember.
+ * @param {Function} [options.execFn] - Injected `execFile` (tests).
+ * @param {number} [options.timeout] - Milliseconds before the probe is killed.
  * @returns {Promise<{ id: string, available: boolean, path: string|null }>}
  */
 async function detectEngineAsync(profile, options = {}) {
@@ -316,6 +333,10 @@ function _cachedDetection(key) {
   return hit.result;
 }
 
+// Bumped every time the cache is dropped, so an answer can be checked against
+// the world it was probed in. See `_rememberDetection`.
+let _detectionGeneration = 0;
+
 /**
  * Remember a detection result, and return it.
  *
@@ -323,11 +344,21 @@ function _cachedDetection(key) {
  * it says we could not look, and storing it would publish "not installed" as a
  * finding for the next full minute — for an engine that may well be installed.
  *
+ * An answer probed BEFORE the cache was last dropped is not one either, and that
+ * is the subtle case: an async probe that started under the old PATH can settle
+ * after "Check again" has cleared everything, and would then repopulate the
+ * fresh cache with the stale finding the operator pressed the button to be rid
+ * of. Clearing a map cannot reach a probe already in flight; the generation can.
+ *
  * @param {string} key - Cache key from `_detectionKey`.
  * @param {{ available: boolean, path: string|null }} result - The answer.
- * @returns {{ available: boolean, path: string|null }} The same result.
+ * @param {number} generation - `_detectionGeneration` when the probe STARTED.
+ * @returns {{ available: boolean, path: string|null }} The same result, stored
+ *   or not. The caller still gets the answer it just probed for — it is only
+ *   unfit to be reused by anyone else.
  */
-function _rememberDetection(key, result) {
+function _rememberDetection(key, result, generation) {
+  if (generation !== _detectionGeneration) return result;
   _detectionResults.set(key, { at: Date.now(), result });
   return result;
 }
@@ -346,6 +377,7 @@ function _rememberDetection(key, result) {
  * @returns {void}
  */
 function _clearDetectionResults() {
+  _detectionGeneration += 1;
   _detectionResults.clear();
   _detectionInflight.clear();
 }
@@ -355,35 +387,99 @@ function _clearDetectionResults() {
  * server's.
  * @param {string} id - Engine id
  * @param {string} target - Binary name
+ * @param {object} [options] - Options.
+ * @param {boolean} [options.fresh] - Probe even if a cached answer is in date.
  * @returns {{ id: string, available: boolean, path: string|null }}
  */
-function _detectWhich(id, target) {
+/**
+ * Did the probe process actually run, or did it never start?
+ *
+ * The difference decides whether "not found" is a finding or a gap, and the two
+ * arrive looking almost identical. A shell that ran and exited non-zero reports
+ * a NUMERIC exit status — `status` from `execSync`, `code` from `execFile`. A
+ * spawn that never happened reports a STRING errno in `code` (`EMFILE`,
+ * `EAGAIN`, `ENOMEM`) and no status at all, because there was no process to have
+ * one.
+ *
+ * This matters more here than it looks: this install's known failure mode is
+ * process exhaustion (#94/#144/#380 — leaked `tmux attach` children filling the
+ * PTY pool). Under it, every spawn fails at once. Treating that as an answer
+ * would cache "not installed" for EVERY engine simultaneously, for a full
+ * minute, on the machine least able to recover — reporting a resource shortage
+ * as a fleet-wide software absence.
+ *
+ * @param {Error} err - Error thrown by, or handed to, a `child_process` call.
+ * @returns {boolean} True when a process ran and exited on its own.
+ */
+function _probeRan(err) {
+  return typeof err.status === 'number' || typeof err.code === 'number';
+}
+
+/**
+ * Turn one `command -v` outcome into an answer, and decide whether to keep it.
+ *
+ * Shared by both probe forms so the cache POLICY exists once. The synchronous
+ * and asynchronous paths differ only in how they get their result; when the
+ * policy lived in both, the two spellings of "is this worth remembering" were
+ * free to drift, and the one nobody re-read would be the one that was wrong.
+ *
+ * @param {string} key - Cache key from `_detectionKey`.
+ * @param {number} generation - `_detectionGeneration` when the probe started.
+ * @param {Error|null} err - Failure, if the probe failed.
+ * @param {string} stdout - Probe output, when it succeeded.
+ * @param {object} context - `{ id, target, timeout }`, for the log lines.
+ * @returns {{ available: boolean, path: string|null }}
+ */
+function _settleWhichProbe(key, generation, err, stdout, context) {
+  if (!err) {
+    const binPath = String(stdout || '').trim();
+    return _rememberDetection(key, { available: !!binPath, path: binPath || null }, generation);
+  }
+  // Our own cap killed it. Said out loud, because a probe that never finishes is
+  // invisible otherwise — the sibling `tmux` listing in this same change logs its
+  // timeout for the same reason, and #894 is what happens when it does not.
+  if (wasTimedOut(err)) {
+    log.warn('Engine detection probe timed out — availability not established, not remembered',
+      { id: context.id, target: context.target, timeout: context.timeout });
+    return { available: false, path: null };
+  }
+  // The process never started. Not an answer either, and NOT remembered.
+  if (!_probeRan(err)) {
+    log.warn('Engine detection probe could not be started — availability not established, '
+      + 'not remembered', { id: context.id, target: context.target, code: err.code });
+    return { available: false, path: null };
+  }
+  // A shell that ran and exited non-zero: the command is not on the PATH. That
+  // IS the answer, and it is worth keeping for the TTL.
+  return _rememberDetection(key, { available: false, path: null }, generation);
+}
+
+function _detectWhich(id, target, options = {}) {
   if (!DETECTION_TARGET_RE.test(String(target || ''))) {
     log.warn('Engine detection target is not a plain command name — refusing to probe it', { id });
     return { id, available: false, path: null };
   }
   const key = _detectionKey('which', target);
-  const cached = _cachedDetection(key);
+  const cached = options.fresh ? null : _cachedDetection(key);
   if (cached) return { id, ...cached };
+  const generation = _detectionGeneration;
+  const context = { id, target, timeout: DETECTION_PROBE_TIMEOUT_MS };
   try {
     // `command -v` rather than `which`: it is a POSIX shell builtin, so it needs
     // nothing on the PATH it is searching — `which` is itself a binary, and on a
     // PATH that does not contain it the probe fails for the wrong reason.
-    const binPath = execSync(`command -v ${target}`, {
+    const stdout = execSync(`command -v ${target}`, {
       timeout: DETECTION_PROBE_TIMEOUT_MS,
       encoding: 'utf8',
       env: { ...process.env, PATH: _detectionPath() },
       stdio: ['ignore', 'pipe', 'ignore']
-    }).trim();
-    return { id, ..._rememberDetection(key, { available: !!binPath, path: binPath || null }) };
+    });
+    return { id, ..._settleWhichProbe(key, generation, null, stdout, context) };
   } catch (err) {
-    // A non-zero exit from `command -v` IS the answer: the command is not on the
-    // PATH. Our own timeout killing the probe is NOT — see `_rememberDetection`.
     // `wasTimedOut`, never `err.killed`: `execSync` sets that flag on
     // `spawnSync`'s result and not on the error it throws, which is how three
     // hand-written versions of this check ended up dead (#891, #894).
-    if (wasTimedOut(err)) return { id, available: false, path: null };
-    return { id, ..._rememberDetection(key, { available: false, path: null }) };
+    return { id, ..._settleWhichProbe(key, generation, err, '', context) };
   }
 }
 
@@ -397,6 +493,10 @@ function _detectWhich(id, target) {
  *
  * @param {string} id - Engine id
  * @param {string} target - Binary name
+ * @param {object} [options] - Options.
+ * @param {boolean} [options.fresh] - Probe even if a cached answer is in date.
+ * @param {Function} [options.execFn] - Injected `execFile` (tests).
+ * @param {number} [options.timeout] - Milliseconds before the probe is killed.
  * @returns {Promise<{ id: string, available: boolean, path: string|null }>}
  */
 async function _detectWhichAsync(id, target, options = {}) {
@@ -405,37 +505,38 @@ async function _detectWhichAsync(id, target, options = {}) {
     return { id, available: false, path: null };
   }
   const key = _detectionKey('which', target);
-  const cached = _cachedDetection(key);
+  const cached = options.fresh ? null : _cachedDetection(key);
   if (cached) return { id, ...cached };
 
+  // A fresh ask still joins a probe already running: that probe is looking right
+  // now, which is what `fresh` asked for, and starting a second one would spawn
+  // a duplicate to learn the same thing a few milliseconds later.
   const running = _detectionInflight.get(key);
   if (running) return { id, ...(await running) };
 
   const execFn = options.execFn || execFile;
+  const generation = _detectionGeneration;
+  const timeout = options.timeout || DETECTION_PROBE_TIMEOUT_MS;
+  const context = { id, target, timeout };
   const probe = new Promise((resolve) => {
     execFn('/bin/sh', ['-c', `command -v ${target}`], {
-      timeout: options.timeout || DETECTION_PROBE_TIMEOUT_MS,
+      timeout,
       encoding: 'utf8',
       env: { ...process.env, PATH: _detectionPath() }
     }, (err, stdout) => {
-      if (err) {
-        if (wasTimedOut(err)) {
-          // Not an answer, so not remembered — the next caller probes again.
-          resolve({ available: false, path: null });
-          return;
-        }
-        resolve(_rememberDetection(key, { available: false, path: null }));
-        return;
-      }
-      const binPath = String(stdout || '').trim();
-      resolve(_rememberDetection(key, { available: !!binPath, path: binPath || null }));
+      resolve(_settleWhichProbe(key, generation, err, stdout, context));
     });
   });
   _detectionInflight.set(key, probe);
   try {
     return { id, ...(await probe) };
   } finally {
-    _detectionInflight.delete(key);
+    // Only if it is still OURS. A `_clearDetectionResults()` during the probe
+    // empties the map, and the next caller then installs its own promise under
+    // the same key — an unconditional delete here would evict that newer probe,
+    // leaving a caller awaiting a promise nothing tracks and the one after it
+    // spawning a third. Delete what you put there, not whatever is at the key.
+    if (_detectionInflight.get(key) === probe) _detectionInflight.delete(key);
   }
 }
 
@@ -443,11 +544,13 @@ async function _detectWhichAsync(id, target, options = {}) {
  * Detect engine by checking if a path exists.
  * @param {string} id - Engine id
  * @param {string} target - File path to check
+ * @param {object} [options] - Options.
+ * @param {boolean} [options.fresh] - Check now rather than trusting the cache.
  * @returns {{ id: string, available: boolean, path: string|null }}
  */
-function _detectPath(id, target) {
+function _detectPath(id, target, options = {}) {
   const key = _detectionKey('path', target);
-  const cached = _cachedDetection(key);
+  const cached = options.fresh ? null : _cachedDetection(key);
   if (cached) return { id, ...cached };
   const fs = require('node:fs');
   // Still synchronous, and deliberately so. Making it `fs.promises` would not
@@ -459,7 +562,8 @@ function _detectPath(id, target) {
   // call into at most one a minute, plus the fact that no shipped engine profile
   // uses the `path` strategy — all four use `which`.
   const exists = fs.existsSync(target);
-  return { id, ..._rememberDetection(key, { available: exists, path: exists ? target : null }) };
+  return { id, ..._rememberDetection(key, { available: exists, path: exists ? target : null },
+    _detectionGeneration) };
 }
 
 /**
@@ -1896,7 +2000,10 @@ const _internal = {
   // The in-flight probes. A test proves single-flight by firing concurrent asks
   // and reading this before any of them settles; there is no way to observe "how
   // many subprocesses were spawned" from outside, and the count is the claim.
-  detectionInflight: _detectionInflight
+  detectionInflight: _detectionInflight,
+  // So a test can look an entry up the way the code does, rather than
+  // hand-writing the key format and passing while the real one drifts.
+  detectionKeyFor: (strategy, target) => _detectionKey(strategy, target)
 };
 
 /**

--- a/lib/master.js
+++ b/lib/master.js
@@ -613,7 +613,8 @@ function ensureMasterSession(options = {}) {
   if (!engineProfile) {
     return { created: false, ...base, error: `Engine "${engineId}" not found` };
   }
-  const det = eng.detectEngine(engineProfile);
+  // `fresh`: a gate, not a display — see the same call in `lib/sessions.js`.
+  const det = eng.detectEngine(engineProfile, { fresh: true });
   if (!det.available) {
     return { created: false, ...base, error: `Engine "${engineId}" not available (binary not found)` };
   }

--- a/lib/projects.js
+++ b/lib/projects.js
@@ -666,21 +666,22 @@ const {
  * async. Existence, governance, git, config and version all arrive that way; this
  * function opens nothing under `project.path`.
  *
- * WHAT IS STILL SYNCHRONOUS HERE, stated because "reads nothing from the project
- * directory" is easy to round up to "cannot block". `engines.detectEngine` still
- * runs a subprocess on this thread — `command -v <name>`, or `fs.existsSync` on
- * a profile's configured path — once per project, on the route the dashboard
- * polls every ten seconds. It does not touch an operator-chosen PROJECT
- * directory, which is the thing macOS refuses to answer for and the whole reason
- * the scanner exists, and it carries its own 2s cap; it is a smaller, different
- * hazard, and it is not fixed yet.
+ * NOTHING HERE SPAWNS A SUBPROCESS SYNCHRONOUSLY, which is worth stating because
+ * the two calls that used to both looked harmless. `tmux.hasSession` and
+ * `engines.detectEngine` each ran on this thread once PER PROJECT, with their own
+ * 5s and 2s caps, on the route the dashboard polls every ten seconds — so a
+ * fleet's honest worst case was its project count times those caps, for two
+ * questions whose answers are properties of the MACHINE and identical for every
+ * project asking. Neither reads an operator-chosen directory, so neither belonged
+ * in the scanner child; what they needed was to be asked once instead of N times.
+ * Session liveness now comes from one shared `tmux list-sessions` snapshot, and
+ * engine availability from the cache in `lib/engines.js`, both awaited.
  *
- * Session liveness no longer is. `tmux.hasSession` ran here the same way, once
- * per project with its own 5s cap, so a fleet's worst case scaled with the
- * project count for an answer that is identical for every project asking. It now
- * comes from one shared `tmux list-sessions` snapshot, awaited rather than
- * blocking. Neither call ever belonged in the scanner child — what they needed
- * was to be asked once instead of N times.
+ * One synchronous filesystem call survives, and only for a profile using the
+ * `path` detection strategy: `fs.existsSync` on the path that profile configures
+ * (`lib/engines.js` `_detectPath`, which explains why making it async would move
+ * the hazard rather than remove it). No shipped engine profile uses that
+ * strategy — all four detect with `command -v`.
  *
  * `facts` is an optional injection for the ONE caller that has already gathered
  * them: `listProjects` reads its projects' facts one at a time, so a list costs
@@ -727,7 +728,11 @@ async function enrichProject(project, facts, context) {
   } else {
     const engineProfile = store.engines.get(project.engineId);
     if (engineProfile) {
-      const det = engines.detectEngine(engineProfile);
+      // Awaited, not blocking. This ran `command -v <name>` on the event loop
+      // once per project on the ten-second poll, to learn a fact about the
+      // MACHINE that is identical for every project using the engine; the cache
+      // behind it now answers all of them from one probe.
+      const det = await engines.detectEngineAsync(engineProfile);
       engine = {
         id: project.engineId,
         name: engineProfile.name,

--- a/lib/projects.js
+++ b/lib/projects.js
@@ -667,14 +667,20 @@ const {
  * function opens nothing under `project.path`.
  *
  * WHAT IS STILL SYNCHRONOUS HERE, stated because "reads nothing from the project
- * directory" is easy to round up to "cannot block". Two calls below still run
- * subprocesses on this thread: `engines.detectEngine` (`command -v <name>`, or
- * `fs.existsSync` on a profile's configured path) and `tmux.hasSession`. Neither
- * touches an operator-chosen PROJECT directory, which is the thing macOS refuses
- * to answer for and the whole reason the scanner exists — they probe a validated
- * command name and a TangleClaw-generated tmux session name, both bounded and
- * both capped by their own timeouts. They are a smaller, different hazard than
- * the one this issue closed, and they are not covered by it.
+ * directory" is easy to round up to "cannot block". `engines.detectEngine` still
+ * runs a subprocess on this thread — `command -v <name>`, or `fs.existsSync` on
+ * a profile's configured path — once per project, on the route the dashboard
+ * polls every ten seconds. It does not touch an operator-chosen PROJECT
+ * directory, which is the thing macOS refuses to answer for and the whole reason
+ * the scanner exists, and it carries its own 2s cap; it is a smaller, different
+ * hazard, and it is not fixed yet.
+ *
+ * Session liveness no longer is. `tmux.hasSession` ran here the same way, once
+ * per project with its own 5s cap, so a fleet's worst case scaled with the
+ * project count for an answer that is identical for every project asking. It now
+ * comes from one shared `tmux list-sessions` snapshot, awaited rather than
+ * blocking. Neither call ever belonged in the scanner child — what they needed
+ * was to be asked once instead of N times.
  *
  * `facts` is an optional injection for the ONE caller that has already gathered
  * them: `listProjects` reads its projects' facts one at a time, so a list costs
@@ -695,9 +701,14 @@ const {
  *   config: object|null, version: string|null, unreadable: string|null,
  *   unreadableHint: string|null}} [facts] - Pre-gathered directory facts, from the
  *   polled scanner. Read here interactively when omitted.
+ * @param {object} [context] - Work shared across one list of projects.
+ * @param {{get: () => Promise<Set<string>>}} [context.tmuxSessionNames] - Live
+ *   session names, from `tmux.createSessionNameSnapshot()`. One snapshot serves a
+ *   whole list; omitting it makes this call create its own, so a caller that
+ *   forgets pays for an extra invocation and is never answered wrongly.
  * @returns {Promise<object>} - Enriched project
  */
-async function enrichProject(project, facts) {
+async function enrichProject(project, facts, context) {
   if (!facts) facts = await readProjectFacts(project);
   // Engine info — openclaw:<connId> resolves via connection registry
   let engine = null;
@@ -727,11 +738,20 @@ async function enrichProject(project, facts) {
   }
 
   // Session info — include both active and wrapping sessions (only if tmux is alive)
+  //
+  // Liveness comes from ONE `tmux list-sessions` shared across the whole list,
+  // not a `tmux has-session` per project: the latter ran on the event loop with
+  // its own 5s cap each, so a fleet's worst case scaled with the project count
+  // for an answer that fits in a single invocation. The snapshot spawns nothing
+  // until something below actually asks, so a project with no session in the
+  // database still costs nothing at all.
   let session = null;
+  const sessionNames = (context && context.tmuxSessionNames) || tmux.createSessionNameSnapshot();
   const activeSession = store.sessions.getActive(project.id);
   if (activeSession) {
     // Only report as active if tmux session is actually alive
-    const tmuxAlive = !activeSession.tmuxSession || tmux.hasSession(activeSession.tmuxSession);
+    const tmuxAlive = !activeSession.tmuxSession
+      || (await sessionNames.get()).has(activeSession.tmuxSession);
     if (tmuxAlive) {
       session = {
         active: true,
@@ -744,7 +764,10 @@ async function enrichProject(project, facts) {
   } else {
     const wrappingSession = store.sessions.getWrapping(project.id);
     if (wrappingSession) {
-      const tmuxAlive = wrappingSession.tmuxSession && tmux.hasSession(wrappingSession.tmuxSession);
+      // Asymmetric with the active branch above, and deliberately so: an active
+      // session with no tmux name counts as live, a wrapping one does not.
+      const tmuxAlive = !!wrappingSession.tmuxSession
+        && (await sessionNames.get()).has(wrappingSession.tmuxSession);
       if (tmuxAlive) {
         session = {
           active: true,
@@ -944,7 +967,12 @@ async function listProjects(options = {}) {
   for (const p of projects) {
     facts.push(await readProjectFacts(p, { interactive: false }));
   }
-  return Promise.all(projects.map((p, i) => enrichProject(p, facts[i])));
+  // ONE tmux invocation for the whole list, shared by every enrichment below.
+  // Built here rather than inside `enrichProject` so the projects that DO have
+  // sessions share a single answer instead of each asking for their own; it
+  // spawns nothing if none of them has a session to ask about.
+  const tmuxSessionNames = tmux.createSessionNameSnapshot();
+  return Promise.all(projects.map((p, i) => enrichProject(p, facts[i], { tmuxSessionNames })));
 }
 
 /**

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -165,8 +165,12 @@ function launchSession(projectName, options = {}) {
     return { session: null, primePrompt: null, ttydUrl: null, error: `Engine "${engineId}" not found` };
   }
 
-  // Check engine availability (for openclaw, SSH must be available)
-  const det = engines.detectEngine(engineProfile);
+  // Check engine availability (for openclaw, SSH must be available).
+  // `fresh`: this is a gate, not a display. Refusing a launch on a minute-old
+  // probe would tell an operator who has just installed the engine that it is
+  // not installed — and one probe on a button press costs nothing, unlike the
+  // per-project poll the cache exists for.
+  const det = engines.detectEngine(engineProfile, { fresh: true });
   if (!det.available) {
     return { session: null, primePrompt: null, ttydUrl: null, error: `Engine "${engineId}" not available (binary not found)` };
   }

--- a/lib/tmux.js
+++ b/lib/tmux.js
@@ -3,7 +3,7 @@
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
-const { execSync } = require('node:child_process');
+const { execSync, execFile } = require('node:child_process');
 const { createLogger } = require('./logger');
 const { wasTimedOut } = require('./exec-timeout');
 const serverInfo = require('./server-info');
@@ -85,11 +85,96 @@ function listSessions() {
 }
 
 /**
+ * Read every live session name in ONE invocation, asynchronously.
+ *
+ * `-F '#{session_name}'` alone, rather than the `|`-joined format `listSessions`
+ * uses: one field has no delimiter to mis-split, so a session someone else
+ * created whose name contains a `|` cannot be truncated into a name that
+ * collides with one of ours. Run through `execFile` with an argv rather than a
+ * shell string for the same reason — nothing here is re-parsed.
+ *
+ * NEVER REJECTS. It resolves to an empty set for every failure, which is the
+ * answer `hasSession` already gives one name at a time: tmux not running, no
+ * sessions, and a tmux server too wedged to answer all read as "none live". The
+ * last of those is an unknown wearing a fact's clothes — a wedged server makes
+ * every session look dead — and it is preserved here deliberately rather than
+ * fixed in passing, because changing it changes what the dashboard shows.
+ *
+ * @param {Function} execFn - `execFile`-shaped runner.
+ * @param {number} timeout - Milliseconds before the invocation is killed.
+ * @returns {Promise<Set<string>>} Live session names; empty when none answered.
+ */
+function _readSessionNames(execFn, timeout) {
+  return new Promise((resolve) => {
+    execFn('tmux', ['list-sessions', '-F', '#{session_name}'],
+      { timeout, encoding: 'utf8' }, (err, stdout) => {
+        if (err) {
+          // A timeout is worth saying out loud; "no server running" is the
+          // ordinary state of a machine with no sessions and would be noise.
+          if (wasTimedOut(err)) {
+            log.error('tmux session listing timed out — every session will read as not live',
+              { timeout });
+          }
+          resolve(new Set());
+          return;
+        }
+        const names = new Set();
+        for (const line of String(stdout || '').split('\n')) {
+          const name = line.trim();
+          if (name) names.add(name);
+        }
+        resolve(names);
+      });
+  });
+}
+
+/**
+ * A single-flight, lazily-loaded snapshot of the live session names.
+ *
+ * Exists because liveness used to be asked one project at a time: enriching a
+ * fleet ran `tmux has-session` once per project, on the event loop, each with
+ * its own 5s cap — so the honest worst case scaled with the project count while
+ * the answer for all of them fits in one invocation.
+ *
+ * Lazy AND memoised, both load-bearing. Lazy: a fleet whose projects have no
+ * sessions at all must still cost nothing, so nothing is spawned until someone
+ * asks. Memoised on the PROMISE rather than the result: the callers run
+ * concurrently under `Promise.all`, so caching only the settled value would let
+ * every one of them miss and spawn before the first reply landed — N spawns
+ * again, from a cache that looks like it works.
+ *
+ * Deliberately one-shot, with no expiry. A snapshot is meant to answer one
+ * list, and its holder throws it away; a long-lived cache here would hand
+ * stale liveness to callers that kill and type into sessions.
+ *
+ * @param {object} [options] - Options.
+ * @param {Function} [options.execFn] - Injected `execFile` (tests).
+ * @param {number} [options.timeout] - Milliseconds before the invocation is killed.
+ * @returns {{ get: () => Promise<Set<string>> }}
+ */
+function createSessionNameSnapshot(options = {}) {
+  const execFn = options.execFn || execFile;
+  const timeout = options.timeout || DEFAULT_TIMEOUT;
+  let pending = null;
+  return {
+    get() {
+      if (!pending) pending = _readSessionNames(execFn, timeout);
+      return pending;
+    }
+  };
+}
+
+/**
  * Check if a tmux session exists.
  *
  * Matches the name EXACTLY: a live `Foo-Bar` does not make `hasSession('Foo')`
  * true. Callers rely on this to decide whether to kill, adopt, or type into a
  * session, so a near-miss must read as absent (see `_target`).
+ *
+ * Deliberately uncached and synchronous. Its callers kill, adopt and type into
+ * the session they are asking about, so an answer that was true a moment ago is
+ * not good enough — `createSessionNameSnapshot` is for the read-only fleet view,
+ * this is for acting on one session.
  *
  * @param {string} name - Session name
  * @returns {boolean}
@@ -611,6 +696,7 @@ module.exports = {
   toSessionName,
   isValidSessionName,
   listSessions,
+  createSessionNameSnapshot,
   hasSession,
   createSession,
   buildStatusLeft,

--- a/test/engines.test.js
+++ b/test/engines.test.js
@@ -618,6 +618,30 @@ describe('engines', () => {
       }
     });
 
+    it('honours fresh on the path strategy as well, on both call forms', async () => {
+      // The `path` strategy is not used by any shipped profile, which is exactly
+      // why it is the arm that gets forgotten — this branch has now applied a
+      // rule to a proper subset of its call sites three separate times.
+      const probeFile = path.join(binDir, 'engine-at-a-path');
+      fs.writeFileSync(probeFile, 'x');
+      const byPath = { id: 'tc-by-path', detection: { strategy: 'path', target: probeFile } };
+
+      assert.equal(engines.detectEngine(byPath).available, true);
+      fs.rmSync(probeFile);
+      assert.equal(engines.detectEngine(byPath).available, true, 'cached, as the poll wants');
+
+      // THE MUTATION THIS CATCHES: `case 'path': return _detectPath(id, target)`
+      // without forwarding options — on either form. An option a function accepts
+      // and silently drops reads at the call site as though it took effect.
+      assert.equal(engines.detectEngine(byPath, { fresh: true }).available, false,
+        'sync form must re-check the path');
+
+      fs.writeFileSync(probeFile, 'x');
+      assert.equal((await engines.detectEngineAsync(byPath)).available, false, 'cached again');
+      assert.equal((await engines.detectEngineAsync(byPath, { fresh: true })).available, true,
+        'async form must re-check it too');
+    });
+
     it('forgets everything when the operator presses Check again', async () => {
       assert.equal(engines.detectEngine(profile).available, true);
       removeBinary();

--- a/test/engines.test.js
+++ b/test/engines.test.js
@@ -432,6 +432,137 @@ describe('engines', () => {
       assert.equal(engines.detectEngine(profile).available, true);
     });
 
+    it('a probe still running when the cache is dropped does not refill it', async () => {
+      // The case clearing a map cannot reach. A probe that STARTED under the old
+      // PATH can settle after Check again has cleared everything, and would then
+      // write the stale finding straight back into the fresh cache — so the
+      // operator presses the button, the cache empties, and a moment later the
+      // answer they pressed it to be rid of is back, now looking freshly probed.
+      const { execFile } = require('node:child_process');
+      const cache = engines._internal.detectionResults;
+
+      // A probe slow enough to still be running when the cache is dropped.
+      const slow = (_file, _args, opts, cb) => execFile('/bin/sh', ['-c', 'sleep 0.4; echo /stale/path'], opts, cb);
+      const inFlight = engines.detectEngineAsync(profile, { execFn: slow, timeout: 5000 });
+
+      engines.resetDetectionCache();
+
+      const result = await inFlight;
+      // The caller that asked still gets its answer — it is only unfit to be
+      // handed to anyone else.
+      assert.equal(result.available, true);
+      // THE MUTATION THIS CATCHES: dropping the generation check in
+      // `_rememberDetection`. Every sequential test still passes; only a probe
+      // racing a clear tells the difference, and that race is exactly what the
+      // Check again button creates.
+      assert.equal(cache.size, 0,
+        'an answer probed before the drop must not survive it');
+    });
+
+    it('probes now when the caller asks for fresh, and still shares what it learns', () => {
+      assert.equal(engines.detectEngine(profile).available, true);
+      removeBinary();
+      assert.equal(engines.detectEngine(profile).available, true, 'cached, as the poll wants');
+
+      // THE MUTATION THIS CATCHES: letting the launch gates read the cache.
+      // `lib/sessions.js` and `lib/master.js` refuse to start a session when
+      // this says unavailable — so a stale `false` tells an operator who just
+      // installed the engine that it is not installed, and no amount of
+      // retrying the button helps until the TTL lapses.
+      assert.equal(engines.detectEngine(profile, { fresh: true }).available, false,
+        'a gate must look, not remember');
+
+      // And what it looked up replaces the stale entry, so the poll behind it
+      // is corrected too rather than each holding a different answer.
+      assert.equal(engines.detectEngine(profile).available, false);
+    });
+
+    it('honours fresh in the async form too, so the flag is never a silent no-op', async () => {
+      assert.equal((await engines.detectEngineAsync(profile)).available, true);
+      removeBinary();
+      assert.equal((await engines.detectEngineAsync(profile)).available, true, 'cached');
+
+      // THE MUTATION THIS CATCHES: supporting `fresh` on the sync path only.
+      // Both forms take the same options object, so a flag the async one quietly
+      // drops is worse than one it never accepted — the call site reads as
+      // asking for a fresh probe and gets a cached answer.
+      assert.equal((await engines.detectEngineAsync(profile, { fresh: true })).available, false);
+    });
+
+    it('does NOT remember a probe that never started', async () => {
+      // A spawn failure is not a finding. `EMFILE` / `EAGAIN` mean no process
+      // ran, so nothing looked for the binary — but the error arrives looking
+      // much like an ordinary non-zero exit, and treating it as one caches
+      // "not installed".
+      //
+      // This install's known failure mode is process exhaustion (#94/#144/#380,
+      // leaked `tmux attach` children filling the PTY pool), where EVERY spawn
+      // fails at once. Caching that would report every engine as uninstalled
+      // simultaneously, for a minute, on the machine least able to recover.
+      const cache = engines._internal.detectionResults;
+      cache.clear();
+
+      // The shape Node produces when the fork fails: a STRING errno in `code`,
+      // and no numeric exit status, because there was no process to exit.
+      const cannotFork = (_file, _args, _opts, cb) => setImmediate(() => cb(
+        Object.assign(new Error('spawn EAGAIN'), { code: 'EAGAIN', errno: -35, syscall: 'spawn' })));
+
+      const result = await engines.detectEngineAsync(profile, { execFn: cannotFork });
+
+      assert.equal(result.available, false, 'nothing was established, so nothing is claimed');
+      // THE MUTATION THIS CATCHES: keeping the old `if (wasTimedOut) skip; else
+      // remember` split, which treats every non-timeout failure as an answer.
+      assert.equal(cache.size, 0, 'a probe that never ran must not be remembered');
+
+      // And the binary really is there — proof the cached "false" would have lied.
+      assert.equal(engines.detectEngine(profile).available, true);
+    });
+
+    it('tells a real non-zero exit apart from a failed spawn', () => {
+      // The other side of the pair: a shell that RAN and exited non-zero reports
+      // a numeric status, and that is an answer worth keeping. If the guard above
+      // were written as "never cache any failure", this would regress to probing
+      // on every poll for every engine the operator does not have installed.
+      const cache = engines._internal.detectionResults;
+      cache.clear();
+      const missing = { id: 'tc-gone', detection: { strategy: 'which', target: '__tc_absent__' } };
+
+      assert.equal(engines.detectEngine(missing).available, false);
+      assert.equal(cache.size, 1, 'a shell that ran and said no is an answer');
+    });
+
+    it('a probe that finishes after a clear does not evict the probe that replaced it', async () => {
+      // `_clearDetectionResults` empties the in-flight map, so a later caller can
+      // install its own promise under the same key while the first is still
+      // running. When the first one lands, its cleanup must not delete the
+      // SECOND caller's entry.
+      //
+      // THE MUTATION THIS CATCHES: an unconditional
+      // `_detectionInflight.delete(key)` in the `finally`. The visible symptom is
+      // subtle — the map empties while a probe is still running, so the caller
+      // after it starts a third — which is why the assertion is on the map's
+      // identity rather than on the answers, which stay correct throughout.
+      const { execFile } = require('node:child_process');
+      const inflight = engines._internal.detectionInflight;
+
+      const slow = (_f, _a, opts, cb) => execFile('/bin/sh', ['-c', 'sleep 0.35; echo /a'], opts, cb);
+      const first = engines.detectEngineAsync(profile, { execFn: slow, timeout: 5000 });
+
+      engines.resetDetectionCache();
+
+      const quick = (_f, _a, opts, cb) => execFile('/bin/sh', ['-c', 'sleep 0.6; echo /b'], opts, cb);
+      const second = engines.detectEngineAsync(profile, { execFn: quick, timeout: 5000 });
+      const secondEntry = inflight.get(engines._internal.detectionKeyFor('which', 'tc-probe-bin'));
+      assert.ok(secondEntry, 'the second caller registered its own probe');
+
+      await first;
+      assert.equal(inflight.get(engines._internal.detectionKeyFor('which', 'tc-probe-bin')), secondEntry,
+        'the first probe finishing must leave the second one registered');
+
+      await second;
+      await first;
+    });
+
     it('forgets everything when the operator presses Check again', async () => {
       assert.equal(engines.detectEngine(profile).available, true);
       removeBinary();

--- a/test/engines.test.js
+++ b/test/engines.test.js
@@ -518,6 +518,30 @@ describe('engines', () => {
       assert.equal(engines.detectEngine(profile).available, true);
     });
 
+    it('does NOT remember a spawn that really failed, driven by a real failed spawn', async () => {
+      // The companion to the fabricated-error test above, and the one that
+      // actually earns the claim. `lib/exec-timeout.js` records why: three
+      // hand-written versions of a child-process predicate in this repo were all
+      // dead, because each asserted its author's MODEL of the error shape rather
+      // than the shape. A stub cannot catch that; a real failure can.
+      //
+      // Executing a path that does not exist produces a genuine ENOENT — no
+      // process, so no numeric status — which is the same class as the EMFILE a
+      // machine out of process slots produces, and reachable without exhausting
+      // this one.
+      const { execFile } = require('node:child_process');
+      const cache = engines._internal.detectionResults;
+      cache.clear();
+
+      const missingBinary = path.join(binDir, 'no-such-shell-at-all');
+      const cannotSpawn = (_file, _args, opts, cb) => execFile(missingBinary, [], opts, cb);
+      const result = await engines.detectEngineAsync(profile, { execFn: cannotSpawn });
+
+      assert.equal(result.available, false);
+      assert.equal(cache.size, 0,
+        'a spawn that genuinely never happened must not be remembered as an answer');
+    });
+
     it('tells a real non-zero exit apart from a failed spawn', () => {
       // The other side of the pair: a shell that RAN and exited non-zero reports
       // a numeric status, and that is an answer worth keeping. If the guard above
@@ -550,8 +574,10 @@ describe('engines', () => {
 
       engines.resetDetectionCache();
 
-      const quick = (_f, _a, opts, cb) => execFile('/bin/sh', ['-c', 'sleep 0.6; echo /b'], opts, cb);
-      const second = engines.detectEngineAsync(profile, { execFn: quick, timeout: 5000 });
+      // Outlasts the first deliberately, so the first one's cleanup runs while
+      // this is still registered — that ordering is the whole point.
+      const slower = (_f, _a, opts, cb) => execFile('/bin/sh', ['-c', 'sleep 0.6; echo /b'], opts, cb);
+      const second = engines.detectEngineAsync(profile, { execFn: slower, timeout: 5000 });
       const secondEntry = inflight.get(engines._internal.detectionKeyFor('which', 'tc-probe-bin'));
       assert.ok(secondEntry, 'the second caller registered its own probe');
 
@@ -561,6 +587,35 @@ describe('engines', () => {
 
       await second;
       await first;
+    });
+
+    it('the setup gate looks too — a remembered yes cannot hold the door open', async () => {
+      // `engineReadiness` is the third gate, behind the setup check and the
+      // wizard's engine step, and its own JSDoc says a "no" must not be stale
+      // "because it is the one that stops them". The cache arrived after that
+      // sentence was written, which is exactly how a rule gets applied to two of
+      // three call sites.
+      //
+      // The registered engine list is pinned to this fixture: unpinned, the real
+      // engines installed on the developer's machine answer first and the
+      // assertion means nothing on one box and something else on CI.
+      const realList = store.engines.list;
+      store.engines.list = () => [{ ...profile, name: 'Probe Engine', pickerHidden: false }];
+      try {
+        assert.equal(engines.detectEngine(profile).available, true, 'primed as installed');
+        removeBinary();
+
+        const readiness = await engines.engineReadiness();
+
+        // THE MUTATION THIS CATCHES: dropping `{ fresh: true }` from the first
+        // check. The cache still says the binary is there, so the gate opens for
+        // an engine that is gone — and every later failure happens somewhere
+        // less able to explain itself than the gate would have been.
+        assert.equal(readiness.installed, false,
+          'a gate must re-look, not replay a minute-old yes');
+      } finally {
+        store.engines.list = realList;
+      }
     });
 
     it('forgets everything when the operator presses Check again', async () => {

--- a/test/engines.test.js
+++ b/test/engines.test.js
@@ -297,6 +297,158 @@ describe('engines', () => {
     });
   });
 
+  // Detection ran once per project on the ten-second poll — `command -v claude`
+  // asked separately for every project using Claude, synchronously on the event
+  // loop, to learn a fact about the MACHINE (#890). These pin that it is asked
+  // once instead, and — the part that is easy to get wrong — that the answers
+  // which must NOT be remembered still are not.
+  describe('detection is answered once, not once per asker (#890)', () => {
+    let binDir;
+    let savedPath;
+
+    /** The fixture engine profile, pointed at a binary this test controls. */
+    const profile = { id: 'tc-probe-engine', detection: { strategy: 'which', target: 'tc-probe-bin' } };
+
+    /** Put the fake binary back on disk. */
+    function installBinary() {
+      fs.writeFileSync(path.join(binDir, 'tc-probe-bin'), '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+    }
+
+    /** Take it away, so the NEXT real probe would answer differently. */
+    function removeBinary() {
+      fs.rmSync(path.join(binDir, 'tc-probe-bin'), { force: true });
+    }
+
+    beforeEach(() => {
+      binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-detect-'));
+      savedPath = process.env.PATH;
+      process.env.PATH = `${binDir}:${savedPath}`;
+      installBinary();
+      // Drops the login-PATH cache too, so `_detectionPath()` falls through to
+      // the PATH set above rather than to whatever this machine's shell reports.
+      engines.resetDetectionCache();
+    });
+
+    afterEach(() => {
+      process.env.PATH = savedPath;
+      fs.rmSync(binDir, { recursive: true, force: true });
+      engines.resetDetectionCache();
+    });
+
+    it('answers a second asker without probing again', () => {
+      assert.equal(engines.detectEngine(profile).available, true);
+      // Changing the world under the cache is how "did it probe again?" is
+      // asked without intercepting the spawn: a re-probe would now say false.
+      removeBinary();
+
+      // THE MUTATION THIS CATCHES: dropping the cache read. Correct either way —
+      // and back to one subprocess per project per poll.
+      assert.equal(engines.detectEngine(profile).available, true,
+        'the second ask must be answered from the first, not from a new probe');
+    });
+
+    it('shares one probe between the async and the synchronous form', async () => {
+      assert.equal((await engines.detectEngineAsync(profile)).available, true);
+      removeBinary();
+      // THE MUTATION THIS CATCHES: giving the async variant its own cache. Two
+      // caches means two policies, and the one nobody looked at goes wrong
+      // quietly — `enrichProject` uses the async form, everything else the sync.
+      assert.equal(engines.detectEngine(profile).available, true,
+        'one cache, or the launch paths keep paying for what the poll just learned');
+    });
+
+    it('collapses concurrent cold-cache asks into a single probe', async () => {
+      const inflight = engines._internal.detectionInflight;
+      // Fired without awaiting, so this reads the state while they are running.
+      const asks = [
+        engines.detectEngineAsync(profile),
+        engines.detectEngineAsync(profile),
+        engines.detectEngineAsync(profile)
+      ];
+
+      // THE MUTATION THIS CATCHES: dropping the in-flight map and probing on
+      // every miss. Enrichment runs under `Promise.all`, so a cold cache would
+      // spawn once per project — the multiplication this whole change removes,
+      // behind a cache that passes every sequential test.
+      assert.equal(inflight.size, 1, 'three askers, one probe');
+
+      for (const result of await Promise.all(asks)) assert.equal(result.available, true);
+      assert.equal(inflight.size, 0, 'and the probe is not left in the map once it settles');
+    });
+
+    it('re-probes once the result is older than its TTL', () => {
+      assert.equal(engines.detectEngine(profile).available, true);
+      removeBinary();
+
+      // Age the real entry and let the real comparison decide, rather than
+      // asserting against a test-only helper.
+      for (const entry of engines._internal.detectionResults.values()) entry.at = 0;
+
+      // THE MUTATION THIS CATCHES: caching forever. An engine installed
+      // mid-session would stay invisible until the operator restarted the server
+      // or found the wizard's "Check again" — and the operator who just
+      // installed one is the least likely to know that button exists.
+      assert.equal(engines.detectEngine(profile).available, false,
+        'a stale answer must be re-asked, not served');
+    });
+
+    it('remembers a real "not installed", because that one IS an answer', () => {
+      const cache = engines._internal.detectionResults;
+      cache.clear();
+      const missing = { id: 'tc-missing', detection: { strategy: 'which', target: '__tc_absent__' } };
+
+      assert.equal(engines.detectEngine(missing).available, false);
+      // The other half of the pair below: a non-zero exit from `command -v` is
+      // the finding "it is not on the PATH", so caching it is correct — the TTL
+      // is what keeps a later install from being hidden forever.
+      assert.equal(cache.size, 1, 'a real "not installed" is worth keeping for the TTL');
+    });
+
+    it('does NOT remember a probe its own timeout killed', async () => {
+      // "We could not look" is not the finding "not installed". Storing it would
+      // publish a guess as an answer for the next full minute, for an engine
+      // that may well be installed — the same false-fact #891 removed from git
+      // reads.
+      //
+      // Driven by a REAL process that outlives its cap, not a stubbed error
+      // object: this repo has written three hand-rolled timeout checks and all
+      // three were dead, because each asserted its author's model of the error
+      // shape rather than the shape a kill actually produces (#891, #894).
+      const { execFile } = require('node:child_process');
+      const cache = engines._internal.detectionResults;
+      cache.clear();
+
+      const stalls = (_file, _args, opts, cb) => execFile('/bin/sh', ['-c', 'sleep 30'], opts, cb);
+      const result = await engines.detectEngineAsync(profile, { execFn: stalls, timeout: 300 });
+
+      assert.equal(result.available, false, 'a probe we could not finish reports nothing found');
+      // THE MUTATION THIS CATCHES: treating the timeout as an ordinary failure
+      // and caching it — one line, and correct-looking, since both paths produce
+      // `available: false`. The difference only shows a minute later, when the
+      // engine that WAS installed is still reported missing.
+      assert.equal(cache.size, 0, 'but it must not be remembered as one');
+
+      // And the proof it was not remembered: the very next ask probes for real.
+      assert.equal(engines.detectEngine(profile).available, true);
+    });
+
+    it('forgets everything when the operator presses Check again', async () => {
+      assert.equal(engines.detectEngine(profile).available, true);
+      removeBinary();
+      assert.equal(engines.detectEngine(profile).available, true, 'still cached');
+
+      // THE MUTATION THIS CATCHES: hooking only `resetDetectionCache`.
+      // `GET /api/engines?refresh=1` — the Check again button — goes through
+      // `refreshDetectionPath`, which does NOT call it. Miss this and the one
+      // button whose entire purpose is "my engine IS installed" answers out of
+      // the stale cache that hid it.
+      await engines.refreshDetectionPath();
+
+      assert.equal(engines.detectEngine(profile).available, false,
+        'a re-resolved PATH must re-ask, not replay');
+    });
+  });
+
   describe('detectEngine', () => {
     it('should detect an available binary', () => {
       // "node" should be available

--- a/test/projects.test.js
+++ b/test/projects.test.js
@@ -883,6 +883,31 @@ describe('projects', () => {
       }
     });
 
+    it('resolves engine availability without taking the blocking path', async () => {
+      // The synchronous `detectEngine` is booby-trapped: if enrichment still
+      // reaches it, the enrich fails loudly instead of passing while quietly
+      // blocking the event loop once per project per poll.
+      //
+      // THE MUTATION THIS CATCHES: reverting the call site to
+      // `engines.detectEngine(engineProfile)`. Correct output, identical
+      // payload, and the defect back — which is exactly why the guard has to be
+      // "which path did it take", not "was the answer right".
+      projects.createProject({ name: 'spawn-count-engine' });
+      const row = store.projects.getByName('spawn-count-engine');
+      const realSync = engines.detectEngine;
+      engines.detectEngine = () => {
+        throw new Error('enrichProject must not probe engines synchronously');
+      };
+      try {
+        const enriched = await withCountedTmux('',
+          () => projects.enrichProject(row));
+        assert.ok(enriched.engine, 'the engine block must still be populated');
+        assert.equal(typeof enriched.engine.available, 'boolean');
+      } finally {
+        engines.detectEngine = realSync;
+      }
+    });
+
     it('matches the session name exactly — a longer live name is not a match', async () => {
       const { project, session } = projectWithSession('spawn-count-exact');
       try {

--- a/test/projects.test.js
+++ b/test/projects.test.js
@@ -750,6 +750,159 @@ describe('projects', () => {
     });
   });
 
+  // Session liveness used to cost one `tmux has-session` per project, run with
+  // `execSync` on the event loop with a 5s cap EACH, on the route the dashboard
+  // polls every ten seconds — so a fleet's worst case scaled with its size for an
+  // answer identical for every project asking (#890). These pin the count, which
+  // is the claim; wall-clock would pass with the defect intact, because a healthy
+  // `tmux has-session` costs a few milliseconds and the defect is that it happens
+  // N times.
+  describe('session liveness costs one tmux invocation per list (#890)', () => {
+    const tmuxModule = require('../lib/tmux');
+    const dirScanner = require('../lib/dir-scanner');
+
+    /**
+     * Run `fn` with tmux's snapshot factory counted and its exec stubbed, and
+     * with the scanner answering healthily so no real child is forked.
+     *
+     * The REAL factory is wrapped rather than replaced, so laziness and
+     * single-flight are exercised as shipped — a hand-written stand-in would
+     * assert the test author's model of the snapshot instead of the snapshot.
+     *
+     * @param {string} stdout - What `tmux list-sessions` replies with.
+     * @param {Function} fn - Test body, called with the counters.
+     * @returns {Promise<any>}
+     */
+    async function withCountedTmux(stdout, fn) {
+      const realFactory = tmuxModule.createSessionNameSnapshot;
+      const realReq = dirScanner.request;
+      const realInteractive = dirScanner.interactiveRequest;
+      const counts = { snapshots: 0, invocations: 0 };
+      tmuxModule.createSessionNameSnapshot = (options = {}) => {
+        counts.snapshots++;
+        return realFactory({
+          ...options,
+          execFn: (_file, _args, _opts, cb) => {
+            counts.invocations++;
+            setImmediate(() => cb(null, stdout));
+          }
+        });
+      };
+      const healthy = () => Promise.resolve({ exists: true, governanceState: 'ungoverned' });
+      dirScanner.request = healthy;
+      dirScanner.interactiveRequest = healthy;
+      try {
+        return await fn(counts);
+      } finally {
+        tmuxModule.createSessionNameSnapshot = realFactory;
+        dirScanner.request = realReq;
+        dirScanner.interactiveRequest = realInteractive;
+      }
+    }
+
+    /**
+     * Register a project with a live session, and return both.
+     * @param {string} name - Project name.
+     * @returns {{ project: object, session: object }}
+     */
+    function projectWithSession(name) {
+      projects.createProject({ name });
+      const project = store.projects.getByName(name);
+      const session = store.sessions.start({
+        projectId: project.id,
+        engineId: 'claude',
+        tmuxSession: `tc-${name}`,
+        primePrompt: ''
+      });
+      return { project, session };
+    }
+
+    it('asks tmux ONCE for a fleet where every project has a session', async () => {
+      const made = ['spawn-count-a', 'spawn-count-b', 'spawn-count-c'].map(projectWithSession);
+      // Three, not two: the count has to distinguish "one for the list" from
+      // "one per project", and with two projects a stray off-by-one reads the same.
+      const stdout = `${made.map((m) => m.session.tmuxSession).join('\n')}\n`;
+      try {
+        const { counts, list } = await withCountedTmux(stdout, async (counts) => {
+          const list = await projects.listProjects();
+          return { counts, list };
+        });
+
+        // THE MUTATION THIS CATCHES: reverting to `tmux.hasSession` per project,
+        // or building the snapshot inside `enrichProject` rather than once in
+        // `listProjects`. Both still answer correctly — and both restore the
+        // per-project multiplication this exists to remove.
+        assert.equal(counts.invocations, 1,
+          'one tmux invocation must answer the whole list');
+        assert.equal(counts.snapshots, 1,
+          'and one snapshot must be built for the list, not one per project');
+
+        for (const { project } of made) {
+          const enriched = list.find((p) => p.id === project.id);
+          assert.ok(enriched.session && enriched.session.active === true,
+            `${project.name} must still be reported as having a live session`);
+        }
+      } finally {
+        for (const { session } of made) store.sessions.kill(session.id, 'test cleanup');
+      }
+    });
+
+    it('asks tmux NOTHING for a project with no session at all', async () => {
+      projects.createProject({ name: 'spawn-count-idle' });
+      const project = store.projects.getByName('spawn-count-idle');
+      // THE MUTATION THIS CATCHES: resolving the snapshot eagerly, in
+      // `listProjects` or at the top of `enrichProject`. A fleet with nothing
+      // running would then pay a tmux invocation per poll to learn nothing —
+      // strictly worse than the per-project calls being replaced.
+      const counts = await withCountedTmux('', async (counts) => {
+        const enriched = await projects.enrichProject(store.projects.get(project.id));
+        assert.equal(enriched.session, null);
+        return counts;
+      });
+
+      assert.equal(counts.invocations, 0,
+        'nothing may be spawned to answer a question nobody asked');
+    });
+
+    it('enrichProject with no caller-supplied snapshot answers from its own', async () => {
+      // The `facts` precedent: an omitted argument makes this function do the
+      // work itself, so a call site that forgets is slower and never wrong. Eight
+      // single-project call sites rely on it.
+      const { project, session } = projectWithSession('spawn-count-solo');
+      try {
+        const { counts, enriched } = await withCountedTmux(`${session.tmuxSession}\n`,
+          async (counts) => ({
+            counts,
+            enriched: await projects.enrichProject(store.projects.get(project.id))
+          }));
+
+        assert.ok(enriched.session && enriched.session.active === true);
+        assert.equal(counts.invocations, 1, 'exactly one, the same as the call it replaced');
+      } finally {
+        store.sessions.kill(session.id, 'test cleanup');
+      }
+    });
+
+    it('matches the session name exactly — a longer live name is not a match', async () => {
+      const { project, session } = projectWithSession('spawn-count-exact');
+      try {
+        // tmux reports a DIFFERENT, longer session. `hasSession` promised exact
+        // matching and its callers depend on it; the snapshot must not soften it.
+        //
+        // THE MUTATION THIS CATCHES: answering with a `startsWith`/`includes`
+        // scan over the names instead of `Set.has`, which would report this
+        // project's dead session as live and hide a session that had crashed.
+        const enriched = await withCountedTmux(`${session.tmuxSession}-extra\n`,
+          () => projects.enrichProject(store.projects.get(project.id)));
+
+        assert.equal(enriched.session, null,
+          'a session that is not in the live set is not live, near-miss or not');
+      } finally {
+        store.sessions.kill(session.id, 'test cleanup');
+      }
+    });
+  });
+
   describe('enrichProject — governanceState (#353)', () => {
     let govDir;
 

--- a/test/tmux.test.js
+++ b/test/tmux.test.js
@@ -34,6 +34,98 @@ describe('tmux — a timed-out command says so (#894)', () => {
   });
 });
 
+describe('tmux — one session listing serves a whole fleet (#890)', () => {
+  /**
+   * A stand-in for `execFile` that counts calls and replies with fixed output.
+   * @param {object} reply - `{ stdout }` to succeed with, or `{ err }` to fail.
+   * @returns {{ execFn: Function, calls: object[] }}
+   */
+  function stubExec(reply) {
+    const calls = [];
+    const execFn = (file, args, opts, cb) => {
+      calls.push({ file, args, opts });
+      setImmediate(() => cb(reply.err || null, reply.stdout || ''));
+    };
+    return { execFn, calls };
+  }
+
+  it('returns every live name, and asks tmux exactly once to learn them all', async () => {
+    const { execFn, calls } = stubExec({ stdout: 'alpha\nbeta\ngamma\n' });
+    const snap = tmux.createSessionNameSnapshot({ execFn });
+
+    assert.deepEqual([...(await snap.get())].sort(), ['alpha', 'beta', 'gamma']);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].file, 'tmux');
+  });
+
+  it('spawns nothing until someone asks', async () => {
+    const { execFn, calls } = stubExec({ stdout: 'alpha\n' });
+    tmux.createSessionNameSnapshot({ execFn });
+    // THE MUTATION THIS CATCHES: reading the list eagerly in the constructor. A
+    // fleet whose projects have no sessions would then pay a tmux invocation per
+    // poll to learn nothing — more expensive than the per-project calls this
+    // replaced, for exactly the operators with the least going on.
+    await new Promise((r) => setImmediate(r));
+    assert.equal(calls.length, 0);
+  });
+
+  it('answers concurrent askers from ONE invocation, not one each', async () => {
+    const { execFn, calls } = stubExec({ stdout: 'alpha\n' });
+    const snap = tmux.createSessionNameSnapshot({ execFn });
+
+    // THE MUTATION THIS CATCHES: memoising the settled Set instead of the
+    // in-flight promise. Enrichment runs under `Promise.all`, so every caller
+    // would miss the cache before the first reply landed and spawn its own tmux
+    // — the per-project multiplication back again, behind a cache that looks
+    // like it works when called sequentially.
+    const results = await Promise.all([snap.get(), snap.get(), snap.get()]);
+
+    assert.equal(calls.length, 1);
+    for (const set of results) assert.ok(set.has('alpha'));
+  });
+
+  it('keeps a name containing the old field delimiter intact', async () => {
+    // `listSessions` asks for four `|`-joined fields and splits on `|`. A tmux
+    // session someone else created whose name contains a `|` splits early there,
+    // yielding a TRUNCATED name — which could collide with a real project's
+    // session and report it live. One field has nothing to split on.
+    const { execFn, calls } = stubExec({ stdout: 'we|rd\n' });
+    const names = await tmux.createSessionNameSnapshot({ execFn }).get();
+
+    assert.ok(names.has('we|rd'), 'the whole name must survive');
+    assert.ok(!names.has('we'), 'and must not be truncated into another name');
+    assert.ok(!calls[0].args.some((a) => a.includes('|')),
+      'asking for one field is what makes that true — a joined format brings the split back');
+  });
+
+  it('reads an unanswerable tmux as no live sessions, without rejecting', async () => {
+    // What `hasSession` already returns per name when tmux will not answer. The
+    // caller enriching a fleet must not have its whole list fail because tmux is
+    // down — that is the ordinary state of a machine with no sessions.
+    const { execFn } = stubExec({ err: Object.assign(new Error('no server running'), { code: 1 }) });
+    assert.equal((await tmux.createSessionNameSnapshot({ execFn }).get()).size, 0);
+  });
+
+  it('resolves empty when the listing times out, rather than hanging the caller', async () => {
+    // Driven by a REAL stalling `tmux`, not a stub: the subject is a timeout, and
+    // a stub asserts the author's model of a timeout rather than the timeout
+    // (#891/#894 — three hand-written versions of this check were all dead).
+    const os = require('node:os');
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-slow-tmux-snap-'));
+    fs.writeFileSync(path.join(binDir, 'tmux'), '#!/bin/sh\nsleep 30\n', { mode: 0o755 });
+    const realPath = process.env.PATH;
+    process.env.PATH = `${binDir}:${realPath}`;
+    try {
+      const names = await tmux.createSessionNameSnapshot({ timeout: 300 }).get();
+      assert.equal(names.size, 0,
+        'a wedged tmux reads as no live sessions — the same answer hasSession already gave');
+    } finally {
+      process.env.PATH = realPath;
+      fs.rmSync(binDir, { recursive: true, force: true });
+    }
+  });
+});
+
 describe('tmux', () => {
   describe('toSessionName', () => {
     it('should pass through valid names unchanged', () => {


### PR DESCRIPTION
## What

`enrichProject` ran two subprocesses **per project**, synchronously on the event loop, on the route the dashboard polls every ten seconds: `command -v <engine>` (2s cap) and `tmux has-session` (5s cap). Both answer a question about the **machine** — identical for every project asking — so the honest worst case scaled with fleet size while the server answered nothing at all on any route.

- **Session liveness** now comes from one `tmux list-sessions` snapshot shared across the list. Lazy, so a fleet with nothing running still spawns nothing; memoised on the in-flight **promise** rather than the settled value, because the callers run under `Promise.all` and caching the result lets every one of them miss before the first reply lands.
- **Engine detection** is cached 60s, keyed on *what was probed* rather than which engine asked, single-flight, with an async form for the poll.
- **Gates probe fresh.** `launchSession`, `ensureMasterSession` and `engineReadiness` all pass `{ fresh: true }` — a gate that remembers refuses to start a session for an engine you just installed, with no retry that helps. `tmux.hasSession` is untouched and still exact for the same reason: its callers kill, adopt and type into the session they ask about.
- **Three outcomes are never cached**, because none is an answer: a probe our own timeout killed, a probe that could not be started at all, and anything predating a cache clear — including a probe already running when "Check again" was pressed.

Neither call went through the scanner child. That child exists to survive operator-chosen paths under macOS TCC; these needed deduplication, not isolation.

## Why

Measured on the live 33-project fleet, one `listProjects()`, counting real `execSync`/`execFile` calls:

| | before | after |
|---|---|---|
| synchronous spawns blocking the event loop | **41** (33 × `command -v`, 8 × `tmux has-session`) | **0** |
| asynchronous spawns | 0 | 5 (4 distinct engines + 1 tmux) |

The enriched payload — engine availability and session state for all 33 projects — is **identical** before and after. Nothing now scales with project count.

This closes #884's chunk-02b acceptance criterion, which #884 recorded as unmet rather than rounding up.

## Test plan

- `node --test 'test/*.test.js'` — **5927 passed, 0 failed, 1 skipped** (5900 before any change).
- Tests assert **spawn counts**, which is the claim. Wall-clock passes with the defect fully intact: a healthy `command -v` costs a few milliseconds and the defect is that it happens thirty-three times.
- Every guard was driven by its named mutation — applied, watched go red, restored, baseline re-confirmed. Each mutation is recorded in the test that carries it under a `THE MUTATION THIS CATCHES` comment.
- Subprocess **failure-mode** guards are driven by real processes, not stubbed errors (a real stalling `tmux`, a real failed spawn), per the lesson in `lib/exec-timeout.js` — three hand-written timeout checks in this repo shipped dead because each asserted its author's model of an error shape.

## Review

Four Critic rounds; the last two returned zero findings. Composed coverage spans merge-base → HEAD with nothing unresolved. Independent PR review: 0 blocking, 0 warning, 1 note (a stale count in the build plan, fixed).

The blocking finding is the one worth reading: **a cache changes what every existing caller is told, not just the slow one.** Reviewers also caught a failed *spawn* being cached as the answer "not installed" — on a machine whose recorded failure mode is process exhaustion (#94/#144/#380), where every spawn fails at once, one fork failure would have blanked every engine for a minute.

## Known and deliberately unchanged

A tmux server too wedged to answer still reports every session as **dead** rather than **unknown** — the same "unknown presented as a fact" that #891 removed from git reads. Preserved exactly rather than changing two things at once, and filed as #900.

Fixes #890