### PR TITLE
An unknown must not render as a fact — the dashboard, and the wrap that commits your repo

### DIFF
--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -4455,3 +4455,43 @@ Both are wrong in the same way the change exists to prevent:
   unknown is carried by a non-null `cause` on a wrapping answer.
 
 **Classification:** fix
+
+## 2026-08-13: Critic round on #908 — the outcome the reorder changed, and the census member that survived
+<!-- prawduct: type=fix | scope=wrap-liveness-908 | chunks=01 -->
+
+Cumulative review of `7aa3d64...f338a42`: 0 blocking, 8 warnings, 9 notes across three reviewers.
+Two findings mattered, and both are about something the first cut did NOT intend.
+
+**R-1 — the reorder silently changed an outcome that had nothing to do with the bug.** Hoisting the
+age test above the liveness test fixed the unanswered case, but it also turned "aged-out row whose
+pane tmux CONFIRMS is gone" from `autoCompleteWrap` into a plain kill — dropping the wrap summary,
+the Medusa teardown and the auto-commit, for a row where tmux had actually answered. The change-log
+called the young cases "unchanged" and never named this delta, and the #105 guard pinned the ORDER
+(`probed === 0`) rather than the outcome, so nothing caught it.
+
+The probe is now consulted on both paths, and the invariant is stated properly: **a probe may ADD
+an outcome, never withhold recovery.** An aged-out row with a confirmed-dead pane completes exactly
+as it always did; live or unestablished, it recovers on age. The guard was re-pointed from `probed
+=== 0` — an implementation detail that made a legitimate refinement look like a regression — to the
+outcome it actually cares about, and the restored behavior gained its own guard.
+
+**R-2/3/4/11/12 — the third census member.** All three reviewers found the same thing
+independently: #908's census names three sites, the first cut fixed two, and the third —
+`_deferEngineInit`'s prime-paste guard, writing a DURABLE ledger row saying `tmux session ended
+before the prime was pasted` on `!hasSession(...)` — survived with its survival recorded nowhere. A
+PR carrying `Fixes #908` would have closed the issue with a member still open, on a branch whose
+own recurring defect is a sweep stated more broadly than the search behind it. Now fixed: the skip
+still happens (the paste needs the server that just failed to answer), but the reason recorded is
+the one that was established.
+
+**Four pre-existing tests re-pointed, not relaxed** — two more in `test/sessions.test.js` and two in
+`test/session-rule-delivery.test.js`, all stubbing `tmux.hasSession` where the code now asks
+`probeSession`. Each stub keeps its original meaning: an ANSWERED liveness.
+
+**One unrelated flake observed, not caused here.** `test/dir-scanner.test.js`'s threadpool-leak
+guard (#883) failed once in a full parallel run and passed alone and on re-run. This branch touches
+no scanner code. It is the timing-sensitive shape the recorded learning warns about — a guard whose
+subject is a timeout must not have a tight cap, because a delayed fork under load is
+indistinguishable from the condition it exists to rule out.
+
+**Classification:** fix

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -57,6 +57,28 @@ unanswered branch deleted (red on the unknown-session guards); and the snapshot 
 spawn). The timeout is driven by a real stalling `tmux` on PATH rather than a stubbed error, because
 this repo has shipped three wrong hand-written models of that error shape (#891/#894).
 
+**What the cumulative review caught, and it was the more consequential half.** The plan carved
+`hasSession` out of scope on the grounds that its callers kill, adopt and type into a session, so a
+conservative `false` suits them. That carve-out did not fit two of them, which do not act on the
+answer but WRITE it: `getSessionStatus` marked a session `crashed` on a failed probe — so one poll
+from an open session page during a wedge persisted the lie, and unlike the display the row does not
+recover when tmux does — and `launchSession` cleared the same record before starting a second
+session over the first. `tmux.probeSession(name)` → `{live, answered, cause}` now serves both, with
+`hasSession` as its boolean face for the callers that really do act. The launch path refuses
+honestly instead: under a wedge that launch fails anyway, on the same server that would not answer.
+The remaining `hasSession` sites were swept and left, each with the reason recorded.
+
+That required flagging `_exec`'s timeout throw, which REPLACES the error `wasTimedOut` reads — so
+the distinction it exists to preserve was being destroyed one layer below the code that needs it.
+
+**Also from the review:** the CHANGELOG claimed the session "stays on the card", which `active: null`
+does not produce until #885 renders it; `api-contract.md` described the live payload as "tmux
+confirmed the pane" when a paneless webui session gets it without tmux being asked; and the wrapping
+branch's honest negative had no guard, so widening its unknown test would have passed the suite.
+Three further defects of the same family were filed rather than absorbed: #905 (`getMasterStatus`),
+#906 (a wedged tmux logs every ten seconds forever) and #907 (`idle`/`lastOutputAge` still report a
+plausible default when nothing was read).
+
 **Classification:** fix
 
 ## 2026-08-12: one repository read costs three git invocations, not seven (#895)

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -4261,6 +4261,7 @@ problem — is **#891**.
 **Classification:** fix
 
 ## 2026-08-13: the dashboard stops stating facts it does not have (#885, #900)
+<!-- prawduct: type=feature | scope=degraded-reads-900-885 | chunks=03 -->
 
 **What changed.** The payload had carried three outcomes per read — yes, no, and *we could not
 establish it* — since #891, #900 and #885's payload half. Nothing rendered the third, so the
@@ -4304,6 +4305,80 @@ third state could only be pinned by source-matching — and that guard survived 
 `renderSessionDetail` and `renderGitDetail` were extracted to make the behaviour testable. The
 extraction is the fix; the guard was the symptom.
 
-chunks=03 work=885-900-degraded-reads
-
 **Classification:** feature
