### PR TITLE
Classify gateway 5xx as a disconnection so the unreachable state works behind Caddy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to TangleClaw are documented in this file.
 
 ### Fixed
 
+- **A backend outage behind the Caddy ingress now registers as a disconnection (#924).** The gate
+  answers for a dead upstream with a 502/503/504, so the outage was never a failed fetch and the
+  client filed it under "some request errored" — no toast, no unreachable card, a dashboard that
+  looked connected while the server was gone (operator-observed during the #709 live smoke). The
+  shared API helper now classifies gateway 5xxs with a non-JSON body as "the server did not
+  answer", so the #709 escalation works identically direct and proxied. The JSON discriminator
+  keeps the server's own meaningful 5xxs — the health check's 503, the tmux-dependency 503, the
+  Medusa-hub 502, all `{error, code}` JSON — surfacing as route errors, never as outages.
+
 - **Creating a project now offers the launch-mode picker instead of silently launching with no
   mode (#401).** The create flow auto-launched the new project with a raw session POST, bypassing
   the picker gate that the card's Open button goes through — and on a fresh install, creating a

--- a/public/api-helper.js
+++ b/public/api-helper.js
@@ -39,6 +39,20 @@
           api.lastErrorCode = null;
           return null;
         }
+        // Behind an ingress the backend's death is not a failed fetch either
+        // (#924): Caddy answers FOR the dead upstream with a 502/503/504 whose
+        // body is empty or HTML. The JSON test is the discriminator that keeps
+        // the server's own meaningful 5xxs — health 503, tmux-dependency 503,
+        // Medusa-hub 502, all `{error, code}` JSON — surfacing as route errors
+        // rather than outages. A gateway page is not the server speaking.
+        if ((res.status === 502 || res.status === 503 || res.status === 504)
+            && !(((res.headers && res.headers.get && res.headers.get('content-type')) || '')
+              .includes('json'))) {
+          setConnected(false);
+          api.lastError = 'Connection lost.';
+          api.lastErrorCode = null;
+          return null;
+        }
         const data = await res.json();
         if (!res.ok) {
           if (res.status === 503 && data.error === 'network-unreachable') {

--- a/public/api-helper.js
+++ b/public/api-helper.js
@@ -15,11 +15,14 @@
    *
    * @param {object} [opts]
    * @param {(connected: boolean) => void} [opts.setConnected] - Optional
-   *   hook called with `true` on a successful response and `false` on a
-   *   network-level failure (TypeError / "Failed to fetch"). Pages without
-   *   a connection banner (e.g. openclaw-view) omit this and the helper
-   *   no-ops the connection-state plumbing while still surfacing the
-   *   "Connection lost." message via `api.lastError`.
+   *   hook called with `true` on a successful response and `false` whenever
+   *   the server did not answer, in any of its shapes: a network-level
+   *   failure (TypeError / "Failed to fetch"), a service-worker cache
+   *   fallback or synthetic 503 (#709), or a gateway 502/503/504 with a
+   *   non-JSON body (#924). Pages without a connection banner (e.g.
+   *   openclaw-view) omit this and the helper no-ops the connection-state
+   *   plumbing while still surfacing the "Connection lost." message via
+   *   `api.lastError`.
    * @returns {Function & { lastError: string|null, lastErrorCode: string|null }}
    */
   function tcCreateApi(opts) {

--- a/test/landing-unreachable-state.test.js
+++ b/test/landing-unreachable-state.test.js
@@ -339,8 +339,9 @@ describe('escalation works through the real service-worker response shapes (#709
  */
 describe('escalation works through the gateway shapes (#924)', () => {
   // Verbatim what Caddy's reverse_proxy answers for a dead upstream: 502,
-  // empty body, no content-type.
-  const caddy502 = () => new Response('', { status: 502, statusText: 'Bad Gateway' });
+  // empty body, no content-type. `null` body, not '' — a string body makes
+  // Response auto-attach text/plain, and the point is the header's absence.
+  const caddy502 = () => new Response(null, { status: 502, statusText: 'Bad Gateway' });
 
   it('a gateway 502 counts as disconnected and reaches the overlay', async () => {
     const ctx = loadFullChain(async () => caddy502());

--- a/test/landing-unreachable-state.test.js
+++ b/test/landing-unreachable-state.test.js
@@ -210,64 +210,65 @@ function runNavigationPin() {
  * real setConnected/attemptReconnect — with fetch resolving the shapes sw.js
  * actually produces.
  */
+
+/**
+ * Build the full client chain with a controllable fetch.
+ *
+ * @param {Function} fetchImpl - What the "service worker" hands the page.
+ * @returns {object} vm context with `elements` attached.
+ */
+function loadFullChain(fetchImpl) {
+  const elements = [makeElement('div')];
+  elements[0].id = 'toast';
+  const sandbox = {
+    console, setTimeout: () => 7, clearTimeout() {},
+    Response, Headers,
+    state: { connected: true },
+    location: { origin: 'https://tc.example:3102' },
+    fetch: fetchImpl,
+    document: {
+      getElementById: (id) => elements.find((e) => e.id === id) || null,
+      createElement: (tag) => makeElement(tag),
+      body: { appendChild: (el) => { elements.push(el); } }
+    }
+  };
+  sandbox.window = sandbox;
+  vm.createContext(sandbox);
+  vm.runInContext(API_HELPER_SRC, sandbox);
+  vm.runInContext([
+    'let reconnectTimer = null;',
+    'let reconnectFailures = 0;',
+    `const UNREACHABLE_AFTER = ${realCeiling()};`,
+    liftFunction(LANDING_SRC, 'function esc(str)'),
+    liftFunction(LANDING_SRC, 'async function attemptReconnect()'),
+    liftFunction(LANDING_SRC, 'function renderUnreachableState()'),
+    liftFunction(LANDING_SRC, 'function hideUnreachableState()'),
+    liftFunction(LANDING_SRC, 'function setConnected(connected)'),
+    // The page's real wiring shape: api() is created from the factory with
+    // the page's setConnected, and loadProjects rides on it.
+    'const api = tcCreateApi({ setConnected });',
+    'async function loadProjects() { await api("/api/projects"); }',
+    'globalThis.api = api;',
+    'globalThis.attemptReconnect = attemptReconnect;',
+    'globalThis.setConnected = setConnected;'
+  ].join('\n'), sandbox);
+  sandbox.elements = elements;
+  return sandbox;
+}
+
+/** The REAL sw.js builders, lifted and run so the shapes cannot drift. */
+function swBuilders() {
+  const ctx = { Response, Headers, JSON, String };
+  vm.createContext(ctx);
+  vm.runInContext([
+    liftFunction(SW_SRC, 'function _swErrorResponse(err)'),
+    liftFunction(SW_SRC, 'function _withCacheFallbackMarker(cached)'),
+    'globalThis.err = _swErrorResponse; globalThis.mark = _withCacheFallbackMarker;'
+  ].join('\n'), ctx);
+  return ctx;
+}
+
 describe('escalation works through the real service-worker response shapes (#709 R-1)', () => {
-  /**
-   * Build the full client chain with a controllable fetch.
-   *
-   * @param {Function} fetchImpl - What the "service worker" hands the page.
-   * @returns {object} vm context with `elements` attached.
-   */
-  function loadFullChain(fetchImpl) {
-    const elements = [makeElement('div')];
-    elements[0].id = 'toast';
-    const sandbox = {
-      console, setTimeout: () => 7, clearTimeout() {},
-      Response, Headers,
-      state: { connected: true },
-      location: { origin: 'https://tc.example:3102' },
-      fetch: fetchImpl,
-      document: {
-        getElementById: (id) => elements.find((e) => e.id === id) || null,
-        createElement: (tag) => makeElement(tag),
-        body: { appendChild: (el) => { elements.push(el); } }
-      }
-    };
-    sandbox.window = sandbox;
-    vm.createContext(sandbox);
-    vm.runInContext(API_HELPER_SRC, sandbox);
-    vm.runInContext([
-      'let reconnectTimer = null;',
-      'let reconnectFailures = 0;',
-      `const UNREACHABLE_AFTER = ${realCeiling()};`,
-      liftFunction(LANDING_SRC, 'function esc(str)'),
-      liftFunction(LANDING_SRC, 'async function attemptReconnect()'),
-      liftFunction(LANDING_SRC, 'function renderUnreachableState()'),
-      liftFunction(LANDING_SRC, 'function hideUnreachableState()'),
-      liftFunction(LANDING_SRC, 'function setConnected(connected)'),
-      // The page's real wiring shape: api() is created from the factory with
-      // the page's setConnected, and loadProjects rides on it.
-      'const api = tcCreateApi({ setConnected });',
-      'async function loadProjects() { await api("/api/projects"); }',
-      'globalThis.api = api;',
-      'globalThis.attemptReconnect = attemptReconnect;',
-      'globalThis.setConnected = setConnected;'
-    ].join('\n'), sandbox);
-    sandbox.elements = elements;
-    return sandbox;
-  }
-
-  /** The REAL sw.js builders, lifted and run so the shapes cannot drift. */
-  function swBuilders() {
-    const ctx = { Response, Headers, JSON, String };
-    vm.createContext(ctx);
-    vm.runInContext([
-      liftFunction(SW_SRC, 'function _swErrorResponse(err)'),
-      liftFunction(SW_SRC, 'function _withCacheFallbackMarker(cached)'),
-      'globalThis.err = _swErrorResponse; globalThis.mark = _withCacheFallbackMarker;'
-    ].join('\n'), ctx);
-    return ctx;
-  }
-
   it('the synthetic 503 counts as disconnected and reaches the overlay', async () => {
     const sw = swBuilders();
     const ctx = loadFullChain(async () => sw.err(new Error('Failed to fetch')));
@@ -323,6 +324,80 @@ describe('escalation works through the real service-worker response shapes (#709
     assert.equal(served.headers.get('X-TC-Cache-Fallback'), '1',
       'sw.js must mark what it serves in place of a dead network');
     assert.equal(served.status, 200, 'the stand-in keeps the cached status');
+  });
+});
+
+/*
+ * The proxied reality (#924, operator-observed): behind the Caddy ingress a
+ * dead backend is not a failed fetch either — the gate ANSWERS for it with a
+ * 502/503/504 whose body is empty or HTML. During the 2026-08-14 live smoke a
+ * 40-second backend outage on the gate origin produced no toast and no
+ * unreachable card; the dashboard looked connected throughout. The JSON test
+ * is the discriminator: the server's own meaningful 5xxs (health 503,
+ * tmux-dependency 503, Medusa-hub 502) are always `{error, code}` JSON and
+ * must keep surfacing as route errors, never as outages.
+ */
+describe('escalation works through the gateway shapes (#924)', () => {
+  // Verbatim what Caddy's reverse_proxy answers for a dead upstream: 502,
+  // empty body, no content-type.
+  const caddy502 = () => new Response('', { status: 502, statusText: 'Bad Gateway' });
+
+  it('a gateway 502 counts as disconnected and reaches the overlay', async () => {
+    const ctx = loadFullChain(async () => caddy502());
+
+    const first = await ctx.api('/api/projects');
+    assert.equal(first, null, 'a gateway page is not data');
+    assert.equal(ctx.state.connected, false,
+      'the gate answering FOR the backend is the backend not answering');
+
+    for (let i = 0; i < realCeiling(); i++) await ctx.attemptReconnect();
+    assert.ok(overlay(ctx), 'the ceiling must be reachable through the proxied shape');
+    assert.equal(overlay(ctx).classList.contains('visible'), true);
+  });
+
+  it('an HTML 503/504 from the gate counts as disconnected too', async () => {
+    for (const status of [503, 504]) {
+      const ctx = loadFullChain(async () => new Response('<html><body>error</body></html>',
+        { status, headers: { 'Content-Type': 'text/html' } }));
+      await ctx.api('/api/projects');
+      assert.equal(ctx.state.connected, false, `HTML ${status} must classify as an outage`);
+    }
+  });
+
+  it("the server's own JSON 5xxs stay route errors, never outages", async () => {
+    // The real shapes lib/errorResponse produces: tmux-dependency 503 and
+    // Medusa-hub 502, both JSON with {error, code}.
+    const shapes = [
+      [503, { error: 'tmux did not answer', code: 'TMUX_UNAVAILABLE' }],
+      [502, { error: 'Medusa hub unreachable', code: 'MEDUSA_SEND_FAILED' }]
+    ];
+    for (const [status, body] of shapes) {
+      const ctx = loadFullChain(async () => new Response(JSON.stringify(body),
+        { status, headers: { 'Content-Type': 'application/json; charset=utf-8' } }));
+      const out = await ctx.api('/api/medusa-ish');
+      assert.equal(out, null);
+      assert.equal(ctx.state.connected, true,
+        `a JSON ${status} is the server SPEAKING — it must not flip connectivity`);
+      assert.equal(ctx.api.lastError, body.error, 'the route error must surface');
+      assert.equal(ctx.api.lastErrorCode, body.code);
+    }
+  });
+
+  it('recovery still works after a gateway outage', async () => {
+    let gatewayDown = true;
+    const ctx = loadFullChain(async () => gatewayDown
+      ? caddy502()
+      : new Response(JSON.stringify({ projects: [] }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }));
+
+    for (let i = 0; i < realCeiling(); i++) await ctx.attemptReconnect();
+    assert.equal(overlay(ctx).classList.contains('visible'), true);
+
+    gatewayDown = false;
+    await ctx.attemptReconnect();
+    assert.equal(ctx.state.connected, true);
+    assert.equal(overlay(ctx).classList.contains('visible'), false,
+      'the backend returning through the gate dismisses the state');
   });
 });
 


### PR DESCRIPTION
## What
`api()` now treats 502/503/504 responses with a non-JSON body as "the server did not answer" — `setConnected(false)`, null return — so the #709 toast → escalation → unreachable-card path works identically on a direct connection and behind the Caddy ingress. JSON 5xxs (the server's own health 503, tmux-dependency 503, Medusa-hub 502, all `{error, code}`) keep their route-error semantics untouched.

## Why
Live-observed: during the #709 smoke, a 40-second backend outage on the :8443 gate origin produced no disconnect UI at all — Caddy answered for the dead upstream with 502s, which are delivered responses, not failed fetches, so the connection detector never fired. The proxied shape is how the operator actually uses TangleClaw. Fixes #924.

## Test plan
- New suite drives the verbatim Caddy shape (502, empty body, no content-type) plus HTML 503/504 through the real `api()`/`setConnected`/`attemptReconnect` chain to the overlay; asserts JSON 5xxs do NOT flip connectivity and recovery still auto-dismisses.
- Falsified both ways: removing the gateway branch → 3 red; dropping the JSON discriminator → the route-error guard goes red.
- Full suite: 6059 pass, 0 fail (1 pre-existing skip).

Fixes #924