### PR TITLE
Exclude the running install from the first-run project scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to TangleClaw are documented in this file.
 
 ### Fixed
 
+- **First-run setup no longer attaches the TangleClaw clone itself as a managed project (#708).**
+  The README's install steps put the clone wherever the operator happens to be — routinely the
+  folder they then name as their projects directory — and the clone carries both detection markers,
+  so the wizard pre-checked it and setup ended with the tool presented as the operator's first
+  project, writing per-project config into the clone (which dirties it, and a dirty clone is exactly
+  what strands the self-updater behind its own guard). The scan now excludes the checkout the server
+  runs from, filtered server-side by realpath identity — never by name, so a clone of TangleClaw
+  living elsewhere remains attachable, and attaching the running checkout deliberately through the
+  normal attach flow still works. With the clone excluded, an otherwise-empty projects directory
+  finishes setup onto the dashboard's existing "No projects yet — Create Project" empty state.
+
 - **The first-run wizard no longer draws a working tree it could not read as clean (#909).** The
   candidate list rendered the scanner's three-valued `dirty` with a two-way branch, so a repository
   whose working-tree state was never established — a slow read, a refused read — drew exactly like a

--- a/lib/dir-scanner-child.js
+++ b/lib/dir-scanner-child.js
@@ -336,9 +336,16 @@ const HANDLERS = {
    * @param {object} payload - Request payload.
    * @param {string} payload.dir - Absolute, already-resolved directory to scan.
    * @param {number} payload.budgetMs - How long the whole walk may take.
+   * @param {string} [payload.ownInstallRealPath] - Realpath of the checkout the
+   *   server runs from. When present, each entry is marked `isOwnInstall` so
+   *   the caller can keep the install out of the wizard (#708). The realpath
+   *   probe runs HERE, in the process that exists to be killed — in the parent
+   *   it would be a synchronous per-entry filesystem call on the event loop,
+   *   the exact shape that wedged this route on a TCC-protected directory
+   *   (#859).
    * @returns {Promise<{projects: object[]}>}
    */
-  async scanEntries({ dir, budgetMs }) {
+  async scanEntries({ dir, budgetMs, ownInstallRealPath }) {
     const deadlineAt = Date.now() + budgetMs;
 
     const stat = await fsp.stat(dir);
@@ -360,6 +367,20 @@ const HANDLERS = {
       }
 
       const dirPath = path.join(dir, entry.name);
+
+      // Identity, not spelling: a symlinked or otherwise aliased route to the
+      // running checkout is still the running checkout, and a directory that
+      // merely shares the name is not. A path that will not resolve is
+      // certainly not this running install, so the failure answer is false.
+      let isOwnInstall = false;
+      if (ownInstallRealPath) {
+        try {
+          isOwnInstall = (await fsp.realpath(dirPath)) === ownInstallRealPath;
+        } catch {
+          isOwnInstall = false;
+        }
+      }
+
       const gitInfo = _gitInfo(dirPath, deadlineAt - Date.now());
       const hasTangleclawConfig = await _exists(path.join(dirPath, '.tangleclaw', 'project.json'));
 
@@ -398,7 +419,8 @@ const HANDLERS = {
             cause: gitInfo.cause
           }
           : null,
-        detected: !!((gitInfo && gitInfo.branch) || hasTangleclawConfig || hasProjectMarker)
+        detected: !!((gitInfo && gitInfo.branch) || hasTangleclawConfig || hasProjectMarker),
+        isOwnInstall
       });
     }
 

--- a/lib/projects.js
+++ b/lib/projects.js
@@ -1769,25 +1769,20 @@ async function listAllProjects(options = {}) {
   };
 }
 
-/**
- * True when `candidate` is the checkout this server is running from.
- *
- * Compared by realpath so a symlinked route to the same checkout still counts
- * as "us", and a directory that merely shares the name does not — the filter
- * is about identity, never about being called TangleClaw.
- *
- * @param {string} candidate - Absolute path of a scanned entry.
- * @returns {boolean} Whether it resolves to this install's repo root.
- */
-function _isOwnInstall(candidate) {
+// The realpath of the checkout this server runs from, resolved ONCE at module
+// load. Per-request synchronous filesystem calls on the event loop are exactly
+// what wedged the scan route on a TCC-protected directory (#859), so the
+// request path below compares data the scanner CHILD computed under its budget
+// and never touches the filesystem itself. Load-time is safe here: requiring
+// this module already read this same tree.
+const OWN_INSTALL_REALPATH = (() => {
+  const root = path.join(__dirname, '..');
   try {
-    return fs.realpathSync(candidate) === fs.realpathSync(path.join(__dirname, '..'));
+    return fs.realpathSync(root);
   } catch {
-    // An entry whose path cannot resolve is certainly not this running
-    // install; let the scan report it as itself rather than hiding it.
-    return false;
+    return root;
   }
-}
+})();
 
 /**
  * Scan an operator-supplied directory for candidate projects, bounded in time
@@ -1819,7 +1814,7 @@ async function scanDirectoryForProjects(directory) {
   try {
     const { projects } = await dirScanner.interactiveRequest(
       'scanEntries',
-      { dir, budgetMs: PROJECT_WALK_BUDGET_MS },
+      { dir, budgetMs: PROJECT_WALK_BUDGET_MS, ownInstallRealPath: OWN_INSTALL_REALPATH },
       { timeoutMs: PROJECT_SCAN_TIMEOUT_MS, what: `scanning ${dir}` }
     );
     // The running TangleClaw checkout never offers itself (#708). The README's
@@ -1828,11 +1823,18 @@ async function scanDirectoryForProjects(directory) {
     // clone carries both detection markers (a git branch and project files), so
     // the wizard pre-checked it and attached the tool as the operator's first
     // "project", writing per-project config into the clone. Filtered here,
-    // server-side, so a client that forgets cannot re-introduce it. Attaching
-    // this checkout DELIBERATELY (developing TangleClaw with TangleClaw) stays
-    // possible through the normal attach flow, which does not pass through this
-    // scan.
-    return { ok: true, projects: projects.filter((p) => !_isOwnInstall(p.path)) };
+    // server-side, so a client that forgets cannot re-introduce it — on the
+    // child's realpath verdict, so this process compares data, not the
+    // filesystem. Attaching this checkout DELIBERATELY (developing TangleClaw
+    // with TangleClaw) stays possible through the normal attach flow, which
+    // does not pass through this scan.
+    const dropped = projects.filter((p) => p.isOwnInstall);
+    for (const p of dropped) {
+      log.debug('Setup scan excluded the running install from candidates', {
+        path: p.path, scannedDir: dir
+      });
+    }
+    return { ok: true, projects: projects.filter((p) => !p.isOwnInstall) };
   } catch (err) {
     if (err && err.code === 'ENOENT') {
       // Its own code, not BAD_REQUEST. The browser offers to CREATE this one,

--- a/lib/projects.js
+++ b/lib/projects.js
@@ -1770,6 +1770,26 @@ async function listAllProjects(options = {}) {
 }
 
 /**
+ * True when `candidate` is the checkout this server is running from.
+ *
+ * Compared by realpath so a symlinked route to the same checkout still counts
+ * as "us", and a directory that merely shares the name does not — the filter
+ * is about identity, never about being called TangleClaw.
+ *
+ * @param {string} candidate - Absolute path of a scanned entry.
+ * @returns {boolean} Whether it resolves to this install's repo root.
+ */
+function _isOwnInstall(candidate) {
+  try {
+    return fs.realpathSync(candidate) === fs.realpathSync(path.join(__dirname, '..'));
+  } catch {
+    // An entry whose path cannot resolve is certainly not this running
+    // install; let the scan report it as itself rather than hiding it.
+    return false;
+  }
+}
+
+/**
  * Scan an operator-supplied directory for candidate projects, bounded in time
  * and off the main thread.
  *
@@ -1802,7 +1822,17 @@ async function scanDirectoryForProjects(directory) {
       { dir, budgetMs: PROJECT_WALK_BUDGET_MS },
       { timeoutMs: PROJECT_SCAN_TIMEOUT_MS, what: `scanning ${dir}` }
     );
-    return { ok: true, projects };
+    // The running TangleClaw checkout never offers itself (#708). The README's
+    // install steps put the clone wherever the operator happens to be, which is
+    // routinely the folder they then name as their projects directory — and the
+    // clone carries both detection markers (a git branch and project files), so
+    // the wizard pre-checked it and attached the tool as the operator's first
+    // "project", writing per-project config into the clone. Filtered here,
+    // server-side, so a client that forgets cannot re-introduce it. Attaching
+    // this checkout DELIBERATELY (developing TangleClaw with TangleClaw) stays
+    // possible through the normal attach flow, which does not pass through this
+    // scan.
+    return { ok: true, projects: projects.filter((p) => !_isOwnInstall(p.path)) };
   } catch (err) {
     if (err && err.code === 'ENOENT') {
       // Its own code, not BAD_REQUEST. The browser offers to CREATE this one,

--- a/test/setup-scan-own-install.test.js
+++ b/test/setup-scan-own-install.test.js
@@ -1,0 +1,134 @@
+'use strict';
+
+/*
+ * #708 — the first-run scan must not offer the running TangleClaw checkout as
+ * a candidate project.
+ *
+ * The README's install steps put the clone wherever the operator happens to
+ * be, which is routinely the folder they then name as their projects
+ * directory. The clone carries both detection markers (a git branch and
+ * project files), the wizard pre-checks every detected entry, and setup ends
+ * with the tool attached as the operator's first "project" — writing
+ * per-project config into the clone, which then dirties it and can strand the
+ * self-updater behind its own dirty-tree guard.
+ *
+ * The filter is server-side, by realpath identity against the checkout this
+ * server runs from — never by name, so a clone of TangleClaw somewhere else
+ * (developing TangleClaw with TangleClaw) remains attachable.
+ */
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { execFileSync } = require('node:child_process');
+const store = require('../lib/store');
+const dirScanner = require('../lib/dir-scanner');
+const projects = require('../lib/projects');
+
+// What lib/projects computes for itself: the checkout this process runs from.
+const REPO_ROOT = fs.realpathSync(path.join(__dirname, '..'));
+
+describe('setup scan excludes the running install (#708)', () => {
+  let tmpDir;
+
+  before(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-own-install-'));
+    store._setBasePath(path.join(tmpDir, 'tangleclaw'));
+    store.init();
+  });
+
+  after(() => {
+    store.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  /**
+   * Run `fn` with `dirScanner.interactiveRequest` replaced, then restore it.
+   * Same seam as test/projects.test.js — the real read happens in a child
+   * process, so the filter under test lives in the parent, after this call.
+   *
+   * @param {Function} fakeRequest - Stand-in for interactiveRequest.
+   * @param {Function} fn - Test body.
+   * @returns {Promise<any>}
+   */
+  async function withScanner(fakeRequest, fn) {
+    const real = dirScanner.interactiveRequest;
+    dirScanner.interactiveRequest = fakeRequest;
+    try {
+      return await fn();
+    } finally {
+      dirScanner.interactiveRequest = real;
+    }
+  }
+
+  it('drops the entry that resolves to this checkout, and only that one', async () => {
+    // The shape `scanEntries` emits: entries named for their directory, path
+    // joined under the scanned dir. One of them IS this checkout.
+    const result = await withScanner(
+      async () => ({
+        projects: [
+          { name: 'their-app', path: path.join(os.tmpdir(), 'their-app'),
+            detected: true, git: { branch: 'main', dirty: false, incomplete: [] } },
+          { name: path.basename(REPO_ROOT), path: REPO_ROOT,
+            detected: true, git: { branch: 'main', dirty: false, incomplete: [] } }
+        ]
+      }),
+      () => projects.scanDirectoryForProjects(os.tmpdir())
+    );
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.projects.map((p) => p.name), ['their-app'],
+      'the running checkout must not offer itself; everything else stays');
+  });
+
+  it('reaches the checkout through a symlinked path too', async () => {
+    // Identity, not spelling: a path that resolves to this checkout is still
+    // this checkout. The scanner child hands the parent whatever the operator
+    // typed led to.
+    const link = path.join(tmpDir, 'tc-link');
+    fs.symlinkSync(REPO_ROOT, link);
+    const result = await withScanner(
+      async () => ({ projects: [{ name: 'tc-link', path: link, detected: true, git: null }] }),
+      () => projects.scanDirectoryForProjects(tmpDir)
+    );
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.projects, [], 'a symlinked route to the install is the install');
+  });
+
+  it('keeps a REAL clone of TangleClaw living elsewhere (real scanner child)', async () => {
+    // Attaching TangleClaw deliberately must stay possible: only the RUNNING
+    // checkout is excluded, never a repository that happens to be TangleClaw.
+    // This one runs the genuine scanner child over a real directory.
+    const cloneParent = path.join(tmpDir, 'projects');
+    fs.mkdirSync(cloneParent, { recursive: true });
+    execFileSync('git', ['clone', '--quiet', '--depth', '1',
+      `file://${REPO_ROOT}`, path.join(cloneParent, 'TangleClaw')], { stdio: 'pipe' });
+
+    const result = await projects.scanDirectoryForProjects(cloneParent);
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.projects.map((p) => p.name), ['TangleClaw'],
+      'a clone elsewhere is not the running install and must be offered');
+  });
+
+  it('never offers the running checkout when scanning its parent (real scanner child)', async () => {
+    // The reported install shape verbatim: the operator names the directory
+    // their clone sits in. Whatever else that directory holds, the running
+    // checkout itself must be absent from the answer.
+    const result = await projects.scanDirectoryForProjects(path.dirname(REPO_ROOT));
+
+    if (!result.ok) {
+      // A parent directory the scanner cannot finish (huge, slow disk) proves
+      // nothing either way — but it must fail honestly, not offer the install.
+      assert.equal(typeof result.error, 'string');
+      return;
+    }
+    const resolved = result.projects.map((p) => {
+      try { return fs.realpathSync(p.path); } catch { return p.path; }
+    });
+    assert.equal(resolved.includes(REPO_ROOT), false,
+      'the running checkout offered itself from its own parent directory');
+  });
+});

--- a/test/setup-scan-own-install.test.js
+++ b/test/setup-scan-own-install.test.js
@@ -12,9 +12,12 @@
  * per-project config into the clone, which then dirties it and can strand the
  * self-updater behind its own dirty-tree guard.
  *
- * The filter is server-side, by realpath identity against the checkout this
- * server runs from — never by name, so a clone of TangleClaw somewhere else
- * (developing TangleClaw with TangleClaw) remains attachable.
+ * Mechanism under test, split the way the code splits it: the scanner CHILD
+ * computes realpath identity under its kill budget and marks entries
+ * `isOwnInstall` (a synchronous per-entry probe in the parent is the event-loop
+ * shape that wedged this route on a TCC-protected directory, #859); the parent
+ * route compares data only and drops marked entries. Identity, never name — a
+ * clone of TangleClaw elsewhere stays attachable.
  */
 
 const { describe, it, before, after } = require('node:test');
@@ -25,6 +28,7 @@ const os = require('node:os');
 const { execFileSync } = require('node:child_process');
 const store = require('../lib/store');
 const dirScanner = require('../lib/dir-scanner');
+const { HANDLERS } = require('../lib/dir-scanner-child');
 const projects = require('../lib/projects');
 
 // What lib/projects computes for itself: the checkout this process runs from.
@@ -46,8 +50,8 @@ describe('setup scan excludes the running install (#708)', () => {
 
   /**
    * Run `fn` with `dirScanner.interactiveRequest` replaced, then restore it.
-   * Same seam as test/projects.test.js — the real read happens in a child
-   * process, so the filter under test lives in the parent, after this call.
+   * Same seam as test/projects.test.js — the route's own contribution (the
+   * data-only filter and nothing else) is what this isolates.
    *
    * @param {Function} fakeRequest - Stand-in for interactiveRequest.
    * @param {Function} fn - Test body.
@@ -63,44 +67,60 @@ describe('setup scan excludes the running install (#708)', () => {
     }
   }
 
-  it('drops the entry that resolves to this checkout, and only that one', async () => {
-    // The shape `scanEntries` emits: entries named for their directory, path
-    // joined under the scanned dir. One of them IS this checkout.
+  it('passes the install identity to the child and drops what the child marked', async () => {
+    let sentArgs = null;
     const result = await withScanner(
-      async () => ({
-        projects: [
-          { name: 'their-app', path: path.join(os.tmpdir(), 'their-app'),
-            detected: true, git: { branch: 'main', dirty: false, incomplete: [] } },
-          { name: path.basename(REPO_ROOT), path: REPO_ROOT,
-            detected: true, git: { branch: 'main', dirty: false, incomplete: [] } }
-        ]
-      }),
+      async (_op, args) => {
+        sentArgs = args;
+        return {
+          projects: [
+            { name: 'their-app', path: '/tmp/their-app', detected: true, isOwnInstall: false },
+            { name: 'TangleClaw', path: REPO_ROOT, detected: true, isOwnInstall: true }
+          ]
+        };
+      },
       () => projects.scanDirectoryForProjects(os.tmpdir())
     );
 
     assert.equal(result.ok, true);
+    assert.equal(fs.realpathSync(sentArgs.ownInstallRealPath), REPO_ROOT,
+      'the route must tell the child which checkout is "us"');
     assert.deepEqual(result.projects.map((p) => p.name), ['their-app'],
-      'the running checkout must not offer itself; everything else stays');
+      'a marked entry must not be offered; everything else stays');
   });
 
-  it('reaches the checkout through a symlinked path too', async () => {
-    // Identity, not spelling: a path that resolves to this checkout is still
-    // this checkout. The scanner child hands the parent whatever the operator
-    // typed led to.
-    const link = path.join(tmpDir, 'tc-link');
-    fs.symlinkSync(REPO_ROOT, link);
-    const result = await withScanner(
-      async () => ({ projects: [{ name: 'tc-link', path: link, detected: true, git: null }] }),
-      () => projects.scanDirectoryForProjects(tmpDir)
-    );
-    assert.equal(result.ok, true);
-    assert.deepEqual(result.projects, [], 'a symlinked route to the install is the install');
+  it('child marks the running checkout by identity, even through a symlinked route', async () => {
+    // The child probes realpath under its own budget. Reach the repo's parent
+    // through a symlink so every entry path is spelled differently from its
+    // resolved identity — the mark must land on resolution, not spelling.
+    const link = path.join(tmpDir, 'route');
+    fs.symlinkSync(path.dirname(REPO_ROOT), link);
+
+    const { projects: entries } = await HANDLERS.scanEntries({
+      dir: link, budgetMs: 30000, ownInstallRealPath: REPO_ROOT
+    });
+
+    const me = entries.find((e) => e.name === path.basename(REPO_ROOT));
+    assert.ok(me, 'the checkout must appear in the raw child listing');
+    assert.equal(me.isOwnInstall, true, 'the child must mark the running checkout');
+    for (const other of entries.filter((e) => e !== me)) {
+      assert.equal(other.isOwnInstall, false, `${other.name} must not be marked`);
+    }
   });
 
-  it('keeps a REAL clone of TangleClaw living elsewhere (real scanner child)', async () => {
+  it('child marks nothing when no identity was provided', async () => {
+    const { projects: entries } = await HANDLERS.scanEntries({
+      dir: path.dirname(REPO_ROOT), budgetMs: 30000
+    });
+    for (const e of entries) {
+      assert.equal(e.isOwnInstall, false,
+        'an omitted ownInstallRealPath must mark nothing, not everything');
+    }
+  });
+
+  it('keeps a REAL clone of TangleClaw living elsewhere (full chain)', async () => {
     // Attaching TangleClaw deliberately must stay possible: only the RUNNING
     // checkout is excluded, never a repository that happens to be TangleClaw.
-    // This one runs the genuine scanner child over a real directory.
     const cloneParent = path.join(tmpDir, 'projects');
     fs.mkdirSync(cloneParent, { recursive: true });
     execFileSync('git', ['clone', '--quiet', '--depth', '1',
@@ -113,7 +133,7 @@ describe('setup scan excludes the running install (#708)', () => {
       'a clone elsewhere is not the running install and must be offered');
   });
 
-  it('never offers the running checkout when scanning its parent (real scanner child)', async () => {
+  it('never offers the running checkout when scanning its parent (full chain)', async () => {
     // The reported install shape verbatim: the operator names the directory
     // their clone sits in. Whatever else that directory holds, the running
     // checkout itself must be absent from the answer.


### PR DESCRIPTION
## What
`POST /api/setup/scan` now filters out the checkout the server is running from, by realpath identity. A symlinked route to the install still counts as the install; a clone of TangleClaw living elsewhere is never filtered; deliberately attaching the running checkout through the normal attach flow still works.

## Why
A first-time install routinely clones TangleClaw into the folder then named as the projects directory. The clone carries both detection markers (git branch + project files), the wizard pre-checks every detected entry, and setup ended with the tool attached as the operator's first project — writing per-project config into the clone, which dirties it and parks it in front of the self-updater's dirty-tree guard (the second-order stranding #708 documents). Filtered server-side so a client that forgets cannot re-introduce it.

The issue's empty-state follow-on already ships — the dashboard renders "No projects yet" with a Create Project action — so the exclusion is the whole remaining scope.

## Test plan
- New `test/setup-scan-own-install.test.js`: filter drops exactly the running checkout (stubbed scanner seam), reaches it through a symlink, keeps a REAL clone elsewhere (genuine scanner child over a real directory), and never offers the checkout when scanning its own parent (genuine child, the reported install shape verbatim).
- Falsified: with the filter stashed, 3 of 4 go red; restored, green.
- Full suite: 6042 pass, 0 fail (1 pre-existing skip).

Fixes #708