+
+## 2026-08-13: an empty list is #885's worst case, not an exemption from it (#885, follow-up)
+<!-- prawduct: type=fix | scope=degraded-reads-900-885 | chunks=03 -->
+
+Found by self-review while the cumulative Critic ran, in the chunk's own code. `renderProjects`
+early-returned on `state.projects.length === 0` **before** rendering the ROOT panel — so on a
+machine with nothing registered yet, whose projects directory could not be read, the dashboard
+answered *"No projects yet. Create your first project."* with no notice anywhere on the page.
+
+That is the defect the whole chunk exists to remove, in its most confident form: not a silently
+shorter list, but a definite and actionable instruction derived from a read that never succeeded.
+It survived the first pass because every guard was written against a populated dashboard.
+
+The ROOT panel now renders on every path — populated, empty, and filtered-to-nothing — and the
+empty state's wording is conditional on whether the scan actually completed. A genuinely empty
+machine still gets the original invitation, which is the case that made the early return look
+harmless.
+
+**The generalisable bit:** a rendering fix that only ever runs against a populated fixture leaves
+the empty and error paths exactly as they were, and those are the paths the fix is *for*.
+
+**Classification:** fix
+
+## 2026-08-13: Critic round on the render half — the surfaces that still stated a fact (#885)
+<!-- prawduct: type=fix | scope=degraded-reads-900-885 | chunks=03 -->
+
+Cumulative review of `7aa3d64...2e57100`: 0 blocking, 14 warnings, 8 notes across three reviewers.
+Three findings were stale — they read the tree mid-mutation-run, when `api-helper.js` was
+transiently broken and the artifact edits were on disk but uncommitted. The rest were real, and
+two of them are the same defect this whole bundle exists to remove, on surfaces the plan's own
+list did not name:
+
+**The header contradicted the cards.** `renderSessionCount` still read `p.session && p.session.active`,
+so during the exact tmux wedge the cards were drawing `?` for, the most prominent number on the
+page said "0 active sessions". It counts the three outcomes separately now. The plan enumerated
+card, panel and detail — the header was not on the list, and "the plan did not say to" is not a
+reason for a surface to keep asserting a number nobody established.
+
+**The most fixable failure was the one with no advice.** `lib/dir-scanner-child.js` reports a
+project directory that is THERE but refused as `EACCES` with no hint of its own, and the renderer's
+fallback table covered only `DIR_MISSING` and `SCAN_FAILED` — so the one failure whose cause is
+known and whose remedy is concrete got a reason and no next step, while the vaguer catch-all got
+advice. Backwards, and the written contract's list of hint-less codes omitted `EACCES` too, so the
+next person extending it would not have noticed either.
+
+**Two cards in one list gave different answers to the same failure.** `lib/dir-scanner-child.js`
+builds its own `git` object for unregistered entries — a second producer of the same contract — and
+projected `{branch, dirty, incomplete}`, dropping `cause`. A registered project named the cause and
+offered the slow-repository remedy; an unregistered one fell back to "the read did not complete"
+with none.
+
+**The duplication fix was reintroduced one badge over.** `renderGitBadge` was extracted precisely
+because a copy in each card renderer let a fix land in only one — and the unreadable badge was then
+copy-pasted into both. Now `renderUnreadableBadge`, with `degradedTooltip` for the join that
+appeared four times.
+
+**One guard is structural on purpose, and it is the exception that proves the rule.** Spreading the
+shared record versus re-listing its fields produces byte-identical output today; the entire value is
+what happens when the record grows a field later. No input distinguishes them, so no behavioural
+test can exist — the property is structural, so the guard is. Every other guard in this round was
+falsified by mutating the code it covers.
+
+**A guard's own fixture was wrong twice, both caught by running it.** The "every code gets a remedy"
+sweep first demanded a fallback for `SCAN_CACHED`, which can never arrive without a hint
+(`lib/project-facts.js` attaches one whenever `tcTimedOut || tcCached`); then, scraping `code: '...'`
+out of the child's source, it demanded one for `ENOTDIR` — a THROWN error that `failureCode` maps to
+`SCAN_FAILED` long before it could reach a card. It is now driven from the written contract's
+`unreadableCode` row, so a code documented without a remedy fails it, and a code that cannot reach
+the renderer does not.
+
+Recorded rather than fixed: `public/setup.js` still draws `dirty: null` as clean in the first-run
+wizard (**#909**), and `getSessionStatus`'s kept record means a wedge now logs an ERROR+WARN pair
+every poll — the same flood shape as **#906**, which was scoped to the dashboard poll only and has
+been widened to name both emitters.
+
+**Classification:** fix

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -26,6 +26,41 @@ Tag-line conventions (ART-4K9M, ratified 2026-07-17):
 -->
 
 
+## 2026-08-13: the projects list says whether it is the whole list (#885 chunk 02)
+
+<!-- prawduct: type=feature | scope=degraded-reads-900-885 | chunks=02 -->
+
+**Why:** the list degraded honestly in the log and silently in the product. `listAllProjects`
+returned a bare array, so a directory that could not be read produced a well-formed `200` that was
+indistinguishable from having no unregistered folders — the half of #883's *"it is invisible and it
+lies"* still standing.
+
+**What changed:** `listAllProjects` returns `{ projects, scan }` and the route passes both through.
+`scan` is built by one helper for the healthy and degraded paths alike, so the two cannot drift into
+different shapes, and `complete` is DERIVED from whether a failure was given rather than passed
+alongside it — a caller cannot report a failure and a complete list at once. Six codes:
+`DIR_MISSING`, `SCAN_TIMEOUT`, `SCAN_CACHED`, `SCAN_ABORTED`, `SCAN_FAILED`, `SCAN_TRUNCATED`, reusing
+the vocabulary `lib/project-facts.js` already puts on a single project's `unreadableCode` rather than
+inventing a second taxonomy for the same conditions one scope up.
+
+**The truncated walk is the opposite failure and is treated as one.** It means the directory answered
+fine and simply has more folders than one scan can check — nothing is broken, nothing to remedy — so
+it carries no hint. Guarded by a mutation that routes it through `_scanFailureHint`, which produces
+the Full Disk Access misdiagnosis this whole area exists to remove.
+
+`git.getInfo` now returns the `cause` it already computed for its log, mapping the internal
+`'complete'` sentinel to `null` so a consumer testing for truthiness is not handed a cause when
+nothing went wrong. It reaches the payload unchanged — `dir-scanner-child.js` returns the whole
+object over IPC.
+
+**Verified by mutation:** truncation routed through the permission hint; the healthy `scan` returned
+on the failure path; `cause` computed and not returned (the state that shipped); and the route
+dropping `scan` on its way out — each applied and watched red before its guard was kept. The route
+guard exists because the field crossing the boundary is the claim: `scan` existing inside
+`listAllProjects` renders nothing.
+
+**Classification:** feature
+
 ## 2026-08-13: a liveness read that could not be established is unknown, not absent (#900)
 
 <!-- prawduct: type=fix | scope=degraded-reads-900-885 | chunks=01 -->

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -4433,3 +4433,25 @@ of true — the same meaning, at the seam that moved. The `#105` suite also gain
 `probeSession`, which it had not needed before.
 
 **Classification:** fix
+
+## 2026-08-13: the unknown wrap status reported idle as a fact (#908, self-review)
+<!-- prawduct: type=fix | scope=wrap-liveness-908 | chunks=01 -->
+
+Caught while deep-scrubbing the change above, before any review saw it. The new
+"could not observe the pane" branch of `getSessionStatus` returned `idle: false` and
+`incomplete: ['live']`.
+
+Both are wrong in the same way the change exists to prevent:
+
+- **`idle: false` is a plausible default** — in the one change whose subject is not shipping
+  plausible defaults. Worse than cosmetic: `public/session.js` reads `idle` as its wrap-completion
+  signal (`data.wrapping && data.idle`), so a definite "not idle" is a wrong answer to the question
+  the page is actually asking. It is now `null`, which is falsy — every existing consumer behaves
+  exactly as before, and both call sites are truthiness tests, so nothing changes behavior.
+- **`incomplete: ['live']` named a field the response does not return.** The convention
+  `session.active` and `git.dirty` established is that `incomplete` names the RETURNED fields that
+  could not be established. Reaching the pane is what produces `idle` and `lastOutputAge`, so those
+  two are what went unestablished; it is now `['idle', 'lastOutputAge']`. That the LIVENESS is
+  unknown is carried by a non-null `cause` on a wrapping answer.
+
+**Classification:** fix

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -59,6 +59,37 @@ dropping `scan` on its way out — each applied and watched red before its guard
 guard exists because the field crossing the boundary is the claim: `scan` existing inside
 `listAllProjects` renders nothing.
 
+**What the review caught, and the pattern in it.** Three reviewers found the same defect
+independently from three different goals: `api-contract.md` said a remembered refusal
+"deliberately" carries no remedy while the code gives it one — and that document is what chunk 03's
+renderer would have been written from, so the error was one step from becoming behavior. The
+underlying rule is now stated rather than implied: **the code and the hint are separate decisions**.
+`SCAN_CACHED` means nothing is being retried right now AND the directory still is not answering, so
+it earns the remedy while staying distinguishable from a fresh timeout.
+
+Deriving one from the other is also what made the duplicate mapping dangerous: `lib/projects.js` and
+`lib/project-facts.js` each mapped the scanner's error flags to codes, with DIFFERENT precedence,
+agreeing only because the flags are set almost exclusively today. The one overlap that already
+exists — a cached refusal carries `tcTimedOut` too — is exactly where the orders disagreed. There is
+now one `failureCode` in `lib/dir-scanner.js`, which owns the flags, and its ordering is documented
+as a contract rather than left as an implementation detail.
+
+**The new launch refusal was reaching the browser as `500 INTERNAL_ERROR`** — the route classifies
+failures by matching substrings of the message, and a refusal written for honesty was being reported
+as a server fault that changed something. It carries a `code` now (`LIVENESS_UNKNOWN` → **503**),
+because a status that depends on the wording of a sentence changes when the sentence improves; the
+same lesson `scanDirectoryForProjects` recorded when a reworded message silently removed a button.
+It also logs, since a refusal visible only in one HTTP response leaves no trace of how often the
+wedge happens.
+
+**Two guards were measuring less than they claimed** and were rewritten: the laziness check asserted
+elapsed wall-clock against the stall it was detecting, so a busy machine and the defect looked
+identical — it counts spawns now; and the "no server running is an ANSWER" check used a hand-built
+error, where the whole subject is telling one real `execFile` failure shape from another. Driving it
+with a real executable exposed a second problem in the guard itself: at a 2000ms cap it passed alone
+and failed under a four-file parallel run, which is precisely the flake shape a guard about timeouts
+must not have.
+
 **Classification:** feature
 
 ## 2026-08-13: a liveness read that could not be established is unknown, not absent (#900)

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -26,6 +26,39 @@ Tag-line conventions (ART-4K9M, ratified 2026-07-17):
 -->
 
 
+## 2026-08-13: a liveness read that could not be established is unknown, not absent (#900)
+
+<!-- prawduct: type=fix | scope=degraded-reads-900-885 | chunks=01 -->
+
+**Why:** session liveness had two outcomes and three real states — tmux confirmed the pane, tmux said
+the pane is gone, and tmux never replied. The third was folded into the second, so a wedged tmux
+server did not degrade the fleet view, it lied to it: every running session vanished and the operator
+was told nothing was running on a machine where everything was. #891 settled the rule for exactly
+this shape in `git.getInfo` (`dirty` became `null` rather than `false`); liveness never got it.
+
+**What changed:** `tmux._readSessionNames` resolves a verdict — `{ names, answered, cause }` — rather
+than a bare set, so a caller cannot read "this name is not in the set" without also being told
+whether tmux answered. `enrichProject` gained the third branch: an active or wrapping session the
+snapshot could not confirm is reported with `active: null`, `incomplete: ['active']` and the cause,
+instead of being dropped. `active` is falsy, so all seven existing consumers behave exactly as
+before; it is not `false`, so the renderer #885 adds can tell unknown from dead.
+
+**The line drawn, and why it is not "every failure is unknown".** Only a read stopped by our own
+timeout counts. A tmux that replied — the exit-1 `no server running` of a machine with no sessions,
+or a missing binary — told us something. Widening unknown to every error would invert the bug: after
+a reboot every stale `active` row would sit at unknown forever, uncleaned, on every machine where
+tmux is not running. `git` draws the same line with `weStopped`.
+
+**Verified by mutation, not by assertion count.** Four named mutations applied and each watched go
+red before the guard was kept: the timeout path claiming `answered: true` (the shipped behaviour,
+red in both suites); every error classified unknown (red on the "no server running" guard); the
+unanswered branch deleted (red on the unknown-session guards); and the snapshot resolved eagerly
+(red on both laziness guards, #890's and this chunk's — an eager read now costs a stall, not just a
+spawn). The timeout is driven by a real stalling `tmux` on PATH rather than a stubbed error, because
+this repo has shipped three wrong hand-written models of that error shape (#891/#894).
+
+**Classification:** fix
+
 ## 2026-08-12: one repository read costs three git invocations, not seven (#895)
 
 <!-- prawduct: type=fix | scope=git-spawn-collapse-895 | chunks=01 | status=shipped -->

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -28,7 +28,7 @@ Tag-line conventions (ART-4K9M, ratified 2026-07-17):
 
 ## 2026-08-13: the projects list says whether it is the whole list (#885 chunk 02)
 
-<!-- prawduct: type=feature | scope=degraded-reads-900-885 | chunks=02 -->
+<!-- prawduct: type=feature | scope=degraded-reads-900-885 | chunks=02 | status=shipped -->
 
 **Why:** the list degraded honestly in the log and silently in the product. `listAllProjects`
 returned a bare array, so a directory that could not be read produced a well-formed `200` that was
@@ -94,7 +94,7 @@ must not have.
 
 ## 2026-08-13: a liveness read that could not be established is unknown, not absent (#900)
 
-<!-- prawduct: type=fix | scope=degraded-reads-900-885 | chunks=01 -->
+<!-- prawduct: type=fix | scope=degraded-reads-900-885 | chunks=01 | status=shipped -->
 
 **Why:** session liveness had two outcomes and three real states — tmux confirmed the pane, tmux said
 the pane is gone, and tmux never replied. The third was folded into the second, so a wedged tmux
@@ -4261,7 +4261,7 @@ problem — is **#891**.
 **Classification:** fix
 
 ## 2026-08-13: the dashboard stops stating facts it does not have (#885, #900)
-<!-- prawduct: type=feature | scope=degraded-reads-900-885 | chunks=03 -->
+<!-- prawduct: type=feature | scope=degraded-reads-900-885 | chunks=03 | status=shipped -->
 
 **What changed.** The payload had carried three outcomes per read — yes, no, and *we could not
 establish it* — since #891, #900 and #885's payload half. Nothing rendered the third, so the
@@ -4308,7 +4308,7 @@ extraction is the fix; the guard was the symptom.
 **Classification:** feature
 
 ## 2026-08-13: an empty list is #885's worst case, not an exemption from it (#885, follow-up)
-<!-- prawduct: type=fix | scope=degraded-reads-900-885 | chunks=03 -->
+<!-- prawduct: type=fix | scope=degraded-reads-900-885 | chunks=03 | status=shipped -->
 
 Found by self-review while the cumulative Critic ran, in the chunk's own code. `renderProjects`
 early-returned on `state.projects.length === 0` **before** rendering the ROOT panel — so on a
@@ -4330,7 +4330,7 @@ the empty and error paths exactly as they were, and those are the paths the fix 
 **Classification:** fix
 
 ## 2026-08-13: Critic round on the render half — the surfaces that still stated a fact (#885)
-<!-- prawduct: type=fix | scope=degraded-reads-900-885 | chunks=03 -->
+<!-- prawduct: type=fix | scope=degraded-reads-900-885 | chunks=03 | status=shipped -->
 
 Cumulative review of `7aa3d64...2e57100`: 0 blocking, 14 warnings, 8 notes across three reviewers.
 Three findings were stale — they read the tree mid-mutation-run, when `api-helper.js` was
@@ -4384,7 +4384,7 @@ been widened to name both emitters.
 **Classification:** fix
 
 ## 2026-08-13: a wrap that could not be observed is not completed, and does not commit (#908)
-<!-- prawduct: type=fix | scope=wrap-liveness-908 | chunks=01 -->
+<!-- prawduct: type=fix | scope=wrap-liveness-908 | chunks=01 | status=shipped -->
 
 **The defect.** `autoCompleteWrap` writes the wrap complete, tears down the session's Medusa
 listener, and calls `_autoCommitIfDirty` — a real `git commit` in the operator's repository. Two
@@ -4435,7 +4435,7 @@ of true — the same meaning, at the seam that moved. The `#105` suite also gain
 **Classification:** fix
 
 ## 2026-08-13: the unknown wrap status reported idle as a fact (#908, self-review)
-<!-- prawduct: type=fix | scope=wrap-liveness-908 | chunks=01 -->
+<!-- prawduct: type=fix | scope=wrap-liveness-908 | chunks=01 | status=shipped -->
 
 Caught while deep-scrubbing the change above, before any review saw it. The new
 "could not observe the pane" branch of `getSessionStatus` returned `idle: false` and
@@ -4457,7 +4457,7 @@ Both are wrong in the same way the change exists to prevent:
 **Classification:** fix
 
 ## 2026-08-13: Critic round on #908 — the outcome the reorder changed, and the census member that survived
-<!-- prawduct: type=fix | scope=wrap-liveness-908 | chunks=01 -->
+<!-- prawduct: type=fix | scope=wrap-liveness-908 | chunks=01 | status=shipped -->
 
 Cumulative review of `7aa3d64...f338a42`: 0 blocking, 8 warnings, 9 notes across three reviewers.
 Two findings mattered, and both are about something the first cut did NOT intend.

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -66,7 +66,13 @@ recover when tmux does — and `launchSession` cleared the same record before st
 session over the first. `tmux.probeSession(name)` → `{live, answered, cause}` now serves both, with
 `hasSession` as its boolean face for the callers that really do act. The launch path refuses
 honestly instead: under a wedge that launch fails anyway, on the same server that would not answer.
-The remaining `hasSession` sites were swept and left, each with the reason recorded.
+The kill, send-keys, adopt and capture sites were swept and left — each acts on the pane
+immediately, so a failed probe costs a failed action, not a false record. **That sweep first
+under-enumerated the family, and the correction is the point:** two more sites reach
+`autoCompleteWrap` on a failed probe, which writes the wrap complete, tears down the listener
+and calls `_autoCommitIfDirty` — a real `git commit` in the operator's repository, on a fact
+nobody established. Filed as #908 rather than folded in, because declining to auto-complete
+interacts with #105's stuck-wrapping recovery and that needs guarding, not assuming.
 
 That required flagging `_exec`'s timeout throw, which REPLACES the error `wasTimedOut` reads — so
 the distinction it exists to preserve was being destroyed one layer below the code that needs it.

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -133,12 +133,18 @@ session over the first. `tmux.probeSession(name)` → `{live, answered, cause}` 
 `hasSession` as its boolean face for the callers that really do act. The launch path refuses
 honestly instead: under a wedge that launch fails anyway, on the same server that would not answer.
 The kill, send-keys, adopt and capture sites were swept and left — each acts on the pane
-immediately, so a failed probe costs a failed action, not a false record. **That sweep first
-under-enumerated the family, and the correction is the point:** two more sites reach
-`autoCompleteWrap` on a failed probe, which writes the wrap complete, tears down the listener
-and calls `_autoCommitIfDirty` — a real `git commit` in the operator's repository, on a fact
-nobody established. Filed as #908 rather than folded in, because declining to auto-complete
-interacts with #105's stuck-wrapping recovery and that needs guarding, not assuming.
+immediately, so a failed probe costs a failed action, not a false record. **That sweep
+under-enumerated the family THREE TIMES, and that is the finding, not any one site.** Each
+successive version concluded "the rest only act on the answer" and each was wrong, so the
+enumeration RULE now replaces the conclusion: ask whether a caller's `false` branch WRITES
+anything — a row, a ledger entry, a commit, a teardown — never what the call site appears to
+intend. Three do. Two reach `autoCompleteWrap`, which writes the wrap complete, tears down the
+listener and calls `_autoCommitIfDirty` — a real `git commit` in the operator's repository, on a
+fact nobody established. The third is `_deferEngineInit`'s prime-paste guard, which writes a
+durable `sessionRuleDeliveries` row reading `tmux session ended before the prime was pasted` for
+an ending nobody observed. All three are on #908 rather than folded in, because declining to
+auto-complete interacts with #105's stuck-wrapping recovery and the prime-paste case has a real
+choice behind it (paste anyway, or skip and record honestly) — both need guarding, not assuming.
 
 That required flagging `_exec`'s timeout throw, which REPLACES the error `wasTimedOut` reads — so
 the distinction it exists to preserve was being destroyed one layer below the code that needs it.

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -4382,3 +4382,54 @@ every poll — the same flood shape as **#906**, which was scoped to the dashboa
 been widened to name both emitters.
 
 **Classification:** fix
+
+## 2026-08-13: a wrap that could not be observed is not completed, and does not commit (#908)
+<!-- prawduct: type=fix | scope=wrap-liveness-908 | chunks=01 -->
+
+**The defect.** `autoCompleteWrap` writes the wrap complete, tears down the session's Medusa
+listener, and calls `_autoCommitIfDirty` — a real `git commit` in the operator's repository. Two
+sites reached it from `!tmux.hasSession(...)`, which answers false for a pane that is gone AND for a
+tmux server too wedged to reply. So a wedge could end a running wrap and commit a working tree on a
+fact nobody established, with no recovery when tmux returned. The session page polls
+`getSessionStatus` continuously *during* a wrap, so the poll most likely to meet the wedge is
+precisely the one running while a wrap is in flight.
+
+**Why this is a restructure and not one extra condition — the part worth keeping.** The obvious fix
+is "if the probe did not answer, decline". That reintroduces #105. The age-based stale-wrapping
+recovery — the thing that guarantees a wrapping row can never brick a project — was nested INSIDE
+the liveness branch, so a probe that never answered skipped the recovery too. Declining would have
+traded a false commit for a row stuck `wrapping` until tmux came back.
+
+**Age is now tested before liveness, and that ordering is the fix.** Age is evidence this process
+owns: a wrap that began three hours ago is an orphan whether or not tmux will discuss it. The four
+outcomes are now explicit — older than the threshold recovers on age without probing at all;
+younger splits on an ANSWERED probe into live (refuse, unchanged) and dead (complete, unchanged);
+and an unanswered probe changes nothing, refusing on the launch path with the same
+`LIVENESS_UNKNOWN` code chunk 01 introduced for the active-session case a few lines above.
+
+**The read path cannot refuse, so it reports.** `getSessionStatus` returns `wrapping: true` with
+`incomplete: ['live']` and the cause, rather than finalizing. `incomplete`/`cause` are present on
+the healthy wrapping answer too (empty and null), so a consumer reads the value instead of probing
+for the field.
+
+**Two harness defects, both caught by the guards rather than by review.**
+
+1. **The commit traps were inert.** Every guard booby-trapped `git.commit` so a regression would
+   fail loudly instead of writing history — but `_autoCommitIfDirty` returns early unless the
+   project path is a git repository, and the fixture directory is not one. `git.commit` was
+   therefore UNREACHABLE and every trap passed regardless of what the code did. Only the
+   positive-direction test ("an observed-dead wrap still commits") failed and exposed it. The
+   helper now stubs `isGitRepo` to arm the trap, and that positive assertion is retained
+   specifically to prove the trap can fire.
+2. **The launch path's answered-dead branch had no guard at all.** Widening the refusal from
+   `!probe.answered` to `!probe.live` survived the entire suite — a mutation that would refuse
+   every launch after a genuinely finished wrap, bricking the project for an hour. Found by
+   mutation, fixed by adding the missing test.
+
+**Two pre-existing tests were re-pointed, not relaxed.** `#91`'s wrapping test and `#105`'s
+recent-row test both stubbed `tmux.hasSession` to mean "alive"; the wrapping path now asks
+`probeSession`, so their stub no longer bit. Both now stub `probeSession` with an ANSWERED liveness
+of true — the same meaning, at the seam that moved. The `#105` suite also gained save/restore for
+`probeSession`, which it had not needed before.
+
+**Classification:** fix

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -4259,3 +4259,51 @@ cold repository is killed and handed a Full Disk Access remedy for a permission 
 problem — is **#891**.
 
 **Classification:** fix
+
+## 2026-08-13: the dashboard stops stating facts it does not have (#885, #900)
+
+**What changed.** The payload had carried three outcomes per read — yes, no, and *we could not
+establish it* — since #891, #900 and #885's payload half. Nothing rendered the third, so the
+dashboard drew it as the second: a wedged tmux server made every running session disappear, an
+unreadable folder shortened the list silently, and a repository whose working tree could not be
+read was drawn as clean. Four seams now render, and a healthy dashboard is unchanged.
+
+**The design decision that mattered.** "Reduce six payload shapes to one `{known, why, remedy}`
+record" reads as an invitation to build one code→remedy table. That would be wrong, and the
+rendering is where it shows: `read-timed-out` means a **wedged tmux server** for a session and a
+**protected folder** for a directory scan. A shared table tells an operator to grant Full Disk
+Access because tmux hung — the exact misdiagnosis `_scanFailureHint` exists to prevent. So causes
+normalise and remedies do not: each source supplies its own, preferring the sentence the server
+authored at the failure site over anything a renderer could infer.
+
+**No `sw.js` change, and that is deliberate.** The standing rule is that a new `public/*.js` must
+join `STATIC_ASSETS` with a `CACHE_NAME` bump. The rule was avoided rather than followed, by
+putting the helpers in `api-helper.js` — already `NETWORK_FIRST_PATHS`, already loaded before
+`ui.js`. Two reasons: bumping `CACHE_NAME` on a feature branch behind the basic_auth gate is what
+locked the operator out of Chrome on 2026-07-28; and a cache-first pure-helper sibling of a
+network-first script is precisely the version skew the `wrap-drawer.js` comment documents.
+
+**Three defects found by RENDERING the output, not by testing it.** The guards were green and the
+prose was wrong: `incomplete` was printed raw, so the operator read *"Could not establish dirty"*;
+the amber attention border was applied to the truncated-scan case that the same chunk argues is not
+a fault; and `listed` was computed and never drawn. Each got a translation layer, a narrowed
+condition, and a render site respectively — and each has a mutation that turns it red.
+
+**Two guards were vacuous and were replaced with behaviour.** A source check on the ROOT count
+survived `countLabel = false`, because the string it looked for still existed in the dead branch.
+A check for `git-unknown` survived deleting the marker, because the class `badge-git-unknown`
+contains that substring. Pure renderers are now lifted out of `ui.js` and executed against real
+inputs. Separately, the mutation harness itself was wrong twice — it reported "did not apply" for
+patterns appearing in more than one renderer (perl replaces the first match) and silently failed to
+apply several mutations to shell-quoting errors. **A mutation that never applied must never be
+reported as caught**; the harness now compares occurrence counts and passes patterns through the
+environment.
+
+**Requirement recorded rather than absorbed:** `toggleCardDetail` reaches for the DOM, so its
+third state could only be pinned by source-matching — and that guard survived its own mutation.
+`renderSessionDetail` and `renderGitDetail` were extracted to make the behaviour testable. The
+extraction is the fix; the guard was the symptom.
+
+chunks=03 work=885-900-degraded-reads
+
+**Classification:** feature

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -463,6 +463,26 @@ All notable changes to TangleClaw are documented in this file.
 
 ### Fixed
 
+- **A tmux server that will not answer no longer reports every session as dead (#900).** Session
+  liveness had two outcomes and three real states: tmux confirmed the pane, tmux said the pane is
+  gone, and *tmux never replied*. The third was folded into the second, so a wedged tmux server did
+  not degrade the fleet view — it lied to it. Every running session silently disappeared, and the
+  operator was shown "nothing is running" for a machine where everything was, in exactly the state
+  (#94/#144/#380 — PTY exhaustion) where knowing what is still up matters most.
+
+  A liveness read that could not be established now says so. The session stays on the card with its
+  `active` reported as `null` rather than vanishing, which is the same answer `git` gives for a
+  field its read could not establish (#891): unknown is its own state, not the negative one.
+
+  **Only a read our own timeout stopped counts as unknown**, and the asymmetry is deliberate. A tmux
+  that *replied* — including the ordinary "no server running" of a machine with no sessions at all —
+  told us something, and that something is that nothing is live. Widening unknown to every failure
+  would invert the bug rather than fix it: after a reboot, every stale session row would sit at
+  unknown forever on every machine where tmux simply is not running.
+
+  Rendering the difference is #885; this is the half that stops the payload from stating a fact
+  nobody established.
+
 - **A brand-new project shows its real branch name instead of "unknown" (#895).** Reading a
   repository with no commits yet used `git rev-parse --abbrev-ref HEAD`, which fails outright over an
   unborn HEAD — so every freshly-created project reported its branch as `unknown` until its first

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ All notable changes to TangleClaw are documented in this file.
 
 ### Added
 
+- **The projects list can now say it is incomplete, and why (#885).** When the projects directory
+  cannot be read, the list degrades to your registered projects and logs the reason. It always has —
+  the problem was that it did so **silently**: the browser got a well-formed list, and nothing
+  distinguished *"these are all your projects"* from *"these are the ones we could still see"*.
+  Unregistered folders simply were not there, which reads as having none.
+
+  `GET /api/projects` now answers with a `scan` block alongside the projects: which directory was
+  walked, whether the list is complete, a machine-readable code, one sentence for a human, and the
+  remedy where one fits. Six states are distinguished — the directory is not there at all, it did
+  not answer, it did not answer recently and is being backed off, the read was cancelled as
+  collateral for another directory's hang, it failed outright, or **it answered fine and simply has
+  more folders than one scan can check in time**.
+
+  That last one is the opposite failure and is deliberately not dressed as the same one: nothing is
+  broken, so it carries no remedy. Telling someone to grant Full Disk Access for a folder that
+  answered perfectly well is the misdiagnosis this whole area exists to remove.
+
+  A repository's git reading gained the same honesty: the reason a field could not be established
+  (`read-timed-out`, `git-refused-to-read-repository`, `git-status-unparsed`) now travels with the
+  reading instead of only reaching the log — so a repository that is *slow* stops being
+  indistinguishable from one that is *broken*, and only the second is something you can fix.
+
+  **The dashboard does not draw any of this yet.** This is the data; the rendering is the next
+  chunk of #885.
+
 - **A missing projects folder now offers to create itself.** `~/Documents/Projects` is the path the
   wizard pre-fills, and a stock macOS install does not have it — macOS creates `Documents`, nothing
   creates `Projects`, and nothing in TangleClaw did either. So the first action of a brand-new

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,12 @@ All notable changes to TangleClaw are documented in this file.
 
   Internal vocabulary stays internal: an operator is never shown `dirty` or `read-timed-out`.
 
+  The worst case of all is now covered too: a machine with nothing registered yet, whose projects
+  directory could not be read, used to answer **"No projects yet — create your first project."**
+  That is a definite, actionable and wrong claim, and it appeared with no notice at all because the
+  ROOT panel was skipped entirely on the empty path. It now says the list could not be built, and
+  points at the reason. A genuinely empty machine still gets the original invitation.
+
 - **A missing projects folder now offers to create itself.** `~/Documents/Projects` is the path the
   wizard pre-fills, and a stock macOS install does not have it — macOS creates `Documents`, nothing
   creates `Projects`, and nothing in TangleClaw did either. So the first action of a brand-new
@@ -524,9 +530,9 @@ All notable changes to TangleClaw are documented in this file.
 
   A liveness read that could not be established now says so. The session comes back with `active`
   reported as `null` instead of being dropped from the payload — the same answer `git` gives for a
-  field its read could not establish (#891): unknown is its own state, not the negative one. **The
-  dashboard does not draw the difference yet** — that is #885, and until it lands an unconfirmed
-  session still reads on the card exactly as an absent one.
+  field its read could not establish (#891): unknown is its own state, not the negative one. The
+  dashboard draws that difference — a distinct status dot, an *Unknown* detail row, and an
+  "N unknown" clause in the header count — as described in the #885 entry above.
 
   What changes for you today is what gets **written down**. Two paths recorded a session's death on
   the strength of a probe that had failed rather than answered. A status poll from an open session
@@ -542,8 +548,8 @@ All notable changes to TangleClaw are documented in this file.
   would invert the bug rather than fix it: after a reboot, every stale session row would sit at
   unknown forever on every machine where tmux simply is not running.
 
-  Rendering the difference is #885; this is the half that stops the payload from stating a fact
-  nobody established.
+  This is the half that stops the payload from stating a fact nobody established; #885, above,
+  is the half that draws it.
 
 - **A brand-new project shows its real branch name instead of "unknown" (#895).** Reading a
   repository with no commits yet used `git rev-parse --abbrev-ref HEAD`, which fails outright over an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -551,6 +551,30 @@ All notable changes to TangleClaw are documented in this file.
   This is the half that stops the payload from stating a fact nobody established; #885, above,
   is the half that draws it.
 
+- **A tmux server that will not answer can no longer end your wrap — or commit your repository
+  (#908).** Two paths decided a wrapping session was finished from a single question: *is the pane
+  there?* That question answers "no" both for a pane that has genuinely gone and for a tmux server
+  too wedged to reply, and the code could not tell the two apart. On the second, it wrote the wrap
+  as complete, tore down the session's listener, and ran a real `git commit` in your project — all
+  on a fact nobody had established. None of it came back when tmux recovered.
+
+  It now asks a question with three answers. A pane tmux *says* is gone still completes the wrap,
+  exactly as before. A pane tmux would not discuss leaves the wrap open, changes nothing, and — on
+  a launch — refuses with a message naming what could not be established rather than inventing a
+  reason.
+
+  **The recovery you already had still works, and making sure of that is why this is a restructure
+  rather than one extra check.** A stuck wrap is claimed on age after an hour, so a project can
+  never be bricked by one (#105). That recovery used to live *inside* the liveness question — so a
+  server that never answered skipped the recovery too, and simply declining would have traded a
+  false commit for a project stuck until tmux came back. Age is settled first now, because how long
+  a wrap has been running is something TangleClaw knows on its own: a wrap that began this morning
+  is an orphan whether or not tmux is willing to talk about it.
+
+  The deeper defect — that reading a session's status can finalize a wrap at all — is filed as
+  **#910** rather than fixed here, because changing *when* a wrap finalizes changes how the session
+  page detects completion, and that deserves its own verification.
+
 - **A brand-new project shows its real branch name instead of "unknown" (#895).** Reading a
   repository with no commits yet used `git rev-parse --abbrev-ref HEAD`, which fails outright over an
   unborn HEAD — so every freshly-created project reported its branch as `unknown` until its first

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -470,9 +470,19 @@ All notable changes to TangleClaw are documented in this file.
   operator was shown "nothing is running" for a machine where everything was, in exactly the state
   (#94/#144/#380 — PTY exhaustion) where knowing what is still up matters most.
 
-  A liveness read that could not be established now says so. The session stays on the card with its
-  `active` reported as `null` rather than vanishing, which is the same answer `git` gives for a
-  field its read could not establish (#891): unknown is its own state, not the negative one.
+  A liveness read that could not be established now says so. The session comes back with `active`
+  reported as `null` instead of being dropped from the payload — the same answer `git` gives for a
+  field its read could not establish (#891): unknown is its own state, not the negative one. **The
+  dashboard does not draw the difference yet** — that is #885, and until it lands an unconfirmed
+  session still reads on the card exactly as an absent one.
+
+  What changes for you today is what gets **written down**. Two paths recorded a session's death on
+  the strength of a probe that had failed rather than answered. A status poll from an open session
+  page marked a running session `crashed` during a wedge — permanently, since the row does not
+  return when tmux recovers — and pressing Launch cleared the same record before starting a second
+  session over the first. Both now require tmux to have actually said the pane is gone. A launch
+  that cannot establish it says so and changes nothing, rather than mangling the record and then
+  failing anyway on the same unresponsive server.
 
   **Only a read our own timeout stopped counts as unknown**, and the asymmetry is deliberate. A tmux
   that *replied* — including the ordinary "no server running" of a machine with no sessions at all —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,35 @@ All notable changes to TangleClaw are documented in this file.
   reading instead of only reaching the log — so a repository that is *slow* stops being
   indistinguishable from one that is *broken*, and only the second is something you can fix.
 
-  **The dashboard does not draw any of this yet.** This is the data; the rendering is the next
-  chunk of #885.
+  **The dashboard now draws all of it** — see the entry below.
+
+- **The dashboard stops stating facts it does not have (#885).** Every read behind the fleet view
+  has three outcomes — yes, no, and *we could not establish it* — and the dashboard drew the third
+  as the second. A wedged tmux server made every running session vanish; an unreadable folder made
+  projects vanish; a repository whose working tree could not be read was drawn as clean. Each of
+  those is a definite answer the server never gave.
+
+  Four seams now render:
+
+  - **The ROOT panel** gains a notice row whenever the list is short, carrying the reason and the
+    remedy as visible text rather than a tooltip — and the count stops saying *total*, because a
+    short list is not one. A directory that answered fine and is merely large is shown as
+    information, not a fault: different wording, different glyph, no remedy, and the panel does not
+    change colour.
+  - **A project whose own folder did not answer** gets a warning badge on its card, so the missing
+    git and engine detail has a stated reason instead of looking like a project that has none.
+  - **A session whose liveness could not be read** gets a distinct status dot carrying a glyph, not
+    a colour alone, and the card detail says *Unknown* with the cause instead of *No active
+    session*.
+  - **`git.dirty` that could not be established** renders as `?` rather than as the absence of the
+    dirty marker — which is exactly how a clean repository is drawn.
+
+  A remembered refusal now also says that nothing is being retried right now, *while keeping* its
+  remedy: the backoff is an additional fact, not a replacement for advice about a condition that
+  has not changed. And an ordinary read failure, which the server leaves without a remedy because
+  it cannot know the cause, gets one that names no cause.
+
+  Internal vocabulary stays internal: an operator is never shown `dirty` or `read-timed-out`.
 
 - **A missing projects folder now offers to create itself.** `~/Documents/Projects` is the path the
   wizard pre-fills, and a stock macOS install does not have it — macOS creates `Documents`, nothing

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -158,7 +158,9 @@ Global rules are stored at `~/.tangleclaw/global-rules.md`. On first load, this 
 
 ### Toolbar
 
-- **Session count**: Shows how many active sessions are running
+- **Session count**: Shows how many active sessions are running. If TangleClaw could not reach the
+  tmux server for some of them, it adds "· N unknown" rather than counting those as inactive — the
+  count never asserts a number it could not establish
 - **Filter**: Opens the search/filter panel
 - **+ New**: Opens the create project drawer
 
@@ -169,8 +171,15 @@ Projects are displayed as compact cards. Each card shows:
 - **Name** — the project directory name
 - **Version badge** — the project's current version (if available), shown as a subtle badge
 - **Engine badge** — which AI engine is selected (e.g., "Claude Code")
-- **Git info** — branch, dirty state, last commit age
-- **Session indicator** — a green breathing dot when a session is active
+- **Git info** — branch, dirty state, last commit age. A `?` after the branch name means the
+  working tree could not be read, which is **not** the same as clean — hover or tap the badge for
+  the reason
+- **Session indicator** — a green breathing dot when a session is active, nothing when there is no
+  session, and a `?` dot when TangleClaw could not reach tmux to find out. The three are
+  deliberately distinct: an unreadable state is never drawn as an absent one
+- **Unreadable badge** — a ⚠ marker when the project's own folder did not answer. Its git, engine
+  and version details are missing rather than absent, and the badge carries the reason and, where
+  there is one, the remedy
 - **Peek icon** — an eye icon to quickly peek at session output without entering the session wrapper
 - **Delete button** — a subtle "x" on the card (password required if configured)
 - **Launch** — tap the card or launch button to enter the session

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -195,7 +195,9 @@ Tap the delete button on a project card. If a `deletePassword` is configured, yo
 
 ### Attaching Existing Projects
 
-TangleClaw shows ALL directories in your `projectsDir` on the landing page — not just registered ones. Unregistered directories appear with a muted style and an **Attach** button.
+TangleClaw shows every directory in your `projectsDir` on the landing page — not just registered ones. Unregistered directories appear with a muted style and an **Attach** button.
+
+If the list is ever *short* — the folder could not be read, or it holds more directories than one scan can check in time — the ROOT panel says so, gives the reason and the remedy, and the count changes from "total" to "listed". A short list is never presented silently as a complete one.
 
 Tap **Attach** to register a directory as a TangleClaw project. This:
 - Reads any existing `.tangleclaw/project.json` for engine settings

--- a/lib/dir-scanner-child.js
+++ b/lib/dir-scanner-child.js
@@ -383,8 +383,20 @@ const HANDLERS = {
         // `dirty: null` this walk never got to check is indistinguishable here
         // from a repository that is genuinely clean — the same false fact the
         // projectFacts path carries it to prevent.
+        //
+        // `cause` travels for the same reason one level down: it is WHY those
+        // fields were not established, and the dashboard renders it. Dropping it
+        // here gave two cards in the same list different answers to the same
+        // failure — a registered project naming the cause and offering the
+        // slow-repository remedy, an unregistered one falling back to "the read
+        // did not complete" with no advice at all.
         git: gitInfo
-          ? { branch: gitInfo.branch, dirty: gitInfo.dirty, incomplete: gitInfo.incomplete }
+          ? {
+            branch: gitInfo.branch,
+            dirty: gitInfo.dirty,
+            incomplete: gitInfo.incomplete,
+            cause: gitInfo.cause
+          }
           : null,
         detected: !!((gitInfo && gitInfo.branch) || hasTangleclawConfig || hasProjectMarker)
       });

--- a/lib/dir-scanner.js
+++ b/lib/dir-scanner.js
@@ -112,6 +112,40 @@ function _aborted(reason) {
 }
 
 /**
+ * Name the failure a scan hit, as a value a consumer can branch on.
+ *
+ * LIVES HERE BECAUSE THE FLAGS DO. This module is the only thing that sets
+ * `tcTimedOut`, `tcAborted` and `tcCached`, and the mapping from them to a code
+ * had grown a second copy — `lib/projects.js` for a whole-directory scan,
+ * `lib/project-facts.js` for one project's read — with DIFFERENT precedence.
+ * They agreed only because the flags happen to be set almost exclusively today;
+ * the one overlap that already exists (`_notAnswering` sets `tcCached` on top of
+ * `tcTimedOut`) is exactly where the orders disagree, so one new combination
+ * would have had a single response describing one failure with two codes.
+ *
+ * ORDER IS THE CONTRACT, not an implementation detail:
+ *
+ * - `tcCached` first, because a remembered refusal ALSO carries `tcTimedOut` by
+ *   design — reading the timeout first reports every backoff as a fresh one, and
+ *   loses the only signal that says nothing is being retried right now.
+ * - `tcAborted` next: collateral says nothing about this path at all.
+ * - `SCAN_FAILED` last, for an ordinary error that is none of the above.
+ *
+ * The remedy is a SEPARATE decision and deliberately not derived from the code:
+ * `SCAN_CACHED` still earns the Full Disk Access hint, because the condition
+ * behind it is unchanged (see `_notAnswering`) even though its cost is not.
+ *
+ * @param {Error & {tcCached?: boolean, tcTimedOut?: boolean, tcAborted?: boolean}} [err]
+ * @returns {string} `SCAN_CACHED` | `SCAN_TIMEOUT` | `SCAN_ABORTED` | `SCAN_FAILED`.
+ */
+function failureCode(err) {
+  if (err && err.tcCached) return 'SCAN_CACHED';
+  if (err && err.tcTimedOut) return 'SCAN_TIMEOUT';
+  if (err && err.tcAborted) return 'SCAN_ABORTED';
+  return 'SCAN_FAILED';
+}
+
+/**
  * Build the answer given for a path already known not to answer.
  *
  * Carries `tcTimedOut` because the CONDITION is unchanged — the directory is
@@ -716,6 +750,7 @@ const _interactiveScanner = createScanner();
 
 module.exports = {
   createScanner,
+  failureCode,
   // Background/polled work. Callers here may pass `pathKey` to opt into the
   // failure backoff, because nobody is waiting on any individual request.
   request: (op, payload, opts) => _backgroundScanner.request(op, payload, opts),

--- a/lib/git.js
+++ b/lib/git.js
@@ -131,7 +131,7 @@ function isGitRepo(dir) {
  * @param {string} dir - Project directory path
  * @param {object} [options] - Read options.
  * @param {number} [options.budgetMs] - Total wall clock for all git work here.
- * @returns {{ branch: string, dirty: boolean|null, lastCommit: string, lastCommitAge: string, latestTag: string|null, incomplete: string[] }|null}
+ * @returns {{ branch: string, dirty: boolean|null, lastCommit: string, lastCommitAge: string, latestTag: string|null, incomplete: string[], cause: string|null }|null}
  */
 function getInfo(dir, options = {}) {
   const cacheKey = cacheKeyFor(dir);
@@ -256,7 +256,7 @@ function _branchFromRef(ref) {
  *   is HOW MANY invocations happen, and a count cannot be observed from the
  *   outside — the answers are identical either way, which is the whole claim.
  *   Same seam, same name, as `lib/tmux.js` and `lib/engines.js`.
- * @returns {{ branch: string, dirty: boolean|null, lastCommit: string, lastCommitAge: string, latestTag: string|null, incomplete: string[] }|null}
+ * @returns {{ branch: string, dirty: boolean|null, lastCommit: string, lastCommitAge: string, latestTag: string|null, incomplete: string[], cause: string|null }|null}
  */
 function _fetchInfo(dir, options = {}) {
   const budgetMs = Number.isFinite(options.budgetMs) ? options.budgetMs : GIT_INFO_BUDGET_MS;
@@ -468,7 +468,16 @@ function _fetchInfo(dir, options = {}) {
     // read is gone; what shares one now is `branch`, pushed by the is-a-repo
     // probe and again by the `--abbrev-ref` recovery beside it when a read has no
     // budget left for either.
-    incomplete: [...new Set(incomplete)]
+    incomplete: [...new Set(incomplete)],
+    // WHY the reading went short, not just which fields did. It reached the log
+    // and stopped there, which meant the dashboard could show that `dirty` was
+    // unknown but never that the repository is merely slow rather than broken —
+    // and only one of those is something an operator can act on.
+    //
+    // `null` rather than the internal `'complete'` sentinel on a whole reading:
+    // a consumer testing `cause` for truthiness must not be told a cause when
+    // nothing went wrong, and `'complete'` reads as one.
+    cause: cause === 'complete' ? null : cause
   };
 }
 

--- a/lib/project-facts.js
+++ b/lib/project-facts.js
@@ -177,10 +177,12 @@ async function readProjectFacts(project, options = {}) {
       error: err && err.message,
       hint
     });
-    let code = 'SCAN_FAILED';
-    if (err && err.tcCached) code = 'SCAN_CACHED';
-    else if (err && err.tcTimedOut) code = 'SCAN_TIMEOUT';
-    return _degraded((err && err.message) || 'the directory did not answer', hint, code);
+    // One mapping, in the module that sets the flags. This read had its own copy
+    // with a different precedence from the whole-directory scan's, and the two
+    // agreed only because the flags are set almost exclusively — the one overlap
+    // that exists today is where they disagreed.
+    return _degraded((err && err.message) || 'the directory did not answer', hint,
+      dirScanner.failureCode(err));
   }
 }
 

--- a/lib/projects.js
+++ b/lib/projects.js
@@ -657,6 +657,55 @@ const {
 // ── Project Enrichment ──
 
 /**
+ * The session payload for a pane tmux confirmed is there.
+ *
+ * `incomplete` and `cause` are present on the healthy object too, empty and
+ * null. A field that appears only on failure makes every consumer probe for its
+ * existence instead of reading its value — the same rule `unreadable` follows a
+ * few lines below.
+ *
+ * @param {object} row - Session row from the store.
+ * @param {string} status - Status to report (`row.status`, or `'wrapping'`).
+ * @returns {{active: true, status: string, startedAt: string, tmuxSession: string,
+ *   incomplete: string[], cause: null}}
+ */
+function _liveSession(row, status) {
+  return {
+    active: true,
+    status,
+    startedAt: row.startedAt,
+    tmuxSession: row.tmuxSession,
+    incomplete: [],
+    cause: null
+  };
+}
+
+/**
+ * The session payload for a pane whose liveness could not be established.
+ *
+ * `active: null` rather than `false`: the read did not happen, so there is no
+ * negative to report. Falsy, so every consumer that tests `session.active`
+ * behaves as it did before this state existed; distinguishable, so a consumer
+ * that wants to say "unknown" can.
+ *
+ * @param {object} row - Session row from the store.
+ * @param {string} status - Status to report (`row.status`, or `'wrapping'`).
+ * @param {string|null} cause - Why the read established nothing, e.g. `read-timed-out`.
+ * @returns {{active: null, status: string, startedAt: string, tmuxSession: string,
+ *   incomplete: string[], cause: string|null}}
+ */
+function _unknownSession(row, status, cause) {
+  return {
+    active: null,
+    status,
+    startedAt: row.startedAt,
+    tmuxSession: row.tmuxSession,
+    incomplete: ['active'],
+    cause: cause || null
+  };
+}
+
+/**
  * Enrich a project record with git info, session status, and engine info.
  *
  * Facts about the project's OWN directory come from `readProjectFacts`
@@ -703,10 +752,11 @@ const {
  *   unreadableHint: string|null}} [facts] - Pre-gathered directory facts, from the
  *   polled scanner. Read here interactively when omitted.
  * @param {object} [context] - Work shared across one list of projects.
- * @param {{get: () => Promise<Set<string>>}} [context.tmuxSessionNames] - Live
- *   session names, from `tmux.createSessionNameSnapshot()`. One snapshot serves a
- *   whole list; omitting it makes this call create its own, so a caller that
- *   forgets pays for an extra invocation and is never answered wrongly.
+ * @param {{get: () => Promise<{names: Set<string>, answered: boolean, cause: string|null}>}}
+ *   [context.tmuxSessionNames] - Live session names AND whether tmux answered at
+ *   all, from `tmux.createSessionNameSnapshot()`. One snapshot serves a whole
+ *   list; omitting it makes this call create its own, so a caller that forgets
+ *   pays for an extra invocation and is never answered wrongly.
  * @returns {Promise<object>} - Enriched project
  */
 async function enrichProject(project, facts, context) {
@@ -742,7 +792,8 @@ async function enrichProject(project, facts, context) {
     }
   }
 
-  // Session info — include both active and wrapping sessions (only if tmux is alive)
+  // Session info — active and wrapping sessions alike, reported as live only
+  // when tmux confirmed the pane, and as unknown when it could not be asked.
   //
   // Liveness comes from ONE `tmux list-sessions` shared across the whole list,
   // not a `tmux has-session` per project: the latter ran on the event loop with
@@ -750,36 +801,39 @@ async function enrichProject(project, facts, context) {
   // for an answer that fits in a single invocation. The snapshot spawns nothing
   // until something below actually asks, so a project with no session in the
   // database still costs nothing at all.
+  //
+  // THREE outcomes, not two. A tmux server that did not answer establishes
+  // nothing, so a session it could not confirm is reported as UNKNOWN rather
+  // than quietly dropped — dropping it told the operator "nothing is running"
+  // for a machine where everything was (#900). `active: null` is the same
+  // answer `git.dirty` gives for a field its read could not establish (#891),
+  // and it is what makes this safe for existing consumers: every one of them
+  // tests `session && session.active`, so a null reads exactly as today's
+  // not-active until something is taught to look for it.
   let session = null;
   const sessionNames = (context && context.tmuxSessionNames) || tmux.createSessionNameSnapshot();
   const activeSession = store.sessions.getActive(project.id);
   if (activeSession) {
-    // Only report as active if tmux session is actually alive
-    const tmuxAlive = !activeSession.tmuxSession
-      || (await sessionNames.get()).has(activeSession.tmuxSession);
-    if (tmuxAlive) {
-      session = {
-        active: true,
-        status: activeSession.status,
-        startedAt: activeSession.startedAt,
-        tmuxSession: activeSession.tmuxSession
-      };
+    // Short-circuited so a session with no tmux handle still spawns nothing —
+    // the snapshot's laziness is only worth having if the callers preserve it.
+    const verdict = activeSession.tmuxSession ? await sessionNames.get() : null;
+    if (!verdict || verdict.names.has(activeSession.tmuxSession)) {
+      session = _liveSession(activeSession, activeSession.status);
+    } else if (!verdict.answered) {
+      session = _unknownSession(activeSession, activeSession.status, verdict.cause);
     }
-    // If tmux is dead, don't report — getSessionStatus() will clean up the DB state
+    // tmux answered and this pane is gone: don't report — getSessionStatus()
+    // will clean up the DB state.
   } else {
     const wrappingSession = store.sessions.getWrapping(project.id);
     if (wrappingSession) {
       // Asymmetric with the active branch above, and deliberately so: an active
       // session with no tmux name counts as live, a wrapping one does not.
-      const tmuxAlive = !!wrappingSession.tmuxSession
-        && (await sessionNames.get()).has(wrappingSession.tmuxSession);
-      if (tmuxAlive) {
-        session = {
-          active: true,
-          status: 'wrapping',
-          startedAt: wrappingSession.startedAt,
-          tmuxSession: wrappingSession.tmuxSession
-        };
+      const verdict = wrappingSession.tmuxSession ? await sessionNames.get() : null;
+      if (verdict && verdict.names.has(wrappingSession.tmuxSession)) {
+        session = _liveSession(wrappingSession, 'wrapping');
+      } else if (verdict && !verdict.answered) {
+        session = _unknownSession(wrappingSession, 'wrapping', verdict.cause);
       }
       // If tmux is dead, don't report as active — let launch/status clean up
     }

--- a/lib/projects.js
+++ b/lib/projects.js
@@ -1575,24 +1575,6 @@ function _scanFailureHint(err) {
 }
 
 /**
- * Which failure the scan hit, as a value a consumer can branch on.
- *
- * The same vocabulary `lib/project-facts.js` puts on a single project's
- * `unreadableCode`, so a renderer showing "this folder would not answer" and one
- * showing "the whole directory would not answer" describe them in the same terms
- * rather than each inventing a taxonomy.
- *
- * @param {Error & {tcCached?: boolean, tcTimedOut?: boolean, tcAborted?: boolean}} err
- * @returns {string} `SCAN_CACHED` | `SCAN_TIMEOUT` | `SCAN_ABORTED` | `SCAN_FAILED`.
- */
-function _scanFailureCode(err) {
-  if (err && err.tcCached) return 'SCAN_CACHED';
-  if (err && err.tcTimedOut) return 'SCAN_TIMEOUT';
-  if (err && err.tcAborted) return 'SCAN_ABORTED';
-  return 'SCAN_FAILED';
-}
-
-/**
  * The `scan` block every projects listing carries.
  *
  * Called with no failure for the healthy path, so the healthy answer is built by
@@ -1602,7 +1584,7 @@ function _scanFailureCode(err) {
  *
  * @param {string} dir - The directory the scan was for.
  * @param {object} [failure] - Omitted on the healthy path.
- * @param {string} [failure.code] - Machine-readable cause; see `_scanFailureCode`.
+ * @param {string} [failure.code] - Machine-readable cause; see `dirScanner.failureCode`.
  * @param {string} [failure.reason] - One sentence for a human.
  * @param {string} [failure.hint] - The remedy, where one fits the failure.
  * @param {number} [failure.listed] - Entries reported before a cut-off.
@@ -1749,7 +1731,7 @@ async function listAllProjects(options = {}) {
     return {
       projects: registered.map(p => ({ ...p, registered: true })),
       scan: _scanState(projectsDir, {
-        code: _scanFailureCode(err),
+        code: dirScanner.failureCode(err),
         reason: 'Could not read the projects directory, so folders that are not registered '
           + 'are missing from this list. Registered projects are unaffected.',
         hint: _scanFailureHint(err)

--- a/lib/projects.js
+++ b/lib/projects.js
@@ -1575,6 +1575,52 @@ function _scanFailureHint(err) {
 }
 
 /**
+ * Which failure the scan hit, as a value a consumer can branch on.
+ *
+ * The same vocabulary `lib/project-facts.js` puts on a single project's
+ * `unreadableCode`, so a renderer showing "this folder would not answer" and one
+ * showing "the whole directory would not answer" describe them in the same terms
+ * rather than each inventing a taxonomy.
+ *
+ * @param {Error & {tcCached?: boolean, tcTimedOut?: boolean, tcAborted?: boolean}} err
+ * @returns {string} `SCAN_CACHED` | `SCAN_TIMEOUT` | `SCAN_ABORTED` | `SCAN_FAILED`.
+ */
+function _scanFailureCode(err) {
+  if (err && err.tcCached) return 'SCAN_CACHED';
+  if (err && err.tcTimedOut) return 'SCAN_TIMEOUT';
+  if (err && err.tcAborted) return 'SCAN_ABORTED';
+  return 'SCAN_FAILED';
+}
+
+/**
+ * The `scan` block every projects listing carries.
+ *
+ * Called with no failure for the healthy path, so the healthy answer is built by
+ * the same function as the degraded one and the two cannot drift into different
+ * shapes. `complete` is derived from whether a code was given rather than passed
+ * separately — a caller cannot report a failure and a complete list at once.
+ *
+ * @param {string} dir - The directory the scan was for.
+ * @param {object} [failure] - Omitted on the healthy path.
+ * @param {string} [failure.code] - Machine-readable cause; see `_scanFailureCode`.
+ * @param {string} [failure.reason] - One sentence for a human.
+ * @param {string} [failure.hint] - The remedy, where one fits the failure.
+ * @param {number} [failure.listed] - Entries reported before a cut-off.
+ * @returns {{dir: string, complete: boolean, code: string|null, reason: string|null,
+ *   hint: string|null, listed: number|null}}
+ */
+function _scanState(dir, failure) {
+  return {
+    dir,
+    complete: !failure,
+    code: (failure && failure.code) || null,
+    reason: (failure && failure.reason) || null,
+    hint: (failure && failure.hint) || null,
+    listed: failure && Number.isFinite(failure.listed) ? failure.listed : null
+  };
+}
+
+/**
  * List all projects: merge SQLite-registered projects with ALL filesystem directories.
  * Unregistered dirs get { registered: false } entries with basic git info.
  * ASYNC (#859): the filesystem scan runs off the main thread and is bounded, so a
@@ -1603,8 +1649,15 @@ function _scanFailureHint(err) {
  * learnings entry says fix the family, not the call site, after #859's first fix
  * landed on `listAllProjects` and missed `POST /api/setup/scan`.
  *
+ * RETURNS THE LIST AND WHETHER IT IS THE WHOLE LIST. Degrading silently was the
+ * remaining half of the defect: the browser got a 200 and a well-formed array,
+ * and nothing distinguished "these are all your projects" from "these are the
+ * ones we could still see" (#885). `scan` is always present and always the same
+ * shape, so a consumer reads its fields rather than probing for them.
+ *
  * @param {object} [options] - Filter options passed to store.projects.list for registered projects
- * @returns {Promise<object[]>}
+ * @returns {Promise<{projects: object[], scan: {dir: string, complete: boolean,
+ *   code: string|null, reason: string|null, hint: string|null, listed: number|null}}>}
  */
 async function listAllProjects(options = {}) {
   const registered = await listProjects(options);
@@ -1668,7 +1721,17 @@ async function listAllProjects(options = {}) {
     );
   } catch (err) {
     if (err && err.code === 'ENOENT') {
-      return registered.map(p => ({ ...p, registered: true }));
+      // Not a failure to read — there is nothing there to read. Still incomplete,
+      // and still worth saying: an operator whose configured projects directory
+      // does not exist sees only registered projects forever, and the remedy is
+      // creating or re-pointing the directory rather than granting a permission.
+      return {
+        projects: registered.map(p => ({ ...p, registered: true })),
+        scan: _scanState(projectsDir, {
+          code: 'DIR_MISSING',
+          reason: `The projects directory does not exist: ${projectsDir}`
+        })
+      };
     }
     // A remembered refusal is not news. The scanner already logged a WARN naming
     // this path when it really failed, and it logs another each time the backoff
@@ -1683,7 +1746,15 @@ async function listAllProjects(options = {}) {
       error: err && err.message,
       hint: _scanFailureHint(err)
     });
-    return registered.map(p => ({ ...p, registered: true }));
+    return {
+      projects: registered.map(p => ({ ...p, registered: true })),
+      scan: _scanState(projectsDir, {
+        code: _scanFailureCode(err),
+        reason: 'Could not read the projects directory, so folders that are not registered '
+          + 'are missing from this list. Registered projects are unaffected.',
+        hint: _scanFailureHint(err)
+      })
+    };
   }
 
   if (walk.truncated) {
@@ -1696,9 +1767,24 @@ async function listAllProjects(options = {}) {
   }
 
   const result = registered.map(p => ({ ...p, registered: true }));
-  return [...result, ...walk.unregistered].sort((a, b) =>
-    a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
-  );
+  return {
+    projects: [...result, ...walk.unregistered].sort((a, b) =>
+      a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
+    ),
+    // A truncated walk is the OPPOSITE failure and must not be described as the
+    // same one: nothing is broken, the directory is just bigger or slower than
+    // the budget. It gets no remedy, because there is nothing to fix — telling
+    // someone to grant Full Disk Access for a folder that answered perfectly
+    // well is the misdiagnosis this whole area exists to remove.
+    scan: walk.truncated
+      ? _scanState(projectsDir, {
+        code: 'SCAN_TRUNCATED',
+        reason: 'The projects directory has more folders than one scan could check in time, '
+          + 'so this list is short rather than complete. Nothing is wrong with it.',
+        listed: walk.unregistered.length
+      })
+      : _scanState(projectsDir)
+  };
 }
 
 /**

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -144,45 +144,85 @@ function launchSession(projectName, options = {}) {
     }
   }
 
-  // Check for stale wrapping session
+  // Check for stale wrapping session.
+  //
+  // AGE IS TESTED BEFORE LIVENESS, and the order is the whole point. Age is
+  // evidence this process owns: a wrap that began ten days ago is an orphan
+  // whether or not tmux is willing to talk about it. Nesting the age recovery
+  // inside a liveness branch — which is where it used to live — meant a tmux
+  // that never answered skipped the recovery too, so the row could sit
+  // `wrapping` forever with no way out. That is exactly the brick #105 was
+  // filed for, and it would have been reintroduced by the one condition this
+  // change exists to add.
   const wrapping = store.sessions.getWrapping(project.id);
   if (wrapping) {
-    const tmuxAlive = wrapping.tmuxSession && tmux.hasSession(wrapping.tmuxSession);
-    if (tmuxAlive) {
-      // Wrapping rows older than the threshold are orphans — wrap was invoked
-      // but never completed (e.g. server restart, tmux orphaned). Auto-recover
-      // instead of bricking the project (#105). Falls back to startedAt for
-      // legacy rows that pre-date the wrap_started_at column.
-      const ageRef = wrapping.wrapStartedAt || wrapping.startedAt;
-      const ageRefMs = _parseSqliteUtcMs(ageRef);
-      // Fail-safe direction: an unparseable timestamp is treated as stale and
-      // recovered rather than fresh-and-blocked, since blocking is the exact
-      // bug class #105 was filed for.
-      const ageMs = Number.isFinite(ageRefMs)
-        ? Date.now() - ageRefMs
-        : STALE_WRAPPING_THRESHOLD_MS + 1;
-      if (ageMs > STALE_WRAPPING_THRESHOLD_MS) {
-        log.warn('Recovering stale wrapping session before launch', {
-          project: projectName,
-          session: wrapping.id,
-          ageSeconds: Math.floor(ageMs / 1000),
-          basedOn: wrapping.wrapStartedAt ? 'wrap_started_at' : 'started_at'
+    // Wrapping rows older than the threshold are orphans — wrap was invoked
+    // but never completed (e.g. server restart, tmux orphaned). Auto-recover
+    // instead of bricking the project (#105). Falls back to startedAt for
+    // legacy rows that pre-date the wrap_started_at column.
+    const ageRef = wrapping.wrapStartedAt || wrapping.startedAt;
+    const ageRefMs = _parseSqliteUtcMs(ageRef);
+    // Fail-safe direction: an unparseable timestamp is treated as stale and
+    // recovered rather than fresh-and-blocked, since blocking is the exact
+    // bug class #105 was filed for.
+    const ageMs = Number.isFinite(ageRefMs)
+      ? Date.now() - ageRefMs
+      : STALE_WRAPPING_THRESHOLD_MS + 1;
+
+    if (ageMs > STALE_WRAPPING_THRESHOLD_MS) {
+      log.warn('Recovering stale wrapping session before launch', {
+        project: projectName,
+        session: wrapping.id,
+        ageSeconds: Math.floor(ageMs / 1000),
+        basedOn: wrapping.wrapStartedAt ? 'wrap_started_at' : 'started_at'
+      });
+      try {
+        tmux.killSession(wrapping.tmuxSession);
+      } catch (err) {
+        log.warn('Failed to kill stale tmux during recovery', { error: err.message });
+      }
+      store.sessions.kill(wrapping.id, 'auto-recovered stale wrapping row');
+      // Forget the recovered session's Medusa listener + id (MED-2K9P Chunk 04).
+      _teardownMedusa(project, wrapping);
+      clearIdleCache(wrapping.tmuxSession);
+      // Fall through to fresh launch
+    } else {
+      // Young enough to still be a real wrap, so the pane's state decides. A row
+      // with no tmux handle has nothing to ask about; that is an answered
+      // negative, not an unknown.
+      const probe = wrapping.tmuxSession
+        ? tmux.probeSession(wrapping.tmuxSession)
+        : { live: false, answered: true, cause: null };
+
+      if (!probe.answered) {
+        // `autoCompleteWrap` writes the wrap complete, tears down the listener
+        // and COMMITS THE OPERATOR'S REPOSITORY. None of that may happen on a
+        // probe that never answered — and unlike a display, none of it comes
+        // back when tmux does (#908). Refusing costs a launch; the age branch
+        // above still claims the row within the hour, so nothing is stuck.
+        log.warn('Could not establish whether a wrapping session is still live — '
+          + 'refusing to auto-complete it', {
+          project: projectName, session: wrapping.id, cause: probe.cause
         });
-        try {
-          tmux.killSession(wrapping.tmuxSession);
-        } catch (err) {
-          log.warn('Failed to kill stale tmux during recovery', { error: err.message });
-        }
-        store.sessions.kill(wrapping.id, 'auto-recovered stale wrapping row');
-        // Forget the recovered session's Medusa listener + id (MED-2K9P Chunk 04).
-        _teardownMedusa(project, wrapping);
-        clearIdleCache(wrapping.tmuxSession);
-        // Fall through to fresh launch
-      } else {
+        return {
+          session: null,
+          primePrompt: null,
+          ttydUrl: null,
+          // Same machine-readable code as the active-session refusal above: the
+          // route classifies by code, and both are the same condition.
+          code: 'LIVENESS_UNKNOWN',
+          error: `Could not determine whether "${projectName}" has finished wrapping — `
+            + 'tmux did not answer. Nothing was changed. Check the tmux server '
+            + '(`tmux ls`) and try again.'
+        };
+      }
+
+      if (probe.live) {
         return { session: null, primePrompt: null, ttydUrl: null, error: `Session is currently wrapping for "${projectName}"` };
       }
-    } else {
-      // Dead wrapping session — auto-complete it
+
+      // tmux ANSWERED that the pane is gone — a real negative, so the wrap is
+      // genuinely over and completing it is honest.
       autoCompleteWrap(project, wrapping);
       log.info('Cleaned up stale wrapping session before launch', { project: projectName, session: wrapping.id });
     }
@@ -1555,9 +1595,44 @@ function getSessionStatus(projectName) {
   // Check for wrapping session
   const wrapping = store.sessions.getWrapping(project.id);
   if (wrapping) {
-    const tmuxAlive = wrapping.tmuxSession && tmux.hasSession(wrapping.tmuxSession);
+    // A row with no tmux handle has nothing to ask about — an answered negative.
+    const wrapProbe = wrapping.tmuxSession
+      ? tmux.probeSession(wrapping.tmuxSession)
+      : { live: false, answered: true, cause: null };
 
-    if (tmuxAlive) {
+    if (!wrapProbe.answered) {
+      // This is a READ, and the branch below it finalizes a wrap and commits the
+      // operator's repository. A poll that could not establish the pane's state
+      // must not do either (#908) — the session page calls this continuously
+      // during a wrap, so the poll most likely to meet a wedged server is
+      // exactly the one running while a wrap is in flight.
+      //
+      // Reported as still wrapping with the liveness named, rather than as
+      // finished: `wrapping: true` is what the row actually says, and `live`
+      // is the field we could not establish. The launch path's age recovery
+      // still claims the row within the hour, so nothing is stuck.
+      //
+      // That this read mutates AT ALL on the branch below is the deeper defect,
+      // deliberately left: re-timing wrap completion changes a headline feature
+      // and needs its own verification. Filed as #910.
+      return {
+        active: false,
+        wrapping: true,
+        sessionId: wrapping.id,
+        project: projectName,
+        engine: wrapping.engineId,
+        tmuxSession: wrapping.tmuxSession,
+        startedAt: wrapping.startedAt,
+        // Present on the healthy answers too, so a consumer reads the value
+        // rather than probing for the field's existence.
+        incomplete: ['live'],
+        cause: wrapProbe.cause,
+        idle: false,
+        lastOutputAge: null
+      };
+    }
+
+    if (wrapProbe.live) {
       // Cache pane output while wrapping (for capture when tmux dies)
       try {
         const capture = tmux.capturePane(wrapping.tmuxSession, { lines: 100 });
@@ -1577,12 +1652,18 @@ function getSessionStatus(projectName) {
         engine: wrapping.engineId,
         tmuxSession: wrapping.tmuxSession,
         startedAt: wrapping.startedAt,
+        // Empty on the healthy path, not absent — a field that appears only on
+        // failure makes every consumer probe for its existence instead of
+        // reading its value.
+        incomplete: [],
+        cause: null,
         idle: idleInfo.idle,
         lastOutputAge: idleInfo.lastOutputAge
       };
     }
 
-    // tmux is dead — auto-complete the wrap
+    // tmux ANSWERED that the pane is gone, so the wrap is genuinely over and
+    // completing it is honest.
     const completed = autoCompleteWrap(project, wrapping);
     return {
       active: false,

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -1623,11 +1623,22 @@ function getSessionStatus(projectName) {
         engine: wrapping.engineId,
         tmuxSession: wrapping.tmuxSession,
         startedAt: wrapping.startedAt,
-        // Present on the healthy answers too, so a consumer reads the value
-        // rather than probing for the field's existence.
-        incomplete: ['live'],
+        // `incomplete` names the RETURNED fields that could not be established,
+        // which is the convention `session.active` and `git.dirty` already
+        // follow — not the internal concept behind them. Reaching the pane is
+        // what produces idle and lastOutputAge, so a pane we could not reach
+        // leaves both unestablished; that the LIVENESS is unknown is what a
+        // non-null `cause` on a wrapping answer means.
+        //
+        // `idle: null`, never `false`. A definite "not idle" is precisely the
+        // plausible default this whole family exists to stop shipping, and the
+        // session page treats idle as a wrap-completion signal — so a false
+        // there is a wrong answer to the question the page is asking. Null is
+        // falsy, so every consumer that has not learned about this state
+        // behaves exactly as it did before it existed.
+        incomplete: ['idle', 'lastOutputAge'],
         cause: wrapProbe.cause,
-        idle: false,
+        idle: null,
         lastOutputAge: null
       };
     }

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -146,10 +146,15 @@ function launchSession(projectName, options = {}) {
 
   // Check for stale wrapping session.
   //
-  // AGE IS TESTED BEFORE LIVENESS, and the order is the whole point. Age is
-  // evidence this process owns: a wrap that began ten days ago is an orphan
-  // whether or not tmux is willing to talk about it. Nesting the age recovery
-  // inside a liveness branch — which is where it used to live — meant a tmux
+  // AGE DECIDES BEFORE LIVENESS DOES — note "decides", not "runs". The probe
+  // below executes first, because the aged-out branch still needs its answer to
+  // tell a confirmed-dead pane (complete the wrap) from a live or unestablished
+  // one (recover on age). What matters is that the probe can only ADD an
+  // outcome; it can never withhold the recovery.
+  //
+  // Age is evidence this process owns: a wrap that began ten days ago is an
+  // orphan whether or not tmux is willing to talk about it. Nesting the age
+  // recovery inside a liveness branch — where it used to live — meant a tmux
   // that never answered skipped the recovery too, so the row could sit
   // `wrapping` forever with no way out. That is exactly the brick #105 was
   // filed for, and it would have been reintroduced by the one condition this

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -103,8 +103,25 @@ function launchSession(projectName, options = {}) {
   // Check for existing active session
   const existing = store.sessions.getActive(project.id);
   if (existing) {
+    // Same rule as the status read: this branch RECORDS a death, so it may only
+    // run on an observed one. A tmux too wedged to answer would otherwise have
+    // the operator's running session written off as crashed and a second one
+    // launched over it — and the launch itself would then fail anyway, because
+    // creating a session needs the same server that just would not reply. An
+    // honest refusal beats a mangled record plus an obscure failure.
+    const probe = existing.tmuxSession ? tmux.probeSession(existing.tmuxSession) : null;
+    if (probe && !probe.answered) {
+      return {
+        session: null,
+        primePrompt: null,
+        ttydUrl: null,
+        error: `Could not determine whether "${projectName}" already has a session running — `
+          + 'tmux did not answer. Nothing was changed. Check the tmux server '
+          + '(`tmux ls`) and try again.'
+      };
+    }
     // If tmux is dead, clean up the stale session instead of blocking
-    if (existing.tmuxSession && !tmux.hasSession(existing.tmuxSession)) {
+    if (probe && !probe.live) {
       store.sessions.markCrashed(existing.id, 'tmux session died');
       clearIdleCache(existing.tmuxSession);
       log.warn('Cleaned up stale active session before launch', { project: projectName, session: existing.id });
@@ -1468,19 +1485,35 @@ function getSessionStatus(projectName) {
       };
     }
 
-    // Check if tmux session is actually alive
-    if (active.tmuxSession && !tmux.hasSession(active.tmuxSession)) {
+    // Is the tmux session actually alive — and did tmux say so, or say nothing?
+    //
+    // THIS IS A READ THAT WRITES, which is why it cannot use the plain boolean.
+    // `hasSession` answers false both for a pane that is gone and for a tmux
+    // server too wedged to reply, and this branch PERSISTS that answer: one
+    // poll from an open session page during a wedge marks a running session
+    // crashed, and the row does not come back when tmux recovers. A status read
+    // may not record a death it did not observe (#900).
+    //
+    // One probe, not two: the old shape asked `hasSession` again inside the
+    // else-branch, spawning a second tmux for a question already answered.
+    const probe = active.tmuxSession ? tmux.probeSession(active.tmuxSession) : null;
+    if (probe && probe.answered && !probe.live) {
       // tmux died unexpectedly — mark as crashed so frontend detects session end
       store.sessions.markCrashed(active.id, 'tmux session died');
       clearIdleCache(active.tmuxSession);
       log.warn('Active session tmux died', { project: projectName, session: active.id });
       // Fall through to wrapping/lastSession checks below
     } else {
+      if (probe && !probe.answered) {
+        log.warn('Could not establish whether this session is still live — leaving the '
+          + 'record alone rather than marking it crashed',
+        { project: projectName, session: active.id, cause: probe.cause });
+      }
       // Check idle status via tmux
       let idle = false;
       let lastOutputAge = 0;
 
-      if (active.tmuxSession && tmux.hasSession(active.tmuxSession)) {
+      if (probe && probe.live) {
         const idleInfo = detectIdle(active.tmuxSession);
         idle = idleInfo.idle;
         lastOutputAge = idleInfo.lastOutputAge;

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -111,10 +111,24 @@ function launchSession(projectName, options = {}) {
     // honest refusal beats a mangled record plus an obscure failure.
     const probe = existing.tmuxSession ? tmux.probeSession(existing.tmuxSession) : null;
     if (probe && !probe.answered) {
+      // Logged, because this is the one refusal an operator can hit repeatedly
+      // with nothing else recording it: the status read's equivalent branch logs,
+      // and every other launch failure here is either an ordinary state or ends
+      // up in the activity log. A refusal that appears only in one HTTP response
+      // leaves no trace of how often the wedge is happening.
+      log.warn('Refused to launch — could not establish whether a session is already running',
+        { project: projectName, session: existing.id, cause: probe.cause });
       return {
         session: null,
         primePrompt: null,
         ttydUrl: null,
+        // The condition travels as a VALUE. The launch route classifies failures
+        // by matching substrings of this sentence, so a refusal with prose alone
+        // falls through to 500 INTERNAL_ERROR — which is doubly wrong here:
+        // nothing internal failed, and nothing changed. Rewording a message must
+        // not be able to change a status code (`scanDirectoryForProjects` learned
+        // the same lesson when a reworded sentence removed a button).
+        code: 'LIVENESS_UNKNOWN',
         error: `Could not determine whether "${projectName}" already has a session running — `
           + 'tmux did not answer. Nothing was changed. Check the tmux server '
           + '(`tmux ls`) and try again.'

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -169,31 +169,50 @@ function launchSession(projectName, options = {}) {
       ? Date.now() - ageRefMs
       : STALE_WRAPPING_THRESHOLD_MS + 1;
 
+    // The probe is consulted on BOTH paths, but it can only ever ADD an outcome,
+    // never withhold recovery. That is the distinction the ordering exists to
+    // protect: an unanswered probe must not be able to block the age recovery
+    // (#105), which is what nesting the age test inside a liveness branch did.
+    const probe = wrapping.tmuxSession
+      ? tmux.probeSession(wrapping.tmuxSession)
+      : { live: false, answered: true, cause: null };
+
     if (ageMs > STALE_WRAPPING_THRESHOLD_MS) {
-      log.warn('Recovering stale wrapping session before launch', {
-        project: projectName,
-        session: wrapping.id,
-        ageSeconds: Math.floor(ageMs / 1000),
-        basedOn: wrapping.wrapStartedAt ? 'wrap_started_at' : 'started_at'
-      });
-      try {
-        tmux.killSession(wrapping.tmuxSession);
-      } catch (err) {
-        log.warn('Failed to kill stale tmux during recovery', { error: err.message });
+      // An old row whose pane tmux CONFIRMS is gone is still auto-completed, as
+      // it always was — the wrap is genuinely over, and completing it preserves
+      // the summary, the listener teardown and the auto-commit. Reordering the
+      // age test above the liveness test changed this outcome silently in the
+      // first cut of #908; it is restored deliberately, because nothing about an
+      // unanswered probe justifies altering what happens when tmux DID answer.
+      if (probe.answered && !probe.live) {
+        autoCompleteWrap(project, wrapping);
+        log.info('Completed an aged-out wrapping session whose pane tmux confirmed was gone', {
+          project: projectName, session: wrapping.id, ageSeconds: Math.floor(ageMs / 1000)
+        });
+      } else {
+        // Live, or unestablished. Either way the row has outlived the threshold,
+        // so it is recovered rather than left to block the project — recovery
+        // does NOT depend on the probe having answered.
+        log.warn('Recovering stale wrapping session before launch', {
+          project: projectName,
+          session: wrapping.id,
+          ageSeconds: Math.floor(ageMs / 1000),
+          basedOn: wrapping.wrapStartedAt ? 'wrap_started_at' : 'started_at',
+          livenessAnswered: probe.answered
+        });
+        try {
+          tmux.killSession(wrapping.tmuxSession);
+        } catch (err) {
+          log.warn('Failed to kill stale tmux during recovery', { error: err.message });
+        }
+        store.sessions.kill(wrapping.id, 'auto-recovered stale wrapping row');
+        // Forget the recovered session's Medusa listener + id (MED-2K9P Chunk 04).
+        _teardownMedusa(project, wrapping);
+        clearIdleCache(wrapping.tmuxSession);
       }
-      store.sessions.kill(wrapping.id, 'auto-recovered stale wrapping row');
-      // Forget the recovered session's Medusa listener + id (MED-2K9P Chunk 04).
-      _teardownMedusa(project, wrapping);
-      clearIdleCache(wrapping.tmuxSession);
       // Fall through to fresh launch
     } else {
-      // Young enough to still be a real wrap, so the pane's state decides. A row
-      // with no tmux handle has nothing to ask about; that is an answered
-      // negative, not an unknown.
-      const probe = wrapping.tmuxSession
-        ? tmux.probeSession(wrapping.tmuxSession)
-        : { live: false, answered: true, cause: null };
-
+      // Young enough to still be a real wrap, so the pane's state decides.
       if (!probe.answered) {
         // `autoCompleteWrap` writes the wrap complete, tears down the listener
         // and COMMITS THE OPERATOR'S REPOSITORY. None of that may happen on a
@@ -2624,11 +2643,27 @@ function _deferEngineInit(tmuxName, projectName, engineId, engineProfile, primeT
     delay += startupDelay;
 
     setTimeout(() => {
-      if (!tmux.hasSession(tmuxName)) {
-        // Session died before the prime could be pasted — the rules did not
-        // arrive, and the ledger says so rather than staying silent.
+      // The ledger row this writes is DURABLE, so the reason it records has to
+      // be one that was actually established. `hasSession` answers false both
+      // for a pane that ended and for a tmux server that would not reply, and
+      // recording "the session ended" for the second is a fact nobody observed
+      // — the third site on #908's census, and the one whose write outlives the
+      // condition that caused it.
+      const primeProbe = tmux.probeSession(tmuxName);
+      if (!primeProbe.live) {
+        // The paste is skipped either way — it needs the server that just failed
+        // to answer — but WHY it was skipped is not the same in both cases, and
+        // the ledger is read later by someone asking whether the rules arrived.
         if (deliveryBase) {
-          _recordRuleDelivery({ ...deliveryBase, channel: 'prime-paste', outcome: 'skipped', skipReason: 'tmux session ended before the prime was pasted' });
+          _recordRuleDelivery({
+            ...deliveryBase,
+            channel: 'prime-paste',
+            outcome: 'skipped',
+            skipReason: primeProbe.answered
+              ? 'tmux session ended before the prime was pasted'
+              : 'could not establish whether the tmux session was still running when the '
+                + 'prime was due to be pasted — tmux did not answer'
+          });
         }
         return;
       }

--- a/lib/tmux.js
+++ b/lib/tmux.js
@@ -56,7 +56,12 @@ function _exec(command, options = {}) {
     // tmux server produced no timeout log at all (#894).
     if (wasTimedOut(err)) {
       log.error('tmux command timed out', { command, timeout });
-      throw new Error(`tmux command timed out after ${timeout}ms`);
+      // Flagged, because this throw REPLACES the error `wasTimedOut` can read:
+      // a caller that needs to tell "tmux said no" from "tmux said nothing"
+      // cannot re-derive it from a message string. `tcTimedOut` is the name the
+      // scanner already uses for the same distinction (`lib/dir-scanner.js`).
+      throw Object.assign(new Error(`tmux command timed out after ${timeout}ms`),
+        { tcTimedOut: true });
     }
     throw err;
   }
@@ -193,15 +198,50 @@ function createSessionNameSnapshot(options = {}) {
  * not good enough — `createSessionNameSnapshot` is for the read-only fleet view,
  * this is for acting on one session.
  *
+ * FALSE MEANS "not confirmed live", which is the right answer for a caller about
+ * to act on a pane and the wrong one for a caller about to RECORD that the pane
+ * is gone — a tmux that did not answer would have a live session written off as
+ * crashed. Anything that persists or refuses on the strength of the answer must
+ * use `probeSession` and check `answered` first.
+ *
  * @param {string} name - Session name
+ * @param {object} [options] - Passed through to the exec (`timeout`).
  * @returns {boolean}
  */
-function hasSession(name) {
+function hasSession(name, options) {
+  return probeSession(name, options).live;
+}
+
+/**
+ * Ask whether one session is live, and whether tmux answered at all.
+ *
+ * The same question `hasSession` asks, with the third outcome kept instead of
+ * flattened: a wedged tmux server (#94/#144/#380) makes every probe fail, and a
+ * caller that treats that failure as "the pane is gone" writes a fact nobody
+ * established. `createSessionNameSnapshot` draws the same distinction for the
+ * whole fleet at once; this is the single-session form, for callers that need
+ * an answer about a specific pane right now.
+ *
+ * `answered: true` with `live: false` is a real negative — tmux ran and said the
+ * session is not there. Only a read our own timeout stopped is unknown; the
+ * asymmetry, and why widening it would invert the bug, is argued at
+ * `_readSessionNames`.
+ *
+ * @param {string} name - Session name
+ * @param {object} [options] - Passed through to the exec.
+ * @param {number} [options.timeout] - Milliseconds before the probe is killed.
+ *   The same injection seam `createSessionNameSnapshot` takes, and for the same
+ *   reason: the unanswered branch can only be driven by a probe that really is
+ *   killed, and a test cannot wait out the default cap to see it.
+ * @returns {{live: boolean, answered: boolean, cause: string|null}}
+ */
+function probeSession(name, options = {}) {
   try {
-    _exec(`tmux has-session -t ${_target(name)} 2>/dev/null`);
-    return true;
-  } catch {
-    return false;
+    _exec(`tmux has-session -t ${_target(name)} 2>/dev/null`, options);
+    return { live: true, answered: true, cause: null };
+  } catch (err) {
+    if (err && err.tcTimedOut) return { live: false, answered: false, cause: 'read-timed-out' };
+    return { live: false, answered: true, cause: null };
   }
 }
 
@@ -715,6 +755,7 @@ module.exports = {
   listSessions,
   createSessionNameSnapshot,
   hasSession,
+  probeSession,
   createSession,
   buildStatusLeft,
   refreshStatusBars,

--- a/lib/tmux.js
+++ b/lib/tmux.js
@@ -93,16 +93,25 @@ function listSessions() {
  * collides with one of ours. Run through `execFile` with an argv rather than a
  * shell string for the same reason — nothing here is re-parsed.
  *
- * NEVER REJECTS. It resolves to an empty set for every failure, which is the
- * answer `hasSession` already gives one name at a time: tmux not running, no
- * sessions, and a tmux server too wedged to answer all read as "none live". The
- * last of those is an unknown wearing a fact's clothes — a wedged server makes
- * every session look dead — and it is preserved here deliberately rather than
- * fixed in passing, because changing it changes what the dashboard shows.
+ * NEVER REJECTS, and it never reports an absence it did not observe. Three
+ * outcomes reach the caller, not two: tmux listed the live names, tmux told us
+ * there is nothing live, or tmux did not answer at all. The third used to be
+ * folded into the second — an unknown wearing a fact's clothes, which made a
+ * wedged server report every running session as dead across the whole fleet
+ * view (#94/#144/#380 record this install reaching exactly that state).
+ *
+ * ONLY A STOP WE CAUSED IS AN UNKNOWN. A tmux that replied — including the
+ * exit-1 `no server running` that is the ordinary state of a machine with no
+ * sessions, and a missing `tmux` binary — told us something, and that something
+ * is "nothing is live". Calling every failure unknown would invert the bug
+ * rather than fix it: after a reboot, every stale `active` row would sit at
+ * unknown forever on every machine where tmux is simply not running. `git`
+ * draws the same line with `weStopped` (`lib/git.js`).
  *
  * @param {Function} execFn - `execFile`-shaped runner.
  * @param {number} timeout - Milliseconds before the invocation is killed.
- * @returns {Promise<Set<string>>} Live session names; empty when none answered.
+ * @returns {Promise<{names: Set<string>, answered: boolean, cause: string|null}>}
+ *   `answered: false` means the set says nothing about what is live.
  */
 function _readSessionNames(execFn, timeout) {
   return new Promise((resolve) => {
@@ -112,10 +121,12 @@ function _readSessionNames(execFn, timeout) {
           // A timeout is worth saying out loud; "no server running" is the
           // ordinary state of a machine with no sessions and would be noise.
           if (wasTimedOut(err)) {
-            log.error('tmux session listing timed out — every session will read as not live',
-              { timeout });
+            log.error('tmux session listing timed out — no session\'s liveness can be '
+              + 'established from this read', { timeout });
+            resolve({ names: new Set(), answered: false, cause: 'read-timed-out' });
+            return;
           }
-          resolve(new Set());
+          resolve({ names: new Set(), answered: true, cause: null });
           return;
         }
         const names = new Set();
@@ -123,7 +134,7 @@ function _readSessionNames(execFn, timeout) {
           const name = line.trim();
           if (name) names.add(name);
         }
-        resolve(names);
+        resolve({ names, answered: true, cause: null });
       });
   });
 }
@@ -147,10 +158,16 @@ function _readSessionNames(execFn, timeout) {
  * list, and its holder throws it away; a long-lived cache here would hand
  * stale liveness to callers that kill and type into sessions.
  *
+ * `get()` resolves the whole VERDICT — `{ names, answered, cause }` — not a bare
+ * set, so a caller cannot read "this name is not in the set" without also being
+ * told whether tmux answered at all. That is the shape, rather than a set plus
+ * a second accessor, because the failure being prevented is precisely reading
+ * one without the other.
+ *
  * @param {object} [options] - Options.
  * @param {Function} [options.execFn] - Injected `execFile` (tests).
  * @param {number} [options.timeout] - Milliseconds before the invocation is killed.
- * @returns {{ get: () => Promise<Set<string>> }}
+ * @returns {{ get: () => Promise<{names: Set<string>, answered: boolean, cause: string|null}> }}
  */
 function createSessionNameSnapshot(options = {}) {
   const execFn = options.execFn || execFile;

--- a/public/api-helper.js
+++ b/public/api-helper.js
@@ -1020,6 +1020,15 @@
   // `{known, why, remedy}` — so the dashboard speaks about a wedged tmux server
   // and an unreadable folder in the same voice, and a seventh source added later
   // joins in one place instead of growing a seventh render path.
+  //
+  // TWO RETURN CONVENTIONS, deliberately. `tcSessionRead` and `tcGitRead` always
+  // return a record, because their caller is already rendering that thing and
+  // only needs to know whether to qualify it. `tcScanNotice` and
+  // `tcUnreadableNotice` return NULL when nothing is wrong, because their caller
+  // renders nothing at all in that case — a notice row and a badge that do not
+  // exist. Hence `if (!read.known)` at two render sites and `if (notice)` at the
+  // other two. Sources that extend the record spread it rather than re-listing
+  // its fields, so a field added here reaches all four.
 
   /**
    * Build the one internal degraded-read record.
@@ -1043,11 +1052,15 @@
   // authored at the failure site, which is more specific than anything a
   // renderer could infer — those are used verbatim. Only session liveness and
   // git carry a bare `cause` token, so only those are translated here.
-  const TC_CAUSE_TEXT = {
+  // Null-prototype, here and in the three tables below: every one of them is
+  // keyed by a value that arrives in a JSON payload, and a plain object would
+  // answer `constructor` or `toString` with an inherited member — which then
+  // gets interpolated into a sentence an operator reads.
+  const TC_CAUSE_TEXT = Object.assign(Object.create(null), {
     'read-timed-out': 'the read was stopped by TangleClaw after it stopped responding',
     'git-refused-to-read-repository': 'git refused to read this repository',
     'git-status-unparsed': 'git answered in a form TangleClaw could not read'
-  };
+  });
 
   /**
    * Turn a bare `cause` token into a sentence.
@@ -1069,13 +1082,13 @@
   // operator is the same defect as printing a cause token: it reads as a leak,
   // and "dirty" in particular means nothing to someone who did not write it.
   // Every name `lib/git.js` can push is covered here.
-  const TC_GIT_FIELD_TEXT = {
+  const TC_GIT_FIELD_TEXT = Object.assign(Object.create(null), {
     dirty: 'whether there are uncommitted changes',
     branch: 'the current branch',
     lastCommit: 'the last commit',
     lastCommitAge: 'how long ago the last commit was',
     latestTag: 'the latest tag'
-  };
+  });
 
   /**
    * Name the unestablished git fields in words, as a readable list.
@@ -1198,12 +1211,19 @@
   // the failure shape it fits, and inventing one for the rest would reintroduce
   // exactly the misdiagnosis this whole area exists to remove — telling someone
   // to change a permission for a directory that answered perfectly well.
-  const TC_CODE_REMEDY = {
+  const TC_CODE_REMEDY = Object.assign(Object.create(null), {
     DIR_MISSING: 'Create the directory, or point TangleClaw at a different one in Settings.',
-    // Covers EACCES, ENOTDIR and every other ordinary error. Names no specific
-    // cause, because this code is the catch-all and asserting one would guess.
+    // The directory is there and this server may not read it. It is the one
+    // failure whose cause IS known and whose remedy is concrete, so leaving it
+    // without advice — while the vaguer catch-all below gets some — was exactly
+    // backwards. `lib/dir-scanner-child.js` reports it for a project's own
+    // directory and attaches no hint of its own.
+    EACCES: 'TangleClaw is not allowed to read this folder. Check its permissions, or grant '
+      + 'node Full Disk Access if it sits under ~/Documents, ~/Desktop or ~/Downloads.',
+    // The catch-all: ENOTDIR, EIO and anything else. Names no specific cause,
+    // because asserting one here would be a guess.
     SCAN_FAILED: 'Check that the directory still exists and that TangleClaw can read it.'
-  };
+  });
 
   // Codes whose meaning includes "and nothing is retrying it right now". Kept
   // separate from the remedy above ON PURPOSE: a remembered refusal still earns
@@ -1211,9 +1231,9 @@
   // describes is unchanged — the backoff is an additional fact, not a
   // replacement for the remedy, and deriving either from the other is the defect
   // three reviewers found independently.
-  const TC_CODE_NOT_RETRYING = {
+  const TC_CODE_NOT_RETRYING = Object.assign(Object.create(null), {
     SCAN_CACHED: 'This is a remembered result — the directory is not being retried right now.'
-  };
+  });
 
   /**
    * The notice the ROOT panel shows when the projects list is short.
@@ -1239,12 +1259,11 @@
       scan.reason || 'The projects directory could not be fully read, so this list may be short.',
       notRetrying
     ].filter(Boolean).join(' ');
-    const base = tcDegradedRead(false, why,
-      tcSentence(scan.hint) || TC_CODE_REMEDY[code] || null);
+    // Spread rather than re-listing the fields: a field added to the shared
+    // record must reach this source too, and copying `known`/`why`/`remedy` by
+    // hand is exactly how it would silently not.
     return {
-      known: false,
-      why: base.why,
-      remedy: base.remedy,
+      ...tcDegradedRead(false, why, tcSentence(scan.hint) || TC_CODE_REMEDY[code] || null),
       kind: code === 'SCAN_TRUNCATED' ? 'info' : 'warn',
       listed: Number.isFinite(scan.listed) ? scan.listed : null
     };
@@ -1268,15 +1287,14 @@
       'Its git, engine and version detail are missing rather than absent.',
       notRetrying
     ].filter(Boolean).join(' ');
-    const record = tcDegradedRead(false, why,
+    return tcDegradedRead(false, why,
       tcSentence(project.unreadableHint) || TC_CODE_REMEDY[code] || null);
-    return { known: false, why: record.why, remedy: record.remedy };
   }
 
-  global.tcDegradedRead = tcDegradedRead;
-  global.tcCauseText = tcCauseText;
-  global.tcGitFieldText = tcGitFieldText;
-  global.tcSentence = tcSentence;
+  // Only the classifiers the render sites actually call are exported.
+  // `tcDegradedRead`, `tcCauseText`, `tcGitFieldText` and `tcSentence` are
+  // internal to the four below and reached by closure — exporting them would
+  // enlarge the global surface that every page carries for no consumer.
   global.tcSessionLiveness = tcSessionLiveness;
   global.tcSessionRead = tcSessionRead;
   global.tcGitDirtyState = tcGitDirtyState;

--- a/public/api-helper.js
+++ b/public/api-helper.js
@@ -1007,6 +1007,282 @@
     return available.map((e) => e.id).sort()[0] || '';
   }
 
+  // ── Degraded reads: one internal shape for every "we could not establish it" ──
+  //
+  // The projects payload carries SIX representations of a read that did not
+  // answer, each shaped for its own question: `session.active: null` with
+  // `incomplete`/`cause`, `git.dirty: null` with `incomplete`/`cause`, a
+  // project's `unreadable`/`unreadableHint`/`unreadableCode` trio, and the
+  // list-level `scan` block. They differ in the payload because they answer
+  // different questions, and flattening them there would lose that.
+  //
+  // Here the job is the opposite. Everything below reduces to ONE record —
+  // `{known, why, remedy}` — so the dashboard speaks about a wedged tmux server
+  // and an unreadable folder in the same voice, and a seventh source added later
+  // joins in one place instead of growing a seventh render path.
+
+  /**
+   * Build the one internal degraded-read record.
+   *
+   * A constructor rather than an object literal at each site, so the shape
+   * cannot drift between the four sources that produce it.
+   *
+   * @param {boolean} known - Whether the read established its answer.
+   * @param {string|null} [why] - One sentence for a human, or null when known.
+   * @param {string|null} [remedy] - What the operator can do, where anything
+   *   honest can be said. Null is a legitimate answer: a truncated walk has no
+   *   remedy because nothing is wrong.
+   * @returns {{known: boolean, why: string|null, remedy: string|null}}
+   */
+  function tcDegradedRead(known, why, remedy) {
+    return { known: !!known, why: why || null, remedy: remedy || null };
+  }
+
+  // Prose for the causes the SERVER does not already write a sentence for.
+  // `scan` and the per-project trio arrive with their own `reason`/`hint`
+  // authored at the failure site, which is more specific than anything a
+  // renderer could infer — those are used verbatim. Only session liveness and
+  // git carry a bare `cause` token, so only those are translated here.
+  const TC_CAUSE_TEXT = {
+    'read-timed-out': 'the read was stopped by TangleClaw after it stopped responding',
+    'git-refused-to-read-repository': 'git refused to read this repository',
+    'git-status-unparsed': 'git answered in a form TangleClaw could not read'
+  };
+
+  /**
+   * Turn a bare `cause` token into a sentence.
+   *
+   * Unknown tokens degrade to a generic sentence rather than being echoed raw:
+   * a token is an internal vocabulary item and reads as a defect when it
+   * reaches an operator. Returning null instead would be worse — it would drop
+   * the only signal that anything went short.
+   *
+   * @param {string|null} cause - `session.cause` or `git.cause`.
+   * @returns {string} A sentence, never empty.
+   */
+  function tcCauseText(cause) {
+    return TC_CAUSE_TEXT[cause] || 'the read did not complete';
+  }
+
+  // What each unestablished git field is, in words. `incomplete` carries the
+  // payload's own field names — `dirty`, `latestTag` — and printing those at an
+  // operator is the same defect as printing a cause token: it reads as a leak,
+  // and "dirty" in particular means nothing to someone who did not write it.
+  // Every name `lib/git.js` can push is covered here.
+  const TC_GIT_FIELD_TEXT = {
+    dirty: 'whether there are uncommitted changes',
+    branch: 'the current branch',
+    lastCommit: 'the last commit',
+    lastCommitAge: 'how long ago the last commit was',
+    latestTag: 'the latest tag'
+  };
+
+  /**
+   * Name the unestablished git fields in words, as a readable list.
+   *
+   * An unrecognised field falls back to its raw name rather than being dropped:
+   * a field TangleClaw could not read must still be reported, and a new name
+   * appearing here is a prompt to add it above, not a reason to say nothing.
+   *
+   * @param {string[]} fields - `git.incomplete`.
+   * @returns {string} e.g. "whether there are uncommitted changes and the latest tag".
+   */
+  function tcGitFieldText(fields) {
+    const words = fields.map((f) => TC_GIT_FIELD_TEXT[f] || f);
+    if (words.length <= 1) return words[0] || 'part of this repository';
+    return `${words.slice(0, -1).join(', ')} and ${words[words.length - 1]}`;
+  }
+
+  /**
+   * Capitalise a sentence for display.
+   *
+   * The server authors its hints to follow a label in a log line, so they begin
+   * lower-case. Rendered as a standalone remedy — the one sentence a stranded
+   * operator reads — that looks like a truncated message. Only the first letter
+   * is touched; the wording is the server's and stays exactly as written.
+   *
+   * @param {string|null} text - Sentence to present.
+   * @returns {string|null} The same text, first letter capitalised.
+   */
+  function tcSentence(text) {
+    if (!text) return null;
+    return text.charAt(0).toUpperCase() + text.slice(1);
+  }
+
+  /**
+   * Classify a project's session liveness.
+   *
+   * Three outcomes where the card used to draw two. `active === null` is the
+   * unknown — it mirrors `git.dirty: null`, and it is falsy so every consumer
+   * that has not learned about this state behaves exactly as before.
+   *
+   * An ABSENT session row is `'none'`, not `'unknown'`: nothing was read and
+   * nothing failed, the project simply has no session. Collapsing that into
+   * unknown would mark every idle project on the dashboard as degraded.
+   *
+   * @param {object|null} project - An enriched project from `GET /api/projects`.
+   * @returns {'live'|'none'|'unknown'}
+   */
+  function tcSessionLiveness(project) {
+    const session = project && project.session;
+    if (!session) return 'none';
+    if (session.active === true) return 'live';
+    if (session.active === null) return 'unknown';
+    return 'none';
+  }
+
+  /**
+   * The degraded-read record for a project's session liveness.
+   *
+   * The remedy is specific to tmux and is NOT taken from any shared table: a
+   * `read-timed-out` here means the tmux server stopped answering (the PTY
+   * exhaustion this dashboard has hit repeatedly), which has nothing to do with
+   * the filesystem permission that the same token means for a directory scan.
+   * One vocabulary of causes, deliberately not one vocabulary of remedies.
+   *
+   * @param {object|null} project - An enriched project.
+   * @returns {{known: boolean, why: string|null, remedy: string|null}}
+   */
+  function tcSessionRead(project) {
+    if (tcSessionLiveness(project) !== 'unknown') return tcDegradedRead(true);
+    const session = project.session;
+    return tcDegradedRead(
+      false,
+      `Whether this session is still running could not be established — ${tcCauseText(session.cause)}.`,
+      'The tmux server is not answering. Once it responds this clears on its own; '
+        + '`tmux kill-server` clears a wedged one, ending every session on this machine.'
+    );
+  }
+
+  /**
+   * Classify a repository's dirty state.
+   *
+   * Returns null when there is no repository at all, so a plain directory never
+   * renders as an unknown. (The build plan named three values; the null is a
+   * deliberate addition — without it every non-repo card would grow a `?`.)
+   *
+   * @param {object|null} git - `project.git`, or null when not a repository.
+   * @returns {'clean'|'dirty'|'unknown'|null}
+   */
+  function tcGitDirtyState(git) {
+    if (!git) return null;
+    if (git.dirty === null || git.dirty === undefined) return 'unknown';
+    return git.dirty ? 'dirty' : 'clean';
+  }
+
+  /**
+   * The degraded-read record for a repository reading.
+   *
+   * Reports unknown when the read went short in ANY field, not only `dirty` —
+   * `incomplete` is the authoritative list and a branch or tag that could not be
+   * read is just as unestablished as a working-tree state.
+   *
+   * @param {object|null} git - `project.git`.
+   * @returns {{known: boolean, why: string|null, remedy: string|null}}
+   */
+  function tcGitRead(git) {
+    const incomplete = (git && Array.isArray(git.incomplete)) ? git.incomplete : [];
+    if (!git || incomplete.length === 0) return tcDegradedRead(true);
+    return tcDegradedRead(
+      false,
+      `Could not establish ${tcGitFieldText(incomplete)} — ${tcCauseText(git.cause)}.`,
+      git.cause === 'read-timed-out'
+        ? 'A large or slow repository can exceed the time TangleClaw allows one reading. '
+          + 'It retries on the next poll.'
+        : null
+    );
+  }
+
+  // What a renderer can honestly advise when the server supplied no hint.
+  // Deliberately sparse. The server attaches the Full Disk Access remedy only to
+  // the failure shape it fits, and inventing one for the rest would reintroduce
+  // exactly the misdiagnosis this whole area exists to remove — telling someone
+  // to change a permission for a directory that answered perfectly well.
+  const TC_CODE_REMEDY = {
+    DIR_MISSING: 'Create the directory, or point TangleClaw at a different one in Settings.',
+    // Covers EACCES, ENOTDIR and every other ordinary error. Names no specific
+    // cause, because this code is the catch-all and asserting one would guess.
+    SCAN_FAILED: 'Check that the directory still exists and that TangleClaw can read it.'
+  };
+
+  // Codes whose meaning includes "and nothing is retrying it right now". Kept
+  // separate from the remedy above ON PURPOSE: a remembered refusal still earns
+  // the Full Disk Access advice the server attached, because the condition it
+  // describes is unchanged — the backoff is an additional fact, not a
+  // replacement for the remedy, and deriving either from the other is the defect
+  // three reviewers found independently.
+  const TC_CODE_NOT_RETRYING = {
+    SCAN_CACHED: 'This is a remembered result — the directory is not being retried right now.'
+  };
+
+  /**
+   * The notice the ROOT panel shows when the projects list is short.
+   *
+   * Returns null when the list is complete, so the caller renders nothing
+   * without testing fields itself.
+   *
+   * `kind` separates the two opposite reasons a list can be short. A truncated
+   * walk is `'info'`: the directory answered fine and is merely bigger than one
+   * scan's budget, so drawing it as a fault — and especially attaching a
+   * permissions remedy to it — is the misdiagnosis this work exists to remove.
+   * Everything else is `'warn'`.
+   *
+   * @param {object|null} scan - The `scan` block from `GET /api/projects`.
+   * @returns {{known: false, why: string, remedy: string|null, kind: 'warn'|'info',
+   *   listed: number|null}|null} Null when the list is complete.
+   */
+  function tcScanNotice(scan) {
+    if (!scan || scan.complete !== false) return null;
+    const code = scan.code || null;
+    const notRetrying = TC_CODE_NOT_RETRYING[code] || null;
+    const why = [
+      scan.reason || 'The projects directory could not be fully read, so this list may be short.',
+      notRetrying
+    ].filter(Boolean).join(' ');
+    const base = tcDegradedRead(false, why,
+      tcSentence(scan.hint) || TC_CODE_REMEDY[code] || null);
+    return {
+      known: false,
+      why: base.why,
+      remedy: base.remedy,
+      kind: code === 'SCAN_TRUNCATED' ? 'info' : 'warn',
+      listed: Number.isFinite(scan.listed) ? scan.listed : null
+    };
+  }
+
+  /**
+   * The degraded-read record for a project whose own directory did not answer.
+   *
+   * Returns null for a readable project so the caller renders no badge.
+   *
+   * @param {object|null} project - An enriched project carrying the
+   *   `unreadable` / `unreadableHint` / `unreadableCode` trio.
+   * @returns {{known: false, why: string, remedy: string|null}|null}
+   */
+  function tcUnreadableNotice(project) {
+    if (!project || !project.unreadable) return null;
+    const code = project.unreadableCode || null;
+    const notRetrying = TC_CODE_NOT_RETRYING[code] || null;
+    const why = [
+      `This project's folder could not be read — ${project.unreadable}.`,
+      'Its git, engine and version detail are missing rather than absent.',
+      notRetrying
+    ].filter(Boolean).join(' ');
+    const record = tcDegradedRead(false, why,
+      tcSentence(project.unreadableHint) || TC_CODE_REMEDY[code] || null);
+    return { known: false, why: record.why, remedy: record.remedy };
+  }
+
+  global.tcDegradedRead = tcDegradedRead;
+  global.tcCauseText = tcCauseText;
+  global.tcGitFieldText = tcGitFieldText;
+  global.tcSentence = tcSentence;
+  global.tcSessionLiveness = tcSessionLiveness;
+  global.tcSessionRead = tcSessionRead;
+  global.tcGitDirtyState = tcGitDirtyState;
+  global.tcGitRead = tcGitRead;
+  global.tcScanNotice = tcScanNotice;
+  global.tcUnreadableNotice = tcUnreadableNotice;
   global.tcBuildEngineOptions = tcBuildEngineOptions;
   global.tcResolvePickerEngine = tcResolvePickerEngine;
   global.tcEnableLocalSelectionOverride = tcEnableLocalSelectionOverride;

--- a/public/landing.js
+++ b/public/landing.js
@@ -7,6 +7,11 @@
 
 const state = {
   projects: [],
+  // Whether the projects list is the WHOLE list, and why not when it isn't.
+  // `GET /api/projects` always carries this; null only before the first load.
+  // Without it a directory that could not be read shows up as a shorter list
+  // and nothing else, which states a completeness the server never claimed.
+  projectsScan: null,
   engines: [],
   config: null,
   filterText: '',
@@ -1013,6 +1018,12 @@ async function loadProjects() {
   const data = await api('/api/projects?archived=true');
   if (!data) return;
   state.projects = (data.projects || []).sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }));
+  // Kept as sent, including on the healthy path — a field that only appears on
+  // failure makes every reader probe for its existence instead of reading its
+  // value. `renderRootPanel` decides what to draw; this only stops the answer
+  // being discarded, which is what made a short list indistinguishable from a
+  // complete one.
+  state.projectsScan = data.scan || null;
   collectTags();
   renderProjects();
   renderSessionCount();

--- a/public/style.css
+++ b/public/style.css
@@ -1439,6 +1439,11 @@ body {
 .root-notice-listed {
   color: var(--text-muted);
 }
+/* Sessions whose liveness could not be established, in the header count. Amber
+   attention rather than the active colour: they are not known to be running. */
+.count-unknown {
+  color: #f0b860;
+}
 .root-label {
   font-size: 9px;
   font-weight: 700;

--- a/public/style.css
+++ b/public/style.css
@@ -758,6 +758,19 @@ body {
   border-radius: 8px;
   font-weight: 600;
 }
+/* A project whose own folder did not answer (#885). Its git, engine and version
+   detail are MISSING rather than absent, so this badge explains why the card's
+   other badges are not there. Amber attention, same as the drift badge: the
+   project is fine, the reading of it is not. */
+.badge-unreadable {
+  background: #4a3410;
+  color: #f0b860;
+  border: 1px solid #7a5418;
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: 8px;
+  font-weight: 600;
+}
 /* Possible-secret indicator on an upload (#343, CC-4) — amber "attention," and
    flag-only: the file is never scrubbed or blocked, so this signals "look,"
    not "error." Shares the drift badge's amber palette for one visual language. */
@@ -1352,15 +1365,79 @@ body {
 }
 
 /* ── Root Panel ── */
+/* The panel is a column so a notice row can sit under the ROOT line; the line
+   itself keeps the row layout the panel used to have, so the healthy panel is
+   unchanged. */
 .root-panel {
   display: flex;
-  align-items: center;
-  gap: 8px;
+  flex-direction: column;
+  gap: 6px;
   padding: 5px 12px;
   background: #060d14;
   border: 1px solid #1a3a5a;
   border-radius: var(--radius-btn);
   margin-bottom: 4px;
+}
+.root-panel-line {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+/* An incomplete list is "look at this," not a failure — the server is answering
+   and registered projects are unaffected. Shares the amber attention palette of
+   .badge-drift / .badge-secret so the dashboard has one visual language for it,
+   and takes a left rule rather than a fill so the panel stays readable.
+   Never dismissible: it describes the current poll and clears itself. */
+.root-panel-degraded {
+  border-color: #7a5418;
+}
+.root-notice {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  font-size: 12px;
+  line-height: 1.45;
+  padding: 6px 8px;
+  border-radius: var(--radius-btn);
+  background: rgba(74, 52, 16, 0.5);
+  border-left: 3px solid #7a5418;
+}
+/* A truncated walk is the opposite failure: the directory answered fine and is
+   simply larger than one scan's budget. It is information, not attention, and
+   must not borrow the amber that means "something needs looking at". */
+.root-notice-info {
+  background: rgba(26, 58, 90, 0.5);
+  border-left-color: var(--root-accent);
+}
+.root-notice-glyph {
+  flex-shrink: 0;
+  font-size: 13px;
+  line-height: 1.3;
+  color: #f0b860;
+}
+.root-notice-info .root-notice-glyph {
+  color: var(--root-accent);
+}
+.root-notice-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.root-notice-text {
+  color: #f0b860;
+}
+.root-notice-info .root-notice-text {
+  color: var(--text-muted);
+}
+/* The remedy is the entire operator-facing value of degrading instead of
+   hanging, so it is shown outright rather than hidden behind a tooltip a phone
+   cannot hover. */
+.root-notice-remedy {
+  color: var(--text-muted);
+}
+.root-notice-listed {
+  color: var(--text-muted);
 }
 .root-label {
   font-size: 9px;
@@ -1480,6 +1557,26 @@ body {
   background: transparent;
   border: 1px solid var(--text-muted);
 }
+/* Liveness that could not be established. Wider than the other dots because it
+   holds a glyph: an operator who cannot distinguish its hue must still be able
+   to tell "no session" from "we could not find out", so the state is never
+   carried by colour alone. Deliberately unanimated — the breathing dot means a
+   session is running, and this one does not claim that. */
+.status-dot.unknown {
+  width: 12px;
+  height: 12px;
+  background: transparent;
+  border: 1px solid #7a5418;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.status-dot-glyph {
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 1;
+  color: #f0b860;
+}
 @keyframes breathe-card {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.4; }
@@ -1566,6 +1663,18 @@ body {
   height: 5px;
   border-radius: 50%;
   background: var(--amber);
+}
+/* A working tree whose state could not be read. A glyph rather than the dirty
+   dot's absence, because absence already means clean — that is the reading this
+   marker exists to stop. */
+.git-unknown {
+  display: inline-block;
+  margin-left: 3px;
+  font-weight: 700;
+  color: #f0b860;
+}
+.badge-git-unknown {
+  border: 1px solid #7a5418;
 }
 
 /* ── Card Row Actions ── */
@@ -1694,6 +1803,26 @@ body {
 .detail-value {
   color: var(--text);
   text-align: right;
+}
+/* The detail rows are the one surface with room to name WHY a read went short,
+   so the cause is written out here rather than only marked. */
+.detail-unknown {
+  color: #f0b860;
+}
+.detail-remedy {
+  color: var(--text-muted);
+}
+.detail-row-warn .detail-label {
+  color: #f0b860;
+}
+/* A cause plus a remedy does not fit on one line on a 320px phone; let the
+   value wrap under its label instead of forcing the row wide. */
+.detail-row-warn {
+  align-items: flex-start;
+  gap: 10px;
+}
+.detail-row-warn .detail-value {
+  line-height: 1.45;
 }
 .detail-actions {
   display: flex;

--- a/public/ui.js
+++ b/public/ui.js
@@ -80,16 +80,103 @@ function renderProjects() {
   grid.innerHTML = rootHtml + filtered.map(renderCard).join('') + archivedHtml;
 }
 
+/**
+ * Render the ROOT directory panel, including the notice row that appears when
+ * the projects list is short.
+ *
+ * The count says "total" only when the scan actually completed. A directory
+ * that could not be read produces a shorter list, and calling that shorter
+ * number the total asserts a completeness the server explicitly did not claim —
+ * the silent half of #885.
+ *
+ * The notice is always present while the condition holds and carries no
+ * dismissal: it describes the CURRENT poll, so it must clear itself when the
+ * read recovers rather than be dismissed into a lie. That also keeps it free of
+ * any timer-driven lifecycle, which this project does not use.
+ *
+ * @returns {string} HTML for the panel, or '' when no projects directory is set.
+ */
 function renderRootPanel() {
   if (!state.config || !state.config.projectsDir) return '';
   const nonArchived = state.projects.filter(p => !p.archived);
   const totalCount = nonArchived.length;
   const registered = nonArchived.filter(p => p.registered !== false).length;
-  return `<div class="root-panel">
-    <span class="root-label">ROOT</span>
-    <span class="root-path">${esc(state.config.projectsDir)}</span>
-    <span class="root-count">${registered} registered / ${totalCount} total</span>
+
+  const notice = tcScanNotice(state.projectsScan);
+  const countLabel = notice
+    ? `${registered} registered / ${totalCount} listed`
+    : `${registered} registered / ${totalCount} total`;
+
+  let noticeHtml = '';
+  if (notice) {
+    // The glyph is paired with text, never carrying the meaning alone — the
+    // accessibility floor this project holds is that an error is never
+    // communicated by colour (or by a coloured glyph) on its own.
+    const glyph = notice.kind === 'info' ? '&#8505;' : '&#9888;';
+    const remedyHtml = notice.remedy
+      ? `<span class="root-notice-remedy">${esc(notice.remedy)}</span>`
+      : '';
+    // How far the walk got, when it reported that. Only a cut-off knows this,
+    // and it turns "the list is short" into something the operator can size.
+    const listedHtml = notice.listed !== null
+      ? `<span class="root-notice-listed">${notice.listed} unregistered folder${notice.listed === 1 ? '' : 's'} were checked before the cut-off.</span>`
+      : '';
+    noticeHtml = `<div class="root-notice root-notice-${notice.kind}" role="status">
+      <span class="root-notice-glyph" aria-hidden="true">${glyph}</span>
+      <span class="root-notice-body">
+        <span class="root-notice-text">${esc(notice.why)}</span>
+        ${listedHtml}
+        ${remedyHtml}
+      </span>
+    </div>`;
+  }
+
+  // The amber border means "something needs looking at". A truncated walk does
+  // not, so it gets the notice row without recolouring the whole panel.
+  const degradedClass = notice && notice.kind === 'warn' ? ' root-panel-degraded' : '';
+
+  return `<div class="root-panel${degradedClass}">
+    <div class="root-panel-line">
+      <span class="root-label">ROOT</span>
+      <span class="root-path">${esc(state.config.projectsDir)}</span>
+      <span class="root-count">${countLabel}</span>
+    </div>
+    ${noticeHtml}
   </div>`;
+}
+
+/**
+ * Render the git branch badge for a project card.
+ *
+ * Shared by the registered and unregistered cards. They each had their own copy
+ * of this markup, which is how a fix to one silently left the other reporting a
+ * repository it could not read as clean.
+ *
+ * A working tree whose state could not be established renders `?` rather than
+ * the dirty marker's absence. Absence of the marker means clean, and drawing an
+ * unestablished read that way is the defect #891 removed from the payload.
+ *
+ * @param {object} project - Project data carrying an optional `git`.
+ * @returns {string} HTML for the badge, or '' when not a repository.
+ */
+function renderGitBadge(project) {
+  const dirtyState = tcGitDirtyState(project.git);
+  if (dirtyState === null) return '';
+  const read = tcGitRead(project.git);
+  let marker = '';
+  if (dirtyState === 'dirty') {
+    marker = '<span class="git-dirty"></span>';
+  } else if (dirtyState === 'unknown') {
+    marker = '<span class="git-unknown" aria-hidden="true">?</span>';
+  }
+  // The tooltip is the only place the cause fits on a compact card; the `?`
+  // glyph is what makes the state visible without it, so meaning never rests on
+  // hover alone.
+  const title = read.known
+    ? ''
+    : ` title="${esc([read.why, read.remedy].filter(Boolean).join(' '))}"`;
+  const cls = dirtyState === 'unknown' ? 'badge badge-git badge-git-unknown' : 'badge badge-git';
+  return `<span class="${cls}"${title}>${esc(project.git.branch)}${marker}</span>`;
 }
 
 function renderCard(project) {
@@ -103,7 +190,14 @@ function renderCard(project) {
     return renderArchivedCard(project);
   }
 
+  // `hasSession` still drives every ACTION on this card, and still treats an
+  // unknown as not-live. That is deliberate: launching, peeking and killing all
+  // need a tmux server that answers, and the one that did not answer is the
+  // reason this state exists. Chunk 01 made `launchSession` refuse honestly in
+  // that case, so the button leads somewhere truthful. Only the DISPLAY below
+  // learns the third state.
   const hasSession = project.session && project.session.active;
+  const liveness = tcSessionLiveness(project);
   const sessionClass = hasSession ? ' has-session' : '';
   const n = esc(project.name);
 
@@ -111,9 +205,7 @@ function renderCard(project) {
     ? `<span class="badge badge-version">${esc(project.git.latestTag)}</span>`
     : '';
 
-  const gitBadge = project.git
-    ? `<span class="badge badge-git">${esc(project.git.branch)}${project.git.dirty ? '<span class="git-dirty"></span>' : ''}</span>`
-    : '';
+  const gitBadge = renderGitBadge(project);
 
   const engineBadge = project.engine
     ? (() => {
@@ -152,15 +244,34 @@ function renderCard(project) {
     ? `<span class="badge badge-drift" title="Legacy governance: this project runs a vendored Prawduct hook rather than the V2 plugin. Open Info to migrate it.">&#9888; legacy governance</span>`
     : '';
 
-  const statusDot = hasSession
-    ? `<span class="status-dot active" title="Session active"></span>`
-    : `<span class="status-dot" title="No active session"></span>`;
+  // Three outcomes where there used to be two. The unknown carries a `?` glyph
+  // rather than only a colour, because an operator who cannot distinguish the
+  // dot's hue must still be able to tell a dead session from an unreadable one.
+  const sessionRead = tcSessionRead(project);
+  let statusDot;
+  if (liveness === 'live') {
+    statusDot = `<span class="status-dot active" title="Session active"></span>`;
+  } else if (liveness === 'unknown') {
+    statusDot = `<span class="status-dot unknown" title="${esc([sessionRead.why, sessionRead.remedy].filter(Boolean).join(' '))}">`
+      + `<span class="status-dot-glyph" aria-hidden="true">?</span></span>`;
+  } else {
+    statusDot = `<span class="status-dot" title="No active session"></span>`;
+  }
+
+  // A project whose own folder did not answer is listed WITHOUT its git, engine
+  // and version detail — so the card's other badges are absent for a reason the
+  // card would otherwise not give. This is that reason.
+  const unreadable = tcUnreadableNotice(project);
+  const unreadableBadge = unreadable
+    ? `<span class="badge badge-unreadable" title="${esc([unreadable.why, unreadable.remedy].filter(Boolean).join(' '))}">&#9888; unreadable</span>`
+    : '';
 
   return `<article class="project-card compact${sessionClass}" tabindex="0"
     onclick="toggleCardDetail('${n}')" onkeydown="if(event.key==='Enter')toggleCardDetail('${n}')">
     <div class="card-row">
       ${statusDot}
       <span class="card-name" title="${n}">${n}</span>
+      ${unreadableBadge}
       ${versionBadge}
       ${gitBadge}
       ${engineBadge}
@@ -183,14 +294,17 @@ function renderCard(project) {
 
 function renderUnregisteredCard(project) {
   const n = esc(project.name);
-  const gitBadge = project.git
-    ? `<span class="badge badge-git">${esc(project.git.branch)}${project.git.dirty ? '<span class="git-dirty"></span>' : ''}</span>`
+  const gitBadge = renderGitBadge(project);
+  const unreadable = tcUnreadableNotice(project);
+  const unreadableBadge = unreadable
+    ? `<span class="badge badge-unreadable" title="${esc([unreadable.why, unreadable.remedy].filter(Boolean).join(' '))}">&#9888; unreadable</span>`
     : '';
 
   return `<article class="project-card compact unregistered" tabindex="0">
     <div class="card-row">
       <span class="status-dot unregistered"></span>
       <span class="card-name card-name-muted" title="${n}">${n}</span>
+      ${unreadableBadge}
       ${gitBadge}
       <span class="card-row-actions">
         <button class="btn btn-compact btn-attach" onclick="event.stopPropagation(); attachProject('${n}')">Attach</button>
@@ -219,6 +333,53 @@ function renderArchivedCard(project) {
   </article>`;
 }
 
+/**
+ * The Session row's value in the card detail.
+ *
+ * Pure, and separate from `toggleCardDetail`, because that function reaches for
+ * the DOM and this is the part with three outcomes worth testing directly.
+ *
+ * @param {object} project - Project data.
+ * @returns {string} HTML for the detail value.
+ */
+function renderSessionDetail(project) {
+  const liveness = tcSessionLiveness(project);
+  if (liveness === 'live') {
+    return `Active since ${esc(project.session.startedAt || '')}`;
+  }
+  if (liveness === 'none') return 'No active session';
+  // The detail row is the one surface with room to say WHY, so it names the
+  // cause rather than only marking it.
+  const read = tcSessionRead(project);
+  return `<span class="detail-unknown">Unknown</span> — ${esc(read.why)}`
+    + (read.remedy ? ` <span class="detail-remedy">${esc(read.remedy)}</span>` : '');
+}
+
+/**
+ * The Git row's value in the card detail.
+ *
+ * A working tree that could not be read is named as unknown rather than left to
+ * the reader's assumption — the bare branch name with no "(dirty)" is how a
+ * clean repository has always been drawn.
+ *
+ * @param {object} project - Project data.
+ * @returns {string} HTML for the detail value.
+ */
+function renderGitDetail(project) {
+  const dirtyState = tcGitDirtyState(project.git);
+  if (dirtyState === null) return 'Not a git repo';
+  const suffix = dirtyState === 'dirty'
+    ? ' (dirty)'
+    : (dirtyState === 'unknown' ? ' (working tree unknown)' : '');
+  let info = `${esc(project.git.branch)}${suffix}`;
+  const read = tcGitRead(project.git);
+  if (!read.known) {
+    info += ` — <span class="detail-unknown">${esc(read.why)}</span>`
+      + (read.remedy ? ` <span class="detail-remedy">${esc(read.remedy)}</span>` : '');
+  }
+  return info;
+}
+
 function toggleCardDetail(name) {
   const cards = document.querySelectorAll('.project-card');
   for (const card of cards) {
@@ -241,16 +402,24 @@ function toggleCardDetail(name) {
     detail.className = 'card-detail';
 
     const engineInfo = project.engine ? `${esc(project.engine.name)}` : 'No engine';
-    const sessionInfo = project.session && project.session.active
-      ? `Active since ${esc(project.session.startedAt || '')}`
-      : 'No active session';
+
+    const sessionInfo = renderSessionDetail(project);
     const tagsInfo = (project.tags || []).length > 0 ? project.tags.map(t => esc(t)).join(', ') : 'None';
-    const gitInfo = project.git ? `${esc(project.git.branch)}${project.git.dirty ? ' (dirty)' : ''}` : 'Not a git repo';
+    const gitInfo = renderGitDetail(project);
+
+    const unreadable = tcUnreadableNotice(project);
+    const unreadableRow = unreadable
+      ? `<div class="detail-row detail-row-warn"><span class="detail-label">Folder</span>`
+        + `<span class="detail-value"><span class="detail-unknown">${esc(unreadable.why)}</span>`
+        + (unreadable.remedy ? ` <span class="detail-remedy">${esc(unreadable.remedy)}</span>` : '')
+        + `</span></div>`
+      : '';
     const groupsInfo = (project.groups || []).length > 0
       ? project.groups.map(g => `${esc(g.name)} (${g.docCount || 0} docs)`).join(', ')
       : 'None';
 
     detail.innerHTML = `
+      ${unreadableRow}
       <div class="detail-row"><span class="detail-label">Engine</span><span class="detail-value">${engineInfo}</span></div>
       <div class="detail-row"><span class="detail-label">Session</span><span class="detail-value">${sessionInfo}</span></div>
       <div class="detail-row"><span class="detail-label">Git</span><span class="detail-value">${gitInfo}</span></div>

--- a/public/ui.js
+++ b/public/ui.js
@@ -48,24 +48,40 @@ function renderProjects() {
   const grid = document.getElementById('cardsGrid');
   const filtered = filterProjects();
 
+  // The ROOT panel carries the "this list may be short" notice, so it is
+  // rendered on EVERY path — including the empty ones. An empty list is the
+  // worst case of #885, not an exemption from it: a projects directory that
+  // could not be read, on a machine with nothing registered yet, produced
+  // "No projects yet. Create your first project" — a definite and actionable
+  // claim, and the wrong one.
+  const rootHtml = renderRootPanel();
+
   if (state.projects.length === 0) {
-    grid.innerHTML = `<div class="empty-state">
+    // Only the emptiness is in doubt, and only when the scan came up short.
+    // With a complete scan this is still a genuinely empty machine and the
+    // original invitation is exactly right.
+    const listIsShort = tcScanNotice(state.projectsScan) !== null;
+    grid.innerHTML = rootHtml + (listIsShort
+      ? `<div class="empty-state">
+      <h2>No projects could be listed</h2>
+      <p>Nothing is registered yet, and the projects directory could not be read — so this
+      may not be the whole picture. The reason is above.</p>
+      <button class="btn btn-primary" onclick="openCreateModal()">+ Create Project</button>
+    </div>`
+      : `<div class="empty-state">
       <h2>No projects yet</h2>
       <p>Create your first project to get started with AI-assisted development.</p>
       <button class="btn btn-primary" onclick="openCreateModal()">+ Create Project</button>
-    </div>`;
+    </div>`);
     return;
   }
 
   if (filtered.length === 0) {
-    grid.innerHTML = `<div class="empty-state">
+    grid.innerHTML = rootHtml + `<div class="empty-state">
       <p>No projects match your filter.</p>
     </div>`;
     return;
   }
-
-  // Root directory panel
-  const rootHtml = renderRootPanel();
 
   // Archived projects section (collapsed by default)
   const archived = state.projects.filter(p => p.archived);
@@ -121,7 +137,13 @@ function renderRootPanel() {
     const listedHtml = notice.listed !== null
       ? `<span class="root-notice-listed">${notice.listed} unregistered folder${notice.listed === 1 ? '' : 's'} were checked before the cut-off.</span>`
       : '';
-    noticeHtml = `<div class="root-notice root-notice-${notice.kind}" role="status">
+    // Deliberately NOT an aria-live region. The dashboard rebuilds this whole
+    // grid every ten seconds, so `role="status"` would re-announce the same
+    // sentence to a screen reader on every poll for as long as the condition
+    // lasts. It is persistent page content in document order, right under the
+    // ROOT line it qualifies, and the glyph is decorative because the text
+    // beside it carries the entire meaning.
+    noticeHtml = `<div class="root-notice root-notice-${notice.kind}">
       <span class="root-notice-glyph" aria-hidden="true">${glyph}</span>
       <span class="root-notice-body">
         <span class="root-notice-text">${esc(notice.why)}</span>
@@ -143,6 +165,36 @@ function renderRootPanel() {
     </div>
     ${noticeHtml}
   </div>`;
+}
+
+/**
+ * The tooltip text for a degraded-read record: the reason, then the remedy.
+ *
+ * One helper because every surface that can show one wants the same joined
+ * sentence, and four hand-written copies of the same `filter(Boolean).join(' ')`
+ * is how they drift.
+ *
+ * @param {{why: string|null, remedy: string|null}} record - A degraded-read record.
+ * @returns {string} Escaped text for a `title` attribute.
+ */
+function degradedTooltip(record) {
+  return esc([record.why, record.remedy].filter(Boolean).join(' '));
+}
+
+/**
+ * Render the "this folder could not be read" badge, or '' when it was.
+ *
+ * Shared by the registered and unregistered cards for the same reason
+ * `renderGitBadge` below is: a badge duplicated across both renderers is one a
+ * later fix updates in only one place.
+ *
+ * @param {object} project - Project data carrying the `unreadable` trio.
+ * @returns {string} HTML for the badge, or '' when the folder was readable.
+ */
+function renderUnreadableBadge(project) {
+  const unreadable = tcUnreadableNotice(project);
+  if (!unreadable) return '';
+  return `<span class="badge badge-unreadable" title="${degradedTooltip(unreadable)}">&#9888; unreadable</span>`;
 }
 
 /**
@@ -172,9 +224,7 @@ function renderGitBadge(project) {
   // The tooltip is the only place the cause fits on a compact card; the `?`
   // glyph is what makes the state visible without it, so meaning never rests on
   // hover alone.
-  const title = read.known
-    ? ''
-    : ` title="${esc([read.why, read.remedy].filter(Boolean).join(' '))}"`;
+  const title = read.known ? '' : ` title="${degradedTooltip(read)}"`;
   const cls = dirtyState === 'unknown' ? 'badge badge-git badge-git-unknown' : 'badge badge-git';
   return `<span class="${cls}"${title}>${esc(project.git.branch)}${marker}</span>`;
 }
@@ -252,7 +302,7 @@ function renderCard(project) {
   if (liveness === 'live') {
     statusDot = `<span class="status-dot active" title="Session active"></span>`;
   } else if (liveness === 'unknown') {
-    statusDot = `<span class="status-dot unknown" title="${esc([sessionRead.why, sessionRead.remedy].filter(Boolean).join(' '))}">`
+    statusDot = `<span class="status-dot unknown" title="${degradedTooltip(sessionRead)}">`
       + `<span class="status-dot-glyph" aria-hidden="true">?</span></span>`;
   } else {
     statusDot = `<span class="status-dot" title="No active session"></span>`;
@@ -261,10 +311,7 @@ function renderCard(project) {
   // A project whose own folder did not answer is listed WITHOUT its git, engine
   // and version detail — so the card's other badges are absent for a reason the
   // card would otherwise not give. This is that reason.
-  const unreadable = tcUnreadableNotice(project);
-  const unreadableBadge = unreadable
-    ? `<span class="badge badge-unreadable" title="${esc([unreadable.why, unreadable.remedy].filter(Boolean).join(' '))}">&#9888; unreadable</span>`
-    : '';
+  const unreadableBadge = renderUnreadableBadge(project);
 
   return `<article class="project-card compact${sessionClass}" tabindex="0"
     onclick="toggleCardDetail('${n}')" onkeydown="if(event.key==='Enter')toggleCardDetail('${n}')">
@@ -295,10 +342,7 @@ function renderCard(project) {
 function renderUnregisteredCard(project) {
   const n = esc(project.name);
   const gitBadge = renderGitBadge(project);
-  const unreadable = tcUnreadableNotice(project);
-  const unreadableBadge = unreadable
-    ? `<span class="badge badge-unreadable" title="${esc([unreadable.why, unreadable.remedy].filter(Boolean).join(' '))}">&#9888; unreadable</span>`
-    : '';
+  const unreadableBadge = renderUnreadableBadge(project);
 
   return `<article class="project-card compact unregistered" tabindex="0">
     <div class="card-row">
@@ -536,10 +580,34 @@ async function openPeekFromCard(name) {
   }
 }
 
+/**
+ * Render the header's session count.
+ *
+ * Counts the three liveness outcomes separately. Counting an unknown as
+ * not-active makes the header state "0 active sessions" during exactly the tmux
+ * wedge the cards below are drawing `?` for — a definite number the server does
+ * not have, on the most prominent surface on the page, contradicting the cards
+ * it summarises. Unlike the launch and kill buttons, this is pure display of
+ * the fleet, so it takes the third state rather than the conservative answer.
+ *
+ * The unknowns clause appears only when there are any, so a healthy dashboard
+ * reads exactly as it always did.
+ *
+ * @returns {void}
+ */
 function renderSessionCount() {
-  const active = state.projects.filter(p => p.session && p.session.active).length;
+  let active = 0;
+  let unknown = 0;
+  for (const project of state.projects) {
+    const liveness = tcSessionLiveness(project);
+    if (liveness === 'live') active++;
+    else if (liveness === 'unknown') unknown++;
+  }
   const el = document.getElementById('sessionCount');
-  el.innerHTML = `<span class="count-num">${active}</span> active session${active !== 1 ? 's' : ''}`;
+  const unknownPart = unknown > 0
+    ? ` &middot; <span class="count-unknown" title="Whether these sessions are still running could not be established — the tmux server did not answer.">${unknown} unknown</span>`
+    : '';
+  el.innerHTML = `<span class="count-num">${active}</span> active session${active !== 1 ? 's' : ''}${unknownPart}`;
 }
 
 function renderTagRow() {

--- a/server.js
+++ b/server.js
@@ -3150,6 +3150,16 @@ route('POST', '/api/sessions/:project', async (_req, res, params, body) => {
   }
 
   if (result.error) {
+    // A refusal that carries a CODE is classified by it. The prose matching below
+    // predates codes here and stays for the callers that still return only a
+    // sentence, but nothing new should join them: a status code that depends on
+    // the wording of a message changes when the message is improved.
+    if (result.code === 'LIVENESS_UNKNOWN') {
+      // 503, not 500: nothing internal failed. tmux — a dependency — did not
+      // answer, this call changed nothing, and trying again once the server is
+      // responsive is the remedy.
+      return errorResponse(res, 503, result.error, result.code);
+    }
     if (result.error.includes('already active')) {
       return errorResponse(res, 409, result.error, 'CONFLICT');
     }

--- a/server.js
+++ b/server.js
@@ -2769,8 +2769,11 @@ route('GET', '/api/projects', async (req, res) => {
   if (query.tag) options.tag = query.tag;
   if (query.engine) options.engine = query.engine;
 
-  const list = await projects.listAllProjects(options);
-  jsonResponse(res, 200, { projects: list });
+  // `scan` travels with the list, because the list alone cannot say whether it is
+  // the whole list — a directory that would not answer degrades to the registered
+  // projects, and that used to look identical to having no others (#885).
+  const { projects: list, scan } = await projects.listAllProjects(options);
+  jsonResponse(res, 200, { projects: list, scan });
 });
 
 // POST /api/projects/attach — Attach an existing filesystem directory as a project

--- a/test/api-projects.test.js
+++ b/test/api-projects.test.js
@@ -143,6 +143,22 @@ describe('api-projects', () => {
       assert.ok(project.hasOwnProperty('git'));
     });
 
+    it('says whether the list is the whole list (#885)', async () => {
+      // THE MUTATION THIS CATCHES: dropping `scan` from the route body. The list
+      // degrades to registered projects when the projects directory cannot be
+      // read, and a 200 with a well-formed array looks identical either way —
+      // which is the entire defect. The field has to cross the boundary, not
+      // just exist inside `listAllProjects`.
+      const { status, data } = await request('GET', '/api/projects');
+
+      assert.equal(status, 200);
+      assert.ok(data.scan, 'the response must carry the scan state');
+      assert.equal(typeof data.scan.complete, 'boolean');
+      assert.ok('code' in data.scan && 'reason' in data.scan && 'hint' in data.scan,
+        'always present, null when healthy — a consumer reads these, never probes for them');
+      assert.ok(data.scan.dir, 'and names the directory it is talking about');
+    });
+
     it('filters by tag', async () => {
       const { data } = await request('GET', '/api/projects?tag=test');
       assert.ok(data.projects.every((p) => p.tags.includes('test')));

--- a/test/api-sessions.test.js
+++ b/test/api-sessions.test.js
@@ -549,6 +549,40 @@ describe('api-sessions', () => {
       const res = await request(server, 'POST', '/api/sessions/nonexistent', {});
       assert.equal(res.status, 404);
     });
+
+    it('answers 503, not 500, when tmux would not say whether a session is running', async () => {
+      // The refusal exists because a wedged tmux must not have a running session
+      // written off (#900) — but a refusal that reaches the browser as
+      // `500 INTERNAL_ERROR` tells the operator the opposite of the truth twice
+      // over: nothing internal failed, and nothing was changed.
+      //
+      // THE MUTATION THIS CATCHES: dropping the code branch in the route, so the
+      // refusal falls through to the prose matcher and out as a 500. It also
+      // pins the code path itself — classifying by substring means a reworded
+      // message silently changes the status.
+      const tmux = require('../lib/tmux');
+      const store2 = require('../lib/store');
+      const project = store2.projects.getByName('api-sess-test');
+      const session = store2.sessions.start({
+        projectId: project.id, engineId: 'claude', tmuxSession: 'tc-api-sess-wedge'
+      });
+      const realProbe = tmux.probeSession;
+      tmux.probeSession = () => ({ live: false, answered: false, cause: 'read-timed-out' });
+      try {
+        const res = await request(server, 'POST', '/api/sessions/api-sess-test', {});
+
+        assert.equal(res.status, 503);
+        assert.equal(res.body.code, 'LIVENESS_UNKNOWN');
+        assert.match(res.body.error, /could not determine/i);
+        assert.equal(store2.sessions.get(session.id).status, 'active',
+          'and the record it could not verify is still there');
+      } finally {
+        tmux.probeSession = realProbe;
+        if (store2.sessions.get(session.id).status === 'active') {
+          store2.sessions.kill(session.id, 'test cleanup');
+        }
+      }
+    });
   });
 
   describe('GET /api/activity', () => {

--- a/test/degraded-reads-frontend.test.js
+++ b/test/degraded-reads-frontend.test.js
@@ -396,27 +396,37 @@ describe('degraded-read normalisation (#885)', () => {
     });
 
     it('no hint-less code reaches a card with a reason and no next step', () => {
-      // Driven from the WRITTEN CONTRACT's `unreadableCode` row, not from a
-      // list restated here and not from a source scrape — scraping every
-      // `code: '...'` in the child pulls in thrown-error codes like ENOTDIR that
-      // `failureCode` maps to SCAN_FAILED long before they could reach a card.
-      // Coupling to the contract means a code documented without a remedy fails
-      // here, which is the drift worth catching.
+      // Derived from the PRODUCERS, which are tracked files. An earlier version
+      // read the documented list out of `.prawduct/artifacts/api-contract.md` —
+      // and that directory is GITIGNORED, so the guard passed on the machine
+      // that wrote it and could never pass in CI. A fixture that depends on a
+      // file which merely happens to exist locally is not a fixture.
+      //
+      // Two producers, and only these two can put a value in `unreadableCode`:
+      //   - `dirScanner.failureCode`, called by `lib/project-facts.js`; and
+      //   - `lib/dir-scanner-child.js`'s refused-read reply, whose raw `code` is
+      //     forwarded verbatim by `readProjectFacts`.
+      // The child's OTHER literal codes (ENOTDIR, ENOSYS) are thrown errors that
+      // `failureCode` maps to SCAN_FAILED long before they could reach a card,
+      // which is why this does not scrape every `code:` in that file — doing so
+      // demanded a remedy for ENOTDIR, a value no card can ever display.
       //
       // `lib/project-facts.js` attaches the Full Disk Access hint exactly when
       // `tcTimedOut || tcCached`, so SCAN_TIMEOUT and SCAN_CACHED always arrive
-      // WITH one and need no fallback. The rest arrive hint-less and are the
-      // renderer's to answer.
-      const contract = fs.readFileSync(
-        path.resolve(__dirname, '..', '.prawduct', 'artifacts', 'api-contract.md'), 'utf8');
-      const row = contract.split('\n').find(
-        (l) => l.includes('`unreadableCode`') && l.includes('Machine-readable cause'));
-      assert.ok(row, 'api-contract.md must document unreadableCode');
-      const documented = [...row.matchAll(/`([A-Z_]{4,})`/g)].map((m) => m[1]);
-      assert.ok(documented.includes('EACCES'),
-        'EACCES must stay documented for this guard to mean anything');
+      // WITH one and need no fallback. The rest arrive hint-less.
+      const childSrc = fs.readFileSync(
+        path.resolve(__dirname, '..', 'lib', 'dir-scanner-child.js'), 'utf8');
+      assert.match(childSrc, /code: 'EACCES'/,
+        'the child must still forward EACCES for this guard to mean anything');
+      const reachable = [
+        dirScanner.failureCode({ tcCached: true, tcTimedOut: true }),
+        dirScanner.failureCode({ tcTimedOut: true }),
+        dirScanner.failureCode({ tcAborted: true }),
+        dirScanner.failureCode(new Error('x')),
+        'EACCES'
+      ];
       const alwaysHinted = new Set(['SCAN_TIMEOUT', 'SCAN_CACHED']);
-      for (const code of documented.filter((c) => !alwaysHinted.has(c))) {
+      for (const code of reachable.filter((c) => !alwaysHinted.has(c))) {
         const notice = unreadableNotice({
           name: 'p', unreadable: 'x', unreadableHint: null, unreadableCode: code
         });

--- a/test/degraded-reads-frontend.test.js
+++ b/test/degraded-reads-frontend.test.js
@@ -247,6 +247,17 @@ describe('degraded-read normalisation (#885)', () => {
       }
     });
 
+    it('does not answer an inherited property for a hostile field name', () => {
+      // The lookup tables are keyed by payload values. A plain object answers
+      // `constructor` with a function, which then lands inside a sentence an
+      // operator reads. Mutation: drop the null prototype.
+      const record = gitRead({
+        branch: 'main', dirty: null, incomplete: ['constructor'], cause: 'toString'
+      });
+      assert.equal(typeof record.why, 'string');
+      assert.doesNotMatch(record.why, /function|\[object|native code/i);
+    });
+
     it('lists several short fields readably', () => {
       const record = gitRead({
         branch: '', dirty: null, incomplete: ['branch', 'dirty', 'latestTag'], cause: 'read-timed-out'
@@ -369,6 +380,68 @@ describe('degraded-read normalisation (#885)', () => {
       assert.match(notice.remedy, /Full Disk Access/);
     });
 
+    it('advises on EACCES — the failure whose remedy is most obvious', () => {
+      // `lib/dir-scanner-child.js` reports a project directory that is THERE but
+      // refused as `EACCES` with no hint of its own. Without a fallback the card
+      // named the fault and offered nothing, while the vaguer SCAN_FAILED one
+      // level up did get advice — exactly backwards.
+      const notice = unreadableNotice({
+        name: 'p',
+        unreadable: 'permission denied',
+        unreadableHint: null,
+        unreadableCode: 'EACCES'
+      });
+      assert.ok(notice.remedy, 'EACCES must not leave the operator with no next step');
+      assert.match(notice.remedy, /permission|Full Disk Access/i);
+    });
+
+    it('no hint-less code reaches a card with a reason and no next step', () => {
+      // Driven from the WRITTEN CONTRACT's `unreadableCode` row, not from a
+      // list restated here and not from a source scrape — scraping every
+      // `code: '...'` in the child pulls in thrown-error codes like ENOTDIR that
+      // `failureCode` maps to SCAN_FAILED long before they could reach a card.
+      // Coupling to the contract means a code documented without a remedy fails
+      // here, which is the drift worth catching.
+      //
+      // `lib/project-facts.js` attaches the Full Disk Access hint exactly when
+      // `tcTimedOut || tcCached`, so SCAN_TIMEOUT and SCAN_CACHED always arrive
+      // WITH one and need no fallback. The rest arrive hint-less and are the
+      // renderer's to answer.
+      const contract = fs.readFileSync(
+        path.resolve(__dirname, '..', '.prawduct', 'artifacts', 'api-contract.md'), 'utf8');
+      const row = contract.split('\n').find(
+        (l) => l.includes('`unreadableCode`') && l.includes('Machine-readable cause'));
+      assert.ok(row, 'api-contract.md must document unreadableCode');
+      const documented = [...row.matchAll(/`([A-Z_]{4,})`/g)].map((m) => m[1]);
+      assert.ok(documented.includes('EACCES'),
+        'EACCES must stay documented for this guard to mean anything');
+      const alwaysHinted = new Set(['SCAN_TIMEOUT', 'SCAN_CACHED']);
+      for (const code of documented.filter((c) => !alwaysHinted.has(c))) {
+        const notice = unreadableNotice({
+          name: 'p', unreadable: 'x', unreadableHint: null, unreadableCode: code
+        });
+        // SCAN_ABORTED is the one that legitimately has none — this path may be
+        // healthy, and advising a fix would blame the wrong folder.
+        if (code === 'SCAN_ABORTED') {
+          assert.equal(notice.remedy, null, 'a collateral abort must stay adviceless');
+        } else {
+          assert.ok(notice.remedy,
+            `${code} reaches a card with no remedy — add it to the fallback table`);
+        }
+      }
+    });
+
+    it('lets the server hint win over the renderer fallback', () => {
+      // The server authors its hint at the failure site and is more specific
+      // than anything the table could infer.
+      const notice = unreadableNotice({
+        name: 'p', unreadable: 'x',
+        unreadableHint: 'a very specific server remedy',
+        unreadableCode: 'EACCES'
+      });
+      assert.match(notice.remedy, /A very specific server remedy/);
+    });
+
     it('gives a collateral abort no remedy of its own', () => {
       // A read cancelled because ANOTHER directory was being given up on is not
       // a verdict on this one. The server attaches no hint deliberately, and
@@ -382,6 +455,79 @@ describe('degraded-read normalisation (#885)', () => {
       });
       assert.equal(notice.remedy, null);
     });
+  });
+});
+
+describe('the shared record is actually shared (#885)', () => {
+  // Structural on purpose, and the exception proves the rule about preferring
+  // behaviour: spreading the constructor and re-listing its fields produce
+  // byte-identical output TODAY. The entire value is what happens when the
+  // record grows a field later — a re-listing source silently would not get it.
+  // There is no input that distinguishes the two now, so no behavioural test
+  // can exist; the property being protected is structural, so the guard is too.
+  it('the sources that extend the record spread it rather than re-listing it', () => {
+    const helper = fs.readFileSync(
+      path.resolve(__dirname, '..', 'public', 'api-helper.js'), 'utf8');
+    for (const decl of ['function tcScanNotice(scan)', 'function tcUnreadableNotice(project)']) {
+      const body = functionBody(helper, decl);
+      assert.match(body, /\.\.\.tcDegradedRead\(|return tcDegradedRead\(/,
+        `${decl} must spread or return the shared constructor, not rebuild its fields`);
+      assert.doesNotMatch(body, /known:\s*false,\s*\n?\s*why:/,
+        `${decl} re-lists the record's fields — a field added to tcDegradedRead would not reach it`);
+    }
+  });
+
+  it('every source reports the same key set for the shared fields', () => {
+    const shared = ['known', 'why', 'remedy'];
+    const records = [
+      globalThis.tcSessionRead({
+        session: { active: null, incomplete: ['active'], cause: 'read-timed-out' }
+      }),
+      globalThis.tcGitRead({ branch: 'm', dirty: null, incomplete: ['dirty'], cause: 'read-timed-out' }),
+      globalThis.tcScanNotice({
+        dir: '/p', complete: false, code: 'SCAN_TIMEOUT', reason: 'x', hint: null, listed: null
+      }),
+      globalThis.tcUnreadableNotice({ name: 'p', unreadable: 'x', unreadableCode: 'EACCES' })
+    ];
+    for (const record of records) {
+      for (const key of shared) {
+        assert.ok(key in record, `every degraded-read record must carry "${key}"`);
+      }
+    }
+  });
+});
+
+describe('an unregistered card gets the same answer as a registered one (#885)', () => {
+  it('the walk projects every field the renderer reads', () => {
+    // `lib/dir-scanner-child.js` builds its OWN git object for unregistered
+    // entries rather than passing `getInfo`'s through, so it is a second
+    // producer of the same contract. It shipped without `cause`, which meant
+    // two cards in one list gave different answers to the same failure: the
+    // registered one named the cause and offered the slow-repository remedy,
+    // the unregistered one fell back to "the read did not complete" with none.
+    const childSrc = fs.readFileSync(
+      path.resolve(__dirname, '..', 'lib', 'dir-scanner-child.js'), 'utf8');
+    const projection = childSrc.slice(childSrc.indexOf('git: gitInfo'));
+    for (const field of ['branch', 'dirty', 'incomplete', 'cause']) {
+      assert.match(projection.slice(0, 400), new RegExp(`${field}:\\s*gitInfo\\.${field}`),
+        `the walk must project git.${field} — the dashboard reads it`);
+    }
+  });
+
+  it('both card kinds render an identical badge for an identical failure', () => {
+    // The behavioural half: same git object, same rendered badge. If a producer
+    // narrows the object for one card, this diverges.
+    const root = path.resolve(__dirname, '..');
+    const uiSrc = fs.readFileSync(path.join(root, 'public/ui.js'), 'utf8');
+    const badge = liftRenderer(uiSrc, 'function renderGitBadge(project)', 'renderGitBadge', {
+      esc,
+      degradedTooltip: liftRenderer(uiSrc, 'function degradedTooltip(record)', 'degradedTooltip', { esc }),
+      tcGitDirtyState: globalThis.tcGitDirtyState,
+      tcGitRead: globalThis.tcGitRead
+    });
+    const failing = { branch: 'main', dirty: null, incomplete: ['dirty'], cause: 'read-timed-out' };
+    assert.match(badge({ git: failing }), /retries on the next poll/,
+      'a projected git object carrying cause must earn the same remedy');
   });
 });
 
@@ -530,6 +676,107 @@ describe('the dashboard actually consults the helpers (#885)', () => {
     assert.match(html, /The directory did not respond\. On macOS that is what a protected folder does\./);
   });
 
+  describe('the empty list, which is the worst case rather than an exemption', () => {
+    /**
+     * Run the real `renderProjects` against a project list and scan, capturing
+     * what it writes into the grid.
+     * @param {object[]} projects - `state.projects`.
+     * @param {object|null} scan - `state.projectsScan`.
+     * @returns {string} The grid's innerHTML.
+     */
+    function renderGrid(projects, scan, filtered) {
+      const grid = { innerHTML: '' };
+      liftRenderer(ui, 'function renderProjects()', 'renderProjects', {
+        document: { getElementById: () => grid },
+        filterProjects: () => (filtered === undefined ? projects : filtered),
+        renderCard: (p) => `<card>${p.name}</card>`,
+        renderRootPanel: () => '<ROOT-PANEL>',
+        state: { projects, projectsScan: scan },
+        tcScanNotice: globalThis.tcScanNotice
+      })();
+      return grid.innerHTML;
+    }
+
+    const SHORT = {
+      dir: '/p', complete: false, code: 'SCAN_TIMEOUT',
+      reason: 'Could not read the projects directory.', hint: null, listed: null
+    };
+    const COMPLETE = {
+      dir: '/p', complete: true, code: null, reason: null, hint: null, listed: null
+    };
+
+    it('does not claim "No projects yet" when the directory could not be read', () => {
+      // Mutation: drop the listIsShort branch. This is #885's worst case — a
+      // definite, actionable and wrong statement on a machine where nothing is
+      // registered and the scan failed.
+      const html = renderGrid([], SHORT);
+      assert.doesNotMatch(html, /No projects yet/);
+      assert.match(html, /could not be listed|could not be read/);
+    });
+
+    it('still invites a first project on a genuinely empty machine', () => {
+      const html = renderGrid([], COMPLETE);
+      assert.match(html, /No projects yet/);
+      assert.match(html, /Create your first project/);
+    });
+
+    it('renders the ROOT panel on every path, empty and filtered included', () => {
+      // Mutation: restore the early returns that skipped it. The notice would be
+      // invisible in exactly the cases that need it most.
+      assert.match(renderGrid([], SHORT), /<ROOT-PANEL>/, 'empty list');
+      assert.match(renderGrid([], COMPLETE), /<ROOT-PANEL>/, 'empty and healthy');
+      const filteredOut = renderGrid([{ name: 'a' }], SHORT, []);
+      assert.match(filteredOut, /<ROOT-PANEL>/, 'filtered to nothing');
+      assert.match(filteredOut, /No projects match your filter/);
+      // And the ordinary path still renders panel + cards.
+      const populated = renderGrid([{ name: 'a' }], COMPLETE);
+      assert.match(populated, /<ROOT-PANEL><card>a<\/card>/);
+    });
+  });
+
+  describe('the header session count', () => {
+    /**
+     * Run the real `renderSessionCount` over a project list.
+     * @param {object[]} projects - `state.projects`.
+     * @returns {string} The header's innerHTML.
+     */
+    function count(projects) {
+      const el = { innerHTML: '' };
+      liftRenderer(ui, 'function renderSessionCount()', 'renderSessionCount', {
+        document: { getElementById: () => el },
+        state: { projects },
+        tcSessionLiveness: globalThis.tcSessionLiveness
+      })();
+      return el.innerHTML;
+    }
+
+    const LIVE = { session: { active: true, incomplete: [], cause: null } };
+    const UNKNOWN = { session: { active: null, incomplete: ['active'], cause: 'read-timed-out' } };
+    const NONE = { session: null };
+
+    it('does not count an unknown session as not-active', () => {
+      // Mutation: count unknowns as inactive. The header then reads "0 active
+      // sessions" during the exact wedge the cards below are drawing `?` for —
+      // a definite number the server does not have, contradicting the cards it
+      // summarises, on the most prominent surface on the page.
+      const html = count([UNKNOWN, UNKNOWN, NONE]);
+      assert.match(html, /0<\/span> active sessions/);
+      assert.match(html, /2 unknown/, 'the unknowns must be surfaced, not absorbed');
+    });
+
+    it('counts live sessions and unknowns separately', () => {
+      assert.match(count([LIVE, LIVE, UNKNOWN]), /2<\/span> active sessions/);
+      assert.match(count([LIVE, LIVE, UNKNOWN]), /1 unknown/);
+    });
+
+    it('reads exactly as before on a healthy dashboard', () => {
+      // No unknowns must mean no extra clause at all.
+      const html = count([LIVE, NONE]);
+      assert.equal(html, '<span class="count-num">1</span> active session',
+        'a healthy header must be exactly what it always was');
+    });
+  });
+
   it('renderRootPanel consults the shared helper rather than re-deriving completeness', () => {
     const body = functionBody(ui, 'function renderRootPanel()');
     assert.ok(body.includes('tcScanNotice(state.projectsScan)'),
@@ -557,6 +804,7 @@ describe('the dashboard actually consults the helpers (#885)', () => {
     function badge(git) {
       const render = liftRenderer(ui, 'function renderGitBadge(project)', 'renderGitBadge', {
         esc,
+        degradedTooltip: liftRenderer(ui, 'function degradedTooltip(record)', 'degradedTooltip', { esc }),
         tcGitDirtyState: globalThis.tcGitDirtyState,
         tcGitRead: globalThis.tcGitRead
       });
@@ -602,13 +850,32 @@ describe('the dashboard actually consults the helpers (#885)', () => {
       'the unknown dot must carry a glyph — an error is never communicated by colour alone');
   });
 
-  it('an unreadable project is badged on both card kinds', () => {
+  it('both card kinds share ONE unreadable badge, with no private copy', () => {
+    // The badge was copy-pasted into both renderers — the same duplication
+    // `renderGitBadge` exists to remove, one badge over. Mutation: inline the
+    // markup into either renderer again.
     for (const decl of ['function renderCard(project)', 'function renderUnregisteredCard(project)']) {
       const body = functionBody(ui, decl);
-      assert.ok(body.includes('tcUnreadableNotice(project)'),
-        `${decl} must surface a folder that could not be read`);
-      assert.ok(body.includes('badge-unreadable'), `${decl} must render the badge`);
+      assert.ok(body.includes('renderUnreadableBadge(project)'),
+        `${decl} must use the shared badge`);
+      assert.doesNotMatch(body, /badge-unreadable/,
+        `${decl} must not carry its own copy of the markup`);
     }
+  });
+
+  it('the unreadable badge renders the reason and the remedy in its tooltip', () => {
+    const render = liftRenderer(ui, 'function renderUnreadableBadge(project)', 'renderUnreadableBadge', {
+      esc,
+      degradedTooltip: liftRenderer(ui, 'function degradedTooltip(record)', 'degradedTooltip', { esc }),
+      tcUnreadableNotice: globalThis.tcUnreadableNotice
+    });
+    assert.equal(render({ name: 'p', unreadable: null }), '', 'a readable folder gets no badge');
+    const html = render({
+      name: 'p', unreadable: 'permission denied', unreadableHint: null, unreadableCode: 'EACCES'
+    });
+    assert.match(html, /badge-unreadable/);
+    assert.match(html, /title="[^"]*permission denied/);
+    assert.match(html, /title="[^"]*(permissions|Full Disk Access)/);
   });
 
   describe('the card detail rows, run for real', () => {

--- a/test/degraded-reads-frontend.test.js
+++ b/test/degraded-reads-frontend.test.js
@@ -1,0 +1,693 @@
+'use strict';
+
+/*
+ * #885 — the dashboard must render a read that could not be established as
+ * unknown, never as its negative.
+ *
+ * The payload already distinguishes the three outcomes (#900 for liveness, #891
+ * for git, #885's payload half for the scan and the per-project trio). Nothing
+ * rendered any of it: a wedged tmux server drew every running session as "no
+ * session", an unreadable folder silently shortened the list, and `dirty: null`
+ * drew a repository as clean.
+ *
+ * These are the pure decision helpers the renderer branches on, in
+ * `public/api-helper.js` — the shared frontend base, required directly here the
+ * same way test/engine-picker-gating.test.js requires it. Testing them tests
+ * every render site at once, which is the point of normalising six payload
+ * shapes to one record before anything draws.
+ *
+ * The scan codes are NOT hand-written string literals. They are driven through
+ * the real `dirScanner.failureCode`, so that renaming a code server-side fails
+ * these guards instead of silently leaving the dashboard branching on a value
+ * the server no longer emits.
+ */
+
+const { describe, it, before } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const dirScanner = require('../lib/dir-scanner');
+
+/**
+ * Slice out a top-level function body by brace-matching from its declaration.
+ *
+ * `public/ui.js` and `public/landing.js` are browser global scripts rather than
+ * requireable modules, so their wiring is pinned against source the same way
+ * test/landing-wrap-single-flight.test.js pins the dashboard wrap trigger.
+ *
+ * @param {string} src - File source text.
+ * @param {string} decl - The declaration to find, e.g. `function renderCard(project)`.
+ * @returns {string} The body including its braces.
+ */
+function functionBody(src, decl) {
+  const start = src.indexOf(decl);
+  assert.notEqual(start, -1, `${decl} must exist`);
+  const bodyStart = src.indexOf('{', start);
+  let depth = 0;
+  for (let i = bodyStart; i < src.length; i++) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}' && --depth === 0) return src.slice(bodyStart, i + 1);
+  }
+  assert.fail(`${decl} body must close`);
+}
+
+/**
+ * Lift a pure renderer out of `ui.js` and RUN it, with the browser globals it
+ * closes over passed in as parameters.
+ *
+ * Executing the real function beats asserting about its source: a source guard
+ * that a dead branch can satisfy proves nothing, which is exactly what a
+ * `countLabel = false` mutation demonstrated about the first version of these
+ * tests. Only functions that touch no DOM are lifted this way.
+ *
+ * @param {string} src - `ui.js` source text.
+ * @param {string} decl - The declaration, e.g. `function renderRootPanel()`.
+ * @param {string} name - The function's name.
+ * @param {object} scope - Free variables the function needs, by name.
+ * @returns {Function} The real renderer, callable.
+ */
+function liftRenderer(src, decl, name, scope) {
+  const source = decl + functionBody(src, decl);
+  const names = Object.keys(scope);
+  const factory = new Function(...names, `${source}\nreturn ${name};`);
+  return factory(...names.map((k) => scope[k]));
+}
+
+/**
+ * The production `esc`, copied from `public/landing.js` including its
+ * non-string rejection. A more forgiving stub renders values the real one
+ * drops, which would make assertions about rendered text quietly untrue.
+ *
+ * @param {*} str - Value to escape.
+ * @returns {string}
+ */
+function esc(str) {
+  if (typeof str !== 'string') return '';
+  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+}
+
+describe('degraded-read normalisation (#885)', () => {
+  let liveness;
+  let sessionRead;
+  let dirtyState;
+  let gitRead;
+  let scanNotice;
+  let unreadableNotice;
+
+  before(() => {
+    require('../public/api-helper.js');
+    liveness = globalThis.tcSessionLiveness;
+    sessionRead = globalThis.tcSessionRead;
+    dirtyState = globalThis.tcGitDirtyState;
+    gitRead = globalThis.tcGitRead;
+    scanNotice = globalThis.tcScanNotice;
+    unreadableNotice = globalThis.tcUnreadableNotice;
+  });
+
+  // The codes the server can actually produce, obtained from the server's own
+  // mapping rather than restated. `failureCode`'s ORDER is a contract — a
+  // remembered refusal carries BOTH tcCached and tcTimedOut — so the cached
+  // fixture below carries both flags, which is the shape `_notAnswering` really
+  // builds.
+  describe('the codes under test are the codes the server emits', () => {
+    it('failureCode maps the four scan failure flags', () => {
+      assert.equal(dirScanner.failureCode({ tcCached: true, tcTimedOut: true }), 'SCAN_CACHED');
+      assert.equal(dirScanner.failureCode({ tcTimedOut: true }), 'SCAN_TIMEOUT');
+      assert.equal(dirScanner.failureCode({ tcAborted: true }), 'SCAN_ABORTED');
+      assert.equal(dirScanner.failureCode(new Error('EACCES')), 'SCAN_FAILED');
+    });
+  });
+
+  describe('tcSessionLiveness', () => {
+    it('reports unknown when the liveness read did not answer', () => {
+      // Mutation: return 'none' for active === null — today's lie, and the whole
+      // of #900. A wedged tmux server would draw every running session as absent.
+      const project = {
+        session: { active: null, status: 'active', incomplete: ['active'], cause: 'read-timed-out' }
+      };
+      assert.equal(liveness(project), 'unknown');
+    });
+
+    it('reports live when tmux confirmed the pane', () => {
+      assert.equal(liveness({ session: { active: true, incomplete: [], cause: null } }), 'live');
+    });
+
+    it('reports none — not unknown — when there is no session row at all', () => {
+      // Mutation: treat an absent session as unknown. Every idle project on the
+      // dashboard would then render as degraded, which inverts the bug rather
+      // than fixing it.
+      assert.equal(liveness({ session: null }), 'none');
+      assert.equal(liveness({}), 'none');
+      assert.equal(liveness(null), 'none');
+    });
+
+    it('reports none when tmux ANSWERED and the pane was absent', () => {
+      // The honest negative must survive. Unknown must not swallow it.
+      assert.equal(liveness({ session: { active: false, incomplete: [], cause: null } }), 'none');
+    });
+  });
+
+  describe('tcSessionRead', () => {
+    it('carries a why and a tmux-specific remedy when liveness is unknown', () => {
+      const record = sessionRead({
+        session: { active: null, status: 'active', incomplete: ['active'], cause: 'read-timed-out' }
+      });
+      assert.equal(record.known, false);
+      assert.match(record.why, /could not be established/);
+      assert.match(record.remedy, /tmux/);
+    });
+
+    it('does NOT reuse the directory remedy for the same cause token', () => {
+      // `read-timed-out` means a wedged tmux server here and a filesystem
+      // permission for a directory scan. One vocabulary of causes is the design;
+      // one vocabulary of REMEDIES would tell an operator to grant Full Disk
+      // Access because tmux hung.
+      const record = sessionRead({
+        session: { active: null, status: 'active', incomplete: ['active'], cause: 'read-timed-out' }
+      });
+      assert.doesNotMatch(record.remedy, /Full Disk Access/);
+    });
+
+    it('reports known for a live session', () => {
+      const record = sessionRead({ session: { active: true, incomplete: [], cause: null } });
+      assert.equal(record.known, true);
+      assert.equal(record.why, null);
+    });
+  });
+
+  describe('tcGitDirtyState', () => {
+    it('reports unknown when dirty could not be established', () => {
+      // Mutation: return 'clean' for dirty === null. That draws a dirty
+      // repository as clean — the exact unknown-as-fact #891 removed from the
+      // payload, reintroduced at the render boundary.
+      assert.equal(dirtyState({ branch: 'main', dirty: null, incomplete: ['dirty'] }), 'unknown');
+    });
+
+    it('reports dirty and clean when the read established them', () => {
+      assert.equal(dirtyState({ branch: 'main', dirty: true, incomplete: [] }), 'dirty');
+      assert.equal(dirtyState({ branch: 'main', dirty: false, incomplete: [] }), 'clean');
+    });
+
+    it('reports null — not unknown — when there is no repository', () => {
+      // Mutation: return 'unknown' for a missing git object. Every plain
+      // directory on the dashboard would grow a "?" claiming a failed read that
+      // never happened.
+      assert.equal(dirtyState(null), null);
+      assert.equal(dirtyState(undefined), null);
+    });
+  });
+
+  describe('tcGitRead', () => {
+    it('reports unknown for ANY short field, not only dirty', () => {
+      // `incomplete` is the authoritative list. A branch that could not be read
+      // is as unestablished as a working-tree state.
+      const record = gitRead({ branch: '', dirty: true, incomplete: ['branch'], cause: 'read-timed-out' });
+      assert.equal(record.known, false);
+      assert.match(record.why, /branch/);
+    });
+
+    it('names the cause git actually reported', () => {
+      const refused = gitRead({
+        branch: 'main', dirty: null, incomplete: ['dirty'], cause: 'git-refused-to-read-repository'
+      });
+      assert.match(refused.why, /refused/);
+      // A refusal is not a timeout, so it earns no "it retries" reassurance.
+      assert.equal(refused.remedy, null);
+    });
+
+    it('reports known for a complete reading', () => {
+      assert.equal(gitRead({ branch: 'main', dirty: false, incomplete: [], cause: null }).known, true);
+    });
+
+    it('never prints a payload field name at the operator', () => {
+      // Mutation: join `incomplete` raw. "Could not establish dirty" reads as a
+      // leak, and "dirty" means nothing to someone who did not write the field.
+      const record = gitRead({ branch: 'main', dirty: null, incomplete: ['dirty'], cause: 'read-timed-out' });
+      assert.doesNotMatch(record.why, /\bdirty\b/,
+        'the field name must be translated, not echoed');
+      assert.match(record.why, /uncommitted changes/);
+    });
+
+    it('names every field lib/git.js can actually report as short', () => {
+      // Driven from the real producer's vocabulary rather than a guess: any
+      // field name `getInfo` can push must have prose here, or this goes red.
+      const gitSrc = fs.readFileSync(path.resolve(__dirname, '..', 'lib', 'git.js'), 'utf8');
+      const names = new Set();
+      for (const m of gitSrc.matchAll(/step\('([a-zA-Z]+)'/g)) names.add(m[1]);
+      for (const m of gitSrc.matchAll(/incomplete\.push\('([a-zA-Z]+)'\)/g)) names.add(m[1]);
+      assert.ok(names.size >= 4, 'the field vocabulary must have been found');
+      for (const field of names) {
+        const record = gitRead({ branch: 'main', dirty: null, incomplete: [field], cause: 'read-timed-out' });
+        // The raw-name fallback renders as "Could not establish <field> —".
+        // Prose that happens to contain the word is fine ("the current branch");
+        // the bare token standing in for a sentence is not.
+        assert.doesNotMatch(record.why, new RegExp(`establish ${field} —`),
+          `"${field}" reaches the operator untranslated — add it to the field vocabulary`);
+      }
+    });
+
+    it('lists several short fields readably', () => {
+      const record = gitRead({
+        branch: '', dirty: null, incomplete: ['branch', 'dirty', 'latestTag'], cause: 'read-timed-out'
+      });
+      assert.match(record.why, /current branch, whether there are uncommitted changes and the latest tag/);
+    });
+  });
+
+  describe('tcScanNotice', () => {
+    it('returns null when the list is complete', () => {
+      // Mutation: render a notice unconditionally. The healthy dashboard would
+      // carry a permanent warning row.
+      assert.equal(scanNotice({ dir: '/p', complete: true, code: null, reason: null, hint: null, listed: null }), null);
+      assert.equal(scanNotice(null), null);
+    });
+
+    it('reports a truncated walk as info with no remedy', () => {
+      // Mutation: give truncation kind 'warn', or hand it a remedy. Nothing is
+      // wrong with a directory that answered fine and is merely larger than one
+      // scan's budget; advising a permission change there is the misdiagnosis
+      // this whole area exists to remove.
+      const notice = scanNotice({
+        dir: '/p',
+        complete: false,
+        code: 'SCAN_TRUNCATED',
+        reason: 'The projects directory has more folders than one scan could check in time, '
+          + 'so this list is short rather than complete. Nothing is wrong with it.',
+        hint: null,
+        listed: 42
+      });
+      assert.equal(notice.kind, 'info');
+      assert.equal(notice.remedy, null);
+      assert.equal(notice.listed, 42);
+      assert.doesNotMatch(notice.why, /Full Disk Access/);
+    });
+
+    it('keeps the server hint for a remembered refusal AND says nothing is retrying', () => {
+      // Two separate decisions, and deriving either from the other is the defect
+      // three reviewers found independently. The condition is unchanged, so the
+      // Full Disk Access remedy still stands; the backoff is an ADDITIONAL fact.
+      const code = dirScanner.failureCode({ tcCached: true, tcTimedOut: true });
+      const notice = scanNotice({
+        dir: '/p',
+        complete: false,
+        code,
+        reason: 'Could not read the projects directory, so folders that are not registered '
+          + 'are missing from this list. Registered projects are unaffected.',
+        hint: 'the directory did not respond. On macOS that is what a protected folder does '
+          + 'when node has no Full Disk Access.',
+        listed: null
+      });
+      assert.equal(notice.kind, 'warn');
+      assert.match(notice.remedy, /Full Disk Access/,
+        'a remembered refusal must keep the remedy — the condition it describes is unchanged');
+      assert.match(notice.why, /not being retried/,
+        'a remembered refusal must say that nothing is retrying it');
+    });
+
+    it('supplies a remedy for an ordinary failure the server left without one', () => {
+      // An EACCES projects directory arrives as SCAN_FAILED with a null hint —
+      // honest, but the operator gets no advice at all. Mutation: drop the
+      // fallback and the row renders a problem with no next step.
+      const code = dirScanner.failureCode(Object.assign(new Error('EACCES'), { code: 'EACCES' }));
+      const notice = scanNotice({
+        dir: '/p', complete: false, code, reason: 'Could not read the projects directory.',
+        hint: null, listed: null
+      });
+      assert.equal(code, 'SCAN_FAILED');
+      assert.ok(notice.remedy, 'SCAN_FAILED must not leave the operator with no advice');
+      // It must not GUESS a cause: SCAN_FAILED is the catch-all.
+      assert.doesNotMatch(notice.remedy, /Full Disk Access/);
+    });
+
+    it('supplies a remedy for a missing directory', () => {
+      const notice = scanNotice({
+        dir: '/nope', complete: false, code: 'DIR_MISSING',
+        reason: 'The projects directory does not exist: /nope', hint: null, listed: null
+      });
+      assert.match(notice.remedy, /Create the directory|Settings/);
+    });
+
+    it('prefers the server sentence over anything the renderer would invent', () => {
+      const notice = scanNotice({
+        dir: '/p', complete: false, code: 'SCAN_TIMEOUT',
+        reason: 'A very specific server sentence.', hint: null, listed: null
+      });
+      assert.match(notice.why, /A very specific server sentence\./);
+    });
+  });
+
+  describe('tcUnreadableNotice', () => {
+    it('returns null for a readable project', () => {
+      assert.equal(unreadableNotice({ name: 'p', unreadable: null }), null);
+      assert.equal(unreadableNotice({ name: 'p' }), null);
+    });
+
+    it('carries the reason, the server hint, and what is missing', () => {
+      const notice = unreadableNotice({
+        name: 'p',
+        unreadable: 'the directory did not answer',
+        unreadableHint: 'the directory did not respond. On macOS that is what a protected '
+          + 'folder does when node has no Full Disk Access.',
+        unreadableCode: dirScanner.failureCode({ tcTimedOut: true })
+      });
+      assert.equal(notice.known, false);
+      assert.match(notice.why, /did not answer/);
+      assert.match(notice.why, /missing rather than absent/,
+        'the operator must learn the detail is unestablished, not that the project lacks it');
+      assert.match(notice.remedy, /Full Disk Access/);
+    });
+
+    it('says nothing is retrying a remembered refusal, and keeps its remedy', () => {
+      const notice = unreadableNotice({
+        name: 'p',
+        unreadable: 'the directory did not answer',
+        unreadableHint: 'grant Full Disk Access',
+        unreadableCode: dirScanner.failureCode({ tcCached: true, tcTimedOut: true })
+      });
+      assert.match(notice.why, /not being retried/);
+      assert.match(notice.remedy, /Full Disk Access/);
+    });
+
+    it('gives a collateral abort no remedy of its own', () => {
+      // A read cancelled because ANOTHER directory was being given up on is not
+      // a verdict on this one. The server attaches no hint deliberately, and
+      // SCAN_ABORTED has no renderer fallback — advising a permission change
+      // here would blame the wrong folder.
+      const notice = unreadableNotice({
+        name: 'p',
+        unreadable: 'the read was cancelled while another directory was being given up on',
+        unreadableHint: null,
+        unreadableCode: dirScanner.failureCode({ tcAborted: true })
+      });
+      assert.equal(notice.remedy, null);
+    });
+  });
+});
+
+describe('the dashboard actually consults the helpers (#885)', () => {
+  let ui;
+  let landing;
+
+  before(() => {
+    const root = path.resolve(__dirname, '..');
+    ui = fs.readFileSync(path.join(root, 'public/ui.js'), 'utf8');
+    landing = fs.readFileSync(path.join(root, 'public/landing.js'), 'utf8');
+  });
+
+  it('landing.js keeps the scan block instead of discarding it', () => {
+    // Mutation: drop the assignment. Every guard above still passes and the
+    // dashboard renders nothing — the helpers would be dead code.
+    const body = functionBody(landing, 'async function loadProjects()');
+    assert.match(body, /state\.projectsScan\s*=\s*data\.scan/,
+      'loadProjects must keep the scan block; the notice cannot render without it');
+    assert.match(landing, /projectsScan:\s*null/,
+      'state must declare projectsScan so the first render has a defined value');
+  });
+
+  /**
+   * Run the real `renderRootPanel` against a given scan block.
+   * @param {object|null} scan - The `scan` block to render under.
+   * @returns {string} The panel HTML.
+   */
+  function renderRoot(scan) {
+    const render = liftRenderer(ui, 'function renderRootPanel()', 'renderRootPanel', {
+      state: {
+        config: { projectsDir: '/Users/x/Projects' },
+        projects: [
+          { name: 'a', registered: true, archived: false },
+          { name: 'b', registered: false, archived: false }
+        ],
+        projectsScan: scan
+      },
+      esc,
+      tcScanNotice: globalThis.tcScanNotice
+    });
+    return render();
+  }
+
+  const COMPLETE_SCAN = {
+    dir: '/Users/x/Projects', complete: true, code: null, reason: null, hint: null, listed: null
+  };
+
+  it('the healthy panel is unchanged — no notice, and a real total', () => {
+    const html = renderRoot(COMPLETE_SCAN);
+    assert.ok(html.includes('1 registered / 2 total'), 'a complete list still reports a total');
+    assert.doesNotMatch(html, /root-notice/, 'a healthy dashboard carries no warning row');
+  });
+
+  it('the ROOT count stops saying "total" when the list is short', () => {
+    // Mutation: make the label unconditional. The panel would keep asserting a
+    // completeness the server explicitly did not claim — the silent half of
+    // #885. Asserted against RENDERED output, because a source check is
+    // satisfied by a dead branch (a `countLabel = false` mutation proved it).
+    const html = renderRoot({
+      dir: '/Users/x/Projects', complete: false, code: 'SCAN_TIMEOUT',
+      reason: 'Could not read the projects directory.', hint: null, listed: null
+    });
+    assert.doesNotMatch(html, /2 total/,
+      'a short list must not be reported as a total');
+    assert.ok(html.includes('1 registered / 2 listed'));
+  });
+
+  it('the notice carries the reason and the remedy as visible text', () => {
+    // Not a tooltip: the remedy is the whole operator-facing value of degrading
+    // instead of hanging, and a phone cannot hover.
+    const html = renderRoot({
+      dir: '/Users/x/Projects', complete: false, code: 'DIR_MISSING',
+      reason: 'The projects directory does not exist: /Users/x/Projects',
+      hint: null, listed: null
+    });
+    assert.ok(html.includes('root-notice'), 'the notice row must render');
+    assert.ok(html.includes('does not exist'), 'the reason must be visible');
+    assert.ok(html.includes('Create the directory'), 'the remedy must be visible');
+  });
+
+  it('a truncated walk renders as information, not as a fault', () => {
+    const html = renderRoot({
+      dir: '/Users/x/Projects', complete: false, code: 'SCAN_TRUNCATED',
+      reason: 'More folders than one scan could check in time. Nothing is wrong with it.',
+      hint: null, listed: 40
+    });
+    assert.ok(html.includes('root-notice-info'), 'truncation is info, not a warning');
+    assert.doesNotMatch(html, /root-notice-warn/);
+    assert.doesNotMatch(html, /Full Disk Access/,
+      'a directory that answered fine must never be given a permissions remedy');
+    // The glyph carries the distinction for anyone who cannot use the colour, so
+    // it must differ too — a shared warning triangle would erase the difference
+    // for exactly the readers the palette alone already fails.
+    assert.ok(html.includes('&#8505;'), 'an informational notice takes the info glyph');
+    assert.doesNotMatch(html, /&#9888;/, 'truncation must not wear the warning triangle');
+  });
+
+  it('a real fault takes the warning glyph, so the two are distinguishable', () => {
+    const html = renderRoot({
+      dir: '/Users/x/Projects', complete: false, code: 'SCAN_TIMEOUT',
+      reason: 'Could not read the projects directory.', hint: null, listed: null
+    });
+    assert.ok(html.includes('&#9888;'));
+    assert.doesNotMatch(html, /&#8505;/);
+  });
+
+  it('a truncated walk does not recolour the panel as needing attention', () => {
+    // The amber border means "look at this". A directory that answered fine and
+    // is merely large does not. Mutation: apply the class for any notice.
+    const html = renderRoot({
+      dir: '/p', complete: false, code: 'SCAN_TRUNCATED',
+      reason: 'Nothing is wrong with it.', hint: null, listed: 40
+    });
+    assert.doesNotMatch(html, /root-panel-degraded/);
+    const fault = renderRoot({
+      dir: '/p', complete: false, code: 'SCAN_TIMEOUT', reason: 'x', hint: null, listed: null
+    });
+    assert.match(fault, /root-panel-degraded/, 'a real fault still marks the panel');
+  });
+
+  it('shows how far a cut-off walk got, when the scan reported it', () => {
+    // Mutation: drop the count. `listed` is in the payload precisely so a short
+    // list can be sized; computing it without rendering it is dead data.
+    const html = renderRoot({
+      dir: '/p', complete: false, code: 'SCAN_TRUNCATED',
+      reason: 'Nothing is wrong with it.', hint: null, listed: 40
+    });
+    assert.match(html, /40 unregistered folders were checked before the cut-off/);
+    const noCount = renderRoot({
+      dir: '/p', complete: false, code: 'SCAN_TIMEOUT', reason: 'x', hint: null, listed: null
+    });
+    assert.doesNotMatch(noCount, /root-notice-listed/,
+      'a failure with no count must not invent one');
+  });
+
+  it('presents the server remedy as a sentence without rewording it', () => {
+    // Server hints are authored to follow a log label, so they start lower-case;
+    // standalone that reads as truncated. Only the first letter may change — the
+    // wording is the server's and is deliberate house style.
+    const html = renderRoot({
+      dir: '/p', complete: false, code: 'SCAN_TIMEOUT', reason: 'x',
+      hint: 'the directory did not respond. On macOS that is what a protected folder does.',
+      listed: null
+    });
+    assert.match(html, /The directory did not respond\. On macOS that is what a protected folder does\./);
+  });
+
+  it('renderRootPanel consults the shared helper rather than re-deriving completeness', () => {
+    const body = functionBody(ui, 'function renderRootPanel()');
+    assert.ok(body.includes('tcScanNotice(state.projectsScan)'),
+      'the ROOT panel must ask the shared helper');
+  });
+
+  it('both card renderers share ONE git badge, and neither keeps a private copy', () => {
+    // The duplicated markup is why a fix to one card left the other drawing an
+    // unreadable repository as clean. Mutation: restore either private copy.
+    for (const decl of ['function renderCard(project)', 'function renderUnregisteredCard(project)']) {
+      const body = functionBody(ui, decl);
+      assert.ok(body.includes('renderGitBadge(project)'),
+        `${decl} must use the shared git badge`);
+      assert.doesNotMatch(body, /project\.git\.dirty\s*\?/,
+        `${decl} must not re-implement the dirty marker — that is the duplication that caused the bug`);
+    }
+  });
+
+  describe('renderGitBadge, run for real', () => {
+    /**
+     * Run the real `renderGitBadge` against a git object.
+     * @param {object|null} git - `project.git`.
+     * @returns {string} Badge HTML.
+     */
+    function badge(git) {
+      const render = liftRenderer(ui, 'function renderGitBadge(project)', 'renderGitBadge', {
+        esc,
+        tcGitDirtyState: globalThis.tcGitDirtyState,
+        tcGitRead: globalThis.tcGitRead
+      });
+      return render({ git });
+    }
+
+    it('marks an unestablished working tree with a VISIBLE glyph, not just a class', () => {
+      // Mutation: drop the marker element. A class-name assertion would survive
+      // that — `badge-git-unknown` contains the substring `git-unknown`, so
+      // matching loosely passes while the operator sees nothing at all. Assert
+      // the rendered glyph, which is the thing an operator can actually read.
+      const unknown = badge({ branch: 'main', dirty: null, incomplete: ['dirty'], cause: 'read-timed-out' });
+      const clean = badge({ branch: 'main', dirty: false, incomplete: [], cause: null });
+      assert.match(unknown, /<span class="git-unknown"[^>]*>\?<\/span>/,
+        'the unknown marker must render a visible glyph');
+      assert.notEqual(unknown, clean,
+        'an unestablished reading must not render identically to a clean one');
+    });
+
+    it('keeps the dirty marker and the clean absence intact', () => {
+      assert.ok(badge({ branch: 'main', dirty: true, incomplete: [], cause: null }).includes('git-dirty'));
+      const clean = badge({ branch: 'main', dirty: false, incomplete: [], cause: null });
+      assert.doesNotMatch(clean, /git-dirty|git-unknown/);
+    });
+
+    it('renders nothing at all when the project is not a repository', () => {
+      assert.equal(badge(null), '');
+    });
+
+    it('names the cause in the badge tooltip when a reading went short', () => {
+      const html = badge({ branch: 'main', dirty: null, incomplete: ['dirty'], cause: 'read-timed-out' });
+      assert.match(html, /title="[^"]*could not establish/i);
+    });
+  });
+
+  it('the card status dot has a third state carrying a glyph, not colour alone', () => {
+    const body = functionBody(ui, 'function renderCard(project)');
+    assert.ok(body.includes('tcSessionLiveness(project)'),
+      'the card must classify liveness through the shared helper');
+    assert.ok(body.includes("liveness === 'unknown'"),
+      'the card must draw the unknown distinctly from "no active session"');
+    assert.ok(body.includes('status-dot-glyph'),
+      'the unknown dot must carry a glyph — an error is never communicated by colour alone');
+  });
+
+  it('an unreadable project is badged on both card kinds', () => {
+    for (const decl of ['function renderCard(project)', 'function renderUnregisteredCard(project)']) {
+      const body = functionBody(ui, decl);
+      assert.ok(body.includes('tcUnreadableNotice(project)'),
+        `${decl} must surface a folder that could not be read`);
+      assert.ok(body.includes('badge-unreadable'), `${decl} must render the badge`);
+    }
+  });
+
+  describe('the card detail rows, run for real', () => {
+    /**
+     * Run a lifted detail renderer.
+     * @param {string} decl - Its declaration.
+     * @param {string} name - Its name.
+     * @param {object} project - The project to render.
+     * @returns {string} HTML for the row value.
+     */
+    function detail(decl, name, project) {
+      const render = liftRenderer(ui, decl, name, {
+        esc,
+        tcSessionLiveness: globalThis.tcSessionLiveness,
+        tcSessionRead: globalThis.tcSessionRead,
+        tcGitDirtyState: globalThis.tcGitDirtyState,
+        tcGitRead: globalThis.tcGitRead
+      });
+      return render(project);
+    }
+
+    /**
+     * @param {object} project - The project to render.
+     * @returns {string} The Session row value.
+     */
+    const session = (project) =>
+      detail('function renderSessionDetail(project)', 'renderSessionDetail', project);
+
+    /**
+     * @param {object} project - The project to render.
+     * @returns {string} The Git row value.
+     */
+    const git = (project) =>
+      detail('function renderGitDetail(project)', 'renderGitDetail', project);
+
+    it('says unknown, and why, rather than "No active session"', () => {
+      // Mutation: collapse the unknown branch. The row would state a definite
+      // absence the server never established — the whole of #900 on this surface.
+      const html = session({
+        session: { active: null, status: 'active', incomplete: ['active'], cause: 'read-timed-out' }
+      });
+      assert.match(html, /Unknown/);
+      assert.doesNotMatch(html, /No active session/);
+      assert.match(html, /could not be established/, 'the row must name why');
+    });
+
+    it('still says "No active session" when there genuinely is none', () => {
+      assert.equal(session({ session: null }), 'No active session');
+      assert.equal(session({ session: { active: false, incomplete: [], cause: null } }),
+        'No active session');
+    });
+
+    it('reports a live session unchanged', () => {
+      assert.match(session({ session: { active: true, startedAt: '2026-08-13', incomplete: [] } }),
+        /Active since 2026-08-13/);
+    });
+
+    it('names an unreadable working tree instead of leaving it to look clean', () => {
+      // Mutation: drop the suffix. A bare branch name with no "(dirty)" is
+      // exactly how a CLEAN repository is drawn, so the row would silently lie.
+      const html = git({ git: { branch: 'main', dirty: null, incomplete: ['dirty'], cause: 'read-timed-out' } });
+      assert.match(html, /working tree unknown/);
+      assert.match(html, /Could not establish/i, 'the row must name why');
+      const clean = git({ git: { branch: 'main', dirty: false, incomplete: [], cause: null } });
+      assert.notEqual(html, clean);
+    });
+
+    it('leaves clean, dirty and not-a-repo readings alone', () => {
+      assert.equal(git({ git: { branch: 'main', dirty: false, incomplete: [], cause: null } }), 'main');
+      assert.equal(git({ git: { branch: 'main', dirty: true, incomplete: [], cause: null } }), 'main (dirty)');
+      assert.equal(git({ git: null }), 'Not a git repo');
+    });
+
+    it('toggleCardDetail delegates to both, rather than re-deriving them inline', () => {
+      const body = functionBody(ui, 'function toggleCardDetail(name)');
+      assert.ok(body.includes('renderSessionDetail(project)'));
+      assert.ok(body.includes('renderGitDetail(project)'));
+      assert.ok(body.includes('tcUnreadableNotice(project)'),
+        'an unreadable folder must be explained in the detail too');
+    });
+  });
+});

--- a/test/git.test.js
+++ b/test/git.test.js
@@ -272,6 +272,26 @@ describe('git', () => {
       assert.equal(info.dirty, null, 'and it must never render as clean');
       assert.deepEqual(info.incomplete, ['dirty'],
         'exactly one field was unestablished, and it is named');
+      // WHY it went short travels with the reading, not only into the log. The
+      // dashboard could show that dirtiness was unknown but never that this
+      // repository is broken rather than merely slow — and only one of those is
+      // something an operator can act on (#885).
+      //
+      // THE MUTATION THIS CATCHES: computing `cause` for the log and not
+      // returning it, which is what shipped: the field existed, was correct, and
+      // reached nothing that renders.
+      assert.equal(info.cause, 'git-refused-to-read-repository');
+    });
+
+    it('carries no cause when nothing went short', () => {
+      // `'complete'` is an internal sentinel, and a consumer testing `cause` for
+      // truthiness must not be handed one when the read was fine.
+      const dir = repo('cause-none', ['echo a > a.txt', 'git add a.txt', 'git commit -qm s']);
+
+      const info = git._fetchInfo(dir);
+
+      assert.deepEqual(info.incomplete, []);
+      assert.equal(info.cause, null, 'null, not the string "complete"');
     });
 
     it('names WHICH failure it hit, so the fixable one is distinguishable', () => {

--- a/test/projects.test.js
+++ b/test/projects.test.js
@@ -984,7 +984,7 @@ describe('projects', () => {
       const realReq = dirScanner.request;
       const realInteractive = dirScanner.interactiveRequest;
       const binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-stalled-tmux-'));
-      fs.writeFileSync(path.join(binDir, 'tmux'), '#!/bin/sh\nsleep 30\n', { mode: 0o755 });
+      fs.writeFileSync(path.join(binDir, 'tmux'), '#!/bin/sh\nexec sleep 30\n', { mode: 0o755 });
       const realPath = process.env.PATH;
       process.env.PATH = `${binDir}:${realPath}`;
       tmuxModule.createSessionNameSnapshot = (options = {}) =>
@@ -1052,6 +1052,32 @@ describe('projects', () => {
         assert.equal(enriched.session.active, null);
         assert.equal(enriched.session.status, 'wrapping');
         assert.equal(enriched.session.cause, 'read-timed-out');
+      } finally {
+        store.sessions.kill(session.id, 'test cleanup');
+      }
+    });
+
+    it('still drops a wrapping session tmux positively said is gone', async () => {
+      // The wrapping branch's honest negative, which nothing else pins: widening
+      // its unknown test from `!verdict.answered` to `verdict` passes the whole
+      // suite otherwise, and a wrapping session tmux confirmed is dead would
+      // then publish `active: null` — an unknown invented out of a fact.
+      projects.createProject({ name: 'answered-dead-wrapping' });
+      const project = store.projects.getByName('answered-dead-wrapping');
+      const session = store.sessions.start({
+        projectId: project.id,
+        engineId: 'claude',
+        tmuxSession: 'tc-answered-dead-wrapping',
+        primePrompt: ''
+      });
+      store.sessions.setWrapping(session.id);
+      try {
+        // tmux answers, and names a different session: this pane is gone.
+        const enriched = await withAnsweringTmux('some-other-session\n',
+          () => projects.enrichProject(store.projects.get(project.id)));
+
+        assert.equal(enriched.session, null,
+          'tmux answered — that is a fact, and it must not be softened to unknown');
       } finally {
         store.sessions.kill(session.id, 'test cleanup');
       }

--- a/test/projects.test.js
+++ b/test/projects.test.js
@@ -1651,7 +1651,7 @@ describe('projects', () => {
     }
 
     it('returns the registered projects instead of failing the request', async () => {
-      const list = await withScanner(
+      const { projects: list } = await withScanner(
         () => Promise.reject(timedOut()),
         () => projects.listAllProjects()
       );
@@ -1662,6 +1662,73 @@ describe('projects', () => {
       for (const p of list) {
         assert.equal(p.registered, true, 'a degraded scan may only return registered projects');
       }
+    });
+
+    it('says the list is short, and why, instead of degrading silently (#885)', async () => {
+      // THE MUTATION THIS CATCHES: returning the healthy `scan` on the failure
+      // path — which is what a bare array amounted to. The browser got a 200 and
+      // a well-formed list, and nothing distinguished "these are all your
+      // projects" from "these are the ones we could still see".
+      const { scan } = await withScanner(
+        () => Promise.reject(timedOut()),
+        () => projects.listAllProjects()
+      );
+
+      assert.equal(scan.complete, false);
+      assert.equal(scan.code, 'SCAN_TIMEOUT', 'consumers branch on the code, never on the prose');
+      assert.equal(scan.dir, projects.resolveProjectsDir(store.config.load().projectsDir));
+      assert.ok(scan.reason, 'and a human gets a sentence');
+      assert.match(scan.hint, /Full Disk Access/,
+        'a path that did not answer is the failure the remedy fits');
+    });
+
+    it('carries the healthy scan when nothing went wrong', async () => {
+      // The other half of the same guard: `complete: true` has to be reachable,
+      // or a renderer would warn on every poll of a perfectly healthy machine.
+      const { scan } = await withScanner(
+        () => Promise.resolve({ unregistered: [], truncated: false }),
+        () => projects.listAllProjects()
+      );
+
+      assert.equal(scan.complete, true);
+      assert.equal(scan.code, null);
+      assert.equal(scan.reason, null);
+      assert.equal(scan.hint, null);
+      assert.equal(scan.listed, null);
+    });
+
+    it('reports a projects directory that is not there at all', async () => {
+      // Its own early return, and the one shape most easily left behind: a
+      // missing directory is not a failure to read, so the code returns before
+      // the failure path entirely. THE MUTATION THIS CATCHES: keeping that
+      // return's bare list, which would show an operator whose configured
+      // directory does not exist a permanently short list with no explanation —
+      // and the remedy is creating or re-pointing it, not granting a permission.
+      const { scan } = await withScanner(
+        () => Promise.reject(Object.assign(new Error('no such directory'), { code: 'ENOENT' })),
+        () => projects.listAllProjects()
+      );
+
+      assert.equal(scan.complete, false);
+      assert.equal(scan.code, 'DIR_MISSING');
+      assert.match(scan.reason, /does not exist/);
+      assert.equal(scan.hint, null);
+    });
+
+    it('names a remembered refusal as one, not as a fresh failure', async () => {
+      // The backoff is holding this directory off, so the list is short for a
+      // reason the operator can act on differently: nothing is being retried
+      // right now. Same shape, distinct code.
+      const cached = Object.assign(new Error('refused recently'), { tcCached: true });
+      const { scan } = await withScanner(
+        () => Promise.reject(cached),
+        () => projects.listAllProjects()
+      );
+
+      assert.equal(scan.complete, false);
+      assert.equal(scan.code, 'SCAN_CACHED');
+      assert.equal(scan.hint, null,
+        'a remembered refusal is not a permission diagnosis — only a live timeout earns that');
     });
 
     it('gives the scan a deadline SHORTER than the walk it asks for', async () => {
@@ -1788,11 +1855,15 @@ describe('projects', () => {
     // blocked syscall rather than a never-settling stub.
 
     it('still answers when the directory read fails outright', async () => {
-      const list = await withScanner(
+      const { projects: list, scan } = await withScanner(
         () => Promise.reject(Object.assign(new Error('boom'), { code: 'EACCES' })),
         () => projects.listAllProjects()
       );
       assert.ok(Array.isArray(list));
+      assert.equal(scan.complete, false);
+      assert.equal(scan.code, 'SCAN_FAILED');
+      assert.equal(scan.hint, null,
+        'a failure that is not a path refusing to answer gets no permission remedy');
     });
 
     it('keeps the directories it found when the walk runs out of time', async () => {
@@ -1815,13 +1886,23 @@ describe('projects', () => {
         { id: null, name: 'walked-1', path: '/x/walked-1', registered: false, git: null },
         { id: null, name: 'walked-2', path: '/x/walked-2', registered: false, git: null }
       ];
-      const all = await withScanner(
+      const { projects: all, scan } = await withScanner(
         () => Promise.resolve({ unregistered: partial, truncated: true }),
         () => projects.listAllProjects()
       );
       const found = all.filter(p => p.registered === false);
       assert.deepEqual(found.map(p => p.name).sort(), ['walked-1', 'walked-2'],
         'the directories walked before the deadline must survive, not be discarded');
+
+      // A truncated walk is the OPPOSITE failure and must not be described as the
+      // same one: the directory answered fine, there is just more of it than one
+      // scan can check. THE MUTATION THIS CATCHES: routing truncation through
+      // `_scanFailureHint`, which would tell an operator to grant Full Disk
+      // Access for a folder that has no permission problem at all.
+      assert.equal(scan.complete, false, 'short is not complete, even when nothing is broken');
+      assert.equal(scan.code, 'SCAN_TRUNCATED');
+      assert.equal(scan.hint, null, 'nothing to remedy — there is no fault here');
+      assert.equal(scan.listed, 2, 'and it says how much it did get through');
     });
 
     it('says the list is SHORT rather than letting a truncated walk look complete', async () => {
@@ -1859,7 +1940,7 @@ describe('projects', () => {
       fs.writeFileSync(path.join(projectsDir, 'has-tc-config', '.tangleclaw', 'project.json'), '{}');
       fs.mkdirSync(path.join(projectsDir, 'no-tc-config'), { recursive: true });
 
-      const all = await projects.listAllProjects();
+      const all = (await projects.listAllProjects()).projects;
       const withConfig = all.find(p => p.name === 'has-tc-config');
       const without = all.find(p => p.name === 'no-tc-config');
       assert.ok(withConfig && without, 'both unregistered directories must be listed');
@@ -2194,7 +2275,7 @@ describe('projects', () => {
       // Create an unregistered directory
       fs.mkdirSync(path.join(projectsDir, 'unregistered-proj'), { recursive: true });
 
-      const all = await projects.listAllProjects();
+      const all = (await projects.listAllProjects()).projects;
       const registered = all.filter(p => p.registered === true);
       const unregistered = all.filter(p => p.registered === false);
 
@@ -2203,7 +2284,7 @@ describe('projects', () => {
     });
 
     it('unregistered projects have expected shape', async () => {
-      const all = await projects.listAllProjects();
+      const all = (await projects.listAllProjects()).projects;
       const unreg = all.find(p => p.name === 'unregistered-proj');
       assert.ok(unreg);
       assert.equal(unreg.registered, false);
@@ -2214,7 +2295,7 @@ describe('projects', () => {
     });
 
     it('results are sorted by name', async () => {
-      const all = await projects.listAllProjects();
+      const all = (await projects.listAllProjects()).projects;
       for (let i = 1; i < all.length; i++) {
         assert.ok(all[i - 1].name.toLowerCase() <= all[i].name.toLowerCase(),
           `${all[i - 1].name} should be before ${all[i].name}`);
@@ -2222,7 +2303,7 @@ describe('projects', () => {
     });
 
     it('does not include hidden directories', async () => {
-      const all = await projects.listAllProjects();
+      const all = (await projects.listAllProjects()).projects;
       assert.ok(!all.some(p => p.name.startsWith('.')));
     });
   });
@@ -2306,7 +2387,7 @@ describe('projects', () => {
     });
 
     it('archived projects excluded from listAllProjects unregistered scan', async () => {
-      const all = await projects.listAllProjects();
+      const all = (await projects.listAllProjects()).projects;
       // attachable is archived — should not appear as unregistered
       const asUnreg = all.find(p => p.name === 'attachable' && p.registered === false);
       assert.equal(asUnreg, undefined);

--- a/test/projects.test.js
+++ b/test/projects.test.js
@@ -977,18 +977,28 @@ describe('projects', () => {
      * injected, by wrapping the real factory.
      *
      * @param {Function} fn - Test body.
+     * @param {{onSpawn?: Function}} [opts] - `onSpawn` is called for each tmux
+     *   invocation, so a caller can assert on the COUNT rather than on elapsed
+     *   time. The real runner still does the work; the hook only observes.
      * @returns {Promise<any>}
      */
-    async function withStalledTmux(fn) {
+    async function withStalledTmux(fn, opts = {}) {
       const realFactory = tmuxModule.createSessionNameSnapshot;
       const realReq = dirScanner.request;
       const realInteractive = dirScanner.interactiveRequest;
+      const realExecFile = require('node:child_process').execFile;
       const binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-stalled-tmux-'));
       fs.writeFileSync(path.join(binDir, 'tmux'), '#!/bin/sh\nexec sleep 30\n', { mode: 0o755 });
       const realPath = process.env.PATH;
       process.env.PATH = `${binDir}:${realPath}`;
-      tmuxModule.createSessionNameSnapshot = (options = {}) =>
-        realFactory({ ...options, timeout: 300 });
+      tmuxModule.createSessionNameSnapshot = (options = {}) => realFactory({
+        ...options,
+        timeout: 300,
+        execFn: (...args) => {
+          if (opts.onSpawn) opts.onSpawn();
+          return realExecFile(...args);
+        }
+      });
       const healthy = () => Promise.resolve({ exists: true, governanceState: 'ungoverned' });
       dirScanner.request = healthy;
       dirScanner.interactiveRequest = healthy;
@@ -1091,11 +1101,17 @@ describe('projects', () => {
       // sessionless project, which is worse than the spawn it replaced.
       projects.createProject({ name: 'wedged-tmux-idle' });
       const row = store.projects.getByName('wedged-tmux-idle');
-      const started = Date.now();
-      const enriched = await withStalledTmux(() => projects.enrichProject(row));
+      // Counted, not timed. A wall-clock assertion against the 300ms stall is a
+      // race with the machine: it goes red for an eager read AND for a busy CI
+      // box, and the second reads as the first. The claim is "nothing was
+      // spawned", so count spawns.
+      let spawns = 0;
+      const enriched = await withStalledTmux(() => projects.enrichProject(row), {
+        onSpawn: () => { spawns++; }
+      });
 
       assert.equal(enriched.session, null);
-      assert.ok(Date.now() - started < 250,
+      assert.equal(spawns, 0,
         'nothing may be spawned — let alone waited on — for a question nobody asked');
     });
 
@@ -1697,6 +1713,28 @@ describe('projects', () => {
       assert.equal(scan.listed, null);
     });
 
+    it('says a collateral abort is not this directory refusing', async () => {
+      // The scan never ran: a sibling request in the same child stopped
+      // responding and the child had to be killed. It says NOTHING about this
+      // directory, so it must not be coded as a refusal and must not carry the
+      // permission remedy — telling someone to grant Full Disk Access for a
+      // folder that was never read is the misdiagnosis the whole scanner exists
+      // to remove. Retrying is genuinely likely to work: the next request forks
+      // a fresh child.
+      const aborted = Object.assign(
+        new Error('directory scan abandoned: the scanner was restarted for another path'),
+        { tcAborted: true }
+      );
+      const { scan } = await withScanner(
+        () => Promise.reject(aborted),
+        () => projects.listAllProjects()
+      );
+
+      assert.equal(scan.complete, false);
+      assert.equal(scan.code, 'SCAN_ABORTED');
+      assert.equal(scan.hint, null);
+    });
+
     it('reports a projects directory that is not there at all', async () => {
       // Its own early return, and the one shape most easily left behind: a
       // missing directory is not a failure to read, so the code returns before
@@ -1715,20 +1753,33 @@ describe('projects', () => {
       assert.equal(scan.hint, null);
     });
 
-    it('names a remembered refusal as one, not as a fresh failure', async () => {
-      // The backoff is holding this directory off, so the list is short for a
-      // reason the operator can act on differently: nothing is being retried
-      // right now. Same shape, distinct code.
-      const cached = Object.assign(new Error('refused recently'), { tcCached: true });
+    it('names a remembered refusal as one, and still offers the remedy', async () => {
+      // The fixture carries BOTH flags because that is what the real producer
+      // sets: `dir-scanner.js` `_notAnswering` adds `tcCached` on top of
+      // `tcTimedOut`, and says why — the CONDITION is unchanged (the directory
+      // still is not responding, so the operator still needs the remedy) while
+      // the COST is not (no child, no five-second wait), which is what callers
+      // log differently. A fixture with `tcCached` alone would let this assert
+      // whatever the author expected instead of what a real backoff produces.
+      const cached = Object.assign(
+        new Error('/x did not answer the last 3 time(s) it was read; not trying again for 42s'),
+        { tcTimedOut: true, tcCached: true }
+      );
       const { scan } = await withScanner(
         () => Promise.reject(cached),
         () => projects.listAllProjects()
       );
 
       assert.equal(scan.complete, false);
-      assert.equal(scan.code, 'SCAN_CACHED');
-      assert.equal(scan.hint, null,
-        'a remembered refusal is not a permission diagnosis — only a live timeout earns that');
+      // The CODE is what separates this from a live timeout — a consumer that
+      // wants to say "not being retried right now" reads it here, not from the
+      // presence of a hint.
+      assert.equal(scan.code, 'SCAN_CACHED',
+        'ordering matters: a cached refusal carries tcTimedOut too, so a check that '
+        + 'tested tcTimedOut first would report every backoff as a fresh timeout');
+      assert.match(scan.hint, /Full Disk Access/,
+        'the directory is still not answering, so the remedy still applies — '
+        + '`lib/project-facts.js` gives the same answer for the same condition');
     });
 
     it('gives the scan a deadline SHORTER than the walk it asks for', async () => {

--- a/test/projects.test.js
+++ b/test/projects.test.js
@@ -928,6 +928,186 @@ describe('projects', () => {
     });
   });
 
+  // A tmux server that will not answer establishes NOTHING. Reporting its
+  // silence as "no session" is the defect: every running session disappears
+  // from the fleet view and the operator is told nothing is up on a machine
+  // where everything is (#900).
+  describe('a liveness read that could not be established is unknown, not absent (#900)', () => {
+    const tmuxModule = require('../lib/tmux');
+    const dirScanner = require('../lib/dir-scanner');
+
+    /**
+     * Run `fn` with tmux answering `stdout` from a stub, and the scanner healthy.
+     *
+     * The counting sibling of this lives with the #890 guards; this one only
+     * needs the healthy answer, to show an unknown clearing once tmux replies.
+     *
+     * @param {string} stdout - What `tmux list-sessions` replies with.
+     * @param {Function} fn - Test body.
+     * @returns {Promise<any>}
+     */
+    async function withAnsweringTmux(stdout, fn) {
+      const realFactory = tmuxModule.createSessionNameSnapshot;
+      const realReq = dirScanner.request;
+      const realInteractive = dirScanner.interactiveRequest;
+      tmuxModule.createSessionNameSnapshot = (options = {}) => realFactory({
+        ...options,
+        execFn: (_file, _args, _opts, cb) => setImmediate(() => cb(null, stdout))
+      });
+      const healthy = () => Promise.resolve({ exists: true, governanceState: 'ungoverned' });
+      dirScanner.request = healthy;
+      dirScanner.interactiveRequest = healthy;
+      try {
+        return await fn();
+      } finally {
+        tmuxModule.createSessionNameSnapshot = realFactory;
+        dirScanner.request = realReq;
+        dirScanner.interactiveRequest = realInteractive;
+      }
+    }
+
+    /**
+     * Run `fn` against a REAL `tmux` on PATH that never answers, killed by the
+     * snapshot's own timeout.
+     *
+     * Deliberately not a stubbed callback error. The behaviour under test begins
+     * with recognising a killed process, and this repo has shipped three
+     * hand-written models of that error shape that were all wrong (#891/#894) —
+     * a stub would assert the model, not the mechanism. Only the timeout is
+     * injected, by wrapping the real factory.
+     *
+     * @param {Function} fn - Test body.
+     * @returns {Promise<any>}
+     */
+    async function withStalledTmux(fn) {
+      const realFactory = tmuxModule.createSessionNameSnapshot;
+      const realReq = dirScanner.request;
+      const realInteractive = dirScanner.interactiveRequest;
+      const binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-stalled-tmux-'));
+      fs.writeFileSync(path.join(binDir, 'tmux'), '#!/bin/sh\nsleep 30\n', { mode: 0o755 });
+      const realPath = process.env.PATH;
+      process.env.PATH = `${binDir}:${realPath}`;
+      tmuxModule.createSessionNameSnapshot = (options = {}) =>
+        realFactory({ ...options, timeout: 300 });
+      const healthy = () => Promise.resolve({ exists: true, governanceState: 'ungoverned' });
+      dirScanner.request = healthy;
+      dirScanner.interactiveRequest = healthy;
+      try {
+        return await fn();
+      } finally {
+        process.env.PATH = realPath;
+        fs.rmSync(binDir, { recursive: true, force: true });
+        tmuxModule.createSessionNameSnapshot = realFactory;
+        dirScanner.request = realReq;
+        dirScanner.interactiveRequest = realInteractive;
+      }
+    }
+
+    it('reports an active session as unknown rather than dropping it', async () => {
+      projects.createProject({ name: 'wedged-tmux-active' });
+      const project = store.projects.getByName('wedged-tmux-active');
+      const session = store.sessions.start({
+        projectId: project.id,
+        engineId: 'claude',
+        tmuxSession: 'tc-wedged-tmux-active',
+        primePrompt: ''
+      });
+      try {
+        // THE MUTATION THIS CATCHES: dropping the unanswered branch, so an
+        // unreadable liveness falls through to `session: null` — which is what
+        // shipped before #900, and is indistinguishable on the dashboard from a
+        // session that really has died.
+        const enriched = await withStalledTmux(
+          () => projects.enrichProject(store.projects.get(project.id)));
+
+        assert.ok(enriched.session, 'the session must not vanish because tmux went quiet');
+        assert.equal(enriched.session.active, null,
+          'null, not false: nothing was established, so there is no negative to report');
+        assert.deepEqual(enriched.session.incomplete, ['active']);
+        assert.equal(enriched.session.cause, 'read-timed-out');
+        assert.equal(enriched.session.tmuxSession, 'tc-wedged-tmux-active');
+      } finally {
+        store.sessions.kill(session.id, 'test cleanup');
+      }
+    });
+
+    it('reports a wrapping session as unknown too', async () => {
+      projects.createProject({ name: 'wedged-tmux-wrapping' });
+      const project = store.projects.getByName('wedged-tmux-wrapping');
+      const session = store.sessions.start({
+        projectId: project.id,
+        engineId: 'claude',
+        tmuxSession: 'tc-wedged-tmux-wrapping',
+        primePrompt: ''
+      });
+      store.sessions.setWrapping(session.id);
+      try {
+        // The wrapping branch is asymmetric with the active one — a wrapping
+        // session with no tmux handle is NOT live — so it can lose the unknown
+        // state independently. This is the second half of the same guard.
+        const enriched = await withStalledTmux(
+          () => projects.enrichProject(store.projects.get(project.id)));
+
+        assert.ok(enriched.session, 'a wrapping session must not vanish either');
+        assert.equal(enriched.session.active, null);
+        assert.equal(enriched.session.status, 'wrapping');
+        assert.equal(enriched.session.cause, 'read-timed-out');
+      } finally {
+        store.sessions.kill(session.id, 'test cleanup');
+      }
+    });
+
+    it('leaves a project with no session row alone, and asks the wedged tmux nothing', async () => {
+      // The unknown state must not leak onto projects that never had a session:
+      // a machine with a wedged tmux and one running project must show one
+      // unknown, not a fleet of them. This also re-pins #890's laziness against
+      // the branch rewrite — an eager `get()` would now cost a 300ms stall per
+      // sessionless project, which is worse than the spawn it replaced.
+      projects.createProject({ name: 'wedged-tmux-idle' });
+      const row = store.projects.getByName('wedged-tmux-idle');
+      const started = Date.now();
+      const enriched = await withStalledTmux(() => projects.enrichProject(row));
+
+      assert.equal(enriched.session, null);
+      assert.ok(Date.now() - started < 250,
+        'nothing may be spawned — let alone waited on — for a question nobody asked');
+    });
+
+    it('still reports a live session as live once tmux answers again', async () => {
+      // The recovery half. An unknown that sticks after the server comes back is
+      // the same lie in the other direction, and nothing else in this file
+      // exercises the transition.
+      const { project, session } = (() => {
+        projects.createProject({ name: 'wedged-tmux-recovers' });
+        const p = store.projects.getByName('wedged-tmux-recovers');
+        return {
+          project: p,
+          session: store.sessions.start({
+            projectId: p.id,
+            engineId: 'claude',
+            tmuxSession: 'tc-wedged-tmux-recovers',
+            primePrompt: ''
+          })
+        };
+      })();
+      try {
+        const stalled = await withStalledTmux(
+          () => projects.enrichProject(store.projects.get(project.id)));
+        assert.equal(stalled.session.active, null);
+
+        const recovered = await withAnsweringTmux(`${session.tmuxSession}\n`,
+          () => projects.enrichProject(store.projects.get(project.id)));
+        assert.equal(recovered.session.active, true);
+        assert.deepEqual(recovered.session.incomplete, [],
+          'the healthy payload carries the fields too, empty — a field that appears '
+          + 'only on failure makes every consumer probe for it');
+        assert.equal(recovered.session.cause, null);
+      } finally {
+        store.sessions.kill(session.id, 'test cleanup');
+      }
+    });
+  });
+
   describe('enrichProject — governanceState (#353)', () => {
     let govDir;
 

--- a/test/session-rule-delivery.test.js
+++ b/test/session-rule-delivery.test.js
@@ -472,6 +472,12 @@ describe('startup session-rule delivery (#595)', () => {
       const enginesModule = require('../lib/engines');
       let created = false;
       stub(tmux, 'hasSession', () => created);
+      // The prime-paste guard asks `probeSession` now, so that it can tell a
+      // pane that ENDED from a tmux that would not answer — the ledger row it
+      // writes is durable, and recording "the session ended" for a read that
+      // never happened is a fact nobody established (#908). Same meaning as the
+      // `hasSession` stub above: an ANSWERED liveness that follows `created`.
+      stub(tmux, 'probeSession', () => ({ live: created, answered: true, cause: null }));
       stub(tmux, 'createSession', () => { created = true; return true; });
       stub(tmux, 'sendKeys', () => true);
       stub(enginesModule, 'detectEngine', () => ({ available: true, path: '/usr/bin/claude' }));
@@ -509,11 +515,96 @@ describe('startup session-rule delivery (#595)', () => {
       }
     });
 
+    it('does not record "the session ended" when tmux never answered (#908)', (t) => {
+      // The third site on #908's census, and the one whose write OUTLIVES the
+      // condition. `!tmux.hasSession(...)` answered false both for a pane that
+      // ended and for a server too wedged to reply, and this branch writes a
+      // DURABLE ledger row saying the session ended — a fact nobody established,
+      // read later by someone asking whether the rules arrived.
+      const tmux = require('../lib/tmux');
+      const enginesModule = require('../lib/engines');
+      let created = false;
+      stub(tmux, 'hasSession', () => created);
+      // The wedge: the probe is killed by our own timeout and establishes nothing.
+      stub(tmux, 'probeSession', () => ({ live: false, answered: false, cause: 'read-timed-out' }));
+      stub(tmux, 'createSession', () => { created = true; return true; });
+      stub(tmux, 'sendKeys', () => { throw new Error('must not paste into a pane we could not find'); });
+      stub(enginesModule, 'detectEngine', () => ({ available: true, path: '/usr/bin/claude' }));
+      t.mock.timers.enable({ apis: ['setTimeout'] });
+
+      const launched = makeProject(`pasteunknown-${uid()}`);
+      store.sessionRules.create({ content: 'never arrives', projectId: launched.id });
+      const projConfig = store.projectConfig.load(launched.path);
+      projConfig.silentPrime = false;
+      store.projectConfig.save(launched.path, projConfig);
+
+      try {
+        const result = sessions.launchSession(launched.name);
+        t.mock.timers.tick(60_000);
+
+        const rows = store.sessionRuleDeliveries.listForSession(result.session.id);
+        assert.equal(rows.length, 1, 'the skip is still recorded — silence would be worse');
+        assert.equal(rows[0].delivered, false);
+        // THE MUTATION THIS CATCHES: writing the answered-branch sentence
+        // unconditionally, which is what `!hasSession(...)` did.
+        assert.doesNotMatch(rows[0].skipReason, /session ended/,
+          'a pane whose state was never established did not "end"');
+        assert.match(rows[0].skipReason, /could not establish|did not answer/i,
+          'and the ledger has to say what actually happened instead');
+
+        store.sessions.kill(result.session.id, 'test cleanup');
+      } finally {
+        for (const rule of store.sessionRules.list({ projectId: launched.id })) store.sessionRules.delete(rule.id);
+        store.projects.delete(launched.id);
+      }
+    });
+
+    it('still records "the session ended" when tmux ANSWERED that it had (#908)', (t) => {
+      // The other half — without it the fix could blanket-rename every skip.
+      const tmux = require('../lib/tmux');
+      const enginesModule = require('../lib/engines');
+      let created = false;
+      stub(tmux, 'hasSession', () => created);
+      stub(tmux, 'probeSession', () => ({ live: false, answered: true, cause: null }));
+      stub(tmux, 'createSession', () => { created = true; return true; });
+      stub(tmux, 'sendKeys', () => true);
+      stub(enginesModule, 'detectEngine', () => ({ available: true, path: '/usr/bin/claude' }));
+      t.mock.timers.enable({ apis: ['setTimeout'] });
+
+      const launched = makeProject(`pasteended-${uid()}`);
+      store.sessionRules.create({ content: 'never arrives', projectId: launched.id });
+      const projConfig = store.projectConfig.load(launched.path);
+      projConfig.silentPrime = false;
+      store.projectConfig.save(launched.path, projConfig);
+
+      try {
+        const result = sessions.launchSession(launched.name);
+        t.mock.timers.tick(60_000);
+
+        const rows = store.sessionRuleDeliveries.listForSession(result.session.id);
+        assert.equal(rows.length, 1);
+        assert.equal(rows[0].delivered, false);
+        assert.match(rows[0].skipReason, /session ended/,
+          'an observed ending is still reported as one');
+
+        store.sessions.kill(result.session.id, 'test cleanup');
+      } finally {
+        for (const rule of store.sessionRules.list({ projectId: launched.id })) store.sessionRules.delete(rule.id);
+        store.projects.delete(launched.id);
+      }
+    });
+
     it('records a failed paste with the reason instead of silently losing it', (t) => {
       const tmux = require('../lib/tmux');
       const enginesModule = require('../lib/engines');
       let created = false;
       stub(tmux, 'hasSession', () => created);
+      // The prime-paste guard asks `probeSession` now, so that it can tell a
+      // pane that ENDED from a tmux that would not answer — the ledger row it
+      // writes is durable, and recording "the session ended" for a read that
+      // never happened is a fact nobody established (#908). Same meaning as the
+      // `hasSession` stub above: an ANSWERED liveness that follows `created`.
+      stub(tmux, 'probeSession', () => ({ live: created, answered: true, cause: null }));
       stub(tmux, 'createSession', () => { created = true; return true; });
       stub(tmux, 'sendKeys', () => { throw new Error('pane is gone'); });
       stub(enginesModule, 'detectEngine', () => ({ available: true, path: '/usr/bin/claude' }));

--- a/test/sessions.test.js
+++ b/test/sessions.test.js
@@ -1502,6 +1502,105 @@ describe('sessions', () => {
     });
   });
 
+  // A status READ that writes. `hasSession` answers false both for a pane that
+  // is gone and for a tmux server too wedged to reply, and this path persisted
+  // that answer — so one poll from an open session page during a wedge marked a
+  // running session crashed, permanently: the row does not come back when tmux
+  // recovers (#900).
+  //
+  // The verdict is injected here because the subject is what the branch DOES
+  // with it. That the verdict itself is produced correctly — a killed probe
+  // reporting `answered: false` — is pinned in `test/tmux.test.js` against a
+  // real stalling `tmux` on PATH, which is the only place a stub would lie.
+  describe('a session whose liveness tmux could not report is not recorded as crashed (#900)', () => {
+    let sessions;
+    const tmux = require('../lib/tmux');
+    let projectId;
+
+    before(() => {
+      sessions = require('../lib/sessions');
+      const projDir = path.join(projectsDir, 'wedge-status');
+      fs.mkdirSync(projDir, { recursive: true });
+      projectId = store.projects.create({
+        name: 'wedge-status', path: projDir, engine: 'claude'
+      }).id;
+    });
+
+    /**
+     * Run `fn` with `tmux.probeSession` answering `verdict`.
+     * @param {object} verdict - `{live, answered, cause}`.
+     * @param {Function} fn - Test body.
+     * @returns {any}
+     */
+    function withProbe(verdict, fn) {
+      const real = tmux.probeSession;
+      tmux.probeSession = () => verdict;
+      try {
+        return fn();
+      } finally {
+        tmux.probeSession = real;
+      }
+    }
+
+    it('leaves the record alone when tmux did not answer', () => {
+      const session = store.sessions.start({
+        projectId, engineId: 'claude', tmuxSession: 'tc-wedge-status'
+      });
+      try {
+        // THE MUTATION THIS CATCHES: marking crashed on `!live` alone — which is
+        // what `!tmux.hasSession(...)` meant here, and what shipped.
+        withProbe({ live: false, answered: false, cause: 'read-timed-out' },
+          () => sessions.getSessionStatus('wedge-status'));
+
+        assert.equal(store.sessions.get(session.id).status, 'active',
+          'a death nobody observed must not be written to the database');
+      } finally {
+        if (store.sessions.get(session.id).status === 'active') {
+          store.sessions.kill(session.id, 'test cleanup');
+        }
+      }
+    });
+
+    it('still records a crash when tmux DID answer that the pane is gone', () => {
+      const session = store.sessions.start({
+        projectId, engineId: 'claude', tmuxSession: 'tc-wedge-status-dead'
+      });
+      try {
+        // The other half, and the one that keeps the fix from being a blanket
+        // "never mark crashed": an observed death is still recorded, or a real
+        // crash would leave the session page waiting forever.
+        withProbe({ live: false, answered: true, cause: null },
+          () => sessions.getSessionStatus('wedge-status'));
+
+        assert.equal(store.sessions.get(session.id).status, 'crashed');
+      } finally {
+        if (store.sessions.get(session.id).status === 'active') {
+          store.sessions.kill(session.id, 'test cleanup');
+        }
+      }
+    });
+
+    it('refuses to launch over a session it cannot see, rather than clearing it', () => {
+      const session = store.sessions.start({
+        projectId, engineId: 'claude', tmuxSession: 'tc-wedge-status-launch'
+      });
+      try {
+        const result = withProbe({ live: false, answered: false, cause: 'read-timed-out' },
+          () => sessions.launchSession('wedge-status'));
+
+        assert.equal(result.session, null);
+        assert.match(result.error, /could not determine/i,
+          'the refusal has to say what it could not establish, not "already active"');
+        assert.equal(store.sessions.get(session.id).status, 'active',
+          'and it must not clear the record on its way out');
+      } finally {
+        if (store.sessions.get(session.id).status === 'active') {
+          store.sessions.kill(session.id, 'test cleanup');
+        }
+      }
+    });
+  });
+
   describe('getSessionStatus (no active session)', () => {
     let sessions;
     const tmux = require('../lib/tmux');

--- a/test/sessions.test.js
+++ b/test/sessions.test.js
@@ -1584,6 +1584,14 @@ describe('sessions', () => {
       const session = store.sessions.start({
         projectId, engineId: 'claude', tmuxSession: 'tc-wedge-status-launch'
       });
+      // Booby-trapped, because the failure mode of this guard is not a wrong
+      // assertion — it is a REAL `tmux new-session` starting a real agent that
+      // outlives the run (#902). Reaching this line means the refusal did not
+      // fire, and the test must say so loudly rather than launch.
+      const realCreate = tmux.createSession;
+      tmux.createSession = () => {
+        throw new Error('launchSession must refuse before creating a session');
+      };
       try {
         const result = withProbe({ live: false, answered: false, cause: 'read-timed-out' },
           () => sessions.launchSession('wedge-status'));
@@ -1594,6 +1602,7 @@ describe('sessions', () => {
         assert.equal(store.sessions.get(session.id).status, 'active',
           'and it must not clear the record on its way out');
       } finally {
+        tmux.createSession = realCreate;
         if (store.sessions.get(session.id).status === 'active') {
           store.sessions.kill(session.id, 'test cleanup');
         }

--- a/test/sessions.test.js
+++ b/test/sessions.test.js
@@ -1819,23 +1819,69 @@ describe('sessions', () => {
       const realKill = tmux.killSession;
       const realCreate = tmux.createSession;
       const realDetect = engines.detectEngine;
-      let probed = 0;
-      tmux.probeSession = () => { probed++; return { live: false, answered: false, cause: 'read-timed-out' }; };
+      tmux.probeSession = () => ({ live: false, answered: false, cause: 'read-timed-out' });
       tmux.killSession = () => {};
       tmux.createSession = () => true;
-      engines.detectEngine = () => ({ available: true, path: "/usr/bin/claude" });
+      engines.detectEngine = () => ({ available: true, path: '/usr/bin/claude' });
       try {
-        // MUTATION THIS CATCHES: putting the age check back inside a liveness
-        // branch. The row would stay `wrapping` forever on a wedged server.
+        // MUTATION THIS CATCHES: letting an unanswered probe withhold the age
+        // recovery. The row would stay `wrapping` forever on a wedged server —
+        // the exact brick #105 exists to prevent.
+        //
+        // The invariant is the OUTCOME, not whether a probe happened. An earlier
+        // version of this guard asserted the probe was never called, which
+        // pinned an implementation detail: the probe MAY be consulted here (it
+        // has to be, to preserve auto-complete for a confirmed-dead pane), it
+        // just may not be allowed to withhold recovery.
         sessions.launchSession('wedge-wrap');
 
         assert.equal(store.sessions.get(wrapping.id).status, 'killed',
           'an hours-old wrapping row is an orphan whether or not tmux will discuss it');
-        assert.equal(probed, 0,
-          'age settles it without a probe — asking first is what re-creates the brick');
       } finally {
         tmux.probeSession = realProbe;
         tmux.killSession = realKill;
+        tmux.createSession = realCreate;
+        engines.detectEngine = realDetect;
+        cleanup(wrapping.id);
+        const active = store.sessions.getActive(projectId);
+        if (active) store.sessions.kill(active.id, 'test cleanup');
+      }
+    });
+
+    it('an aged-out row whose pane tmux CONFIRMS is gone is completed, not killed', () => {
+      // The outcome the first cut of #908 changed by accident. Hoisting the age
+      // test above the liveness test silently turned "old + confirmed dead" from
+      // autoCompleteWrap into a plain kill — dropping the wrap summary, the
+      // Medusa teardown and the auto-commit, for a row where tmux had actually
+      // ANSWERED. Nothing about fixing the unanswered case justifies altering
+      // what happens when tmux did answer, so this pins the pre-existing outcome.
+      const wrapping = startWrapping('tc-wedge-wrap-old-dead');
+      store.getDb()
+        .prepare(`UPDATE sessions SET wrap_started_at = datetime('now', '-3 hours') WHERE id = ?`)
+        .run(wrapping.id);
+
+      const realProbe = tmux.probeSession;
+      const realCommit = git.commit;
+      const realIsRepo = git.isGitRepo;
+      const realCreate = tmux.createSession;
+      const realDetect = engines.detectEngine;
+      let committed = 0;
+      tmux.probeSession = () => ({ live: false, answered: true, cause: null });
+      git.isGitRepo = () => true;
+      git.commit = () => { committed++; return { committed: true }; };
+      tmux.createSession = () => true;
+      engines.detectEngine = () => ({ available: true, path: '/usr/bin/claude' });
+      try {
+        sessions.launchSession('wedge-wrap');
+
+        assert.equal(store.sessions.get(wrapping.id).status, 'wrapped',
+          'tmux answered that the pane is gone, so the wrap is over and completing it is honest');
+        assert.equal(committed, 1,
+          'and the auto-commit that outcome has always carried still runs');
+      } finally {
+        tmux.probeSession = realProbe;
+        git.commit = realCommit;
+        git.isGitRepo = realIsRepo;
         tmux.createSession = realCreate;
         engines.detectEngine = realDetect;
         cleanup(wrapping.id);
@@ -3577,6 +3623,15 @@ describe('sessions', () => {
       store.sessions.setWrapping(stale.id);
       _backdateWrapStart(stale.id, 2); // wrap began 2h ago — well past threshold
       tmux.hasSession = (name) => name === 'stale-wrap-OLD' || name === 'stale-wrap';
+      // Re-pointed from `hasSession` (#908): the wrapping path asks
+      // `probeSession` now. Same meaning as before — this pane is ANSWERED live,
+      // which is the case this test has always been about. A confirmed-DEAD pane
+      // takes the auto-complete branch instead, which is pinned separately.
+      tmux.probeSession = (name) => ({
+        live: name === 'stale-wrap-OLD' || name === 'stale-wrap',
+        answered: true,
+        cause: null
+      });
 
       const result = sessions.launchSession('stale-wrap');
 
@@ -3649,6 +3704,12 @@ describe('sessions', () => {
       _clearWrapStart(legacy.id);
       _backdateStartedAt(legacy.id, 3); // started 3h ago
       tmux.hasSession = (name) => name === 'legacy-wrap-OLD' || name === 'stale-wrap';
+      // Re-pointed from `hasSession` (#908), same meaning: an ANSWERED live pane.
+      tmux.probeSession = (name) => ({
+        live: name === 'legacy-wrap-OLD' || name === 'stale-wrap',
+        answered: true,
+        cause: null
+      });
 
       const result = sessions.launchSession('stale-wrap');
 

--- a/test/sessions.test.js
+++ b/test/sessions.test.js
@@ -1725,8 +1725,15 @@ describe('sessions', () => {
 
         assert.equal(status.wrapping, true, 'the row says wrapping; the read must not overrule it');
         assert.notEqual(status.wrapCompleted, true);
-        assert.deepEqual(status.incomplete, ['live']);
+        assert.deepEqual(status.incomplete, ['idle', 'lastOutputAge'],
+          'the fields it could not establish are the ones it returns, named');
         assert.equal(status.cause, 'read-timed-out');
+        // `false` here would be a plausible default in the one change whose
+        // subject is not shipping plausible defaults — and the session page
+        // reads `idle` as its wrap-completion signal, so a definite "not idle"
+        // is a wrong answer to the question it is asking.
+        assert.equal(status.idle, null, 'idle is unknown, not false');
+        assert.equal(status.lastOutputAge, null);
         assert.equal(store.sessions.get(wrapping.id).status, 'wrapping');
       } finally {
         cleanup(wrapping.id);

--- a/test/sessions.test.js
+++ b/test/sessions.test.js
@@ -1610,6 +1610,249 @@ describe('sessions', () => {
     });
   });
 
+  // The same defect one state along: a WRAPPING row. `autoCompleteWrap` writes
+  // the wrap complete, tears down the Medusa listener, and commits the
+  // operator's repository — so a tmux server too wedged to answer could end a
+  // wrap that was still running and commit a working tree, on a fact nobody
+  // established. Nothing recovered when tmux came back (#908).
+  //
+  // Every test here booby-traps `git.commit`. The failure mode of these guards
+  // is not a wrong assertion — it is a REAL commit in a repository, so a
+  // regression has to fail loudly rather than quietly write history.
+  describe('a wrap whose liveness tmux could not report is not completed (#908)', () => {
+    let sessions;
+    const tmux = require('../lib/tmux');
+    const git = require('../lib/git');
+    const engines = require('../lib/engines');
+    let projectId;
+    let projDir;
+
+    before(() => {
+      sessions = require('../lib/sessions');
+      projDir = path.join(projectsDir, 'wedge-wrap');
+      fs.mkdirSync(projDir, { recursive: true });
+      projectId = store.projects.create({
+        name: 'wedge-wrap', path: projDir, engine: 'claude'
+      }).id;
+    });
+
+    /**
+     * Run `fn` with `tmux.probeSession` answering `verdict`, and with
+     * `git.commit` trapped so that reaching it fails the test instead of
+     * committing a real repository.
+     * @param {object} verdict - `{live, answered, cause}`.
+     * @param {Function} fn - Test body.
+     * @returns {any}
+     */
+    function withProbeAndNoCommit(verdict, fn) {
+      const realProbe = tmux.probeSession;
+      const realCommit = git.commit;
+      const realIsRepo = git.isGitRepo;
+      const realCreate = tmux.createSession;
+      tmux.probeSession = () => verdict;
+      // ARMING THE TRAP, and it is load-bearing. `_autoCommitIfDirty` returns
+      // early unless the project path is a git repository, and the fixture
+      // directory is not one — so without this the commit trap below is
+      // UNREACHABLE and every guard in this describe passes whether or not the
+      // code auto-completes. A trap that cannot fire measures nothing.
+      git.isGitRepo = () => true;
+      git.commit = () => {
+        throw new Error('a wrap that could not be observed must not commit the operator repository');
+      };
+      tmux.createSession = () => {
+        throw new Error('launchSession must refuse before creating a session');
+      };
+      try {
+        return fn();
+      } finally {
+        tmux.probeSession = realProbe;
+        git.commit = realCommit;
+        git.isGitRepo = realIsRepo;
+        tmux.createSession = realCreate;
+      }
+    }
+
+    /**
+     * Create a wrapping session row for the fixture project.
+     * @param {string} tmuxName - tmux handle to record on the row.
+     * @returns {object} The wrapping session row.
+     */
+    function startWrapping(tmuxName) {
+      const s = store.sessions.start({ projectId, engineId: 'claude', tmuxSession: tmuxName });
+      store.sessions.setWrapping(s.id);
+      return store.sessions.get(s.id);
+    }
+
+    /**
+     * Clean up whatever state a test left behind.
+     * @param {number} id - Session id.
+     */
+    function cleanup(id) {
+      const row = store.sessions.get(id);
+      if (row && row.status !== 'wrapped' && row.status !== 'killed') {
+        store.sessions.kill(id, 'test cleanup');
+      }
+    }
+
+    it('launchSession refuses instead of completing a wrap it could not observe', () => {
+      const wrapping = startWrapping('tc-wedge-wrap-launch');
+      try {
+        // THE MUTATION THIS CATCHES: auto-completing on `!live` alone, which is
+        // what `!tmux.hasSession(...)` meant here and what shipped.
+        const result = withProbeAndNoCommit(
+          { live: false, answered: false, cause: 'read-timed-out' },
+          () => sessions.launchSession('wedge-wrap')
+        );
+
+        assert.equal(result.session, null);
+        assert.equal(result.code, 'LIVENESS_UNKNOWN',
+          'the route classifies by code, so the refusal must carry one');
+        assert.match(result.error, /could not determine/i);
+        assert.equal(store.sessions.get(wrapping.id).status, 'wrapping',
+          'the wrap must still be open — completing it is what nobody established');
+      } finally {
+        cleanup(wrapping.id);
+      }
+    });
+
+    it('getSessionStatus reports still-wrapping rather than finalizing it', () => {
+      const wrapping = startWrapping('tc-wedge-wrap-status');
+      try {
+        const status = withProbeAndNoCommit(
+          { live: false, answered: false, cause: 'read-timed-out' },
+          () => sessions.getSessionStatus('wedge-wrap')
+        );
+
+        assert.equal(status.wrapping, true, 'the row says wrapping; the read must not overrule it');
+        assert.notEqual(status.wrapCompleted, true);
+        assert.deepEqual(status.incomplete, ['live']);
+        assert.equal(status.cause, 'read-timed-out');
+        assert.equal(store.sessions.get(wrapping.id).status, 'wrapping');
+      } finally {
+        cleanup(wrapping.id);
+      }
+    });
+
+    it('still completes the wrap when tmux ANSWERED that the pane is gone', () => {
+      // The other half. Without this the fix is a blanket "never auto-complete",
+      // which would strand every genuinely finished wrap.
+      const wrapping = startWrapping('tc-wedge-wrap-dead');
+      const realProbe = tmux.probeSession;
+      const realCommit = git.commit;
+      const realIsRepo = git.isGitRepo;
+      let committed = 0;
+      tmux.probeSession = () => ({ live: false, answered: true, cause: null });
+      git.isGitRepo = () => true;
+      git.commit = () => { committed++; return { committed: true }; };
+      try {
+        const status = sessions.getSessionStatus('wedge-wrap');
+        assert.equal(status.wrapCompleted, true);
+        assert.equal(store.sessions.get(wrapping.id).status, 'wrapped');
+        // This assertion is what PROVES the traps in the other tests are armed:
+        // it shows the commit really is reachable from this path under the same
+        // stubs, so a guard that expects NO commit is measuring something.
+        assert.equal(committed, 1, 'an observed-dead wrap still runs its auto-commit');
+      } finally {
+        tmux.probeSession = realProbe;
+        git.commit = realCommit;
+        git.isGitRepo = realIsRepo;
+        cleanup(wrapping.id);
+      }
+    });
+
+    it('launchSession still completes a young wrap tmux ANSWERED was dead, and proceeds', () => {
+      // The launch-path counterpart of the test above, and it exists because a
+      // mutation proved it was missing: widening the refusal from
+      // `!probe.answered` to `!probe.live` survived the whole suite. That
+      // mutation would refuse every launch after a genuinely finished wrap —
+      // the project becomes unlaunchable until the row ages out an hour.
+      const wrapping = startWrapping('tc-wedge-wrap-dead-launch');
+      const realProbe = tmux.probeSession;
+      const realCommit = git.commit;
+      const realIsRepo = git.isGitRepo;
+      const realCreate = tmux.createSession;
+      const realDetect = engines.detectEngine;
+      tmux.probeSession = () => ({ live: false, answered: true, cause: null });
+      git.isGitRepo = () => true;
+      git.commit = () => ({ committed: true });
+      tmux.createSession = () => true;
+      engines.detectEngine = () => ({ available: true, path: '/usr/bin/claude' });
+      try {
+        const result = sessions.launchSession('wedge-wrap');
+
+        assert.equal(store.sessions.get(wrapping.id).status, 'wrapped',
+          'tmux answered that the pane is gone, so the wrap is genuinely over');
+        assert.ok(result.session,
+          'and the launch proceeds — refusing here would brick the project for an hour');
+      } finally {
+        tmux.probeSession = realProbe;
+        git.commit = realCommit;
+        git.isGitRepo = realIsRepo;
+        tmux.createSession = realCreate;
+        engines.detectEngine = realDetect;
+        cleanup(wrapping.id);
+        const active = store.sessions.getActive(projectId);
+        if (active) store.sessions.kill(active.id, 'test cleanup');
+      }
+    });
+
+    // The #105 interaction, and the reason this fix is a restructure rather than
+    // one extra condition. The age recovery used to be nested INSIDE the
+    // liveness branch, so a probe that never answered skipped it too — and a
+    // refusal on the unanswered path would then have left the row `wrapping`
+    // with no way out, which is the exact brick #105 was filed for. Age is
+    // evidence this process owns, so it is now tested first.
+    it('still recovers a row older than the threshold when the probe never answers (#105)', () => {
+      const wrapping = startWrapping('tc-wedge-wrap-stale');
+      const db = store.getDb();
+      db.prepare(`UPDATE sessions SET wrap_started_at = datetime('now', '-3 hours') WHERE id = ?`)
+        .run(wrapping.id);
+
+      const realProbe = tmux.probeSession;
+      const realKill = tmux.killSession;
+      const realCreate = tmux.createSession;
+      const realDetect = engines.detectEngine;
+      let probed = 0;
+      tmux.probeSession = () => { probed++; return { live: false, answered: false, cause: 'read-timed-out' }; };
+      tmux.killSession = () => {};
+      tmux.createSession = () => true;
+      engines.detectEngine = () => ({ available: true, path: "/usr/bin/claude" });
+      try {
+        // MUTATION THIS CATCHES: putting the age check back inside a liveness
+        // branch. The row would stay `wrapping` forever on a wedged server.
+        sessions.launchSession('wedge-wrap');
+
+        assert.equal(store.sessions.get(wrapping.id).status, 'killed',
+          'an hours-old wrapping row is an orphan whether or not tmux will discuss it');
+        assert.equal(probed, 0,
+          'age settles it without a probe — asking first is what re-creates the brick');
+      } finally {
+        tmux.probeSession = realProbe;
+        tmux.killSession = realKill;
+        tmux.createSession = realCreate;
+        engines.detectEngine = realDetect;
+        cleanup(wrapping.id);
+        const active = store.sessions.getActive(projectId);
+        if (active) store.sessions.kill(active.id, 'test cleanup');
+      }
+    });
+
+    it('still refuses a launch while a young wrap is genuinely live', () => {
+      const wrapping = startWrapping('tc-wedge-wrap-live');
+      try {
+        const result = withProbeAndNoCommit(
+          { live: true, answered: true, cause: null },
+          () => sessions.launchSession('wedge-wrap')
+        );
+        assert.equal(result.session, null);
+        assert.match(result.error, /currently wrapping/);
+        assert.equal(store.sessions.get(wrapping.id).status, 'wrapping');
+      } finally {
+        cleanup(wrapping.id);
+      }
+    });
+  });
+
   describe('getSessionStatus (no active session)', () => {
     let sessions;
     const tmux = require('../lib/tmux');
@@ -3012,7 +3255,7 @@ describe('sessions', () => {
   describe('wrap state persistence (#91)', () => {
     let sessions;
     const tmux = require('../lib/tmux');
-    let originalHasSession, originalCapturePane, originalKillSession;
+    let originalHasSession, originalCapturePane, originalKillSession, originalProbeSession;
 
     before(() => {
       sessions = require('../lib/sessions');
@@ -3022,7 +3265,14 @@ describe('sessions', () => {
       originalHasSession = tmux.hasSession;
       originalCapturePane = tmux.capturePane;
       originalKillSession = tmux.killSession;
+      originalProbeSession = tmux.probeSession;
       tmux.hasSession = () => true;
+      // The wrapping path asks `probeSession`, not `hasSession` (#908) — the
+      // seam moved when the branch learned to distinguish "tmux said the pane is
+      // gone" from "tmux never answered". Re-pointed, not relaxed: this stub
+      // still means exactly what `hasSession = () => true` meant, an ANSWERED
+      // liveness of true.
+      tmux.probeSession = () => ({ live: true, answered: true, cause: null });
       tmux.capturePane = () => ['line1', 'line2', 'line3'];
       tmux.killSession = () => {};
     });
@@ -3031,6 +3281,7 @@ describe('sessions', () => {
       tmux.hasSession = originalHasSession;
       tmux.capturePane = originalCapturePane;
       tmux.killSession = originalKillSession;
+      tmux.probeSession = originalProbeSession;
       // Cleanup wrapping sessions
       const project = store.projects.getByName('prime-test');
       if (project) {
@@ -3254,11 +3505,14 @@ describe('sessions', () => {
       });
     });
 
+    let originalProbeSession;
+
     beforeEach(() => {
       originalHasSession = tmux.hasSession;
       originalDetectEngine = enginesModule.detectEngine;
       originalKillSession = tmux.killSession;
       originalCreateSession = tmux.createSession;
+      originalProbeSession = tmux.probeSession;
       killedTmux = [];
       tmux.killSession = (name) => { killedTmux.push(name); };
       tmux.createSession = () => true;
@@ -3269,6 +3523,7 @@ describe('sessions', () => {
       tmux.hasSession = originalHasSession;
       tmux.killSession = originalKillSession;
       tmux.createSession = originalCreateSession;
+      tmux.probeSession = originalProbeSession;
       enginesModule.detectEngine = originalDetectEngine;
       const project = store.projects.getByName('stale-wrap');
       if (project) {
@@ -3361,7 +3616,11 @@ describe('sessions', () => {
       });
       store.sessions.setWrapping(recent.id);
       // wrap_started_at defaults to now (just set by setWrapping) — well within threshold
-      tmux.hasSession = (name) => name === 'recent-wrap';
+      // Re-pointed from `hasSession` to `probeSession` (#908): an ANSWERED
+      // liveness of true, which is what the old stub meant.
+      tmux.probeSession = (name) => ({
+        live: name === 'recent-wrap', answered: true, cause: null
+      });
 
       const result = sessions.launchSession('stale-wrap');
 

--- a/test/tmux.test.js
+++ b/test/tmux.test.js
@@ -18,7 +18,7 @@ describe('tmux — a timed-out command says so (#894)', () => {
     // very model that was wrong.
     const os = require('node:os');
     const binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-slow-tmux-'));
-    fs.writeFileSync(path.join(binDir, 'tmux'), '#!/bin/sh\nsleep 30\n', { mode: 0o755 });
+    fs.writeFileSync(path.join(binDir, 'tmux'), '#!/bin/sh\nexec sleep 30\n', { mode: 0o755 });
     const realPath = process.env.PATH;
     process.env.PATH = `${binDir}:${realPath}`;
     try {
@@ -31,6 +31,49 @@ describe('tmux — a timed-out command says so (#894)', () => {
       process.env.PATH = realPath;
       fs.rmSync(binDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe('tmux — one session probe, two questions (#900)', () => {
+  it('reports that tmux never answered, where hasSession can only say "not live"', () => {
+    // A REAL stalling `tmux`, for the reason the file's other timeout guards use
+    // one: the behaviour begins with recognising a killed process, and this repo
+    // has shipped three wrong hand-written models of that error shape
+    // (#891/#894). It also covers a step a stub would skip entirely — `_exec`
+    // REPLACES the timeout error with one of its own, so the flag it puts on
+    // that replacement is the only thing `probeSession` has left to read.
+    const os = require('node:os');
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-slow-tmux-probe-'));
+    fs.writeFileSync(path.join(binDir, 'tmux'), '#!/bin/sh\nexec sleep 30\n', { mode: 0o755 });
+    const realPath = process.env.PATH;
+    process.env.PATH = `${binDir}:${realPath}`;
+    try {
+      const probe = tmux.probeSession('anything', { timeout: 300 });
+
+      // THE MUTATION THIS CATCHES: reporting `answered: true` for a killed
+      // probe. Every caller that RECORDS a death — `getSessionStatus` marking a
+      // session crashed, `launchSession` clearing one — would then write a fact
+      // nobody established, and the record does not recover when tmux does.
+      assert.equal(probe.answered, false);
+      assert.equal(probe.live, false);
+      assert.equal(probe.cause, 'read-timed-out');
+
+      assert.equal(tmux.hasSession('anything', { timeout: 300 }), false,
+        'the boolean form keeps its conservative answer for callers about to act');
+    } finally {
+      process.env.PATH = realPath;
+      fs.rmSync(binDir, { recursive: true, force: true });
+    }
+  });
+
+  it('reports a plain "no such session" as an answer', () => {
+    // tmux is really on PATH here and really replies. The negative has to stay a
+    // negative, or the fix above degenerates into "never conclude anything".
+    const probe = tmux.probeSession('tc-definitely-not-a-real-session-900');
+
+    assert.equal(probe.answered, true);
+    assert.equal(probe.live, false);
+    assert.equal(probe.cause, null);
   });
 });
 
@@ -127,7 +170,7 @@ describe('tmux — one session listing serves a whole fleet (#890)', () => {
     // operator most needs to see what is still up.
     const os = require('node:os');
     const binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-slow-tmux-snap-'));
-    fs.writeFileSync(path.join(binDir, 'tmux'), '#!/bin/sh\nsleep 30\n', { mode: 0o755 });
+    fs.writeFileSync(path.join(binDir, 'tmux'), '#!/bin/sh\nexec sleep 30\n', { mode: 0o755 });
     const realPath = process.env.PATH;
     process.env.PATH = `${binDir}:${realPath}`;
     try {

--- a/test/tmux.test.js
+++ b/test/tmux.test.js
@@ -53,7 +53,10 @@ describe('tmux — one session listing serves a whole fleet (#890)', () => {
     const { execFn, calls } = stubExec({ stdout: 'alpha\nbeta\ngamma\n' });
     const snap = tmux.createSessionNameSnapshot({ execFn });
 
-    assert.deepEqual([...(await snap.get())].sort(), ['alpha', 'beta', 'gamma']);
+    const verdict = await snap.get();
+    assert.deepEqual([...verdict.names].sort(), ['alpha', 'beta', 'gamma']);
+    assert.equal(verdict.answered, true, 'tmux replied, so the set is the whole truth');
+    assert.equal(verdict.cause, null);
     assert.equal(calls.length, 1);
     assert.equal(calls[0].file, 'tmux');
   });
@@ -81,7 +84,7 @@ describe('tmux — one session listing serves a whole fleet (#890)', () => {
     const results = await Promise.all([snap.get(), snap.get(), snap.get()]);
 
     assert.equal(calls.length, 1);
-    for (const set of results) assert.ok(set.has('alpha'));
+    for (const verdict of results) assert.ok(verdict.names.has('alpha'));
   });
 
   it('keeps a name containing the old field delimiter intact', async () => {
@@ -90,7 +93,7 @@ describe('tmux — one session listing serves a whole fleet (#890)', () => {
     // yielding a TRUNCATED name — which could collide with a real project's
     // session and report it live. One field has nothing to split on.
     const { execFn, calls } = stubExec({ stdout: 'we|rd\n' });
-    const names = await tmux.createSessionNameSnapshot({ execFn }).get();
+    const { names } = await tmux.createSessionNameSnapshot({ execFn }).get();
 
     assert.ok(names.has('we|rd'), 'the whole name must survive');
     assert.ok(!names.has('we'), 'and must not be truncated into another name');
@@ -98,27 +101,41 @@ describe('tmux — one session listing serves a whole fleet (#890)', () => {
       'asking for one field is what makes that true — a joined format brings the split back');
   });
 
-  it('reads an unanswerable tmux as no live sessions, without rejecting', async () => {
-    // What `hasSession` already returns per name when tmux will not answer. The
-    // caller enriching a fleet must not have its whole list fail because tmux is
-    // down — that is the ordinary state of a machine with no sessions.
+  it('treats a tmux that replied "no server running" as an ANSWER of none live', async () => {
+    // THE MUTATION THIS CATCHES: widening "unknown" from a stop we caused to
+    // every failure. tmux not running is the ordinary state of a machine with no
+    // sessions — an answer, not a gap. Call it unknown and every stale `active`
+    // row on a rebooted machine sits at unknown forever, never cleaned up,
+    // which is the same defect as #900 pointed the other way.
     const { execFn } = stubExec({ err: Object.assign(new Error('no server running'), { code: 1 }) });
-    assert.equal((await tmux.createSessionNameSnapshot({ execFn }).get()).size, 0);
+    const verdict = await tmux.createSessionNameSnapshot({ execFn }).get();
+
+    assert.equal(verdict.names.size, 0);
+    assert.equal(verdict.answered, true);
+    assert.equal(verdict.cause, null);
   });
 
-  it('resolves empty when the listing times out, rather than hanging the caller', async () => {
+  it('reports that it could not establish anything when the listing times out (#900)', async () => {
     // Driven by a REAL stalling `tmux`, not a stub: the subject is a timeout, and
     // a stub asserts the author's model of a timeout rather than the timeout
     // (#891/#894 — three hand-written versions of this check were all dead).
+    //
+    // THE MUTATION THIS CATCHES: resolving the empty set with `answered: true`,
+    // which is what this did before #900. A wedged tmux server then made every
+    // running session in the fleet report as not live — an unknown wearing a
+    // fact's clothes, on precisely the machine state (#94/#144/#380) where the
+    // operator most needs to see what is still up.
     const os = require('node:os');
     const binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-slow-tmux-snap-'));
     fs.writeFileSync(path.join(binDir, 'tmux'), '#!/bin/sh\nsleep 30\n', { mode: 0o755 });
     const realPath = process.env.PATH;
     process.env.PATH = `${binDir}:${realPath}`;
     try {
-      const names = await tmux.createSessionNameSnapshot({ timeout: 300 }).get();
-      assert.equal(names.size, 0,
-        'a wedged tmux reads as no live sessions — the same answer hasSession already gave');
+      const verdict = await tmux.createSessionNameSnapshot({ timeout: 300 }).get();
+      assert.equal(verdict.answered, false,
+        'a wedged tmux establishes nothing — the empty set must not read as "none live"');
+      assert.equal(verdict.cause, 'read-timed-out');
+      assert.equal(verdict.names.size, 0);
     } finally {
       process.env.PATH = realPath;
       fs.rmSync(binDir, { recursive: true, force: true });

--- a/test/tmux.test.js
+++ b/test/tmux.test.js
@@ -150,12 +150,36 @@ describe('tmux — one session listing serves a whole fleet (#890)', () => {
     // sessions — an answer, not a gap. Call it unknown and every stale `active`
     // row on a rebooted machine sits at unknown forever, never cleaned up,
     // which is the same defect as #900 pointed the other way.
-    const { execFn } = stubExec({ err: Object.assign(new Error('no server running'), { code: 1 }) });
-    const verdict = await tmux.createSessionNameSnapshot({ execFn }).get();
+    //
+    // A REAL executable exiting 1 with tmux's own message on stderr, not a
+    // hand-built error: this classifier's whole job is telling one `execFile`
+    // failure shape from another, and a stub asserts the author's model of the
+    // shape rather than the shape (#891/#894, three times).
+    const os = require('node:os');
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-dead-tmux-'));
+    fs.writeFileSync(path.join(binDir, 'tmux'),
+      '#!/bin/sh\necho "no server running on /tmp/tmux-501/default" >&2\nexit 1\n',
+      { mode: 0o755 });
+    const realPath = process.env.PATH;
+    process.env.PATH = `${binDir}:${realPath}`;
+    try {
+      // A generous cap on purpose. The stub exits immediately, so this costs
+      // nothing on the happy path — but the whole point of the guard is that the
+      // verdict came from tmux REPLYING rather than from our timeout, and a tight
+      // cap makes that indistinguishable whenever the machine is busy enough to
+      // delay a fork. Seen: this failed under a four-file parallel run at 2000ms
+      // and passed alone, which is the flake shape a guard about timeouts must
+      // not have.
+      const verdict = await tmux.createSessionNameSnapshot({ timeout: 20000 }).get();
 
-    assert.equal(verdict.names.size, 0);
-    assert.equal(verdict.answered, true);
-    assert.equal(verdict.cause, null);
+      assert.equal(verdict.names.size, 0);
+      assert.equal(verdict.answered, true,
+        'tmux ran and told us there is nothing live — that is an answer');
+      assert.equal(verdict.cause, null);
+    } finally {
+      process.env.PATH = realPath;
+      fs.rmSync(binDir, { recursive: true, force: true });
+    }
   });
 
   it('reports that it could not establish anything when the listing times out (#900)', async () => {

--- a/test/tmux.test.js
+++ b/test/tmux.test.js
@@ -157,8 +157,13 @@ describe('tmux — one session listing serves a whole fleet (#890)', () => {
     // shape rather than the shape (#891/#894, three times).
     const os = require('node:os');
     const binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-dead-tmux-'));
+    // The shim leaves a marker, because `answered: true` is ALSO what a machine
+    // with no `tmux` at all produces — so without proof the shim executed, this
+    // guard cannot tell "tmux replied with exit 1" from "the fixture never ran",
+    // which is the vacuousness it was rewritten to escape.
+    const ran = path.join(binDir, 'ran');
     fs.writeFileSync(path.join(binDir, 'tmux'),
-      '#!/bin/sh\necho "no server running on /tmp/tmux-501/default" >&2\nexit 1\n',
+      `#!/bin/sh\ntouch "${ran}"\necho "no server running on /tmp/tmux-501/default" >&2\nexit 1\n`,
       { mode: 0o755 });
     const realPath = process.env.PATH;
     process.env.PATH = `${binDir}:${realPath}`;
@@ -172,6 +177,8 @@ describe('tmux — one session listing serves a whole fleet (#890)', () => {
       // not have.
       const verdict = await tmux.createSessionNameSnapshot({ timeout: 20000 }).get();
 
+      assert.ok(fs.existsSync(ran),
+        'the shim must actually have run — otherwise this asserts nothing about a tmux that replied');
       assert.equal(verdict.names.size, 0);
       assert.equal(verdict.answered, true,
         'tmux ran and told us there is nothing live — that is an answer');


### PR DESCRIPTION
Fixes #885
Fixes #900
Fixes #908

Every read behind the dashboard has three outcomes — *yes*, *no*, and *we could not establish it* — and the code had branches for two. The third was drawn as the second, so the product stated definite answers it did not have. This closes that in the two places it mattered most: what you see, and what it writes.

## What changes for an operator

**The dashboard stops asserting things it could not read.** A wedged tmux server used to make every running session vanish; an unreadable folder shortened the project list in silence; a repository whose working tree could not be read was drawn as clean. Five surfaces now show the difference — the ROOT panel gains a notice row with the reason and the remedy (and the count stops saying "total"), a project whose folder did not answer gains a badge, unknown liveness gets a distinct dot carrying a glyph rather than a colour, `git.dirty: null` renders as `?`, and the header count reads "N unknown" instead of counting those sessions as inactive.

The worst case is covered too: a machine with nothing registered whose projects directory could not be read used to answer *"No projects yet — create your first project."* A confident, actionable, wrong instruction.

**A tmux server that will not answer can no longer end your wrap — or commit your repository.** Two paths decided a wrap was finished from a question that answers "no" both for a pane that is gone and for a server too wedged to reply. On the second they wrote the wrap complete, tore down the session listener, and ran a real `git commit` in your project, with nothing recovering when tmux returned.

## The design decisions worth reviewing

**One vocabulary of causes is not one vocabulary of remedies.** `read-timed-out` means a wedged tmux server for a session and a protected folder for a directory scan. A shared code→remedy table — the obvious reading of "normalise six payload shapes to one record" — would advise Full Disk Access because tmux hung, which is the exact misdiagnosis this area exists to remove. Causes normalise into one `{known, why, remedy}` record in `public/api-helper.js`; advice stays per-source and prefers the sentence the server authored at the failure site.

**A probe may add an outcome, never withhold a fallback.** The obvious #908 fix — decline when the probe did not answer — would have reintroduced #105, because the stale-wrapping age recovery was nested *inside* the liveness branch. Declining would have traded a false commit for a row stuck `wrapping` until tmux came back. Age is evidence this process owns, so it decides first; the probe can only add the confirmed-dead outcome, never block recovery.

**No `sw.js` `CACHE_NAME` bump, deliberately.** The standing rule is that a new asset joins `STATIC_ASSETS` with a bump. The rule was *avoided* rather than followed, by putting the helpers in `api-helper.js` — already `NETWORK_FIRST_PATHS` alongside `ui.js` and `style.css`, so a plain reload serves the new code. Bumping `CACHE_NAME` on a branch behind the basic_auth gate is what locked the operator out of Chrome on 2026-07-28.

## Test plan

- Full suite: **6015 passed, 0 failed, 1 skipped**; recorded evidence tree matches HEAD.
- Every guard was falsified by mutating the code it covers. Three defects were found that way rather than by reading: the `git.commit` booby-traps were *unreachable* (the fixture is not a git repo, so they passed regardless of behaviour); the launch path's answered-dead branch had no guard at all; and a `#105` guard pinned the probe count instead of the outcome, which hid a regression beside it.
- Guards for the tmux verdict drive a **real** stalling executable rather than a stubbed exec, with a marker file proving the fixture actually ran.
- Six pre-existing tests were re-pointed from `hasSession` to `probeSession` — the seam moved; no assertion was relaxed.

## Deliberately not in this PR

- **#910** — that a status *read* finalizes a wrap and commits at all. #908 makes the trigger honest; re-timing wrap completion changes how the session page detects it and needs its own verification.
- **#909** — the first-run wizard still draws `dirty: null` as clean.
- **#905 / #906 / #907** — the same unknown-as-fact shape on the Project Master and session-status surfaces.

## Review

Independent PR review: **0 blocking, 0 warnings, 2 notes** — both accepted. The branch name carries one of the three issues (nothing is pushed until now, and the PR body carries the family); and the new CSS uses palette literals where two custom properties would collapse 13 sites, which is best ridden with #909 since it touches the same surfaces.