### PR TITLE
Read a repository in three git invocations instead of seven (#895)

### DIFF
--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -26,6 +26,44 @@ Tag-line conventions (ART-4K9M, ratified 2026-07-17):
 -->
 
 
+## 2026-08-12: one repository read costs three git invocations, not seven (#895)
+
+<!-- prawduct: type=fix | scope=git-spawn-collapse-895 | chunks=01 | status=shipped -->
+
+**Why:** `_fetchInfo` ran seven `git` invocations to answer five questions, and #891 has to bound all
+seven under one budget that must also fit inside the scanner child's deadline. Measured on this
+repository, warm, reading the same directory both ways: **7 invocations / 165.3ms → 3 / 75.2ms**,
+every field identical.
+
+**What changed:** `status --porcelain=v1 --branch` answers is-it-a-repo, which branch, and dirtiness
+in one call; `log -1 --format=%s%n%cr` answers subject and age in another; `describe` is unchanged.
+Has-commits is read POSITIVELY off `status`'s `No commits yet on` marker, replacing a `rev-parse
+HEAD` probe whose FAILURE meant "no commits" — so a repository that failed it for any other reason
+stops being reported as empty, and an unborn repository reads in ONE invocation instead of four while
+reporting its real branch name where `rev-parse --abbrev-ref HEAD` failed and yielded `unknown`.
+
+**The issue's own design was a bug, and the fixture that proves it is in the suite.** It proposed
+folding `rev-parse --is-inside-work-tree` into `status`. Measured: with `.git/index` unreadable,
+`status` exits 128 while `--is-inside-work-tree` still answers `true` — so inferring not-a-repository
+from a failed `status` returns null for a broken-but-real repo, and `dir-scanner-child.js` decides a
+directory IS a project from `gitInfo && gitInfo.branch`. The project would vanish from the dashboard
+rather than lose a badge. That probe stays the authority and is merely deferred to the failure path.
+Two other edge cases the issue asked to handle turned out not to exist — a branch name cannot contain
+`...`, and `%s` is always one line — so guards were removed rather than written.
+
+**What the review caught across four rounds**, all three instances of one shape — a rule applied to
+the call site that prompted it rather than to the rule's own scope. A failed `status` was discarding
+four fields the seven-invocation read still established (neither `log` nor `describe` reads the
+index). An unborn HEAD can track an upstream — `git clone` of an empty repository prints `## No
+commits yet on main...origin/main` — and the unborn path took that verbatim as the branch badge. And
+the `cause` field added to tell a slow repository from a broken one was **inverted in production**:
+derived from the remaining budget, which every real caller keeps positive, so a `status` our own cap
+killed was reported as one git refused to read. It is decided at the throw now, from `wasTimedOut`.
+
+**Also:** the guard for that last one had driven `budgetMs: 0` — the one input production never
+supplies — so it passed against the bug. The lesson is recorded: name the real caller that produces
+a fixture's input, or the guard measures nothing.
+
 ## 2026-08-11: the project poll stops asking every project a question about the machine (#890)
 
 <!-- prawduct: type=fix | scope=enrichproject-spawns-890 | chunks=01,02 | status=shipped -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -463,6 +463,12 @@ All notable changes to TangleClaw are documented in this file.
 
 ### Fixed
 
+- **A brand-new project shows its real branch name instead of "unknown" (#895).** Reading a
+  repository with no commits yet used `git rev-parse --abbrev-ref HEAD`, which fails outright over an
+  unborn HEAD — so every freshly-created project reported its branch as `unknown` until its first
+  commit. `git status` names the branch there quite happily, and that is where the branch now comes
+  from.
+
 - **Checking which engines are installed no longer costs one probe per project (#890).** Enriching
   the project list ran `command -v claude` once per project, synchronously on the event loop, every
   ten seconds — asking separately, for each project, a question about the *machine* whose answer is
@@ -2004,6 +2010,27 @@ All notable changes to TangleClaw are documented in this file.
   nothing until a pattern that must hit does.**
 
 ### Internal
+
+- **Reading one repository's state costs three `git` invocations instead of seven (#895).**
+  `git status --porcelain=v1 --branch` answers is-it-a-repo, which branch, and whether the tree is
+  dirty in one call; `git log -1 --format=%s%n%cr` answers the last commit's subject and age in
+  another. **Measured on this repository, warm: 7 invocations / 165ms → 3 invocations / 75ms**, with
+  every field identical either way.
+
+  It also halves the worst case #891 bounded — the shared budget now has three places to stall
+  instead of seven — and drops a repository with no commits from four invocations to one.
+
+  **The issue's literal "collapse to three" would have been a bug, and the fixture that proves it is
+  in the suite.** With `.git/index` unreadable, `git status` fails while
+  `git rev-parse --is-inside-work-tree` still answers `true` — so inferring "not a repository" from a
+  failed `status` would make a broken-but-real project *vanish from the dashboard* rather than lose a
+  badge. That probe therefore stays as the authority on repository-or-not, just deferred to the
+  failure path, where the healthy read never pays for it. The honest cost: a directory that is not a
+  repository now takes two invocations instead of one.
+
+  Whether a repository has any commits is also read positively, off `status`'s `No commits yet on`
+  marker, replacing a `rev-parse HEAD` probe whose *failure* was treated as "no commits" — so a
+  repository that failed it for any other reason is no longer reported as empty.
 
 - **Build plan for #884, and a correction to what #884 says is broken.** The issue scopes the
   remaining event-loop hazard as "32 `existsSync` sites". Reading `enrichProject`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2032,6 +2032,18 @@ All notable changes to TangleClaw are documented in this file.
   marker, replacing a `rev-parse HEAD` probe whose *failure* was treated as "no commits" — so a
   repository that failed it for any other reason is no longer reported as empty.
 
+  **A repository whose `status` fails still reports everything else it can.** Neither the last
+  commit nor the latest tag needs the index, so a repository with an unreadable one keeps its branch,
+  subject, age and tag, and loses only its clean/dirty state — which comes back as *unknown* rather
+  than as *clean*. The seven-invocation read answered those fields too, and collapsing them to
+  unknown would have told you less than before, not more.
+
+  **The log now says which of three things went wrong**, because they call for different responses:
+  we stopped the read (slow repository), git ran and refused to read the repository (needs
+  repairing), or git answered in a shape TangleClaw does not recognise. Every short read previously
+  emitted one identical line, so the only one you could act on was indistinguishable from the two you
+  could not.
+
 - **Build plan for #884, and a correction to what #884 says is broken.** The issue scopes the
   remaining event-loop hazard as "32 `existsSync` sites". Reading `enrichProject`
   (`lib/projects.js`) rather than the issue shows it performs **five** distinct synchronous

--- a/lib/git.js
+++ b/lib/git.js
@@ -85,15 +85,22 @@ function _exec(command, cwd, timeout = PER_CALL_CAP_MS) {
  * @param {string[]} fields - Field names that were not established.
  * @returns {void}
  */
-function _reportIncomplete(dir, budgetMs, fields) {
+function _reportIncomplete(dir, budgetMs, fields, cause) {
   const key = cacheKeyFor(dir);
   const level = _warnedIncomplete.has(key) ? 'debug' : 'warn';
   _warnedIncomplete.add(key);
-  // Says what is true of every case: these fields were not established. The
-  // budget is the usual cause but not the only one — a `git status` that fails
-  // for its own reasons lands here too, and naming the budget would report a
-  // cause that did not happen.
-  log[level]('Git info incomplete — fields not established', { dir, budgetMs, fields });
+  // The message says what is true of every case — these fields were not
+  // established — because the budget is the usual cause but not the only one, and
+  // naming it unconditionally would report a cause that did not happen.
+  //
+  // `cause` distinguishes them, and it is the difference between a log an
+  // operator can act on and one they cannot. "The budget ran out" means a slow
+  // repository and suggests waiting; "git refused to read this repository" means
+  // a repository that needs repairing, and it is the only one of these an
+  // operator can actually fix. They were indistinguishable while every path
+  // emitted an identical line.
+  log[level]('Git info incomplete — fields not established',
+    { dir, budgetMs, fields, cause: cause || 'unknown' });
 }
 
 /**
@@ -163,16 +170,24 @@ function getInfo(dir, options = {}) {
  * refused outright. There is deliberately no guard for that case; it cannot occur.
  *
  * @param {string} output - Raw stdout from `git status --porcelain=v1 --branch`.
- * @returns {{ branch: string, dirty: boolean, hasCommits: boolean }}
+ * @returns {{ branch: string, dirty: boolean, hasCommits: boolean }|null} Null when
+ *   the output carries no `## ` header — see the caller for why that is treated
+ *   as "established nothing" rather than parsed optimistically.
  */
 function _parseStatus(output) {
   const lines = String(output || '').split('\n');
   const header = (lines[0] || '').trim();
+  // No header means this is not output from the command we asked for, and the
+  // dangerous part is that it still PARSES: zero further lines reads as a clean
+  // tree, so a repository would be reported definitely-clean on the strength of
+  // output nothing understood.
+  if (!header.startsWith('## ')) return null;
+
   // Anything after the header is a changed path. `_exec` trims, so a clean tree
   // is exactly one line.
   const dirty = lines.slice(1).some((line) => line.trim().length > 0);
 
-  const rest = header.startsWith('## ') ? header.slice(3) : header;
+  const rest = header.slice(3);
 
   // Detached: git says so in words. `'HEAD'` is what `rev-parse --abbrev-ref`
   // answered here before the collapse, and callers already read it that way.
@@ -181,16 +196,40 @@ function _parseStatus(output) {
   }
 
   // Unborn HEAD. The branch exists as a name even though nothing points at it.
-  const NO_COMMITS = 'No commits yet on ';
-  if (rest.startsWith(NO_COMMITS)) {
-    return { branch: rest.slice(NO_COMMITS.length).trim() || 'unknown', dirty, hasCommits: false };
+  //
+  // Older git says `Initial commit on <branch>` for the same state (renamed in
+  // 2.16). Both are matched because the cost is one array entry and the failure
+  // mode otherwise is a branch badge reading `Initial`.
+  for (const marker of ['No commits yet on ', 'Initial commit on ']) {
+    if (rest.startsWith(marker)) {
+      // Stripped the SAME way as the normal path. An unborn branch can track an
+      // upstream — clone an empty repository and git prints
+      // `## No commits yet on main...origin/main` — so taking the remainder
+      // verbatim would render that whole string as the branch, for exactly the
+      // brand-new project this change exists to name correctly.
+      return { branch: _branchFromRef(rest.slice(marker.length)), dirty, hasCommits: false };
+    }
   }
 
-  // `<branch>...<upstream>[ ahead/behind]`. The upstream and the divergence
-  // counts are deliberately dropped: nothing renders them, and parsing a field
-  // no one reads is a second thing to keep correct.
-  const branch = rest.split('...')[0].split(' ')[0].trim();
-  return { branch: branch || 'unknown', dirty, hasCommits: true };
+  return { branch: _branchFromRef(rest), dirty, hasCommits: true };
+}
+
+/**
+ * Take the branch name out of a `## ` line's ref portion.
+ *
+ * `<branch>...<upstream> [ahead 1, behind 2]` — the upstream and the divergence
+ * counts are deliberately dropped: nothing renders them, and parsing a field no
+ * one reads is a second thing to keep correct.
+ *
+ * Splitting on `...` is unambiguous because a branch name cannot contain it (see
+ * `_parseStatus`). Shared by the normal and unborn-HEAD paths so the two cannot
+ * drift — they did, and a clone of an empty repository was the case that showed it.
+ *
+ * @param {string} ref - The `## ` line with its marker prefix removed.
+ * @returns {string} The branch name, or `'unknown'` if there is nothing to take.
+ */
+function _branchFromRef(ref) {
+  return String(ref).split('...')[0].split(' ')[0].trim() || 'unknown';
 }
 
 /**
@@ -271,43 +310,86 @@ function _fetchInfo(dir, options = {}) {
   // merely unreadable — measured, exit 128 — while that same directory answers
   // `rev-parse --is-inside-work-tree` with `true`. So a failure sends us to that
   // probe to settle repository-or-not, rather than concluding it here.
-  const status = step('branch', null, (t) => exec('git status --porcelain=v1 --branch', dir, t));
+  // Keyed to `dirty`, the one field ONLY this invocation can answer. It also
+  // answers `branch`, but when it fails that field is recovered below — so
+  // keying it here would name `branch` unestablished in a reading that goes on to
+  // establish it, which is the same class of false statement as the reverse.
+  //
+  // Whether there was any budget LEFT when this ran is captured before it runs,
+  // because afterwards the two failures are indistinguishable: `step` records a
+  // skipped-for-budget field exactly as it records a git error, and the error
+  // itself dies in its catch.
+  const hadBudgetForStatus = endsAt - Date.now() > 0;
+  const status = step('dirty', null, (t) => exec('git status --porcelain=v1 --branch', dir, t));
 
-  if (!status.ok) {
-    // `status` did not answer. Ask the one question that decides whether this
-    // directory is a project at all — the SAME command that used to decide it,
-    // so this path's verdict is unchanged from before the collapse.
+  // Null when `status` ran but produced something this parser does not recognise
+  // — no `## ` header. Not reachable from a healthy git (the header is
+  // unconditional for a repository), and handled anyway because the alternative
+  // is the failure this whole module is built to avoid: with no header, the
+  // "changed paths" count is zero and the read would report a repository as
+  // CLEAN on the strength of output it could not understand.
+  const parsed = status.ok ? _parseStatus(status.value) : null;
+
+  let branch;
+  let dirty;
+  let hasCommits;
+  // Which of the three ways this read can go short actually happened. Carried to
+  // the log, because only one of them is something an operator can fix.
+  let cause = 'complete';
+
+  if (parsed) {
+    branch = parsed.branch;
+    dirty = parsed.dirty;
+    hasCommits = parsed.hasCommits;
+  } else {
+    // `status` did not answer, or did not answer in a shape we can read.
     //
-    // Its failure IS the answer: not a repository. Its success means we have a
-    // repository we could not read, which must come back as a partial reading
-    // and never as `null` — `lib/dir-scanner-child.js` derives whether a
-    // directory IS a project from `gitInfo && gitInfo.branch`, so `null` here
-    // would delete a broken project from the dashboard instead of costing it a
-    // badge.
-    const repo = step('branch', false, (t) => {
-      exec('git rev-parse --is-inside-work-tree', dir, t);
-      return true;
-    }, true);
-    if (repo.ok && repo.value !== true) return null;
+    // When it FAILED, ask the one question that decides whether this directory is
+    // a project at all — the SAME command that used to decide it, so this path's
+    // verdict is unchanged from before the collapse. Its failure IS the answer:
+    // not a repository. Its success means a repository we could not read, which
+    // must come back as a partial reading and never as `null` —
+    // `lib/dir-scanner-child.js` derives whether a directory IS a project from
+    // `gitInfo && gitInfo.branch`, so `null` here would delete a broken project
+    // from the dashboard instead of costing it a badge.
+    //
+    // When `status` SUCCEEDED but parsed to nothing, that question is already
+    // settled — only a repository answers it at all — so the probe is skipped.
+    if (!status.ok) {
+      const repo = step('branch', false, (t) => {
+        exec('git rev-parse --is-inside-work-tree', dir, t);
+        return true;
+      }, true);
+      if (repo.ok && repo.value !== true) return null;
+    }
 
-    // Either we could not look at all, or this is a repository we could not
-    // read. Both establish nothing, and this exit returns early, so it reports
-    // on its own way out rather than falling through to the shared report below.
-    const nothing = ['branch', 'dirty', 'lastCommit', 'lastCommitAge', 'latestTag'];
-    _reportIncomplete(dir, budgetMs, nothing);
-    return {
-      branch: 'unknown', dirty: null, lastCommit: '', lastCommitAge: '', latestTag: null,
-      incomplete: nothing
-    };
+    // A repository we could not `status`. It does NOT follow that we know
+    // nothing about it: `.git/index` being unreadable is the measured case, and
+    // neither `log` nor `describe` reads the index. Collapsing every field to
+    // unknown here would tell the operator strictly less than the read this
+    // replaced did, which is the one thing this change promised not to do — so
+    // the fields that are still answerable are still asked for, below.
+    //
+    // Only `dirty` is genuinely lost, because `status` is its only source, and it
+    // stays `null` rather than `false`: the dashboard draws it as a dot, so
+    // `false` would paint a repository in an unknown state as definitely clean.
+    // Three distinct ways to get here, and only the last is something an
+    // operator can act on: the budget was already gone, git ran and refused to
+    // read the repository, or git answered in a shape this parser does not know.
+    if (status.ok) cause = 'git-status-unparsed';
+    else if (!hadBudgetForStatus) cause = 'budget-exhausted';
+    else cause = 'git-refused-to-read-repository';
+    branch = step('branch', 'unknown',
+      (t) => exec('git rev-parse --abbrev-ref HEAD', dir, t), true).value;
+    dirty = null;
+    if (!incomplete.includes('dirty')) incomplete.push('dirty');
+    // Nothing told us whether there are commits, so let `log` answer by trying.
+    hasCommits = true;
+
+    // When the budget is what stopped `status`, every `step` above and below sees
+    // no remaining time, skips, and records its field — so a budget-exhausted
+    // read still costs nothing extra and still names everything.
   }
-
-  const parsed = _parseStatus(status.value);
-  // `dirty` follows `status`: it was established by the same invocation that
-  // established the branch, so it cannot be separately unknown here. When
-  // `status` did NOT run, the early return above already reports it as `null`
-  // rather than `false` — an unknown must never render as a clean repository.
-  const branch = parsed.branch;
-  const dirty = parsed.dirty;
 
   let lastCommit = '';
   let lastCommitAge = '';
@@ -318,7 +400,7 @@ function _fetchInfo(dir, options = {}) {
   // it for some other reason was reported as empty; a marker git prints on
   // purpose cannot be wrong that way. It also costs nothing: an unborn
   // repository now reads in ONE invocation rather than four.
-  if (parsed.hasCommits) {
+  if (hasCommits) {
     // Two fields in one invocation. `%s` is the subject and is always exactly one
     // line — git folds a multi-line first paragraph into it — so a two-line
     // format cannot be pulled out of alignment by a commit message.
@@ -347,7 +429,8 @@ function _fetchInfo(dir, options = {}) {
     // Per process rather than per interval: this runs in a child the supervisor
     // recreates, so the set dies with it and a genuinely new incident is loud
     // again without a timer to get wrong.
-    _reportIncomplete(dir, budgetMs, incomplete);
+    _reportIncomplete(dir, budgetMs, incomplete,
+      cause === 'complete' ? 'budget-exhausted' : cause);
   }
 
   return {

--- a/lib/git.js
+++ b/lib/git.js
@@ -83,6 +83,8 @@ function _exec(command, cwd, timeout = PER_CALL_CAP_MS) {
  * @param {string} dir - Directory the read was for.
  * @param {number} budgetMs - Budget the read was given.
  * @param {string[]} fields - Field names that were not established.
+ * @param {string} [cause] - Which of the ways a read goes short happened here:
+ *   `read-timed-out`, `git-refused-to-read-repository`, or `git-status-unparsed`.
  * @returns {void}
  */
 function _reportIncomplete(dir, budgetMs, fields, cause) {
@@ -397,9 +399,9 @@ function _fetchInfo(dir, options = {}) {
     // Nothing told us whether there are commits, so let `log` answer by trying.
     hasCommits = true;
 
-    // When the budget is what stopped `status`, every `step` above and below sees
-    // no remaining time, skips, and records its field — so a budget-exhausted
-    // read still costs nothing extra and still names everything.
+    // When time is what stopped `status`, every `step` above and below sees no
+    // remaining budget, skips, and records its field — so a read that ran out of
+    // time still costs nothing extra and still names everything.
   }
 
   let lastCommit = '';
@@ -424,10 +426,22 @@ function _fetchInfo(dir, options = {}) {
     } else {
       // One invocation, two fields: neither was established.
       if (!incomplete.includes('lastCommitAge')) incomplete.push('lastCommitAge');
+      // Same rule as `status` above, and for the same reason: WHY this went short
+      // is decided at the throw, never from where in the read it happened.
+      // Position is not evidence — reaching this line means there was budget when
+      // `log` started, which says nothing about whether the throw was our cap or
+      // git refusing.
+      if (cause === 'complete') {
+        cause = logged.weStopped ? 'read-timed-out' : 'git-refused-to-read-repository';
+      }
     }
-    // No tags is an answer, not a gap.
-    latestTag = step('latestTag', null,
-      (t) => exec('git describe --tags --abbrev=0', dir, t), true).value;
+    // No tags is an answer, not a gap — so only a stop puts this in `incomplete`.
+    const described = step('latestTag', null,
+      (t) => exec('git describe --tags --abbrev=0', dir, t), true);
+    latestTag = described.value;
+    if (!described.ok && cause === 'complete') {
+      cause = described.weStopped ? 'read-timed-out' : 'git-refused-to-read-repository';
+    }
   }
 
   if (incomplete.length > 0) {
@@ -440,11 +454,7 @@ function _fetchInfo(dir, options = {}) {
     // Per process rather than per interval: this runs in a child the supervisor
     // recreates, so the set dies with it and a genuinely new incident is loud
     // again without a timer to get wrong.
-    // `complete` here means `status` itself answered, so whatever went short did
-    // so further down — a `log` or `describe` we stopped or that failed. Those
-    // are only reached with budget left, so time is what ran out.
-    _reportIncomplete(dir, budgetMs, incomplete,
-      cause === 'complete' ? 'read-timed-out' : cause);
+    _reportIncomplete(dir, budgetMs, incomplete, cause);
   }
 
   return {

--- a/lib/git.js
+++ b/lib/git.js
@@ -28,20 +28,23 @@ const PER_CALL_CAP_MS = 5000;
 /**
  * How long ALL of one directory's git work gets, in total.
  *
- * Reading a repository takes seven `git` invocations (see `_fetchInfo`). Capping
- * each of them separately meant the honest worst case was seven times the cap —
- * ~35s — while the scan deadline that kills the child process sits at 5s. A
- * repository whose git work merely stalled was therefore killed and reported to
- * the operator as a Full Disk Access problem, which it was not; and because the
- * kill discards this module's cache, the retry after the backoff was equally
- * cold and did it again.
+ * Reading a repository takes three `git` invocations (see `_fetchInfo`). Capping
+ * each of them separately meant the honest worst case was a multiple of the cap,
+ * while the scan deadline that kills the child process sits at 5s. A repository
+ * whose git work merely stalled was therefore killed and reported to the operator
+ * as a Full Disk Access problem, which it was not; and because the kill discards
+ * this module's cache, the retry after the backoff was equally cold and did it
+ * again.
  *
  * 4000ms is not a guess at how slow git can be. It is chosen so that this budget
  * plus the small root-level file reads that share the same deadline still fits
  * INSIDE that deadline (`lib/project-facts.js` derives the deadline from this
- * constant, so the two cannot drift apart). Measured against this repository —
- * 949 commits, 400 tracked files, warm — all seven invocations cost 85ms
- * together, so the budget carries roughly a 47x margin over a healthy read.
+ * constant, so the two cannot drift apart). The margin over a healthy read is
+ * large — a warm read of this repository costs tens of milliseconds against a
+ * 4000ms budget — and it grew when the read went from seven invocations to three,
+ * because there are fewer places for it to stall. Re-measure rather than trusting
+ * a figure quoted here; the one that used to sit in this sentence described a
+ * seven-invocation read that no longer exists.
  *
  * A repository that genuinely needs longer returns a PARTIAL reading naming what
  * it could not establish, which is the point: a slow repository should cost a
@@ -136,6 +139,61 @@ function getInfo(dir, options = {}) {
 }
 
 /**
+ * Read branch, dirtiness and has-commits out of one `status` output.
+ *
+ * Every shape below was measured against real fixture repositories rather than
+ * recalled, because this parser is the whole reason three invocations can replace
+ * seven. `git status --porcelain=v1 --branch` prints a `## ` header line and then
+ * one line per changed path:
+ *
+ *   `## main`                      — clean or dirty, no upstream
+ *   `## main...origin/main`        — tracking
+ *   `## main...origin/main [ahead 1]` — tracking, diverged
+ *   `## HEAD (no branch)`          — detached
+ *   `## No commits yet on main`    — unborn HEAD, and it EXITS 0
+ *
+ * Two of those are worth stating because they remove guards rather than add them:
+ *
+ * An unborn HEAD does not fail. `rev-parse --abbrev-ref HEAD` does fail there, and
+ * the code this replaced answered `'unknown'` for every freshly-initialised
+ * repository; git names the branch here, so the honest answer is available.
+ *
+ * Splitting on `...` is unambiguous, because a branch name cannot contain it —
+ * git's refname rules forbid `..` anywhere, and `git branch 'has...dots'` is
+ * refused outright. There is deliberately no guard for that case; it cannot occur.
+ *
+ * @param {string} output - Raw stdout from `git status --porcelain=v1 --branch`.
+ * @returns {{ branch: string, dirty: boolean, hasCommits: boolean }}
+ */
+function _parseStatus(output) {
+  const lines = String(output || '').split('\n');
+  const header = (lines[0] || '').trim();
+  // Anything after the header is a changed path. `_exec` trims, so a clean tree
+  // is exactly one line.
+  const dirty = lines.slice(1).some((line) => line.trim().length > 0);
+
+  const rest = header.startsWith('## ') ? header.slice(3) : header;
+
+  // Detached: git says so in words. `'HEAD'` is what `rev-parse --abbrev-ref`
+  // answered here before the collapse, and callers already read it that way.
+  if (rest.startsWith('HEAD (no branch)')) {
+    return { branch: 'HEAD', dirty, hasCommits: true };
+  }
+
+  // Unborn HEAD. The branch exists as a name even though nothing points at it.
+  const NO_COMMITS = 'No commits yet on ';
+  if (rest.startsWith(NO_COMMITS)) {
+    return { branch: rest.slice(NO_COMMITS.length).trim() || 'unknown', dirty, hasCommits: false };
+  }
+
+  // `<branch>...<upstream>[ ahead/behind]`. The upstream and the divergence
+  // counts are deliberately dropped: nothing renders them, and parsing a field
+  // no one reads is a second thing to keep correct.
+  const branch = rest.split('...')[0].split(' ')[0].trim();
+  return { branch: branch || 'unknown', dirty, hasCommits: true };
+}
+
+/**
  * Fetch git info without caching, bounded by ONE budget across every spawn.
  *
  * Returns `null` only when the directory is genuinely not a repository. A
@@ -153,10 +211,15 @@ function getInfo(dir, options = {}) {
  * @param {string} dir - Project directory path
  * @param {object} [options] - Read options.
  * @param {number} [options.budgetMs] - Total wall clock for all git work here.
+ * @param {Function} [options.execFn] - Injected `_exec`. The point of this change
+ *   is HOW MANY invocations happen, and a count cannot be observed from the
+ *   outside — the answers are identical either way, which is the whole claim.
+ *   Same seam, same name, as `lib/tmux.js` and `lib/engines.js`.
  * @returns {{ branch: string, dirty: boolean|null, lastCommit: string, lastCommitAge: string, latestTag: string|null, incomplete: string[] }|null}
  */
 function _fetchInfo(dir, options = {}) {
   const budgetMs = Number.isFinite(options.budgetMs) ? options.budgetMs : GIT_INFO_BUDGET_MS;
+  const exec = options.execFn || _exec;
   const endsAt = Date.now() + budgetMs;
   const incomplete = [];
 
@@ -199,20 +262,37 @@ function _fetchInfo(dir, options = {}) {
     }
   };
 
-  // Whether this is a repository at all is answered first and separately: every
-  // field below is meaningless without it, and it is the cheapest of the seven.
-  // A git-side failure here IS the answer — this is not a repository.
-  const repo = step('branch', false, (t) => {
-    _exec('git rev-parse --is-inside-work-tree', dir, t);
-    return true;
-  }, true);
-  if (!repo.ok) {
-    // We could not look. That is NOT "not a repository", and it must not be
-    // cached as one — `incomplete` is what tells `getInfo` to leave it out.
+  // ONE invocation answers three questions: is this a repository, what branch is
+  // it on, and is the tree dirty. `--porcelain=v1` fixes the format across git
+  // versions; `--branch` adds the leading `## ` line.
+  //
+  // A git-side failure is NOT an answer here, which is the difference from the
+  // probe this replaced. `status` fails on a repository whose `.git/index` is
+  // merely unreadable — measured, exit 128 — while that same directory answers
+  // `rev-parse --is-inside-work-tree` with `true`. So a failure sends us to that
+  // probe to settle repository-or-not, rather than concluding it here.
+  const status = step('branch', null, (t) => exec('git status --porcelain=v1 --branch', dir, t));
+
+  if (!status.ok) {
+    // `status` did not answer. Ask the one question that decides whether this
+    // directory is a project at all — the SAME command that used to decide it,
+    // so this path's verdict is unchanged from before the collapse.
     //
-    // This exit establishes NOTHING, which makes it the one that most needs to
-    // say so: it returns early, so it has to report on its own way out rather
-    // than falling through to the shared report below.
+    // Its failure IS the answer: not a repository. Its success means we have a
+    // repository we could not read, which must come back as a partial reading
+    // and never as `null` — `lib/dir-scanner-child.js` derives whether a
+    // directory IS a project from `gitInfo && gitInfo.branch`, so `null` here
+    // would delete a broken project from the dashboard instead of costing it a
+    // badge.
+    const repo = step('branch', false, (t) => {
+      exec('git rev-parse --is-inside-work-tree', dir, t);
+      return true;
+    }, true);
+    if (repo.ok && repo.value !== true) return null;
+
+    // Either we could not look at all, or this is a repository we could not
+    // read. Both establish nothing, and this exit returns early, so it reports
+    // on its own way out rather than falling through to the shared report below.
     const nothing = ['branch', 'dirty', 'lastCommit', 'lastCommitAge', 'latestTag'];
     _reportIncomplete(dir, budgetMs, nothing);
     return {
@@ -220,51 +300,41 @@ function _fetchInfo(dir, options = {}) {
       incomplete: nothing
     };
   }
-  if (repo.value !== true) return null;
 
-  // A git-side failure IS an answer here, and `'unknown'` is the honest one:
-  // `rev-parse --abbrev-ref HEAD` cannot name a branch over an unborn HEAD, so a
-  // freshly-initialised repository fails it as a matter of course. Marking that
-  // unestablished would leave every brand-new project permanently partial —
-  // never cached, re-spawning git on every poll, for a state that is normal.
-  //
-  // `'unknown'` is safe to treat this way because it SAYS it is unknown. That is
-  // exactly what separates it from `dirty` below, where the only available
-  // fallback is a plausible lie.
-  const branch = step('branch', 'unknown',
-    (t) => _exec('git rev-parse --abbrev-ref HEAD', dir, t), true);
-  // Any failure at all leaves us not knowing, so no `errorIsAnswer` here: a
-  // `git status` that errors for its own reasons still must not render as clean.
-  const dirty = step('dirty', null,
-    (t) => _exec('git status --porcelain', dir, t).length > 0);
-
-  // Whether the repository has any commits at all, before asking log/describe
-  // about them. A repository with NO commits is a real answer — `git rev-parse
-  // HEAD` fails there and empty message/age/tag are the truth about it — while a
-  // probe the budget cut short is not, and it fails the same way. `ok` separates
-  // them; reading the returned value alone reported every freshly-initialised
-  // repository as unestablished.
-  const head = step('lastCommit', false, (t) => {
-    _exec('git rev-parse HEAD', dir, t);
-    return true;
-  }, true);
+  const parsed = _parseStatus(status.value);
+  // `dirty` follows `status`: it was established by the same invocation that
+  // established the branch, so it cannot be separately unknown here. When
+  // `status` did NOT run, the early return above already reports it as `null`
+  // rather than `false` — an unknown must never render as a clean repository.
+  const branch = parsed.branch;
+  const dirty = parsed.dirty;
 
   let lastCommit = '';
   let lastCommitAge = '';
   let latestTag = null;
-  if (head.ok && head.value === true) {
-    lastCommit = step('lastCommit', '', (t) => _exec('git log -1 --format=%s', dir, t)).value;
-    lastCommitAge = step('lastCommitAge', '', (t) => _exec('git log -1 --format=%cr', dir, t)).value;
+  // Whether the repository has any commits is now read POSITIVELY, off the `## `
+  // line, instead of being inferred from a failing `rev-parse HEAD`. That probe
+  // treated ANY non-timeout failure as "no commits", so a repository that failed
+  // it for some other reason was reported as empty; a marker git prints on
+  // purpose cannot be wrong that way. It also costs nothing: an unborn
+  // repository now reads in ONE invocation rather than four.
+  if (parsed.hasCommits) {
+    // Two fields in one invocation. `%s` is the subject and is always exactly one
+    // line — git folds a multi-line first paragraph into it — so a two-line
+    // format cannot be pulled out of alignment by a commit message.
+    const logged = step('lastCommit', null,
+      (t) => exec('git log -1 --format=%s%n%cr', dir, t));
+    if (logged.ok) {
+      const lines = String(logged.value).split('\n');
+      lastCommit = (lines[0] || '').trim();
+      lastCommitAge = (lines[1] || '').trim();
+    } else {
+      // One invocation, two fields: neither was established.
+      if (!incomplete.includes('lastCommitAge')) incomplete.push('lastCommitAge');
+    }
     // No tags is an answer, not a gap.
     latestTag = step('latestTag', null,
-      (t) => _exec('git describe --tags --abbrev=0', dir, t), true).value;
-  } else if (!head.ok) {
-    // The probe was skipped or killed, so nothing downstream of it was even
-    // attempted. Say so for each field rather than letting three empty values
-    // pass for "this repository has no commits".
-    for (const field of ['lastCommitAge', 'latestTag']) {
-      if (!incomplete.includes(field)) incomplete.push(field);
-    }
+      (t) => exec('git describe --tags --abbrev=0', dir, t), true).value;
   }
 
   if (incomplete.length > 0) {
@@ -281,8 +351,8 @@ function _fetchInfo(dir, options = {}) {
   }
 
   return {
-    branch: branch.value,
-    dirty: dirty.value,
+    branch,
+    dirty,
     lastCommit,
     lastCommitAge,
     latestTag,

--- a/lib/git.js
+++ b/lib/git.js
@@ -282,22 +282,32 @@ function _fetchInfo(dir, options = {}) {
    *   answer. True for the three probes whose failure is informative — not a
    *   repository, no commits, no tags — where the fallback stands as fact. False
    *   everywhere else, because "git errored" tells us nothing about the value.
-   * @returns {{ok: boolean, value: *}} `ok` is the single source of truth for
-   *   whether this field was established; every caller branches on it and none
-   *   re-derives it from the value, the array, or a length snapshot.
+   * @returns {{ok: boolean, value: *, weStopped: boolean}} `ok` is the single
+   *   source of truth for whether this field was established; every caller
+   *   branches on it and none re-derives it from the value, the array, or a
+   *   length snapshot. `weStopped` distinguishes the two ways `ok` can be false:
+   *   WE ran out of time (skipped for want of budget, or killed at the cap)
+   *   versus git ran and refused. They are indistinguishable afterwards — the
+   *   error dies in this catch — so the difference has to be recorded here, at
+   *   the throw, and it is the only thing that lets the log tell a slow
+   *   repository from a broken one.
    */
   const step = (field, fallback, run, errorIsAnswer = false) => {
     const remaining = endsAt - Date.now();
     if (remaining <= 0) {
       incomplete.push(field);
-      return { ok: false, value: fallback };
+      return { ok: false, value: fallback, weStopped: true };
     }
     try {
-      return { ok: true, value: run(Math.min(PER_CALL_CAP_MS, remaining)) };
+      return { ok: true, value: run(Math.min(PER_CALL_CAP_MS, remaining)), weStopped: false };
     } catch (err) {
-      if (errorIsAnswer && !wasTimedOut(err)) return { ok: true, value: fallback };
+      // `wasTimedOut`, not a comparison against the budget: a cap-kill and a
+      // git-side refusal both arrive here as a throw, and only this predicate
+      // separates them (#894 exists because three hand-written versions did not).
+      const weStopped = wasTimedOut(err);
+      if (errorIsAnswer && !weStopped) return { ok: true, value: fallback, weStopped: false };
       incomplete.push(field);
-      return { ok: false, value: fallback };
+      return { ok: false, value: fallback, weStopped };
     }
   };
 
@@ -314,12 +324,6 @@ function _fetchInfo(dir, options = {}) {
   // answers `branch`, but when it fails that field is recovered below — so
   // keying it here would name `branch` unestablished in a reading that goes on to
   // establish it, which is the same class of false statement as the reverse.
-  //
-  // Whether there was any budget LEFT when this ran is captured before it runs,
-  // because afterwards the two failures are indistinguishable: `step` records a
-  // skipped-for-budget field exactly as it records a git error, and the error
-  // itself dies in its catch.
-  const hadBudgetForStatus = endsAt - Date.now() > 0;
   const status = step('dirty', null, (t) => exec('git status --porcelain=v1 --branch', dir, t));
 
   // Null when `status` ran but produced something this parser does not recognise
@@ -373,11 +377,18 @@ function _fetchInfo(dir, options = {}) {
     // Only `dirty` is genuinely lost, because `status` is its only source, and it
     // stays `null` rather than `false`: the dashboard draws it as a dot, so
     // `false` would paint a repository in an unknown state as definitely clean.
-    // Three distinct ways to get here, and only the last is something an
-    // operator can act on: the budget was already gone, git ran and refused to
-    // read the repository, or git answered in a shape this parser does not know.
+    // Three distinct ways to get here, and they call for different responses:
+    // WE stopped the read (no budget left, or our cap killed a slow `status`),
+    // git ran and refused to read the repository, or git answered in a shape
+    // this parser does not know.
+    //
+    // Taken from `weStopped`, which is decided at the throw. Deriving it here
+    // from the remaining budget was wrong in the direction that matters: every
+    // production caller passes a positive budget, so that test could only ever
+    // say "git refused" — including for the slow repository #891 exists for,
+    // sending the operator to repair a repository that is merely slow.
     if (status.ok) cause = 'git-status-unparsed';
-    else if (!hadBudgetForStatus) cause = 'budget-exhausted';
+    else if (status.weStopped) cause = 'read-timed-out';
     else cause = 'git-refused-to-read-repository';
     branch = step('branch', 'unknown',
       (t) => exec('git rev-parse --abbrev-ref HEAD', dir, t), true).value;
@@ -429,8 +440,11 @@ function _fetchInfo(dir, options = {}) {
     // Per process rather than per interval: this runs in a child the supervisor
     // recreates, so the set dies with it and a genuinely new incident is loud
     // again without a timer to get wrong.
+    // `complete` here means `status` itself answered, so whatever went short did
+    // so further down — a `log` or `describe` we stopped or that failed. Those
+    // are only reached with budget left, so time is what ran out.
     _reportIncomplete(dir, budgetMs, incomplete,
-      cause === 'complete' ? 'budget-exhausted' : cause);
+      cause === 'complete' ? 'read-timed-out' : cause);
   }
 
   return {
@@ -439,8 +453,11 @@ function _fetchInfo(dir, options = {}) {
     lastCommit,
     lastCommitAge,
     latestTag,
-    // De-duplicated: the has-commits probe and the message read share a field
-    // name, so a budget that dies on the probe would otherwise name it twice.
+    // De-duplicated, and still load-bearing for a different reason than it once
+    // was. The has-commits probe that used to share a field name with the message
+    // read is gone; what shares one now is `branch`, pushed by the is-a-repo
+    // probe and again by the `--abbrev-ref` recovery beside it when a read has no
+    // budget left for either.
     incomplete: [...new Set(incomplete)]
   };
 }

--- a/lib/project-facts.js
+++ b/lib/project-facts.js
@@ -45,8 +45,9 @@ const FILE_WORK_MARGIN_MS = 1000;
  *
  * DERIVED, NOT CHOSEN. The handler's dominant cost is `git.getInfo`, and this
  * deadline used to be a literal 5000 sitting beside a git read whose honest
- * worst case was ~35s — seven `execSync` spawns each independently capped at
- * five seconds. A repository that merely stalled was therefore killed and
+ * worst case was ~35s — seven `execSync` spawns, as it was then, each
+ * independently capped at five seconds. A repository that merely stalled was
+ * therefore killed and
  * reported to the operator as a Full Disk Access problem it did not have, and
  * the kill discarded git's cache so the retry was equally cold (#891).
  *

--- a/lib/project-facts.js
+++ b/lib/project-facts.js
@@ -45,11 +45,11 @@ const FILE_WORK_MARGIN_MS = 1000;
  *
  * DERIVED, NOT CHOSEN. The handler's dominant cost is `git.getInfo`, and this
  * deadline used to be a literal 5000 sitting beside a git read whose honest
- * worst case was ~35s — seven `execSync` spawns, as it was then, each
+ * worst case was ~35s — seven `execSync` spawns, as the read was then, each
  * independently capped at five seconds. A repository that merely stalled was
- * therefore killed and
- * reported to the operator as a Full Disk Access problem it did not have, and
- * the kill discarded git's cache so the retry was equally cold (#891).
+ * therefore killed and reported to the operator as a Full Disk Access problem it
+ * did not have, and the kill discarded git's cache so the retry was equally cold
+ * (#891).
  *
  * Two numbers that must agree and are maintained separately drift, so this one
  * is computed from the budget it contains. Raising `GIT_INFO_BUDGET_MS` moves

--- a/lib/projects.js
+++ b/lib/projects.js
@@ -953,7 +953,7 @@ async function listProjects(options = {}) {
   //
   // ISSUED ONE AT A TIME, and that is a correctness requirement rather than a
   // throttle. The child is single-threaded and each `projectFacts` now performs
-  // `git.getInfo` — seven `execSync` spawns under one shared budget — plus a
+  // `git.getInfo` — several `execSync` spawns under one shared budget — plus a
   // governance read and a config parse, all synchronous in that process. Firing N requests in one tick
   // put N deadlines on a SERIAL queue, and `dir-scanner.js` starts each timer
   // when the request is ISSUED, not when the child picks it up. The tail of a

--- a/test/git-budget.test.js
+++ b/test/git-budget.test.js
@@ -44,13 +44,13 @@ let realPath = null;
 /**
  * Put a `git` that stalls on chosen subcommands at the front of PATH.
  *
- * It exits 0 with empty stdout otherwise, which is enough: these tests assert on
- * WHICH fields the budget establishes and how long the whole read takes, never
- * on git's output.
+ * A subcommand it does not stall exits 0, and `status` answers with a parseable
+ * `## main` — see the body for why an empty answer there silently disarmed every
+ * guard downstream of it.
  *
- * Patterns are shell globs matched against the WHOLE argument list, not just the
- * subcommand, because the two `rev-parse` calls have to be told apart: the
- * is-a-repo probe and the has-commits probe share `$1`.
+ * Patterns are shell globs matched against the WHOLE argument list rather than
+ * the subcommand alone, so calls sharing a `$1` can be told apart — `rev-parse`
+ * backs both the is-a-repo probe and the branch recovery beside it.
  *
  * @param {string[]|null} stallOn - Globs to stall on (`null` = every invocation).
  * @returns {void}
@@ -135,6 +135,38 @@ describe('git info budget (#891)', () => {
 
       assert.ok(info.incomplete.includes('dirty'),
         'a field whose spawn was killed by the cap must be named unestablished');
+    });
+
+    it('calls a repository we STOPPED slow, not broken', () => {
+      // The distinction an operator acts on. A `status` our own cap killed means
+      // a SLOW repository — #891's entire scenario — and the remedy is patience
+      // or a bigger budget. A `status` git ran and refused means a repository
+      // that needs repairing. They arrive identically: both are a throw.
+      //
+      // THE MUTATION THIS CATCHES: deriving the cause from the remaining budget
+      // instead of from `weStopped` at the throw. Every production caller passes
+      // a positive budget, so that version could only ever say "git refused" —
+      // and would send an operator to repair a healthy repository. A test using
+      // `budgetMs: 0` passes against that bug, because zero is the one input
+      // production never supplies; this one uses a real stalling `git` under a
+      // budget production actually uses.
+      const { setConsoleStream, setLevel } = require('../lib/logger');
+      const lines = [];
+      setConsoleStream({ write: (s) => lines.push(s) });
+      setLevel('debug');
+      try {
+        shadowGit(['status*']);
+        git._fetchInfo(REPO_ROOT, { budgetMs: 1500 });
+      } finally {
+        setConsoleStream(null);
+        setLevel('info');
+      }
+
+      const joined = lines.join('\n');
+      assert.match(joined, /read-timed-out/,
+        'a status WE killed is a slow repository, and must be reported as one');
+      assert.doesNotMatch(joined, /git-refused-to-read-repository/,
+        'and must never be reported as a repository git refused to read');
     });
 
     it('marks BOTH fields of a killed two-field read, not just the one it names', () => {

--- a/test/git-budget.test.js
+++ b/test/git-budget.test.js
@@ -86,7 +86,7 @@ describe('git info budget (#891)', () => {
   });
 
   describe('the budget bounds the whole read, not each spawn', () => {
-    it('stops near its budget instead of paying the per-call cap seven times', () => {
+    it('stops near its budget instead of paying the per-call cap once per spawn', () => {
       shadowGit(null);
       const startedAt = Date.now();
       const info = git._fetchInfo(REPO_ROOT, { budgetMs: 1000 });
@@ -126,23 +126,39 @@ describe('git info budget (#891)', () => {
         'a field whose spawn was killed by the cap must be named unestablished');
     });
 
-    it('marks everything downstream of a killed has-commits probe, not just the probe', () => {
-      // `git rev-parse HEAD` failing means "no commits" — a real answer, whose
-      // empty message/age/tag are the truth. The same call being KILLED means we
-      // never found out, and it fails identically. Only the step's `ok` separates
-      // them; inferring from the returned value silently let a killed probe pass
-      // for an empty repository, leaving lastCommitAge and latestTag reported as
-      // established when nothing had looked at them.
+    it('marks BOTH fields of a killed two-field read, not just the one it names', () => {
+      // THE CONTRACT THIS HAS ALWAYS PROTECTED, unchanged: a step the cap KILLED
+      // establishes nothing, and every field that step would have answered must
+      // be named — never left reporting its empty fallback as though something
+      // had looked.
       //
-      // Stalls on the has-commits probe alone — matched on the full argument list
-      // because it shares `$1` with the is-a-repo probe that must stay fast.
-      shadowGit(['rev-parse HEAD']);
+      // WHAT MOVED, and why this test was rewritten rather than deleted (#895):
+      // it used to stall `git rev-parse HEAD`, the separate has-commits probe.
+      // That probe is gone — has-commits is now read off `status`'s `## No
+      // commits yet on …` marker, which is free and cannot be killed on its own —
+      // so shadowing `rev-parse HEAD` now stalls a command nobody runs, and the
+      // test passed for a mechanism that no longer exists.
+      //
+      // The same hazard lives on the invocation that replaced it: `log -1
+      // --format=%s%n%cr` answers lastCommit AND lastCommitAge together, so a
+      // kill there must name both. Naming only the field the step is keyed under
+      // would leave the other reporting `''` as an established answer — the exact
+      // shape #891 removed.
+      //
+      // `latestTag` is deliberately NOT asserted here any more: `describe` is its
+      // own invocation and still runs, so it is genuinely established. Under the
+      // old shape it was unestablished only because the dead gate probe stopped
+      // it being attempted at all. That is a strictly more honest answer, not a
+      // weakened assertion.
+      shadowGit(['log*']);
       const info = git._fetchInfo(REPO_ROOT, { budgetMs: 3000 });
 
-      for (const field of ['lastCommit', 'lastCommitAge', 'latestTag']) {
+      for (const field of ['lastCommit', 'lastCommitAge']) {
         assert.ok(info.incomplete.includes(field),
-          `${field} sits downstream of a probe that was killed, so it was never established`);
+          `${field} was to be answered by a step that was killed, so it was never established`);
       }
+      assert.equal(info.lastCommit, '', 'and its value stays empty rather than half-parsed');
+      assert.equal(info.lastCommitAge, '');
     });
   });
 

--- a/test/git-budget.test.js
+++ b/test/git-budget.test.js
@@ -60,10 +60,21 @@ function shadowGit(stallOn) {
   // Spaces escaped rather than quoted: a quoted case pattern is literal, and
   // these need to stay globs so `status*` matches its flags.
   const patterns = stallOn && stallOn.map((g) => g.replace(/ /g, '\\ ')).join('|');
-  const body = stallOn === null
+  const stall = stallOn === null
     ? `sleep ${STALL_SECONDS}\n`
     : `case "$*" in\n  ${patterns}) sleep ${STALL_SECONDS} ;;\nesac\n`;
-  fs.writeFileSync(path.join(fakeBinDir, 'git'), `#!/bin/sh\n${body}exit 0\n`, { mode: 0o755 });
+  // A `status` this fake does not stall must answer PARSEABLY, or every read
+  // stops at the first step and the later ones are never reached.
+  //
+  // This is not cosmetic. `_fetchInfo` now takes branch, dirtiness and
+  // has-commits from one `status`, and treats output it cannot parse as
+  // "established nothing" — so a fake that answered `status` with empty stdout
+  // made every downstream assertion pass off an early return, with the command
+  // under test never invoked. The `log*` guard below was exactly that shape:
+  // green, and measuring nothing. A stall guard has to reach the step it stalls.
+  const answer = 'case "$*" in\n  status*) echo "## main" ;;\nesac\n';
+  fs.writeFileSync(path.join(fakeBinDir, 'git'),
+    `#!/bin/sh\n${stall}${answer}exit 0\n`, { mode: 0o755 });
   realPath = process.env.PATH;
   process.env.PATH = `${fakeBinDir}:${realPath}`;
 }

--- a/test/git-budget.test.js
+++ b/test/git-budget.test.js
@@ -104,8 +104,11 @@ describe('git info budget (#891)', () => {
       const elapsed = Date.now() - startedAt;
 
       assert.ok(info !== null, 'a repository whose git work stalls is still a repository');
-      // The assertion that matters is "nowhere near seven caps" (35s), not a
-      // precise number — a loaded CI box is allowed to be late.
+      // The assertion that matters is "nowhere near one cap per spawn", not a
+      // precise number — a loaded CI box is allowed to be late. Stated as the
+      // shape rather than as an arithmetic product, because the product moved
+      // when the read went from seven invocations to three and this comment did
+      // not notice.
       assert.ok(elapsed < 5000, `expected the read to stop near its budget, took ${elapsed}ms`);
     });
 

--- a/test/git.test.js
+++ b/test/git.test.js
@@ -207,10 +207,103 @@ describe('git', () => {
       const info = git._fetchInfo(dir);
 
       assert.ok(info !== null, 'a repository we cannot read is still a repository');
-      assert.equal(info.branch, 'unknown');
       assert.equal(info.dirty, null, 'unknown dirtiness must never render as clean');
-      assert.ok(info.incomplete.includes('branch'), 'and it must say what it could not establish');
-      assert.ok(info.incomplete.includes('dirty'));
+      assert.ok(info.incomplete.includes('dirty'), 'and it must say what it could not establish');
+      // The branch is NOT asserted unknown here: `.git/index` is what `status`
+      // could not read, and naming the branch does not need the index, so the
+      // read recovers it. `incomplete` must therefore NOT claim it is missing —
+      // a field reported unestablished while carrying a real value is the same
+      // class of false statement as the reverse, and both mislead #885's badge.
+      assert.equal(info.branch, 'main');
+      assert.ok(!info.incomplete.includes('branch'),
+        'a field this read established must not be named unestablished');
+    });
+
+    it('names the branch of a CLONE of an empty repository, not the whole header', () => {
+      // The case the shape table missed: an unborn HEAD can still track an
+      // upstream. `git clone` of an empty repository prints
+      // `## No commits yet on main...origin/main`, and taking the remainder of
+      // that marker verbatim renders the entire string as the branch badge — for
+      // precisely the brand-new project whose branch name this change exists to
+      // report correctly.
+      //
+      // THE MUTATION THIS CATCHES: stripping the upstream on the normal path but
+      // not on the unborn-HEAD path. Both paths now go through one helper, so
+      // there is no second place for it to be forgotten.
+      const remote = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-git-emptyremote-'));
+      made.push(remote);
+      execSync('git init --template= -q -b main --bare', { cwd: remote, stdio: 'pipe' });
+
+      const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-git-emptyclone-'));
+      made.push(parent);
+      execSync(`git clone -q ${JSON.stringify(remote)} cloned`, { cwd: parent, stdio: 'pipe' });
+      const dir = path.join(parent, 'cloned');
+
+      const info = git._fetchInfo(dir);
+      assert.ok(info !== null);
+      assert.equal(info.branch, 'main',
+        `expected the branch alone, got ${JSON.stringify(info.branch)}`);
+      assert.equal(info.lastCommit, '');
+    });
+
+    it('still answers what it CAN when status fails on a real repository', () => {
+      // `.git/index` unreadable: `status` fails, but neither `log` nor `describe`
+      // reads the index, so the subject, the age and the tag are all still
+      // answerable — and the seven-invocation read did answer them. Collapsing
+      // them to unknown would tell the operator strictly less than before, which
+      // is the one thing this change promised not to do.
+      //
+      // THE MUTATION THIS CATCHES: early-returning an all-unknown reading as soon
+      // as `status` fails. Every assertion below flips at once.
+      const dir = repo('degraded', [
+        'echo a > a.txt', 'git add a.txt', 'git commit -qm "still readable"',
+        'git tag v9.9.9'
+      ]);
+      fs.chmodSync(path.join(dir, '.git', 'index'), 0o000);
+
+      const info = git._fetchInfo(dir);
+
+      assert.ok(info !== null, 'a repository we cannot status is still a repository');
+      assert.equal(info.branch, 'main', 'the branch is still answerable without the index');
+      assert.equal(info.lastCommit, 'still readable');
+      assert.ok(info.lastCommitAge.length > 0);
+      assert.equal(info.latestTag, 'v9.9.9');
+      // Only dirtiness is genuinely lost — `status` is its only source.
+      assert.equal(info.dirty, null, 'and it must never render as clean');
+      assert.deepEqual(info.incomplete, ['dirty'],
+        'exactly one field was unestablished, and it is named');
+    });
+
+    it('names WHICH failure it hit, so the fixable one is distinguishable', () => {
+      // Every short read logged an identical line, so "this repository is slow"
+      // and "git refuses to read this repository" were the same event to an
+      // operator — and only the second is something they can act on.
+      //
+      // THE MUTATION THIS CATCHES: dropping `cause`, or deriving it after the
+      // fact instead of capturing the remaining budget BEFORE the call. `step`
+      // records a skipped-for-budget field exactly as it records a git error, and
+      // the error dies in its catch, so afterwards the two are indistinguishable.
+      const { setConsoleStream, setLevel } = require('../lib/logger');
+      const lines = [];
+      setConsoleStream({ write: (s) => lines.push(s) });
+      setLevel('debug');
+      try {
+        const broken = repo('cause-broken', ['echo a > a.txt', 'git add a.txt', 'git commit -qm s']);
+        fs.chmodSync(path.join(broken, '.git', 'index'), 0o000);
+        git._fetchInfo(broken);
+
+        const starved = repo('cause-starved', ['echo a > a.txt', 'git add a.txt', 'git commit -qm s']);
+        git._fetchInfo(starved, { budgetMs: 0 });
+      } finally {
+        setConsoleStream(null);
+        setLevel('info');
+      }
+
+      const joined = lines.join('\n');
+      assert.match(joined, /git-refused-to-read-repository/,
+        'a repository git will not read must say so — it is the one an operator can fix');
+      assert.match(joined, /budget-exhausted/,
+        'and a read that simply ran out of time must say that instead');
     });
 
     it('a directory that is genuinely not a repository still reads as null', () => {
@@ -268,6 +361,33 @@ describe('git', () => {
       assert.equal(info.lastCommit, '100% done');
       assert.match(info.lastCommitAge, /ago|second/,
         'the age must be the age, not the rest of the message');
+    });
+
+    it('reports nothing established when status answers in a shape it cannot read', () => {
+      // A `status` that succeeds but carries no `## ` header is not output from
+      // the command we asked for. The hazard is that it PARSES anyway: zero
+      // further lines counts as zero changed paths, so the read would report a
+      // repository as definitely CLEAN on the strength of output nothing
+      // understood — an unknown wearing a fact's clothes, which is the failure
+      // this module exists to prevent.
+      //
+      // THE MUTATION THIS CATCHES: dropping the header check and letting the
+      // parser fall through, which yields `dirty: false` and a branch of
+      // `'unknown'` — the second of those says it is unknown, the first lies.
+      const dir = repo('nostatus', ['echo a > a.txt', 'git add a.txt', 'git commit -qm s']);
+      const execFn = (command, cwd, timeout) => {
+        if (command.includes('status')) return 'not a porcelain header at all';
+        return git._exec(command, cwd, timeout);
+      };
+
+      const info = git._fetchInfo(dir, { execFn });
+
+      assert.ok(info !== null, 'it is still a repository — status answered');
+      assert.equal(info.dirty, null, 'unparsed output must never render as a clean tree');
+      assert.ok(info.incomplete.includes('dirty'), 'and it must name what it lost');
+      // Branch is recovered by its own probe, exactly as on the status-failed
+      // path — an output we could not parse costs the field only `status` owns.
+      assert.equal(info.branch, 'main');
     });
 
     it('establishes nothing, and says so, when the budget is gone before it starts', () => {

--- a/test/git.test.js
+++ b/test/git.test.js
@@ -275,14 +275,17 @@ describe('git', () => {
     });
 
     it('names WHICH failure it hit, so the fixable one is distinguishable', () => {
-      // Every short read logged an identical line, so "this repository is slow"
-      // and "git refuses to read this repository" were the same event to an
-      // operator — and only the second is something they can act on.
+      // Every short read logged an identical line, so "we stopped looking" and
+      // "git refuses to read this repository" were the same event to an operator
+      // — and only the second is something they can act on.
       //
-      // THE MUTATION THIS CATCHES: dropping `cause`, or deriving it after the
-      // fact instead of capturing the remaining budget BEFORE the call. `step`
-      // records a skipped-for-budget field exactly as it records a git error, and
-      // the error dies in its catch, so afterwards the two are indistinguishable.
+      // THE MUTATION THIS CATCHES: dropping `cause` entirely. The harder half —
+      // that a `status` our own CAP killed is also reported as stopped rather
+      // than as broken — cannot be driven from here, because `budgetMs: 0` skips
+      // the step instead of killing it. That path is guarded in
+      // `test/git-budget.test.js` with a real stalling `git` under a budget
+      // production actually uses; a guard written only against `budgetMs: 0`
+      // passes against the inverted classifier this replaced.
       const { setConsoleStream, setLevel } = require('../lib/logger');
       const lines = [];
       setConsoleStream({ write: (s) => lines.push(s) });
@@ -302,7 +305,7 @@ describe('git', () => {
       const joined = lines.join('\n');
       assert.match(joined, /git-refused-to-read-repository/,
         'a repository git will not read must say so — it is the one an operator can fix');
-      assert.match(joined, /budget-exhausted/,
+      assert.match(joined, /read-timed-out/,
         'and a read that simply ran out of time must say that instead');
     });
 
@@ -374,13 +377,23 @@ describe('git', () => {
       // THE MUTATION THIS CATCHES: dropping the header check and letting the
       // parser fall through, which yields `dirty: false` and a branch of
       // `'unknown'` — the second of those says it is unknown, the first lies.
+      const { setConsoleStream, setLevel } = require('../lib/logger');
+      const logged = [];
+      setConsoleStream({ write: (s) => logged.push(s) });
+      setLevel('debug');
       const dir = repo('nostatus', ['echo a > a.txt', 'git add a.txt', 'git commit -qm s']);
       const execFn = (command, cwd, timeout) => {
         if (command.includes('status')) return 'not a porcelain header at all';
         return git._exec(command, cwd, timeout);
       };
 
-      const info = git._fetchInfo(dir, { execFn });
+      let info;
+      try {
+        info = git._fetchInfo(dir, { execFn });
+      } finally {
+        setConsoleStream(null);
+        setLevel('info');
+      }
 
       assert.ok(info !== null, 'it is still a repository — status answered');
       assert.equal(info.dirty, null, 'unparsed output must never render as a clean tree');
@@ -388,6 +401,11 @@ describe('git', () => {
       // Branch is recovered by its own probe, exactly as on the status-failed
       // path — an output we could not parse costs the field only `status` owns.
       assert.equal(info.branch, 'main');
+      // And it is reported as its OWN cause: neither a repository git refused to
+      // read nor one we ran out of time on. Those three call for different
+      // responses, so a shared label would be no better than the single line they
+      // all used to share.
+      assert.match(logged.join('\n'), /git-status-unparsed/);
     });
 
     it('establishes nothing, and says so, when the budget is gone before it starts', () => {

--- a/test/git.test.js
+++ b/test/git.test.js
@@ -82,6 +82,207 @@ describe('git', () => {
     });
   });
 
+  // Reading one repository took SEVEN `git` invocations to answer five questions;
+  // it takes three (#895). The collapse is a parsing change, so every state below
+  // is driven by a REAL repository built into that state — a stubbed `git` output
+  // would assert the author's model of what git prints, which is precisely the
+  // thing under test.
+  describe('one repository read costs three invocations, not seven (#895)', () => {
+    const fs = require('node:fs');
+    const os = require('node:os');
+    const { execSync } = require('node:child_process');
+
+    const made = [];
+    afterEach(() => {
+      while (made.length) {
+        const dir = made.pop();
+        // Some fixtures deliberately remove read permission; restore it or the
+        // cleanup fails and leaks the directory.
+        try { execSync(`chmod -R u+rwX ${JSON.stringify(dir)}`); } catch { /* best effort */ }
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    /**
+     * Build a repository fixture and return its path.
+     *
+     * `--template=` deliberately empty: the default template installs sample
+     * hooks, and a fixture that ships hooks is a fixture that can run them.
+     * Identity is set locally because CI runners have no global git user.
+     *
+     * @param {string} label - Directory prefix, for readable failures.
+     * @param {string[]} steps - Shell commands run in the fixture, in order.
+     * @returns {string} The fixture path.
+     */
+    function repo(label, steps) {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), `tc-git-${label}-`));
+      made.push(dir);
+      const setup = [
+        'git init --template= -q -b main',
+        'git config user.email t@example.com',
+        'git config user.name Test',
+        ...steps
+      ];
+      execSync(setup.join(' && '), { cwd: dir, encoding: 'utf8', stdio: 'pipe' });
+      return dir;
+    }
+
+    /**
+     * Count the `git` invocations one read makes, by wrapping the module's own
+     * exec seam. Counting is the claim: the seven calls cost tens of milliseconds
+     * warm, so wall-clock cannot tell three from seven.
+     *
+     * @param {string} dir - Repository to read.
+     * @returns {{ info: object|null, commands: string[] }}
+     */
+    function readCounting(dir) {
+      const commands = [];
+      // Injected rather than monkey-patched: `_fetchInfo` calls its module-local
+      // `_exec`, so reassigning the export counts nothing and every count-based
+      // assertion would read zero. Same `execFn` seam as `lib/tmux.js` and
+      // `lib/engines.js`, and it runs the REAL command underneath, so these stay
+      // integration tests against real repositories.
+      const execFn = (command, cwd, timeout) => {
+        commands.push(command);
+        return git._exec(command, cwd, timeout);
+      };
+      return { info: git._fetchInfo(dir, { execFn }), commands };
+    }
+
+    it('reads a healthy repository in three invocations', () => {
+      const dir = repo('healthy', ['echo a > a.txt', 'git add a.txt', 'git commit -qm "the subject"']);
+      const { info, commands } = readCounting(dir);
+
+      // THE MUTATION THIS CATCHES: restoring any of the four removed invocations
+      // — `--is-inside-work-tree`, `--abbrev-ref HEAD`, `rev-parse HEAD`, or a
+      // second `log`. Every one of them still produces correct output, which is
+      // why the guard has to count rather than compare answers.
+      assert.equal(commands.length, 3,
+        `expected three invocations, got: ${commands.join(' | ')}`);
+      assert.equal(info.branch, 'main');
+      assert.equal(info.dirty, false);
+      assert.equal(info.lastCommit, 'the subject');
+      assert.ok(info.lastCommitAge.length > 0, 'age must be established');
+      assert.deepEqual(info.incomplete, []);
+    });
+
+    it('reads a repository with no commits in ONE invocation, and names its branch', () => {
+      const dir = repo('unborn', []);
+      const { info, commands } = readCounting(dir);
+
+      // An unborn HEAD does not fail `status` — it reports `## No commits yet on
+      // main`, exit 0 — so has-commits is read positively off that marker and
+      // nothing downstream is attempted.
+      //
+      // THE MUTATION THIS CATCHES: inferring has-commits from a failing `log` or
+      // `rev-parse HEAD` instead of the marker. That treats ANY failure of those
+      // as "no commits", which is how a repository that failed them for some
+      // other reason got reported as empty.
+      assert.equal(commands.length, 1,
+        `expected one invocation, got: ${commands.join(' | ')}`);
+      // `rev-parse --abbrev-ref HEAD` FAILS on an unborn HEAD, so this used to be
+      // `'unknown'` for every freshly-created project. git names the branch.
+      assert.equal(info.branch, 'main');
+      assert.equal(info.lastCommit, '');
+      assert.equal(info.lastCommitAge, '');
+      assert.equal(info.latestTag, null);
+      assert.deepEqual(info.incomplete, [],
+        'an empty repository is a known state, not an unestablished one');
+    });
+
+    it('a repository it cannot READ stays a project — it does not become null', () => {
+      // THE CRITERION THE WHOLE DESIGN TURNS ON. Measured: with `.git/index`
+      // unreadable, `git status` exits 128 while `rev-parse --is-inside-work-tree`
+      // still answers `true`. So "status failed" must NOT be read as "not a
+      // repository".
+      //
+      // THE MUTATION THIS CATCHES: concluding not-a-repository from a failed
+      // `status` — the literal three-invocation design the issue proposed.
+      // `lib/dir-scanner-child.js` decides a directory IS a project from
+      // `gitInfo && gitInfo.branch`, so returning null here deletes a broken
+      // project from the dashboard instead of costing it a badge.
+      const dir = repo('unreadable', ['echo a > a.txt', 'git add a.txt', 'git commit -qm s']);
+      fs.chmodSync(path.join(dir, '.git', 'index'), 0o000);
+
+      const info = git._fetchInfo(dir);
+
+      assert.ok(info !== null, 'a repository we cannot read is still a repository');
+      assert.equal(info.branch, 'unknown');
+      assert.equal(info.dirty, null, 'unknown dirtiness must never render as clean');
+      assert.ok(info.incomplete.includes('branch'), 'and it must say what it could not establish');
+      assert.ok(info.incomplete.includes('dirty'));
+    });
+
+    it('a directory that is genuinely not a repository still reads as null', () => {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-git-plain-'));
+      made.push(dir);
+      assert.equal(git._fetchInfo(dir), null);
+    });
+
+    it('names a detached HEAD the way the probe it replaced did', () => {
+      const dir = repo('detached', [
+        'echo a > a.txt', 'git add a.txt', 'git commit -qm s', 'git checkout -q --detach HEAD'
+      ]);
+      // `## HEAD (no branch)`. `rev-parse --abbrev-ref HEAD` answered `HEAD`, and
+      // callers already read it that way, so the collapse must not change it.
+      assert.equal(git._fetchInfo(dir).branch, 'HEAD');
+    });
+
+    it('takes the branch name alone when an upstream is tracked', () => {
+      const remote = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-git-remote-'));
+      made.push(remote);
+      execSync('git init --template= -q -b main --bare', { cwd: remote, stdio: 'pipe' });
+      const dir = repo('tracking', [
+        'echo a > a.txt', 'git add a.txt', 'git commit -qm s',
+        `git remote add origin ${JSON.stringify(remote)}`, 'git push -q -u origin main',
+        'echo b > b.txt', 'git add b.txt', 'git commit -qm s2'
+      ]);
+      // `## main...origin/main [ahead 1]` — the upstream and the divergence count
+      // are dropped. THE MUTATION THIS CATCHES: taking the header verbatim, which
+      // renders the branch as `main...origin/main [ahead 1]` on the dashboard.
+      assert.equal(git._fetchInfo(dir).branch, 'main');
+    });
+
+    it('reports a dirty tree as dirty, and a branch with a slash intact', () => {
+      const dir = repo('slashy', [
+        'git checkout -q -b feat/some-thing', 'echo a > a.txt', 'git add a.txt',
+        'git commit -qm s', 'echo untracked > b.txt'
+      ]);
+      const info = git._fetchInfo(dir);
+      assert.equal(info.branch, 'feat/some-thing');
+      assert.equal(info.dirty, true);
+    });
+
+    it('keeps a multi-line commit message from pulling the age out of alignment', () => {
+      // `%s` is the subject and is always ONE line — git folds a multi-line first
+      // paragraph into it — which is what makes a two-line `%s%n%cr` format safe.
+      //
+      // THE MUTATION THIS CATCHES: reading the age from a fixed line index without
+      // the folding assumption holding, or splitting the log output on the wrong
+      // separator.
+      const dir = repo('multiline', [
+        'echo a > a.txt', 'git add a.txt',
+        'git commit -qm "100% done" -m "a second paragraph"'
+      ]);
+      const info = git._fetchInfo(dir);
+      assert.equal(info.lastCommit, '100% done');
+      assert.match(info.lastCommitAge, /ago|second/,
+        'the age must be the age, not the rest of the message');
+    });
+
+    it('establishes nothing, and says so, when the budget is gone before it starts', () => {
+      const dir = repo('nobudget', ['echo a > a.txt', 'git add a.txt', 'git commit -qm s']);
+      const info = git._fetchInfo(dir, { budgetMs: 0 });
+
+      assert.ok(info !== null, 'a budget we spent is not evidence the directory is not a repo');
+      assert.equal(info.branch, 'unknown');
+      assert.equal(info.dirty, null);
+      for (const field of ['branch', 'dirty', 'lastCommit', 'lastCommitAge', 'latestTag']) {
+        assert.ok(info.incomplete.includes(field), `${field} must be named as unestablished`);
+      }
+    });
+  });
+
   describe('latestTag', () => {
     it('should include latestTag in getInfo result', () => {
       const info = git.getInfo(path.join(__dirname, '..'));

--- a/test/git.test.js
+++ b/test/git.test.js
@@ -309,6 +309,41 @@ describe('git', () => {
         'and a read that simply ran out of time must say that instead');
     });
 
+    it('blames git, not the clock, when a later step is the one git refuses', () => {
+      // The same rule as the `status` classifier, applied one step down. Reaching
+      // `log` at all means there was budget when it started — which says nothing
+      // about whether the throw that followed was our cap or git refusing. The
+      // cause has to come from `weStopped` at the throw, here as well.
+      //
+      // THE MUTATION THIS CATCHES: deriving the down-path cause from position —
+      // "we got this far, so time must be what ran out" — which reports a
+      // repository git actively refused as merely slow, sending the operator to
+      // wait rather than to look.
+      const { setConsoleStream, setLevel } = require('../lib/logger');
+      const lines = [];
+      setConsoleStream({ write: (s) => lines.push(s) });
+      setLevel('debug');
+      const dir = repo('logrefuses', ['echo a > a.txt', 'git add a.txt', 'git commit -qm s']);
+      // `status` answers normally; `log` fails the way git fails, not the way a
+      // timeout does — no ETIMEDOUT, no SIGTERM.
+      const execFn = (command, cwd, timeout) => {
+        if (command.includes('log -1')) throw Object.assign(new Error('fatal: bad object'), { status: 128 });
+        return git._exec(command, cwd, timeout);
+      };
+      try {
+        git._fetchInfo(dir, { execFn });
+      } finally {
+        setConsoleStream(null);
+        setLevel('info');
+      }
+
+      const joined = lines.join('\n');
+      assert.match(joined, /git-refused-to-read-repository/,
+        'git refusing a later step is still git refusing');
+      assert.doesNotMatch(joined, /read-timed-out/,
+        'and must not be reported as a read we stopped');
+    });
+
     it('a directory that is genuinely not a repository still reads as null', () => {
       const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-git-plain-'));
       made.push(dir);

--- a/test/projects.test.js
+++ b/test/projects.test.js
@@ -1594,8 +1594,8 @@ describe('projects', () => {
       // all-or-nothing failure the old shape did not have: throw mid-loop and
       // the caller degrades to the registered projects, discarding everything
       // already discovered. This route backs the dashboard, and per-entry cost
-      // is dominated by a synchronous git.getInfo (up to seven execSync calls
-      // per directory, cached two minutes) — so a cold-cache load over a few
+      // is dominated by a synchronous git.getInfo (several execSync
+      // calls per directory, cached two minutes) — so a cold-cache load over a few
       // dozen unregistered folders would show NONE of them, with a log line as
       // the only trace. A discovery walk that ran out of budget still
       // discovered what it got to.


### PR DESCRIPTION
## What

`git.getInfo` ran **seven** `git` invocations to answer five questions about one repository, on a path #891 has to bound under a single budget that must also fit inside the scanner child's deadline.

- `git status --porcelain=v1 --branch` answers **is-it-a-repo, which branch, and dirtiness** in one call.
- `git log -1 --format=%s%n%cr` answers **subject and age** in another.
- `git describe --tags --abbrev=0` is unchanged.

Whether a repository has any commits is now read **positively**, off `status`'s `No commits yet on` marker, replacing a `rev-parse HEAD` probe whose *failure* meant "no commits" — so a repository that failed it for any other reason stops being reported as empty. An unborn repository reads in **one** invocation instead of four.

## Why

Measured on this repository, warm, reading the same directory both ways:

| | invocations | warm |
|---|---|---|
| before | **7** | 165.3 ms |
| after | **3** | 75.2 ms |

Every field identical — branch, dirty, subject, age, tag, `incomplete: []`. Counted at `child_process.execSync`, patched *before* `lib/git` is required, so the same measurement runs against both revisions rather than depending on a seam only one of them has.

It also halves what #891 has to bound: three places to stall instead of seven.

## The issue's own design was a bug, and the fixture that proves it ships here

#895 proposed folding `rev-parse --is-inside-work-tree` into `status`. Measured against a real repository: **with `.git/index` unreadable, `status` exits 128 while `--is-inside-work-tree` still answers `true`.** Inferring "not a repository" from a failed `status` therefore returns `null` for a broken-but-real repo — and `lib/dir-scanner-child.js` decides a directory *is* a project from `gitInfo && gitInfo.branch`, so that project would **vanish from the dashboard** rather than lose a badge.

That probe stays the authority on repository-or-not, merely deferred to the failure path, where the healthy read never pays for it. Honest cost: a directory that is *not* a repository goes from one invocation to two.

Two other edge cases the issue asked to handle turned out **not to exist** — a branch name cannot contain `...` (git's refname rules forbid `..`), and `%s` is always exactly one line — so guards were removed rather than written.

## User-visible

A brand-new project shows its **real branch name** instead of `unknown`. `rev-parse --abbrev-ref HEAD` fails over an unborn HEAD; `status` names the branch there quite happily.

A repository whose `status` fails now keeps everything still answerable — branch, subject, age, tag — losing only its clean/dirty state, which reports as *unknown* rather than *clean*. And the log now says **which** of three things went wrong (we stopped the read / git refused to read the repository / git answered in a shape we do not recognise), because only one of those is something an operator can fix.

## Test plan

- `node --test 'test/*.test.js'` — **5942 passed, 0 failed, 1 skipped** (5927 before).
- Fixtures are **real repositories** in every state, built with `git init --template=`; the parser's subject is what git actually prints, and a stub would assert my model of that.
- Eleven guards, each driven red by its named mutation before commit, recorded in the tests under `THE MUTATION THIS CATCHES`.

## Review

Five Critic rounds; the last two returned zero findings. Independent PR review: 0 blocking, 0 warnings, 1 note (fixed). Three of the four serious findings shared one shape — a rule applied to the call site that prompted it rather than to the rule's own scope — including a `cause` classifier that was **inverted in production** and a guard that drove `budgetMs: 0`, the one input production never supplies. Both are fixed, and the lesson is recorded in the project's learnings.

Fixes #895