### PR TITLE
Show the Retry button's attempt in flight on the unreachable card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,8 @@ All notable changes to TangleClaw are documented in this file.
   checks (`launchctl list | grep tangleclaw`, `~/.tangleclaw/logs/server.err.log`). Background
   retry continues underneath and recovery stays automatic the moment the server returns; the only
   navigation out is the operator's own Retry button — no reload, no redirect, per the no-UI-timers
-  norm.
+  norm. The Retry button shows the attempt in flight ("Retrying…", disabled) instead of sitting
+  silent for the seconds an answer takes — the pause read as a dead button in the live smoke.
 
   The honesty extends into the service-worker layer, where the lie originated: on a SW-controlled
   page a dead server never rejects an `/api` fetch — the worker resolved it as either a cached 200

--- a/public/landing.js
+++ b/public/landing.js
@@ -118,7 +118,7 @@ function renderUnreachableState() {
         last logged:</p>
         <pre>launchctl list | grep tangleclaw
 tail -50 ~/.tangleclaw/logs/server.err.log</pre>
-        <button class="btn btn-primary" onclick="retryConnectionNow()">Retry now</button>
+        <button id="unreachableRetryBtn" class="btn btn-primary" onclick="retryConnectionNow()">Retry now</button>
       </div>`;
     document.body.appendChild(el);
   }
@@ -135,10 +135,27 @@ function hideUnreachableState() {
  * The explicit retry the unreachable state offers. The background loop keeps
  * running regardless; this exists so the operator has an action that answers
  * NOW, not in up to five seconds.
+ *
+ * The button shows the attempt in flight (operator feedback, 2026-08-14 live
+ * smoke: the pause between press and answer read as a dead button). On
+ * recovery the whole card dismisses, so the reset in `finally` matters only
+ * when the server is still gone and the card stays up for another press.
  * @returns {Promise<void>}
  */
 async function retryConnectionNow() {
-  await attemptReconnect();
+  const btn = document.getElementById('unreachableRetryBtn');
+  if (btn) {
+    btn.disabled = true;
+    btn.textContent = 'Retrying…';
+  }
+  try {
+    await attemptReconnect();
+  } finally {
+    if (btn) {
+      btn.disabled = false;
+      btn.textContent = 'Retry now';
+    }
+  }
 }
 
 function setConnected(connected) {

--- a/test/landing-unreachable-state.test.js
+++ b/test/landing-unreachable-state.test.js
@@ -164,6 +164,34 @@ describe('dead server escalates to an honest unreachable state (#709)', () => {
     assert.match(html, /retryConnectionNow/, 'must offer an explicit retry action');
   });
 
+  it('the Retry button shows the attempt in flight (operator feedback, #709 smoke)', async () => {
+    const ctx = loadConnectionState();
+    ctx.setConnected(false);
+    for (let i = 0; i < realCeiling(); i++) await ctx.attemptReconnect();
+
+    // The button the overlay's markup renders, registered as the DOM would.
+    const btn = makeElement('button');
+    btn.id = 'unreachableRetryBtn';
+    btn.textContent = 'Retry now';
+    btn.disabled = false;
+    ctx.elements.push(btn);
+
+    // A slow server answer: the press must read as working, not dead.
+    let release;
+    ctx.loadProjects = () => new Promise((resolve) => {
+      release = () => { ctx.setConnected(false); resolve(); };
+    });
+    const pressed = ctx.retryConnectionNow();
+    await new Promise((r) => setImmediate(r));
+    assert.equal(btn.disabled, true, 'the press must disable the button while in flight');
+    assert.equal(btn.textContent, 'Retrying…', 'the pause must say it is working');
+
+    release();
+    await pressed;
+    assert.equal(btn.disabled, false, 'a failed attempt re-arms the button');
+    assert.equal(btn.textContent, 'Retry now');
+  });
+
   it('recovers automatically and re-arms the ceiling', async () => {
     const ctx = loadConnectionState();
     ctx.setConnected(false);

--- a/test/landing-unreachable-state.test.js
+++ b/test/landing-unreachable-state.test.js
@@ -169,7 +169,12 @@ describe('dead server escalates to an honest unreachable state (#709)', () => {
     ctx.setConnected(false);
     for (let i = 0; i < realCeiling(); i++) await ctx.attemptReconnect();
 
-    // The button the overlay's markup renders, registered as the DOM would.
+    // The button the overlay's markup renders, registered as the DOM would —
+    // and pinned to the markup: if either side of the id seam renames, the
+    // `if (btn)` guard silently no-ops the whole indicator, so the fixture id
+    // must be provably the one the real overlay renders.
+    assert.match(overlay(ctx).innerHTML, /id="unreachableRetryBtn"/,
+      'the fixture id must match the id the rendered overlay actually carries');
     const btn = makeElement('button');
     btn.id = 'unreachableRetryBtn';
     btn.textContent = 'Retry now';


### PR DESCRIPTION
## What
Pressing **Retry now** on the unreachable card disables the button and shows "Retrying…" until the attempt resolves; a failed attempt re-arms it, recovery dismisses the whole card.

## Why
Operator feedback from the 2026-08-14 live outage drill that verified #709/#924: the pause between the press and the answer read as a dead button. Amends the (still-unreleased) #709 changelog entry rather than adding a new one.

## Test plan
New test drives the real `retryConnectionNow` with a slow controlled answer: asserts disabled+"Retrying…" mid-flight and re-armed after; removing the busy state goes red. Full suite 6060/0.

Part of the #709 verification follow-ups.