### PR TITLE
Render an honest unreachable state when the server stops answering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to TangleClaw are documented in this file.
 
 ### Fixed
 
+- **A dead server now says so, instead of looping "Connection lost. Retrying…" forever behind a
+  cached shell (#709).** The service worker serves the app shell from cache with the backend
+  completely gone, so the dashboard rendered healthy-looking while nothing behind it answered — and
+  the retry toast claimed a transient blip identically after one failure and after two hundred,
+  collapsing every cause of "server is down" into one symptom naming none of them. After a bounded
+  run of consecutive failed reconnects the client now renders a real unreachable state: the origin
+  it is trying, the possibility that the page is a cached shell, and the two concrete host-side
+  checks (`launchctl list | grep tangleclaw`, `~/.tangleclaw/logs/server.err.log`). Background
+  retry continues underneath and recovery stays automatic the moment the server returns; the only
+  navigation out is the operator's own Retry button — no reload, no redirect, per the no-UI-timers
+  norm.
+
 - **First-run setup no longer attaches the TangleClaw clone itself as a managed project (#708).**
   The README's install steps put the clone wherever the operator happens to be — routinely the
   folder they then name as their projects directory — and the clone carries both detection markers,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ All notable changes to TangleClaw are documented in this file.
   navigation out is the operator's own Retry button — no reload, no redirect, per the no-UI-timers
   norm.
 
+  The honesty extends into the service-worker layer, where the lie originated: on a SW-controlled
+  page a dead server never rejects an `/api` fetch — the worker resolved it as either a cached 200
+  (which the client counted as *connected*, rendering stale data as a healthy dashboard) or a
+  synthetic 503 nothing consumed. The worker now marks cache-served stand-ins with
+  `X-TC-Cache-Fallback`, and the shared API helper treats that marker and the synthetic 503 as what
+  they are — the server did not answer — so stale cache is never handed to renderers as live data
+  and the unreachable state is reachable in exactly the scenario that was reported.
+
 - **First-run setup no longer attaches the TangleClaw clone itself as a managed project (#708).**
   The README's install steps put the clone wherever the operator happens to be — routinely the
   folder they then name as their projects directory — and the clone carries both detection markers,

--- a/public/api-helper.js
+++ b/public/api-helper.js
@@ -28,8 +28,25 @@
     async function api(url, fetchOpts) {
       try {
         const res = await fetch(url, fetchOpts);
+        // On a service-worker-controlled page a dead server never rejects this
+        // fetch (#709): sw.js resolves it as either a cache-served stand-in
+        // (marked with this header) or a synthetic 503. Both mean THE SERVER
+        // DID NOT ANSWER — a cached 200 here is stale data, and counting it as
+        // connected rendered a dead backend as a healthy dashboard.
+        if (res.headers && res.headers.get && res.headers.get('X-TC-Cache-Fallback')) {
+          setConnected(false);
+          api.lastError = 'Connection lost.';
+          api.lastErrorCode = null;
+          return null;
+        }
         const data = await res.json();
         if (!res.ok) {
+          if (res.status === 503 && data.error === 'network-unreachable') {
+            setConnected(false);
+            api.lastError = 'Connection lost.';
+            api.lastErrorCode = null;
+            return null;
+          }
           api.lastError = data.error || `HTTP ${res.status}`;
           api.lastErrorCode = data.code || null;
           console.error(`API ${url}: ${api.lastError}${api.lastErrorCode ? ` (${api.lastErrorCode})` : ''}`);

--- a/public/landing.js
+++ b/public/landing.js
@@ -62,6 +62,85 @@ const apiMutate = window.tcCreateApiMutate(api);
 
 let reconnectTimer = null;
 
+// #709 — consecutive reconnect attempts that still found the server gone.
+// The service worker serves the app shell from cache with the server
+// completely dead, so this page can render healthy-looking while nothing
+// behind it answers. The toast alone claimed "Retrying…" identically after
+// one failure and after two hundred; past this ceiling the claim of a
+// transient blip becomes dishonest and the real unreachable state takes over.
+// Retrying continues underneath it — recovery stays automatic — the ceiling
+// only changes what the operator is TOLD.
+let reconnectFailures = 0;
+const UNREACHABLE_AFTER = 4;
+
+/**
+ * One background reconnect attempt, and the honesty ceiling.
+ *
+ * `loadProjects` flips `state.connected` back through `setConnected(true)` on
+ * success, which resets the counter and dismisses the unreachable state. While
+ * the server stays gone, count — and once the ceiling passes, stop calling it
+ * a blip.
+ *
+ * @returns {Promise<void>}
+ */
+async function attemptReconnect() {
+  await loadProjects();
+  if (state.connected) return;
+  reconnectFailures++;
+  if (reconnectFailures >= UNREACHABLE_AFTER) renderUnreachableState();
+}
+
+/**
+ * Replace the ambiguous retry toast with a state that says what is actually
+ * known: the server at this page's own origin has stopped answering, this
+ * page may be a cached shell, and here is where to look on the host machine.
+ * The overlay is created on first need — a healthy install never carries it.
+ *
+ * Explicitly NOT a reload or redirect: the no-UI-timers norm (#98, #268)
+ * applies, so the only navigation out of this state is the operator's.
+ */
+function renderUnreachableState() {
+  const toast = document.getElementById('toast');
+  if (toast) toast.classList.remove('visible');
+  let el = document.getElementById('unreachableState');
+  if (!el) {
+    el = document.createElement('div');
+    el.id = 'unreachableState';
+    el.className = 'unreachable-state';
+    el.setAttribute('role', 'alert');
+    el.innerHTML = `
+      <div class="unreachable-card">
+        <h2>TangleClaw isn't responding</h2>
+        <p>The server at <strong>${esc(location.origin)}</strong> has stopped answering.
+        This page may have loaded from the browser's offline cache, so what it shows can be
+        stale. It will reconnect by itself the moment the server is back.</p>
+        <p>On the machine that runs TangleClaw, check whether the service is up and what it
+        last logged:</p>
+        <pre>launchctl list | grep tangleclaw
+tail -50 ~/.tangleclaw/logs/server.err.log</pre>
+        <button class="btn btn-primary" onclick="retryConnectionNow()">Retry now</button>
+      </div>`;
+    document.body.appendChild(el);
+  }
+  el.classList.add('visible');
+}
+
+/** Dismiss the unreachable state (the server answered again). */
+function hideUnreachableState() {
+  const el = document.getElementById('unreachableState');
+  if (el) el.classList.remove('visible');
+}
+
+/**
+ * The explicit retry the unreachable state offers. The background loop keeps
+ * running regardless; this exists so the operator has an action that answers
+ * NOW, not in up to five seconds.
+ * @returns {Promise<void>}
+ */
+async function retryConnectionNow() {
+  await attemptReconnect();
+}
+
 function setConnected(connected) {
   if (state.connected === connected) return;
   state.connected = connected;
@@ -75,12 +154,14 @@ function setConnected(connected) {
         if (!reconnectTimer) return;
         reconnectTimer = setTimeout(async () => {
           if (!reconnectTimer) return;
-          await loadProjects();
+          await attemptReconnect();
           reconnectLoop();
         }, 5000);
       })();
     }
   } else {
+    reconnectFailures = 0;
+    hideUnreachableState();
     toast.textContent = 'Reconnected';
     toast.className = 'toast toast-ok visible';
     if (reconnectTimer) {

--- a/public/style.css
+++ b/public/style.css
@@ -1924,6 +1924,40 @@ body {
 }
 .empty-state p { font-size: 14px; margin-bottom: 20px; }
 
+/* ── Unreachable State (#709) ──
+   Sits above everything except nothing: when the backend is gone, no control
+   underneath can work, so covering them is honest rather than rude. Hidden by
+   default; landing.js toggles .visible past the reconnect-failure ceiling. */
+.unreachable-state {
+  position: fixed;
+  inset: 0;
+  z-index: 500;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  background: rgba(0, 0, 0, 0.75);
+}
+.unreachable-state.visible { display: flex; }
+.unreachable-card {
+  max-width: 520px;
+  padding: 24px;
+  background: var(--card-bg);
+  border: 1px solid var(--amber);
+  border-radius: 10px;
+}
+.unreachable-card h2 { margin-bottom: 10px; color: var(--amber); }
+.unreachable-card p { font-size: 14px; margin-bottom: 12px; color: var(--text); }
+.unreachable-card pre {
+  padding: 10px 12px;
+  margin-bottom: 16px;
+  font-size: 12px;
+  overflow-x: auto;
+  background: var(--bg);
+  border: 1px solid var(--border, #333);
+  border-radius: 6px;
+}
+
 /* ── Connection Toast ── */
 .toast {
   position: fixed;

--- a/public/sw.js
+++ b/public/sw.js
@@ -115,6 +115,20 @@ function _swErrorResponse(err) {
   );
 }
 
+// A cache-served stand-in for a network-first request whose network leg FAILED.
+// The marker header is the whole point (#709): without it, a dead server hands
+// the page a healthy-looking 200 and the client counts it as CONNECTED —
+// rendering stale data as live and never escalating to the unreachable state.
+// `api-helper.js` treats the marker as "the server did not answer". Navigations
+// keep the cached shell usable either way; this only makes the failure legible.
+function _withCacheFallbackMarker(cached) {
+  const headers = new Headers(cached.headers);
+  headers.set('X-TC-Cache-Fallback', '1');
+  return cached.body !== undefined
+    ? new Response(cached.body, { status: cached.status, statusText: cached.statusText, headers })
+    : cached;
+}
+
 self.addEventListener('fetch', (event) => {
   const url = new URL(event.request.url);
   const isGet = event.request.method === 'GET';
@@ -142,7 +156,9 @@ self.addEventListener('fetch', (event) => {
         // else (and a GET cache miss) returns a real 503 so the failure is
         // legible instead of the opaque "Returned response is null" (#380).
         if (isGet) {
-          return caches.match(event.request).then((cached) => cached || _swErrorResponse(err));
+          return caches.match(event.request).then(
+            (cached) => (cached ? _withCacheFallbackMarker(cached) : _swErrorResponse(err))
+          );
         }
         return _swErrorResponse(err);
       })

--- a/test/landing-unreachable-state.test.js
+++ b/test/landing-unreachable-state.test.js
@@ -1,0 +1,194 @@
+'use strict';
+
+/*
+ * #709 — a dead server must not render as an endless "Connection lost.
+ * Retrying…" toast behind a cached service-worker shell.
+ *
+ * The SW serves the app shell from cache with the backend completely gone, so
+ * the page looks healthy while nothing behind it answers — and the toast said
+ * exactly the same thing after one failure and after two hundred. Past a
+ * bounded ceiling of consecutive failed reconnects, the client must stop
+ * claiming a transient blip and render the real unreachable state: what host
+ * it is trying, that the shell may be cached, and the concrete checks to run
+ * on the machine. Recovery stays automatic; nothing reloads or redirects
+ * (no-UI-timers norm, #98/#268).
+ *
+ * These tests LIFT the real functions out of public/landing.js and RUN them —
+ * asserting on rendered state, since the whole defect is what the operator
+ * sees. Same lift-and-run approach as test/degraded-reads-frontend.test.js.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const LANDING_SRC = fs.readFileSync(
+  path.join(__dirname, '..', 'public', 'landing.js'), 'utf8');
+
+/**
+ * Slice a top-level function (declaration + body) out of source text by
+ * brace-matching, so the sandbox runs the REAL code rather than a copy.
+ *
+ * @param {string} src - File source text.
+ * @param {string} decl - Declaration to find, e.g. `function esc(str)`.
+ * @returns {string} The declaration plus its balanced body.
+ */
+function liftFunction(src, decl) {
+  const start = src.indexOf(decl);
+  assert.notEqual(start, -1, `${decl} must exist`);
+  const bodyStart = src.indexOf('{', start);
+  let depth = 0;
+  for (let i = bodyStart; i < src.length; i++) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}' && --depth === 0) return src.slice(start, i + 1);
+  }
+  assert.fail(`${decl} body must close`);
+}
+
+/** The real ceiling, read from the source so the test follows it. */
+function realCeiling() {
+  const m = LANDING_SRC.match(/const UNREACHABLE_AFTER = (\d+);/);
+  assert.ok(m, 'UNREACHABLE_AFTER must be declared');
+  return Number(m[1]);
+}
+
+/** A DOM element stub covering what the connection-state code touches. */
+function makeElement(tag) {
+  const classSet = new Set();
+  return {
+    tagName: tag,
+    id: '',
+    innerHTML: '',
+    textContent: '',
+    get className() { return [...classSet].join(' '); },
+    set className(v) { classSet.clear(); v.split(/\s+/).filter(Boolean).forEach((c) => classSet.add(c)); },
+    classList: {
+      add: (c) => classSet.add(c),
+      remove: (c) => classSet.delete(c),
+      contains: (c) => classSet.has(c)
+    },
+    setAttribute() {},
+    appendChild() {}
+  };
+}
+
+/**
+ * Build a sandbox running the real connection-state functions with a
+ * test-controlled `loadProjects`.
+ *
+ * @returns {object} The vm context, with `elements` registry attached.
+ */
+function loadConnectionState() {
+  const elements = [makeElement('div')];
+  elements[0].id = 'toast';
+
+  const sandbox = {
+    console,
+    // The reconnect loop schedules with setTimeout; the tests drive attempts
+    // by hand, so scheduling records nothing and never fires.
+    setTimeout: () => 7, clearTimeout() {},
+    state: { connected: true },
+    location: { origin: 'https://tc.example:3102' },
+    // Mirrors the real contract: api() flips connectivity through
+    // setConnected, and loadProjects rides on api(). The test decides whether
+    // the "server" answers.
+    serverUp: false,
+    document: {
+      getElementById: (id) => elements.find((e) => e.id === id) || null,
+      createElement: (tag) => makeElement(tag),
+      body: { appendChild: (el) => { elements.push(el); } }
+    }
+  };
+  sandbox.loadProjects = async () => { sandbox.setConnected(sandbox.serverUp); };
+  sandbox.window = sandbox;
+  vm.createContext(sandbox);
+
+  const script = [
+    'let reconnectTimer = null;',
+    'let reconnectFailures = 0;',
+    `const UNREACHABLE_AFTER = ${realCeiling()};`,
+    liftFunction(LANDING_SRC, 'function esc(str)'),
+    liftFunction(LANDING_SRC, 'async function attemptReconnect()'),
+    liftFunction(LANDING_SRC, 'function renderUnreachableState()'),
+    liftFunction(LANDING_SRC, 'function hideUnreachableState()'),
+    liftFunction(LANDING_SRC, 'async function retryConnectionNow()'),
+    liftFunction(LANDING_SRC, 'function setConnected(connected)'),
+    'globalThis.attemptReconnect = attemptReconnect;',
+    'globalThis.setConnected = setConnected;',
+    'globalThis.retryConnectionNow = retryConnectionNow;'
+  ].join('\n');
+  vm.runInContext(script, sandbox);
+
+  sandbox.elements = elements;
+  return sandbox;
+}
+
+const overlay = (ctx) => ctx.elements.find((e) => e.id === 'unreachableState');
+const toast = (ctx) => ctx.elements.find((e) => e.id === 'toast');
+
+describe('dead server escalates to an honest unreachable state (#709)', () => {
+  it('holds the toast below the ceiling, then renders the unreachable state', async () => {
+    const ctx = loadConnectionState();
+    const N = realCeiling();
+    ctx.setConnected(false);
+
+    for (let i = 0; i < N - 1; i++) await ctx.attemptReconnect();
+    assert.equal(overlay(ctx), undefined,
+      `below ${N} failures this is still plausibly a blip — no overlay yet`);
+    assert.equal(toast(ctx).classList.contains('visible'), true,
+      'the retry toast carries the state until the ceiling');
+
+    await ctx.attemptReconnect();
+    assert.ok(overlay(ctx), 'the ceiling must produce the unreachable state');
+    assert.equal(overlay(ctx).classList.contains('visible'), true);
+    assert.equal(toast(ctx).classList.contains('visible'), false,
+      'the ambiguous toast stops claiming a blip once the state is honest');
+  });
+
+  it('names the origin, the cached-shell possibility, and the concrete checks', async () => {
+    const ctx = loadConnectionState();
+    ctx.setConnected(false);
+    for (let i = 0; i < realCeiling(); i++) await ctx.attemptReconnect();
+
+    const html = overlay(ctx).innerHTML;
+    assert.match(html, /https:\/\/tc\.example:3102/, 'must name what it is trying to reach');
+    assert.match(html, /cache/i, 'must say the shell may be cached — the honest part');
+    assert.match(html, /launchctl list \| grep tangleclaw/);
+    assert.match(html, /server\.err\.log/);
+    assert.match(html, /retryConnectionNow/, 'must offer an explicit retry action');
+  });
+
+  it('recovers automatically and re-arms the ceiling', async () => {
+    const ctx = loadConnectionState();
+    ctx.setConnected(false);
+    for (let i = 0; i < realCeiling(); i++) await ctx.attemptReconnect();
+    assert.equal(overlay(ctx).classList.contains('visible'), true);
+
+    // The server comes back: the next background attempt succeeds.
+    ctx.serverUp = true;
+    await ctx.attemptReconnect();
+    assert.equal(overlay(ctx).classList.contains('visible'), false,
+      'recovery must dismiss the state without any operator action');
+
+    // The counter reset: a fresh outage gets a fresh ceiling, not an instant overlay.
+    ctx.serverUp = false;
+    ctx.setConnected(false);
+    await ctx.attemptReconnect();
+    assert.equal(overlay(ctx).classList.contains('visible'), false,
+      'one failure after recovery is a blip again');
+  });
+
+  it('never reloads or redirects out of the unreachable state', () => {
+    // The no-UI-timers norm (#98, #268): honest state plus explicit user
+    // action, not a blind refresh. Pinned against the source of the three
+    // functions that own this state.
+    for (const decl of ['function renderUnreachableState()',
+      'function hideUnreachableState()', 'async function retryConnectionNow()']) {
+      const body = liftFunction(LANDING_SRC, decl);
+      assert.doesNotMatch(body, /location\.reload|location\.href\s*=|location\.assign/,
+        `${decl} must not navigate for the operator`);
+    }
+  });
+});

--- a/test/landing-unreachable-state.test.js
+++ b/test/landing-unreachable-state.test.js
@@ -26,6 +26,10 @@ const vm = require('node:vm');
 
 const LANDING_SRC = fs.readFileSync(
   path.join(__dirname, '..', 'public', 'landing.js'), 'utf8');
+const API_HELPER_SRC = fs.readFileSync(
+  path.join(__dirname, '..', 'public', 'api-helper.js'), 'utf8');
+const SW_SRC = fs.readFileSync(
+  path.join(__dirname, '..', 'public', 'sw.js'), 'utf8');
 
 /**
  * Slice a top-level function (declaration + body) out of source text by
@@ -180,6 +184,149 @@ describe('dead server escalates to an honest unreachable state (#709)', () => {
       'one failure after recovery is a blip again');
   });
 
+  it('never reloads or redirects out of the unreachable state', () => {
+    runNavigationPin();
+  });
+});
+
+/** Shared by both suites: the three owning functions must not navigate. */
+function runNavigationPin() {
+  for (const decl of ['function renderUnreachableState()',
+    'function hideUnreachableState()', 'async function retryConnectionNow()']) {
+    const body = liftFunction(LANDING_SRC, decl);
+    assert.doesNotMatch(body, /location\.reload|location\.href\s*=|location\.assign/,
+      `${decl} must not navigate for the operator`);
+  }
+}
+
+/*
+ * The service-worker reality (Critic R-1 on the first round of this change):
+ * on a SW-controlled page a dead server never REJECTS an /api fetch — sw.js
+ * resolves it as either a cache-served 200 or a synthetic 503. The first
+ * version of the escalation counted only fetch rejections, so the overlay was
+ * unreachable in the exact scenario #709 names, and the tests above masked it
+ * by synthesizing the connectivity signal. This suite drives the WHOLE chain —
+ * the real sw.js response builders, the real api() from api-helper.js, the
+ * real setConnected/attemptReconnect — with fetch resolving the shapes sw.js
+ * actually produces.
+ */
+describe('escalation works through the real service-worker response shapes (#709 R-1)', () => {
+  /**
+   * Build the full client chain with a controllable fetch.
+   *
+   * @param {Function} fetchImpl - What the "service worker" hands the page.
+   * @returns {object} vm context with `elements` attached.
+   */
+  function loadFullChain(fetchImpl) {
+    const elements = [makeElement('div')];
+    elements[0].id = 'toast';
+    const sandbox = {
+      console, setTimeout: () => 7, clearTimeout() {},
+      Response, Headers,
+      state: { connected: true },
+      location: { origin: 'https://tc.example:3102' },
+      fetch: fetchImpl,
+      document: {
+        getElementById: (id) => elements.find((e) => e.id === id) || null,
+        createElement: (tag) => makeElement(tag),
+        body: { appendChild: (el) => { elements.push(el); } }
+      }
+    };
+    sandbox.window = sandbox;
+    vm.createContext(sandbox);
+    vm.runInContext(API_HELPER_SRC, sandbox);
+    vm.runInContext([
+      'let reconnectTimer = null;',
+      'let reconnectFailures = 0;',
+      `const UNREACHABLE_AFTER = ${realCeiling()};`,
+      liftFunction(LANDING_SRC, 'function esc(str)'),
+      liftFunction(LANDING_SRC, 'async function attemptReconnect()'),
+      liftFunction(LANDING_SRC, 'function renderUnreachableState()'),
+      liftFunction(LANDING_SRC, 'function hideUnreachableState()'),
+      liftFunction(LANDING_SRC, 'function setConnected(connected)'),
+      // The page's real wiring shape: api() is created from the factory with
+      // the page's setConnected, and loadProjects rides on it.
+      'const api = tcCreateApi({ setConnected });',
+      'async function loadProjects() { await api("/api/projects"); }',
+      'globalThis.api = api;',
+      'globalThis.attemptReconnect = attemptReconnect;',
+      'globalThis.setConnected = setConnected;'
+    ].join('\n'), sandbox);
+    sandbox.elements = elements;
+    return sandbox;
+  }
+
+  /** The REAL sw.js builders, lifted and run so the shapes cannot drift. */
+  function swBuilders() {
+    const ctx = { Response, Headers, JSON, String };
+    vm.createContext(ctx);
+    vm.runInContext([
+      liftFunction(SW_SRC, 'function _swErrorResponse(err)'),
+      liftFunction(SW_SRC, 'function _withCacheFallbackMarker(cached)'),
+      'globalThis.err = _swErrorResponse; globalThis.mark = _withCacheFallbackMarker;'
+    ].join('\n'), ctx);
+    return ctx;
+  }
+
+  it('the synthetic 503 counts as disconnected and reaches the overlay', async () => {
+    const sw = swBuilders();
+    const ctx = loadFullChain(async () => sw.err(new Error('Failed to fetch')));
+
+    for (let i = 0; i < realCeiling(); i++) await ctx.attemptReconnect();
+
+    assert.equal(ctx.state.connected, false,
+      'a resolved 503 from the SW is a dead server, not a served answer');
+    assert.ok(overlay(ctx), 'the ceiling must be reachable through the SW 503 shape');
+    assert.equal(overlay(ctx).classList.contains('visible'), true);
+  });
+
+  it('a cache-served 200 is stale, not live: disconnected, no data, overlay reachable', async () => {
+    const sw = swBuilders();
+    const cached = new Response(JSON.stringify({ projects: [{ name: 'old' }] }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } });
+    const served = sw.mark(cached);
+    const ctx = loadFullChain(async () => served.clone());
+
+    const first = await ctx.api('/api/projects');
+    assert.equal(first, null,
+      'cache-fallback data must not be handed to the renderer as a live answer');
+    assert.equal(ctx.state.connected, false,
+      'a marked cache fallback means the server did not answer');
+
+    for (let i = 0; i < realCeiling(); i++) await ctx.attemptReconnect();
+    assert.ok(overlay(ctx), 'the ceiling must be reachable through the cache-fallback shape');
+    assert.equal(overlay(ctx).classList.contains('visible'), true);
+  });
+
+  it('a genuine 200 still connects and recovers from the overlay', async () => {
+    const sw = swBuilders();
+    let serverUp = false;
+    const ctx = loadFullChain(async () => serverUp
+      ? new Response(JSON.stringify({ projects: [] }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } })
+      : sw.err(new Error('Failed to fetch')));
+
+    for (let i = 0; i < realCeiling(); i++) await ctx.attemptReconnect();
+    assert.equal(overlay(ctx).classList.contains('visible'), true);
+
+    serverUp = true;
+    await ctx.attemptReconnect();
+    assert.equal(ctx.state.connected, true, 'a real answer reconnects');
+    assert.equal(overlay(ctx).classList.contains('visible'), false,
+      'recovery through the real api() dismisses the state');
+  });
+
+  it('the marker survives the real sw.js copy and the real api() reads it', async () => {
+    const sw = swBuilders();
+    const cached = new Response('{}', { status: 200 });
+    const served = sw.mark(cached);
+    assert.equal(served.headers.get('X-TC-Cache-Fallback'), '1',
+      'sw.js must mark what it serves in place of a dead network');
+    assert.equal(served.status, 200, 'the stand-in keeps the cached status');
+  });
+});
+
+describe('unreachable-state functions never navigate (source pin)', () => {
   it('never reloads or redirects out of the unreachable state', () => {
     // The no-UI-timers norm (#98, #268): honest state plus explicit user
     // action, not a blind refresh. Pinned against the source of the three


### PR DESCRIPTION
## What
After a bounded run of consecutive failed reconnects (`UNREACHABLE_AFTER`), the dashboard stops claiming "Connection lost. Retrying…" and renders a real unreachable state: the origin it is trying, that the page may be a cached service-worker shell, and the two concrete host-side checks (`launchctl list | grep tangleclaw`, `~/.tangleclaw/logs/server.err.log`). Background retry continues underneath; recovery is automatic the moment the server answers; the only operator-driven path is an explicit Retry-now button — no reload, no redirect, per the no-UI-timers norm (#98, #268).

## Why
The SW serves the app shell from cache with the backend completely dead, so the page renders healthy-looking while nothing behind it answers — and the toast said the same thing after one failure and after two hundred, collapsing every cause of "server is down" into one symptom naming none of them (#709's first-install session took as long as it did precisely because of this).

The SW-side cache-marking the issue floated as a design question is deliberately not needed: the failure ceiling detects the dead backend directly, so the honest message no longer depends on knowing how the shell loaded.

## Test plan
- New `test/landing-unreachable-state.test.js` lifts and RUNS the real functions: below the ceiling the toast holds and no overlay exists; at the ceiling the overlay renders (origin + cached-shell wording + both checks + retry action) and the toast stops; recovery dismisses it automatically and re-arms the ceiling; a source pin asserts none of the three owning functions navigate.
- Falsified twice: full revert → 4/4 red; targeted mutation removing only the escalation call → red.
- Full suite: green (0 fail, 1 pre-existing skip).

Fixes #709