### PR TITLE
The Project Master has a launch mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **The Project Master has a launch mode (#756).** Every project has had the per-engine launch-mode
+  axis — `default` / `acceptEdits` / `plan` / `bypassPermissions` and their per-engine siblings —
+  and the Master had it at no layer: `lib/master.js` built its session with a hardcoded `null`, so
+  it always started in whatever bare default its engine gave and the operator had no way to change
+  it. It is now settable in Master settings, persisted through `PATCH /api/config`, and reaches the
+  actual CLI flags.
+
+  The old `null` was justified in a comment as *"part of the read-only posture"*, and that reasoning
+  conflated two independent axes. Launch mode governs whether the agent prompts inside **its own
+  session** and is enforced by the engine; access level governs what the Master may do to **the
+  fleet** and is enforced by TangleClaw. A read-only Master in `bypassPermissions` is coherent — it
+  edits its own `memory/` without nagging and still cannot touch the fleet — and a `write` Master in
+  `default` is equally coherent. The settings modal names them as separate, and calls out the one
+  combination (`write` + `bypassPermissions`) that removes confirmation at every layer, because
+  #756's bar is that it be selectable but never reachable unnoticed.
+
+  The mode is reconciled against the Master's **effective** engine in the one place that already
+  resolves engine and enforcement, so the settings modal and the launching session cannot disagree.
+  A mode the resolved engine cannot honor degrades to `default` at launch but is **not** flattened
+  at rest: it stays stored, stays selected in the picker, and is labelled as unavailable with what
+  will run instead — so switching engines and back restores the operator's choice rather than
+  silently discarding it. The picker renders only the modes the server says that engine offers,
+  never a list the frontend derived for itself.
+
 ## [5.4.0] - 2026-08-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,15 @@ All notable changes to TangleClaw are documented in this file.
   session** and is enforced by the engine; access level governs what the Master may do to **the
   fleet** and is enforced by TangleClaw. A read-only Master in `bypassPermissions` is coherent — it
   edits its own `memory/` without nagging and still cannot touch the fleet — and a `write` Master in
-  `default` is equally coherent. The settings modal names them as separate, and calls out the one
-  combination (`write` + `bypassPermissions`) that removes confirmation at every layer, because
-  #756's bar is that it be selectable but never reachable unnoticed.
+  `default` would be equally coherent. The settings modal names them as separate, and the read-only
+  tier's own description no longer promises that everything asks first, since that is now the launch
+  mode's business rather than the access level's.
+
+  The modal also carries the warning for `write` + `bypassPermissions` — the combination that removes
+  confirmation at every layer — but **that warning cannot appear in this release**: `write` is still
+  rejected server-side and `MASTER_ENABLED_ACCESS_LEVELS` remains `['read-only']` until #755 ships
+  real enforcement. It is written now so the branch exists and is tested when the tier lands, not
+  because it is reachable today.
 
   The mode is reconciled against the Master's **effective** engine in the one place that already
   resolves engine and enforcement, so the settings modal and the launching session cannot disagree.

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ What started as session persistence grew into a full orchestration platform — 
 
 ### Dashboard
 - **Project management** — create, attach, archive, filter, tag, and delete projects from a central landing page
-- **Project Master pane** — persistent fleet-aware assistant session embedded in the landing page and as an in-session drawer, with a settings surface (access level, engine, scope, auto-start, editable versioned Hard rules) and a structurally enforced read-only boundary on the Claude engine ([ADR 0008](docs/adr/0008-project-master-session-model.md))
+- **Project Master pane** — persistent fleet-aware assistant session embedded in the landing page and as an in-session drawer, with a settings surface (access level, engine, launch mode, scope, auto-start, editable versioned Hard rules) and a structurally enforced read-only boundary on the Claude engine ([ADR 0008](docs/adr/0008-project-master-session-model.md))
 - **Setup wizard** — first-run guided setup scans for existing projects, detects engines, configures preferences, and walks through HTTPS setup
 - **Universal project version detection** — every project's version resolves through a layered chain (`.tangleclaw/project-version.txt` → `CHANGELOG.md` → `version.json` → `package.json`) and shows on the project card and session banner
 - **One-click self-update** — the update beacon's **Update now** button fetches the latest release tag, checks it out with fail-closed guards, and restarts the server

--- a/lib/master.js
+++ b/lib/master.js
@@ -78,6 +78,31 @@ const MASTER_ACCESS_LEVELS = ['read-only', 'suggest', 'write'];
 const MASTER_ENABLED_ACCESS_LEVELS = ['read-only'];
 
 /**
+ * Every launch-mode id any installed engine defines, plus `'default'`.
+ *
+ * The union rather than one engine's set, because the stored mode is
+ * deliberately allowed to outlive an engine switch: an operator who picks
+ * `acceptEdits` on Claude, switches the Master to Aider, and switches back must
+ * find their choice intact rather than flattened to `default` on the way past.
+ * `_masterRuntime` reconciles at launch, so validation here only has to refuse
+ * a mode NO engine has ever heard of — which is a typo, not a preference.
+ *
+ * `'default'` is included unconditionally: every engine defines it, and it must
+ * stay valid on a machine with no engines installed at all.
+ *
+ * @returns {string[]} Sorted mode ids.
+ */
+function knownLaunchModes() {
+  const seen = new Set(['default']);
+  for (const profile of store.engines.list()) {
+    const modes = profile && profile.launchModes;
+    if (!modes || typeof modes !== 'object') continue;
+    for (const mode of Object.keys(modes)) seen.add(mode);
+  }
+  return [...seen].sort();
+}
+
+/**
  * Resolve the master's home directory (its session cwd and identity root).
  * @returns {string} Absolute path to the master home
  */
@@ -90,13 +115,20 @@ function masterHome() {
  * shipped defaults for anything missing (config-file merge is shallow, so a
  * hand-edited partial object must not surface as undefined fields).
  * @param {object} config - Global config (store.config.load())
- * @returns {{accessLevel: string, engine: string|null, scope: (string|{type: string, groupId: string}), autoStart: boolean}}
+ * @returns {{accessLevel: string, engine: string|null, launchMode: string,
+ *            scope: (string|{type: string, groupId: string}), autoStart: boolean}}
  */
 function masterSettings(config) {
   const raw = (config && typeof config.master === 'object' && config.master) || {};
   return {
     accessLevel: MASTER_ACCESS_LEVELS.includes(raw.accessLevel) ? raw.accessLevel : 'read-only',
     engine: typeof raw.engine === 'string' && raw.engine ? raw.engine : null,
+    // The STORED mode, unreconciled — what the operator picked, which may be a
+    // mode the currently-resolved engine cannot honor (they switched engines
+    // afterwards). `_masterRuntime` reconciles; keeping the raw choice here
+    // means switching back to an engine that honors it restores it rather than
+    // silently flattening the setting to 'default' on the way past (#756).
+    launchMode: typeof raw.launchMode === 'string' && raw.launchMode ? raw.launchMode : 'default',
     scope: raw.scope && raw.scope !== 'all' ? raw.scope : 'all',
     autoStart: raw.autoStart === true
   };
@@ -112,7 +144,9 @@ function masterSettings(config) {
  *   same lib the caller uses for detection, or resolution and availability could
  *   disagree — that split is what made two of these tests depend on which CLIs
  *   the host machine happened to have installed.
- * @returns {{settings: object, engineId: string|null, enforcement: string}}
+ * @returns {{settings: object, engineId: string|null, enforcement: string, launchMode: string}}
+ *   `launchMode` is the RECONCILED mode (what will actually run); the stored
+ *   choice stays on `settings.launchMode`.
  */
 function _masterRuntime(config, enginesLib) {
   const settings = masterSettings(config);
@@ -140,7 +174,17 @@ function _masterRuntime(config, enginesLib) {
   // PreToolUse hooks); other engines run the same instructional identity and
   // the API reports the difference instead of pretending.
   const enforcement = engineId === 'claude' ? 'structural' : 'instructional';
-  return { settings, engineId, enforcement };
+  // Reconciled HERE, for the same reason engine and enforcement are: `ensure`
+  // and `getMasterStatus` must not derive it independently, or the settings
+  // modal shows one mode while the session launches under another. A mode the
+  // effective engine cannot honor becomes 'default' — the universally-valid
+  // interactive mode every engine defines — rather than being passed through to
+  // a flag the CLI would reject (#756, and the honest-degradation bar #741 set).
+  const profile = engineId ? store.engines.get(engineId) : null;
+  const reconciler = (enginesLib && typeof enginesLib.reconcileLaunchMode === 'function')
+    ? enginesLib : engines;
+  const launchMode = reconciler.reconcileLaunchMode(settings.launchMode, profile);
+  return { settings, engineId, enforcement, launchMode };
 }
 
 /**
@@ -593,11 +637,11 @@ function ensureMasterSession(options = {}) {
   const home = options.home || masterHome();
 
   const config = store.config.load();
-  const { settings, engineId, enforcement } = _masterRuntime(config, eng);
+  const { settings, engineId, enforcement, launchMode } = _masterRuntime(config, eng);
 
   refreshMasterIdentity({ home, enginesLib: eng });
 
-  const base = { tmuxSession: MASTER_TMUX_SESSION, home, engine: engineId, accessLevel: settings.accessLevel, enforcement };
+  const base = { tmuxSession: MASTER_TMUX_SESSION, home, engine: engineId, accessLevel: settings.accessLevel, enforcement, launchMode };
 
   // Probe, not the boolean. `hasSession` answers false both for a master that
   // is not running and for a tmux server too wedged to reply, and THIS CALLER
@@ -648,12 +692,20 @@ function ensureMasterSession(options = {}) {
   }
 
   // Generic engine launch command (shellCommand + args). No project → the
-  // OpenClaw branch and orchestration overlays never apply; no launch mode →
-  // the engine's interactive default, so every action ask-gates in the master
-  // terminal (part of the read-only posture — never a warning mode). An
-  // available engine with no launch profile would otherwise start a bare
+  // OpenClaw branch and orchestration overlays never apply.
+  //
+  // The launch mode was hardcoded `null` here, on the reasoning that ask-gating
+  // every action was part of the read-only posture. That conflated two
+  // independent axes (#756): this one governs whether the agent prompts inside
+  // ITS OWN session and is enforced by the engine, while the access level
+  // governs what the Master may do to the fleet and is enforced by TangleClaw.
+  // A read-only Master in `bypassPermissions` is coherent — it edits its own
+  // `memory/` without nagging and still cannot touch the fleet — so the mode is
+  // now the operator's, already reconciled against the effective engine.
+  //
+  // An available engine with no launch profile would otherwise start a bare
   // shell while reporting created:true — refuse instead (honest degradation).
-  const launchCmd = sessions._buildLaunchCommand(engineProfile, null, null);
+  const launchCmd = sessions._buildLaunchCommand(engineProfile, null, launchMode);
   if (!launchCmd) {
     return { created: false, ...base, error: `Engine "${engineId}" has no launch command` };
   }
@@ -671,7 +723,7 @@ function ensureMasterSession(options = {}) {
     return { created: false, ...base, error: `tmux error: ${err.message}` };
   }
 
-  log.info('Project Master session launched', { tmuxSession: MASTER_TMUX_SESSION, home, engine: engineId, accessLevel: settings.accessLevel, enforcement });
+  log.info('Project Master session launched', { tmuxSession: MASTER_TMUX_SESSION, home, engine: engineId, accessLevel: settings.accessLevel, enforcement, launchMode });
   return { created: true, ...base };
 }
 
@@ -702,7 +754,16 @@ function ensureMasterSession(options = {}) {
  */
 function getMasterStatus(options = {}) {
   const t = options.tmuxLib || tmux;
-  const { settings, engineId, enforcement } = _masterRuntime(store.config.load(), options.enginesLib);
+  const { settings, engineId, enforcement, launchMode } = _masterRuntime(store.config.load(), options.enginesLib);
+  // The modes the EFFECTIVE engine actually offers, resolved here so the UI
+  // renders from one answer instead of re-deriving which flags exist — the
+  // third-source-of-truth #768 warns about. An engine that is gone or not yet
+  // installed yields an empty list, which the surface must render as "no modes
+  // to choose from", never as a silently empty picker.
+  const profile = engineId ? store.engines.get(engineId) : null;
+  const offered = (profile && profile.launchModes && typeof profile.launchModes === 'object')
+    ? Object.keys(profile.launchModes).filter((m) => engines.honorsLaunchMode(profile, m))
+    : [];
   const probe = t.probeSession(MASTER_TMUX_SESSION);
   return {
     exists: probe.answered ? probe.live : null,
@@ -716,6 +777,13 @@ function getMasterStatus(options = {}) {
       enabledAccessLevels: MASTER_ENABLED_ACCESS_LEVELS,
       engine: settings.engine,
       resolvedEngine: engineId,
+      // Both halves travel: `launchMode` is what the operator chose and
+      // `resolvedLaunchMode` is what will actually run. They differ exactly
+      // when the stored mode is stranded by an engine switch, and the settings
+      // modal has to be able to say so rather than quietly showing one of them.
+      launchMode: settings.launchMode,
+      resolvedLaunchMode: launchMode,
+      launchModes: offered,
       scope: settings.scope,
       autoStart: settings.autoStart,
       enforcement
@@ -730,6 +798,7 @@ module.exports = {
   MASTER_ENABLED_ACCESS_LEVELS,
   masterHome,
   masterSettings,
+  knownLaunchModes,
   buildMasterClaudeMd,
   buildMasterGuardScript,
   seedBaselineMasterRules,

--- a/lib/master.js
+++ b/lib/master.js
@@ -700,6 +700,17 @@ function ensureMasterSession(options = {}) {
     return { created: false, ...base, error: `Engine "${engineId}" not available (binary not found)` };
   }
 
+  if (launchMode !== settings.launchMode) {
+    // Warn HERE rather than in `_masterRuntime`: this runs once per launch, so
+    // it reports the condition at the condition's cadence. The debug line in
+    // `_masterRuntime` covers the polled status path, and on a default install
+    // (`logger` defaults to `info`) it writes nothing — which is why the honest
+    // record has to live on this path.
+    log.warn('Master launch mode not honored by the resolved engine — launching with the interactive default', {
+      stored: settings.launchMode, using: launchMode, engine: engineId
+    });
+  }
+
   // Generic engine launch command (shellCommand + args). No project → the
   // OpenClaw branch and orchestration overlays never apply.
   //
@@ -778,7 +789,14 @@ function getMasterStatus(options = {}) {
   const offered = (profile && profile.launchModes && typeof profile.launchModes === 'object')
     ? Object.keys(profile.launchModes)
       .filter((m) => engines.honorsLaunchMode(profile, m))
-      .map((id) => ({ id, label: (profile.launchModes[id] && profile.launchModes[id].label) || id }))
+      .map((id) => {
+        const m = profile.launchModes[id] || {};
+        // `warning` and `description` travel too: the sibling picker renders a
+        // ⚠ for a warned mode, and `bypassPermissions` carries "Only use in
+        // isolated environments". A Master picker that dropped them would be
+        // silently the less safe of two controls choosing the same thing.
+        return { id, label: m.label || id, warning: m.warning || null, description: m.description || null };
+      })
     : [];
   const probe = t.probeSession(MASTER_TMUX_SESSION);
   return {

--- a/lib/master.js
+++ b/lib/master.js
@@ -184,6 +184,15 @@ function _masterRuntime(config, enginesLib) {
   const reconciler = (enginesLib && typeof enginesLib.reconcileLaunchMode === 'function')
     ? enginesLib : engines;
   const launchMode = reconciler.reconcileLaunchMode(settings.launchMode, profile);
+  if (launchMode !== settings.launchMode) {
+    // Debug, not warn: `getMasterStatus` runs on every poll, so a warn here
+    // would report a stable condition at the poll's cadence rather than the
+    // condition's — the defect #906 exists to prevent. The status payload
+    // carries both values, so the operator-facing surface is the modal.
+    log.debug('Master launch mode not honored by the resolved engine — using default', {
+      stored: settings.launchMode, resolved: launchMode, engine: engineId
+    });
+  }
   return { settings, engineId, enforcement, launchMode };
 }
 
@@ -761,8 +770,15 @@ function getMasterStatus(options = {}) {
   // installed yields an empty list, which the surface must render as "no modes
   // to choose from", never as a silently empty picker.
   const profile = engineId ? store.engines.get(engineId) : null;
+  // `{id, label}`, not bare ids: the project-settings picker renders
+  // `m.label || key` ("Accept Edits"), and a Master picker showing `acceptEdits`
+  // would be the visibly poorer of two controls doing the same job. The label
+  // lives in the engine profile, so shipping it here keeps the frontend from
+  // needing the profile at all.
   const offered = (profile && profile.launchModes && typeof profile.launchModes === 'object')
-    ? Object.keys(profile.launchModes).filter((m) => engines.honorsLaunchMode(profile, m))
+    ? Object.keys(profile.launchModes)
+      .filter((m) => engines.honorsLaunchMode(profile, m))
+      .map((id) => ({ id, label: (profile.launchModes[id] && profile.launchModes[id].label) || id }))
     : [];
   const probe = t.probeSession(MASTER_TMUX_SESSION);
   return {

--- a/lib/store.js
+++ b/lib/store.js
@@ -64,6 +64,10 @@ const DEFAULT_CONFIG = {
   master: {
     accessLevel: 'read-only',
     engine: null,
+    // #756. Present here, not only in `masterSettings`, so `GET /api/config`
+    // and `GET /api/master/status` agree on an install nobody has PATCHed —
+    // otherwise the field is absent from one and 'default' in the other.
+    launchMode: 'default',
     scope: 'all',
     autoStart: false
   },

--- a/public/ui.js
+++ b/public/ui.js
@@ -3538,7 +3538,7 @@ function renderMasterSettingsBody(s, groups) {
   const stranded = Boolean(offered.length && s.launchMode
     && !offered.some((m) => m.id === s.launchMode));
   const modeOpts = offered
-    .map((m) => `<option value="${esc(m.id)}" ${m.id === s.launchMode ? 'selected' : ''}>${esc(m.label)}</option>`)
+    .map((m) => `<option value="${esc(m.id)}" ${m.id === s.launchMode ? 'selected' : ''}>${esc(m.label)}${m.warning ? ' ⚠' : ''}</option>`)
     .concat(stranded
       ? [`<option value="${esc(s.launchMode)}" selected>${esc(s.launchMode)} — not available on this engine</option>`]
       : [])
@@ -3574,6 +3574,7 @@ function renderMasterSettingsBody(s, groups) {
       <div class="form-hint">
         How the master's own session prompts — enforced by the engine, and separate from
         Access level, which is what the master may do to the fleet.
+        Applies the next time the master session starts.
         ${stranded
           ? `<strong>Saved as <code>${esc(s.launchMode)}</code>, which this engine cannot honor — it will start in <code>${esc(s.resolvedLaunchMode || 'default')}</code>.</strong> Your choice is kept and applies again if you switch back.`
           : ''}
@@ -3797,7 +3798,7 @@ async function saveMasterSettings() {
   };
   const data = await apiMutate('/api/config', 'PATCH', { master: masterPatch });
   if (data) {
-    _setMasterRulesStatus('Settings saved — engine/scope apply on next master start', true);
+    _setMasterRulesStatus('Settings saved — engine, launch mode and scope apply on next master start', true);
   } else {
     _setMasterRulesStatus(api.lastError || 'Save failed', false);
   }

--- a/public/ui.js
+++ b/public/ui.js
@@ -3520,6 +3520,24 @@ function renderMasterSettingsBody(s, groups) {
   const engineOpts = '<option value="">(follow default engine)</option>'
     + buildEngineOptions(state.engines, s.engine || '');
 
+  // Launch mode (#756). Rendered from what the SERVER says this engine offers
+  // (`s.launchModes`) rather than re-derived here — a third source of truth for
+  // which flags exist is exactly what #768 warns against.
+  //
+  // A stored mode the resolved engine cannot honor is shown, selected, and
+  // labelled as unavailable rather than dropped: it is still the operator's
+  // saved preference and comes back if they switch the engine back, so silently
+  // showing 'default' would misreport what is stored (the silent-ignore failure
+  // #741 documents). `resolvedLaunchMode` says what will actually run.
+  const offered = Array.isArray(s.launchModes) ? s.launchModes : [];
+  const stranded = s.launchMode && !offered.includes(s.launchMode);
+  const modeOpts = offered
+    .map((m) => `<option value="${esc(m)}" ${m === s.launchMode ? 'selected' : ''}>${esc(m)}</option>`)
+    .concat(stranded
+      ? [`<option value="${esc(s.launchMode)}" selected>${esc(s.launchMode)} — not available on this engine</option>`]
+      : [])
+    .join('');
+
   const scopeIsGroup = s.scope && s.scope !== 'all';
   const groupOpts = ['<option value="">All projects</option>']
     .concat(groups.map((g) =>
@@ -3541,6 +3559,22 @@ function renderMasterSettingsBody(s, groups) {
       <label class="form-label" for="masterEngineSelect">Engine</label>
       <select id="masterEngineSelect" class="form-select">${engineOpts}</select>
       <div class="form-hint">Applies the next time the master session starts (restart via tmux: <code>tmux kill-session -t tangleclaw-master</code>, then reopen).</div>
+    </div>
+    <div class="form-group">
+      <label class="form-label" for="masterLaunchModeSelect">Launch mode</label>
+      ${offered.length
+        ? `<select id="masterLaunchModeSelect" class="form-select">${modeOpts}</select>`
+        : '<div class="form-hint">No engine is resolved, so there are no launch modes to choose from.</div>'}
+      <div class="form-hint">
+        How the master's own session prompts — enforced by the engine, and separate from
+        Access level, which is what the master may do to the fleet.
+        ${stranded
+          ? `<strong>Saved as <code>${esc(s.launchMode)}</code>, which this engine cannot honor — it will start in <code>${esc(s.resolvedLaunchMode || 'default')}</code>.</strong> Your choice is kept and applies again if you switch back.`
+          : ''}
+        ${s.accessLevel === 'write' && s.resolvedLaunchMode === 'bypassPermissions'
+          ? '<strong>This combination lets the master act on the fleet with no confirmation at any layer.</strong>'
+          : ''}
+      </div>
     </div>
     <div class="form-group">
       <label class="form-label" for="masterScopeSelect">Scope</label>
@@ -3745,9 +3779,13 @@ async function saveMasterSettings() {
   const engineSel = document.getElementById('masterEngineSelect');
   const scopeSel = document.getElementById('masterScopeSelect');
   const autoStartEl = document.getElementById('masterAutoStart');
+  const modeSel = document.getElementById('masterLaunchModeSelect');
   const masterPatch = {
     accessLevel: checked ? checked.value : 'read-only',
     engine: engineSel && engineSel.value ? engineSel.value : null,
+    // Absent select → the engine offered no modes, so send nothing rather than
+    // a guess; PATCH merges over the stored block and leaves the choice intact.
+    ...(modeSel && modeSel.value ? { launchMode: modeSel.value } : {}),
     scope: scopeSel && scopeSel.value ? { type: 'group', groupId: scopeSel.value } : 'all',
     autoStart: !!(autoStartEl && autoStartEl.checked)
   };

--- a/public/ui.js
+++ b/public/ui.js
@@ -3497,7 +3497,7 @@ async function openMasterSettings() {
 function renderMasterSettingsBody(s, groups) {
   const body = document.getElementById('masterSettingsBody');
   const tierHints = {
-    'read-only': 'Structurally enforced on the Claude engine: writes are hard-denied outside the master’s memory/ directory; everything else needs your approval in the master terminal.',
+    'read-only': 'Structurally enforced on the Claude engine: writes are hard-denied outside the master’s memory/ directory. Whether anything else asks first is the Launch mode setting below — this tier bounds what the master may touch, not how often it prompts.',
     'suggest': 'Not available yet — ships only with real enforcement (draft-but-never-commit).',
     'write': 'Not available yet — ships only with real enforcement (full tool access).'
   };
@@ -3530,9 +3530,15 @@ function renderMasterSettingsBody(s, groups) {
   // showing 'default' would misreport what is stored (the silent-ignore failure
   // #741 documents). `resolvedLaunchMode` says what will actually run.
   const offered = Array.isArray(s.launchModes) ? s.launchModes : [];
-  const stranded = s.launchMode && !offered.includes(s.launchMode);
+  // "Stranded" means this engine offers modes but not the stored one. With NO
+  // modes offered there is no engine to strand it against, and claiming
+  // otherwise renders "no modes to choose from" directly above "saved as
+  // default, which this engine cannot honor" — two sentences that cannot both
+  // be true. `offered.length` is the guard that keeps them exclusive.
+  const stranded = Boolean(offered.length && s.launchMode
+    && !offered.some((m) => m.id === s.launchMode));
   const modeOpts = offered
-    .map((m) => `<option value="${esc(m)}" ${m === s.launchMode ? 'selected' : ''}>${esc(m)}</option>`)
+    .map((m) => `<option value="${esc(m.id)}" ${m.id === s.launchMode ? 'selected' : ''}>${esc(m.label)}</option>`)
     .concat(stranded
       ? [`<option value="${esc(s.launchMode)}" selected>${esc(s.launchMode)} — not available on this engine</option>`]
       : [])

--- a/server.js
+++ b/server.js
@@ -794,7 +794,7 @@ function validateMasterPatch(patch, config) {
   if (!patch || typeof patch !== 'object' || Array.isArray(patch)) {
     return { error: 'master must be an object' };
   }
-  const known = ['accessLevel', 'engine', 'scope', 'autoStart'];
+  const known = ['accessLevel', 'engine', 'launchMode', 'scope', 'autoStart'];
   for (const key of Object.keys(patch)) {
     if (!known.includes(key)) return { error: `master.${key} is not a settable field` };
   }
@@ -826,7 +826,28 @@ function validateMasterPatch(patch, config) {
   if (typeof merged.autoStart !== 'boolean') {
     return { error: 'master.autoStart must be a boolean' };
   }
-  return { value: { accessLevel: merged.accessLevel, engine: merged.engine, scope: merged.scope, autoStart: merged.autoStart } };
+  // Validated as a NAME, not against the current engine's honored set. A mode
+  // this engine cannot honor is a legitimate stored value — the operator may
+  // switch engines back — and `_masterRuntime` reconciles it to 'default' at
+  // launch. Rejecting it here would make the setting depend on which engine
+  // happened to be resolved at the moment of the PATCH. What must be refused is
+  // a mode no engine defines at all, which is a typo, not a choice.
+  if (typeof merged.launchMode !== 'string' || !merged.launchMode) {
+    return { error: 'master.launchMode must be a launch-mode id string' };
+  }
+  const knownModes = master.knownLaunchModes();
+  if (!knownModes.includes(merged.launchMode)) {
+    return { error: `master.launchMode must be one of: ${knownModes.join(', ')}` };
+  }
+  return {
+    value: {
+      accessLevel: merged.accessLevel,
+      engine: merged.engine,
+      launchMode: merged.launchMode,
+      scope: merged.scope,
+      autoStart: merged.autoStart
+    }
+  };
 }
 
 // PATCH /api/config

--- a/server.js
+++ b/server.js
@@ -848,9 +848,10 @@ function validateMasterPatch(patch, config) {
       return { error: `master.launchMode must be one of: ${knownModes.join(', ')}` };
     }
   }
-  if (typeof merged.launchMode !== 'string' || !merged.launchMode) {
-    return { error: 'master.launchMode must be a launch-mode id string' };
-  }
+  // No `merged.launchMode` type check: `masterSettings` normalizes it to a
+  // non-empty string before the merge, so a guard here would be unreachable —
+  // dead code that reads like a safety net. The patched value is checked above,
+  // which is the only place an untrusted value enters.
   return {
     value: {
       accessLevel: merged.accessLevel,

--- a/server.js
+++ b/server.js
@@ -832,12 +832,24 @@ function validateMasterPatch(patch, config) {
   // launch. Rejecting it here would make the setting depend on which engine
   // happened to be resolved at the moment of the PATCH. What must be refused is
   // a mode no engine defines at all, which is a typo, not a choice.
+  //
+  // Only what this PATCH actually SENT is name-checked, unlike the fields
+  // above. `knownLaunchModes()` is the union across INSTALLED engines, so
+  // uninstalling an engine shrinks it — and validating the merged value would
+  // then reject every master PATCH on the install, including ones that only
+  // toggle autoStart, over a stored mode the operator never touched. The
+  // reconcile at launch already handles a mode that has become unhonorable.
+  if ('launchMode' in patch) {
+    if (typeof patch.launchMode !== 'string' || !patch.launchMode) {
+      return { error: 'master.launchMode must be a launch-mode id string' };
+    }
+    const knownModes = master.knownLaunchModes();
+    if (!knownModes.includes(patch.launchMode)) {
+      return { error: `master.launchMode must be one of: ${knownModes.join(', ')}` };
+    }
+  }
   if (typeof merged.launchMode !== 'string' || !merged.launchMode) {
     return { error: 'master.launchMode must be a launch-mode id string' };
-  }
-  const knownModes = master.knownLaunchModes();
-  if (!knownModes.includes(merged.launchMode)) {
-    return { error: `master.launchMode must be one of: ${knownModes.join(', ')}` };
   }
   return {
     value: {

--- a/test/api-config.test.js
+++ b/test/api-config.test.js
@@ -779,7 +779,10 @@ describe('API endpoints', () => {
       const { status } = await request(server, 'PATCH', '/api/config', { master: { autoStart: true } });
       assert.equal(status, 200);
       assert.deepEqual(store.config.load().master, {
-        accessLevel: 'read-only', engine: null, scope: 'all', autoStart: true
+        // #756 added launchMode to the normalized shape. It is stored on every
+        // write, not only when patched, so the block never carries a missing
+        // field for `_buildLaunchCommand` to receive as undefined.
+        accessLevel: 'read-only', engine: null, launchMode: 'default', scope: 'all', autoStart: true
       });
     });
 
@@ -790,6 +793,39 @@ describe('API endpoints', () => {
       const saved = store.config.load().master;
       assert.equal(saved.engine, 'claude');
       assert.equal(saved.autoStart, true, 'earlier field must survive the second patch');
+    });
+
+    it('stores a launch mode (#756)', async () => {
+      const { status } = await request(server, 'PATCH', '/api/config', { master: { launchMode: 'acceptEdits' } });
+      assert.equal(status, 200);
+      assert.equal(store.config.load().master.launchMode, 'acceptEdits');
+    });
+
+    it('accepts a mode the CURRENT engine cannot honor, and keeps it stored', async () => {
+      // Deliberate: validation is by name, not against whichever engine happens
+      // to be resolved at the moment of the PATCH. The operator may switch
+      // engines back, and `_masterRuntime` reconciles at launch. Rejecting here
+      // would make the setting's validity depend on unrelated state.
+      const { status } = await request(server, 'PATCH', '/api/config', {
+        master: { engine: 'aider', launchMode: 'acceptEdits' }
+      });
+      assert.equal(status, 200);
+      assert.equal(store.config.load().master.launchMode, 'acceptEdits',
+        'the stored preference survives an engine that cannot honor it');
+    });
+
+    it('rejects a launch mode no engine defines, naming the valid set', async () => {
+      const { status, data } = await request(server, 'PATCH', '/api/config', {
+        master: { launchMode: 'ludicrous-speed' }
+      });
+      assert.equal(status, 400);
+      assert.match(data.error, /master\.launchMode must be one of/);
+      assert.match(data.error, /default/, 'the honest set must name at least the universal mode');
+    });
+
+    it('rejects a non-string launch mode', async () => {
+      const { status } = await request(server, 'PATCH', '/api/config', { master: { launchMode: 7 } });
+      assert.equal(status, 400);
     });
 
     it('rejects not-yet-enforced access levels with an honest reason', async () => {

--- a/test/api-config.test.js
+++ b/test/api-config.test.js
@@ -823,6 +823,19 @@ describe('API endpoints', () => {
       assert.match(data.error, /default/, 'the honest set must name at least the universal mode');
     });
 
+    it('does not reject an unrelated patch over a stored mode gone unhonorable', async () => {
+      // `knownLaunchModes()` is the union across INSTALLED engines, so
+      // uninstalling one shrinks it. Validating the MERGED value would then
+      // 400 every master PATCH on the install — including ones that only
+      // toggle autoStart — over a stored mode the operator never touched.
+      const config = store.config.load();
+      config.master = { ...config.master, launchMode: 'mode-from-a-since-removed-engine' };
+      store.config.save(config);
+      const { status } = await request(server, 'PATCH', '/api/config', { master: { autoStart: true } });
+      assert.equal(status, 200, 'a patch that does not touch launchMode must not be judged on it');
+      assert.equal(store.config.load().master.autoStart, true);
+    });
+
     it('rejects a non-string launch mode', async () => {
       const { status } = await request(server, 'PATCH', '/api/config', { master: { launchMode: 7 } });
       assert.equal(status, 400);

--- a/test/api-config.test.js
+++ b/test/api-config.test.js
@@ -795,6 +795,27 @@ describe('API endpoints', () => {
       assert.equal(saved.autoStart, true, 'earlier field must survive the second patch');
     });
 
+    it('ships launchMode in the DEFAULT master block, before any PATCH (#756)', async () => {
+      // The whole point of the DEFAULT_CONFIG entry: `GET /api/config` and
+      // `GET /api/master/status` must agree on an install nobody has PATCHed.
+      // Every other assertion here reads the block AFTER a patch, and
+      // `validateMasterPatch` sources the field from `masterSettings()`, which
+      // defaults it independently — so deleting the default would leave all of
+      // them green while the two endpoints disagreed.
+      const master = require('../lib/master');
+      assert.equal(store.DEFAULT_CONFIG.master.launchMode, 'default',
+        'a never-PATCHed install must carry launchMode, not omit it');
+      // The invariant the default exists for, asserted as an agreement rather
+      // than as the constant's shape: what `GET /api/config` would report and
+      // what `masterSettings` (behind `GET /api/master/status`) reports must be
+      // the same value on an install nobody has touched.
+      assert.equal(
+        store.DEFAULT_CONFIG.master.launchMode,
+        master.masterSettings({}).launchMode,
+        'config default and master-status default must not disagree'
+      );
+    });
+
     it('stores a launch mode (#756)', async () => {
       const { status } = await request(server, 'PATCH', '/api/config', { master: { launchMode: 'acceptEdits' } });
       assert.equal(status, 200);

--- a/test/master-launch-mode.test.js
+++ b/test/master-launch-mode.test.js
@@ -1,0 +1,200 @@
+'use strict';
+
+/*
+ * #756 — the Master settings modal's launch-mode picker, at the frontend.
+ *
+ * The Master had no launch mode at any layer; `lib/master.js` hardcoded `null`
+ * into its launch command. The backend half is covered in `test/master.test.js`.
+ * This covers the surface, and specifically the two ways a mode picker lies:
+ *
+ *  1. Re-deriving which modes exist instead of rendering what the server said
+ *     this engine offers — the third-source-of-truth failure #768 names.
+ *  2. Dropping a stored mode the current engine cannot honor, so the modal
+ *     shows `default` while config still holds the operator's real choice. That
+ *     is the silent-ignore failure #741 documents.
+ *
+ * These LIFT the real functions out of public/ui.js and RUN them, rather than
+ * regex-matching the source: the existing master-settings suite is source-pinned
+ * (see backlog TST-6L2P), and a source pin cannot tell a rendered option from a
+ * string that merely appears in the file.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const UI_SRC = fs.readFileSync(path.join(__dirname, '..', 'public', 'ui.js'), 'utf8');
+// `esc` is defined in landing.js and shared globally with ui.js — both scripts
+// load on the dashboard. Lifting the REAL one keeps escaping behaviour honest
+// rather than stubbing it into something more forgiving than production.
+const LANDING_SRC = fs.readFileSync(path.join(__dirname, '..', 'public', 'landing.js'), 'utf8');
+
+/**
+ * Slice a top-level function (declaration + body) out of source text.
+ * @param {string} src - File source text.
+ * @param {string} decl - Declaration to find.
+ * @returns {string} The declaration plus its balanced body.
+ */
+function liftFunction(src, decl) {
+  const start = src.indexOf(decl);
+  assert.notEqual(start, -1, `${decl} must exist`);
+  const bodyStart = src.indexOf('{', start);
+  let depth = 0;
+  for (let i = bodyStart; i < src.length; i++) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}' && --depth === 0) return src.slice(start, i + 1);
+  }
+  assert.fail(`${decl} body must close`);
+}
+
+/** The settings shape `GET /api/master/status` returns, with overrides. */
+function status(over = {}) {
+  return {
+    accessLevel: 'read-only',
+    accessLevels: ['read-only', 'suggest', 'write'],
+    enabledAccessLevels: ['read-only'],
+    engine: 'claude',
+    resolvedEngine: 'claude',
+    launchMode: 'default',
+    resolvedLaunchMode: 'default',
+    launchModes: ['default', 'acceptEdits', 'plan', 'bypassPermissions'],
+    scope: 'all',
+    autoStart: false,
+    enforcement: 'structural',
+    ...over
+  };
+}
+
+/**
+ * Render the settings body with the real function and return its HTML.
+ * @param {object} settings - `status.settings` payload.
+ * @returns {string} Rendered innerHTML.
+ */
+function render(settings) {
+  const bodyEl = { innerHTML: '' };
+  const sandbox = {
+    console,
+    state: { engines: [] },
+    document: { getElementById: (id) => (id === 'masterSettingsBody' ? bodyEl : null) },
+    // Not under test here; the engine picker has its own coverage (#707).
+    buildEngineOptions: () => '<option value="claude">Claude</option>'
+  };
+  sandbox.window = sandbox;
+  vm.createContext(sandbox);
+  vm.runInContext([
+    liftFunction(LANDING_SRC, 'function esc(str)'),
+    liftFunction(UI_SRC, 'function renderMasterSettingsBody(s, groups)'),
+    'globalThis.renderMasterSettingsBody = renderMasterSettingsBody;'
+  ].join('\n'), sandbox);
+  sandbox.renderMasterSettingsBody(settings, []);
+  return bodyEl.innerHTML;
+}
+
+/**
+ * Run the real save handler against a fake form and capture the PATCH body.
+ * @param {object} fields - Values the form controls report.
+ * @returns {Promise<object|null>} The `master` patch that would be sent.
+ */
+async function save(fields) {
+  let sent = null;
+  const els = {
+    masterEngineSelect: { value: fields.engine || '' },
+    masterScopeSelect: { value: fields.scope || '' },
+    masterAutoStart: { checked: !!fields.autoStart }
+  };
+  if (fields.launchMode !== undefined) {
+    els.masterLaunchModeSelect = { value: fields.launchMode };
+  }
+  const sandbox = {
+    console,
+    document: {
+      getElementById: (id) => els[id] || null,
+      querySelector: () => ({ value: fields.accessLevel || 'read-only' })
+    },
+    apiMutate: async (_p, _m, body) => { sent = body; return { ok: true }; },
+    api: { lastError: null },
+    _setMasterRulesStatus: () => {}
+  };
+  sandbox.window = sandbox;
+  vm.createContext(sandbox);
+  vm.runInContext([
+    liftFunction(UI_SRC, 'async function saveMasterSettings()'),
+    'globalThis.saveMasterSettings = saveMasterSettings;'
+  ].join('\n'), sandbox);
+  await sandbox.saveMasterSettings();
+  return sent && sent.master;
+}
+
+describe('#756 — the Master settings modal offers a launch mode', () => {
+  it('renders exactly the modes the server said this engine offers', () => {
+    const html = render(status({ launchModes: ['default', 'acceptEdits'] }));
+    assert.match(html, /id="masterLaunchModeSelect"/);
+    assert.match(html, /<option value="acceptEdits"/);
+    // Claude defines these, but this payload did not offer them. Rendering them
+    // anyway would mean the modal derived the list itself.
+    assert.doesNotMatch(html, /<option value="plan"/);
+    assert.doesNotMatch(html, /<option value="bypassPermissions"/);
+  });
+
+  it('selects the stored mode', () => {
+    const html = render(status({ launchMode: 'acceptEdits' }));
+    assert.match(html, /<option value="acceptEdits" selected>/);
+  });
+
+  it('keeps a stranded mode visible, selected, and named as unavailable', () => {
+    // The operator picked acceptEdits on Claude, then switched to an engine
+    // that cannot honor it. Config still holds acceptEdits, so showing
+    // "default" would misreport what is saved.
+    const html = render(status({
+      engine: 'aider', resolvedEngine: 'aider',
+      launchMode: 'acceptEdits', resolvedLaunchMode: 'default',
+      launchModes: ['default', 'yesAlways']
+    }));
+    assert.match(html, /<option value="acceptEdits" selected>/,
+      'the saved choice must still be the selected one');
+    assert.match(html, /not available on this engine/i);
+    assert.match(html, /will start in <code>default<\/code>/,
+      'and it must say what will actually run instead');
+  });
+
+  it('says there are no modes rather than rendering an empty picker', () => {
+    const html = render(status({ resolvedEngine: null, launchModes: [] }));
+    assert.doesNotMatch(html, /id="masterLaunchModeSelect"/);
+    assert.match(html, /no launch modes to choose from/i);
+  });
+
+  it('names the two axes as separate, so neither implies the other', () => {
+    const html = render(status());
+    assert.match(html, /separate from/i);
+    assert.match(html, /Access level/);
+  });
+
+  it('calls out write + bypassPermissions rather than letting it pass unremarked', () => {
+    // #756: that combination is legitimate and selectable, but must not be
+    // reachable without the operator seeing what they picked.
+    const loud = render(status({ accessLevel: 'write', resolvedLaunchMode: 'bypassPermissions' }));
+    assert.match(loud, /no confirmation at any layer/i);
+    const quiet = render(status({ accessLevel: 'read-only', resolvedLaunchMode: 'bypassPermissions' }));
+    assert.doesNotMatch(quiet, /no confirmation at any layer/i,
+      'a read-only master in bypass is coherent — it must not be flagged as dangerous');
+  });
+});
+
+describe('#756 — saving the launch mode', () => {
+  it('sends the picked mode in the master patch', async () => {
+    const patch = await save({ launchMode: 'acceptEdits', engine: 'claude' });
+    assert.equal(patch.launchMode, 'acceptEdits');
+  });
+
+  it('omits launchMode entirely when the engine offered no picker', async () => {
+    // Sending a guess here would overwrite the operator's stored choice with
+    // whatever the modal happened to default to. PATCH merges, so omitting
+    // leaves it intact.
+    const patch = await save({ engine: 'claude' });
+    assert.ok(!('launchMode' in patch),
+      'no picker means no opinion — the stored mode must survive the save');
+    assert.equal(patch.accessLevel, 'read-only', 'the rest of the form still saves');
+  });
+});

--- a/test/master-launch-mode.test.js
+++ b/test/master-launch-mode.test.js
@@ -59,7 +59,15 @@ function status(over = {}) {
     resolvedEngine: 'claude',
     launchMode: 'default',
     resolvedLaunchMode: 'default',
-    launchModes: ['default', 'acceptEdits', 'plan', 'bypassPermissions'],
+    // The real shape `getMasterStatus` emits, verified against the module:
+    // `{id, label}`, so the picker can render "Accept Edits" like its sibling
+    // rather than the raw id.
+    launchModes: [
+      { id: 'default', label: 'Interactive' },
+      { id: 'acceptEdits', label: 'Accept Edits' },
+      { id: 'plan', label: 'Plan Only' },
+      { id: 'bypassPermissions', label: 'Bypass' }
+    ],
     scope: 'all',
     autoStart: false,
     enforcement: 'structural',
@@ -129,9 +137,15 @@ async function save(fields) {
 
 describe('#756 — the Master settings modal offers a launch mode', () => {
   it('renders exactly the modes the server said this engine offers', () => {
-    const html = render(status({ launchModes: ['default', 'acceptEdits'] }));
+    const html = render(status({
+      launchModes: [{ id: 'default', label: 'Interactive' }, { id: 'acceptEdits', label: 'Accept Edits' }]
+    }));
     assert.match(html, /id="masterLaunchModeSelect"/);
     assert.match(html, /<option value="acceptEdits"/);
+    assert.match(html, />Accept Edits</,
+      'the picker must render the human label, like the project-settings picker does');
+    assert.doesNotMatch(html, />acceptEdits</,
+      'a raw mode id in the option text is the visibly-poorer-sibling failure');
     // Claude defines these, but this payload did not offer them. Rendering them
     // anyway would mean the modal derived the list itself.
     assert.doesNotMatch(html, /<option value="plan"/);
@@ -150,7 +164,7 @@ describe('#756 — the Master settings modal offers a launch mode', () => {
     const html = render(status({
       engine: 'aider', resolvedEngine: 'aider',
       launchMode: 'acceptEdits', resolvedLaunchMode: 'default',
-      launchModes: ['default', 'yesAlways']
+      launchModes: [{ id: 'default', label: 'Interactive' }, { id: 'yesAlways', label: 'Yes To All' }]
     }));
     assert.match(html, /<option value="acceptEdits" selected>/,
       'the saved choice must still be the selected one');
@@ -163,6 +177,13 @@ describe('#756 — the Master settings modal offers a launch mode', () => {
     const html = render(status({ resolvedEngine: null, launchModes: [] }));
     assert.doesNotMatch(html, /id="masterLaunchModeSelect"/);
     assert.match(html, /no launch modes to choose from/i);
+    // With no engine there is nothing to strand the stored mode against. The
+    // previous version of this test asserted only the picker's absence, so it
+    // passed while the output also said "saved as default, which this engine
+    // cannot honor" — directly under "there are no modes to choose from".
+    assert.doesNotMatch(html, /cannot honor/i,
+      'an install with no engine must not also claim the mode is unhonorable');
+    assert.doesNotMatch(html, /not available on this engine/i);
   });
 
   it('names the two axes as separate, so neither implies the other', () => {

--- a/test/master-launch-mode.test.js
+++ b/test/master-launch-mode.test.js
@@ -107,6 +107,10 @@ function render(settings) {
  */
 async function save(fields) {
   let sent = null;
+  // The toast text is part of the contract, not decoration: it is what tells
+  // the operator the change is deferred to the next master start. Discarding
+  // it here is what let that half of the fix ship unguarded.
+  const status = { saveMessage: null };
   const els = {
     masterEngineSelect: { value: fields.engine || '' },
     masterScopeSelect: { value: fields.scope || '' },
@@ -123,7 +127,7 @@ async function save(fields) {
     },
     apiMutate: async (_p, _m, body) => { sent = body; return { ok: true }; },
     api: { lastError: null },
-    _setMasterRulesStatus: () => {}
+    _setMasterRulesStatus: (msg) => { status.saveMessage = msg; }
   };
   sandbox.window = sandbox;
   vm.createContext(sandbox);
@@ -132,7 +136,7 @@ async function save(fields) {
     'globalThis.saveMasterSettings = saveMasterSettings;'
   ].join('\n'), sandbox);
   await sandbox.saveMasterSettings();
-  return sent && sent.master;
+  return { patch: sent && sent.master, message: status.saveMessage };
 }
 
 describe('#756 — the Master settings modal offers a launch mode', () => {
@@ -242,7 +246,7 @@ describe('#756 — the Master settings modal offers a launch mode', () => {
 
 describe('#756 — saving the launch mode', () => {
   it('sends the picked mode in the master patch', async () => {
-    const patch = await save({ launchMode: 'acceptEdits', engine: 'claude' });
+    const { patch } = await save({ launchMode: 'acceptEdits', engine: 'claude' });
     assert.equal(patch.launchMode, 'acceptEdits');
   });
 
@@ -250,9 +254,20 @@ describe('#756 — saving the launch mode', () => {
     // Sending a guess here would overwrite the operator's stored choice with
     // whatever the modal happened to default to. PATCH merges, so omitting
     // leaves it intact.
-    const patch = await save({ engine: 'claude' });
+    const { patch } = await save({ engine: 'claude' });
     assert.ok(!('launchMode' in patch),
       'no picker means no opinion — the stored mode must survive the save');
     assert.equal(patch.accessLevel, 'read-only', 'the rest of the form still saves');
+  });
+
+  it('the save confirmation names launch mode among the deferred settings', () => {
+    // The toast said "engine/scope apply on next master start" and omitted the
+    // launch mode, which defers identically. An operator reading it would
+    // reasonably expect the mode to have taken effect already.
+    return save({ launchMode: 'acceptEdits', engine: 'claude' }).then(({ message }) => {
+      assert.match(message, /launch mode/i,
+        'the confirmation must not list only the settings it used to defer');
+      assert.match(message, /next master start/i);
+    });
   });
 });

--- a/test/master-launch-mode.test.js
+++ b/test/master-launch-mode.test.js
@@ -192,6 +192,43 @@ describe('#756 — the Master settings modal offers a launch mode', () => {
     assert.match(html, /Access level/);
   });
 
+  it('the read-only tier no longer promises what the launch mode can remove', () => {
+    // The tier hint used to read "everything else needs your approval in the
+    // master terminal" — the exact property a bypassPermissions launch mode
+    // takes away. The assertions above match the LAUNCH-MODE hint and pass
+    // unchanged if the tier hint reverts, so this is its own guard.
+    const html = render(status());
+    assert.doesNotMatch(html, /everything else needs your approval/i,
+      'the access tier must not promise a prompt the launch mode governs');
+    assert.match(html, /bounds what the master may touch, not how often it prompts/i);
+  });
+
+  it('carries a warned mode\'s ⚠ through to the option, like the sibling picker', () => {
+    // data/engines/claude.json marks bypassPermissions with a warning, and the
+    // project-settings picker renders ⚠ for it. Dropping it here would make the
+    // Master picker silently the less safe of two controls doing one job.
+    const html = render(status({
+      launchModes: [
+        { id: 'default', label: 'Interactive', warning: null },
+        { id: 'bypassPermissions', label: 'Bypass', warning: 'Only use in isolated environments' }
+      ]
+    }));
+    assert.match(html, /Bypass ⚠/, 'a warned mode must carry its glyph');
+    assert.doesNotMatch(html, /Interactive ⚠/, 'and an unwarned one must not');
+  });
+
+  it('says when the choice takes effect, in the launch-mode hint itself', () => {
+    // Scoped to the launch-mode form-group on purpose. The ENGINE control's
+    // hint has always said "Applies the next time the master session starts",
+    // so an unscoped match passes with this hint carrying no such line at all.
+    const html = render(status());
+    const start = html.indexOf("How the master's own session prompts");
+    assert.notEqual(start, -1, 'the launch-mode hint must exist');
+    const hint = html.slice(start, html.indexOf('</div>', start));
+    assert.match(hint, /next time the master session starts/i,
+      'the launch-mode hint must state its own deferral, not rely on a neighbour');
+  });
+
   it('calls out write + bypassPermissions rather than letting it pass unremarked', () => {
     // #756: that combination is legitimate and selectable, but must not be
     // reachable without the operator seeing what they picked.

--- a/test/master.test.js
+++ b/test/master.test.js
@@ -416,11 +416,17 @@ function clearMasterRules() {
 
 describe('masterSettings normalization', () => {
   it('applies defaults for a missing/partial master block (shallow-merge safety)', () => {
-    assert.deepEqual(master.masterSettings({}), { accessLevel: 'read-only', engine: null, scope: 'all', autoStart: false });
+    assert.deepEqual(master.masterSettings({}), {
+      accessLevel: 'read-only', engine: null, launchMode: 'default', scope: 'all', autoStart: false
+    });
     const partial = master.masterSettings({ master: { autoStart: true } });
     assert.equal(partial.autoStart, true);
     assert.equal(partial.accessLevel, 'read-only');
     assert.equal(partial.engine, null);
+    // #756: a hand-edited partial block must not surface launchMode as
+    // undefined — `_buildLaunchCommand` would then receive it and the Master
+    // would launch under whatever that coerces to.
+    assert.equal(partial.launchMode, 'default');
   });
 
   it('rejects out-of-enum access levels back to read-only', () => {
@@ -696,6 +702,123 @@ describe('ensureMasterSession — settings integration', () => {
       config.master = saved;
       store.config.save(config);
     }
+  });
+
+  /*
+   * #756 — the Master had no launch mode at any layer. `lib/master.js` built its
+   * session with a hardcoded `null`, on the reasoning that ask-gating everything
+   * was part of the read-only posture. That conflated two independent axes: this
+   * one governs whether the agent prompts inside ITS OWN session and is enforced
+   * by the engine; the access level governs what the Master may do to the fleet
+   * and is enforced by TangleClaw. A read-only Master in `bypassPermissions` is
+   * coherent — it edits its own `memory/` without nagging and still cannot touch
+   * the fleet.
+   *
+   * These assert the FLAGS that reach the launch command, not the argument
+   * passed to a spy: the engine profile is the thing that turns a mode id into
+   * `--permission-mode acceptEdits`, so a test that stopped at the call boundary
+   * would keep passing if the mode never reached the CLI.
+   */
+  describe('#756 — the Master honors a launch mode', () => {
+    /** Run an ensure with a stored master block, restoring config after. */
+    function ensureWithMaster(masterBlock, opts = {}) {
+      const config = store.config.load();
+      const saved = config.master;
+      try {
+        config.master = { accessLevel: 'read-only', engine: null, scope: 'all', autoStart: false, ...masterBlock };
+        store.config.save(config);
+        const tmuxLib = fakeTmux({ alive: false });
+        const r = master.ensureMasterSession({
+          home, tmuxLib, enginesLib: opts.enginesLib || availableEngines
+        });
+        return { result: r, command: tmuxLib.calls.length ? tmuxLib.calls[0].opts.command : null };
+      } finally {
+        config.master = saved;
+        store.config.save(config);
+      }
+    }
+
+    it('puts the stored mode\'s real flags into the launch command', () => {
+      const { result, command } = ensureWithMaster({ launchMode: 'acceptEdits', engine: 'claude' });
+      assert.equal(result.created, true);
+      assert.match(command, /--permission-mode acceptEdits/,
+        'the mode must reach the CLI, not stop at the call boundary');
+      assert.equal(result.launchMode, 'acceptEdits');
+    });
+
+    it('defaults to the interactive mode when nothing is stored', () => {
+      const { result, command } = ensureWithMaster({ engine: 'claude' });
+      assert.equal(result.launchMode, 'default');
+      assert.doesNotMatch(command, /--permission-mode|--dangerously-skip-permissions/,
+        "the default mode adds no flags — it is the engine's own interactive default");
+    });
+
+    it('reconciles a mode the effective engine cannot honor down to default', () => {
+      // `acceptEdits` is Claude's; aider defines `yesAlways` and knows nothing
+      // about it. Passing it through would hand the CLI a flag it rejects.
+      const { result, command } = ensureWithMaster(
+        { launchMode: 'acceptEdits', engine: 'aider' },
+        { enginesLib: enginesInstalling(['aider']) }
+      );
+      assert.equal(result.launchMode, 'default',
+        'an unhonored mode must reconcile, never reach the CLI');
+      assert.doesNotMatch(String(command), /acceptEdits/);
+    });
+
+    it('does not FLATTEN the stored choice when an engine cannot honor it', () => {
+      // The reconcile happens at launch, not at rest. An operator who picks
+      // acceptEdits on Claude, switches the Master to aider, and switches back
+      // must find their choice intact rather than silently rewritten to
+      // 'default' on the way past.
+      const config = store.config.load();
+      const saved = config.master;
+      try {
+        config.master = { accessLevel: 'read-only', engine: 'aider', launchMode: 'acceptEdits', scope: 'all', autoStart: false };
+        store.config.save(config);
+        master.ensureMasterSession({ home, tmuxLib: fakeTmux({ alive: false }), enginesLib: enginesInstalling(['aider']) });
+        assert.equal(master.masterSettings(store.config.load()).launchMode, 'acceptEdits',
+          'the stored preference must survive an engine that cannot honor it');
+      } finally {
+        config.master = saved;
+        store.config.save(config);
+      }
+    });
+
+    it('status reports the stored mode, the resolved mode, and what the engine offers', () => {
+      const config = store.config.load();
+      const saved = config.master;
+      try {
+        config.master = { accessLevel: 'read-only', engine: 'aider', launchMode: 'acceptEdits', scope: 'all', autoStart: false };
+        store.config.save(config);
+        const st = master.getMasterStatus({ tmuxLib: fakeTmux({ alive: true }), enginesLib: enginesInstalling(['aider']) });
+        assert.equal(st.settings.launchMode, 'acceptEdits', 'what the operator picked');
+        assert.equal(st.settings.resolvedLaunchMode, 'default', 'what will actually run');
+        assert.ok(Array.isArray(st.settings.launchModes), 'the surface must not re-derive the offered set');
+        assert.ok(!st.settings.launchModes.includes('acceptEdits'),
+          'aider does not offer acceptEdits, so the picker must not show it as available');
+      } finally {
+        config.master = saved;
+        store.config.save(config);
+      }
+    });
+
+    it('ensure and status agree on the mode that will run', () => {
+      // The lockstep hazard `_masterRuntime` exists to prevent: the settings
+      // modal must never show one mode while the session launches another.
+      const config = store.config.load();
+      const saved = config.master;
+      try {
+        config.master = { accessLevel: 'read-only', engine: 'aider', launchMode: 'plan', scope: 'all', autoStart: false };
+        store.config.save(config);
+        const lib = enginesInstalling(['aider']);
+        const ensured = master.ensureMasterSession({ home, tmuxLib: fakeTmux({ alive: false }), enginesLib: lib });
+        const status = master.getMasterStatus({ tmuxLib: fakeTmux({ alive: true }), enginesLib: lib });
+        assert.equal(ensured.launchMode, status.settings.resolvedLaunchMode);
+      } finally {
+        config.master = saved;
+        store.config.save(config);
+      }
+    });
   });
 
   it('honors master.engine over defaultEngine, and reports instructional enforcement off-claude', () => {

--- a/test/master.test.js
+++ b/test/master.test.js
@@ -802,6 +802,22 @@ describe('ensureMasterSession — settings integration', () => {
       }
     });
 
+    it('ships each offered mode with its human label, not a bare id', () => {
+      // The project-settings picker renders `m.label || key`; a Master picker
+      // showing `acceptEdits` would be the visibly poorer of two controls doing
+      // the same job. Shipping the label here keeps the frontend from needing
+      // the engine profile at all.
+      const st = master.getMasterStatus({ tmuxLib: fakeTmux({ alive: true }), enginesLib: availableEngines });
+      assert.ok(st.settings.launchModes.length > 0, 'this fixture must offer modes, or it proves nothing');
+      for (const m of st.settings.launchModes) {
+        assert.equal(typeof m.id, 'string');
+        assert.equal(typeof m.label, 'string');
+        assert.ok(m.label.length, `${m.id} must carry a label`);
+      }
+      const def = st.settings.launchModes.find((m) => m.id === 'default');
+      assert.ok(def && def.label !== 'default', 'the label must come from the engine profile, not echo the id');
+    });
+
     it('ensure and status agree on the mode that will run', () => {
       // The lockstep hazard `_masterRuntime` exists to prevent: the settings
       // modal must never show one mode while the session launches another.

--- a/test/master.test.js
+++ b/test/master.test.js
@@ -816,6 +816,19 @@ describe('ensureMasterSession — settings integration', () => {
       }
       const def = st.settings.launchModes.find((m) => m.id === 'default');
       assert.ok(def && def.label !== 'default', 'the label must come from the engine profile, not echo the id');
+
+      // The SAFETY half, which the label assertions above do not cover:
+      // data/engines/claude.json marks bypassPermissions with a warning, and
+      // dropping it server-side would leave the picker unable to render ⚠ no
+      // matter what the frontend does.
+      const bypass = st.settings.launchModes.find((m) => m.id === 'bypassPermissions');
+      assert.ok(bypass, 'claude offers bypassPermissions, or this fixture proves nothing');
+      assert.ok(bypass.warning && bypass.warning.length,
+        'a warned mode must carry its warning to the client');
+      assert.ok(bypass.description && bypass.description.length,
+        'and its description');
+      const plain = st.settings.launchModes.find((m) => m.id === 'default');
+      assert.equal(plain.warning, null, 'an unwarned mode carries null, not a missing field');
     });
 
     it('ensure and status agree on the mode that will run', () => {

--- a/test/master.test.js
+++ b/test/master.test.js
@@ -802,6 +802,82 @@ describe('ensureMasterSession — settings integration', () => {
       }
     });
 
+    it('WARNS on the launch path when the stored mode is not honored', () => {
+      // This warn IS the R-24 fix. The debug line in `_masterRuntime` writes
+      // nothing on a default install (logger defaults to `info`), so the launch
+      // path is the only place the degrade is actually recorded — and nothing
+      // asserted it. The sibling warn in lib/sessions.js is pinned by
+      // test/codex-launch-modes.test.js against a DIFFERENT string
+      // ("not honored by this engine"), so it cannot stand in for this one.
+      const logger = require('../lib/logger');
+      const captured = [];
+      const priorLevel = 'error';
+      logger.setLevel('warn');
+      logger.setConsoleStream({ write: (s) => captured.push(s) });
+      const config = store.config.load();
+      const saved = config.master;
+      try {
+        config.master = { accessLevel: 'read-only', engine: 'aider', launchMode: 'acceptEdits', scope: 'all', autoStart: false };
+        store.config.save(config);
+        master.ensureMasterSession({
+          home, tmuxLib: fakeTmux({ alive: false }), enginesLib: enginesInstalling(['aider'])
+        });
+        assert.match(captured.join(''), /not honored by the resolved engine/,
+          'a stranded mode must leave a record on the path where it actually bites');
+        assert.match(captured.join(''), /acceptEdits/, 'naming what was stored');
+      } finally {
+        config.master = saved;
+        store.config.save(config);
+        logger.setConsoleStream(null);
+        logger.setLevel(priorLevel);
+      }
+    });
+
+    it('records the stranded mode on the STATUS path too, at debug', () => {
+      // The polled path's counterpart to the launch warn. Debug because
+      // `getMasterStatus` runs on every poll and a warn there would report a
+      // stable condition at the poll's cadence (#906). Asserted at debug level
+      // because that is the only level at which it is observable at all.
+      const logger = require('../lib/logger');
+      const captured = [];
+      logger.setLevel('debug');
+      logger.setConsoleStream({ write: (s) => captured.push(s) });
+      const config = store.config.load();
+      const saved = config.master;
+      try {
+        config.master = { accessLevel: 'read-only', engine: 'aider', launchMode: 'acceptEdits', scope: 'all', autoStart: false };
+        store.config.save(config);
+        master.getMasterStatus({ tmuxLib: fakeTmux({ alive: true }), enginesLib: enginesInstalling(['aider']) });
+        assert.match(captured.join(''), /not honored by the resolved engine/);
+      } finally {
+        config.master = saved;
+        store.config.save(config);
+        logger.setConsoleStream(null);
+        logger.setLevel('error');
+      }
+    });
+
+    it('does NOT warn when the stored mode is honored', () => {
+      // The negative case: a warn that always fires is not a signal.
+      const logger = require('../lib/logger');
+      const captured = [];
+      logger.setLevel('warn');
+      logger.setConsoleStream({ write: (s) => captured.push(s) });
+      const config = store.config.load();
+      const saved = config.master;
+      try {
+        config.master = { accessLevel: 'read-only', engine: 'claude', launchMode: 'acceptEdits', scope: 'all', autoStart: false };
+        store.config.save(config);
+        master.ensureMasterSession({ home, tmuxLib: fakeTmux({ alive: false }), enginesLib: availableEngines });
+        assert.doesNotMatch(captured.join(''), /not honored by the resolved engine/);
+      } finally {
+        config.master = saved;
+        store.config.save(config);
+        logger.setConsoleStream(null);
+        logger.setLevel('error');
+      }
+    });
+
     it('ships each offered mode with its human label, not a bare id', () => {
       // The project-settings picker renders `m.label || key`; a Master picker
       // showing `acceptEdits` would be the visibly poorer of two controls doing


### PR DESCRIPTION
## What

Closes **#756** — the first car of the **Master Control** milestone (#829) to land.

Every project has had the per-engine launch-mode axis (`default` / `acceptEdits` / `plan` / `bypassPermissions` and their per-engine siblings). The Master had it at no layer: `lib/master.js` built its session with a hardcoded `null`, so it always started in whatever bare default its engine gave and there was no way to change it.

## Why the old `null` was wrong, not just missing

It carried a comment justifying it as *"part of the read-only posture"*. That conflated two independent axes:

| | Governs | Enforced by |
|---|---|---|
| **Launch mode** (this) | whether the agent prompts inside **its own session** | the engine |
| **Access level** (#755) | what the Master may do to **the fleet** | TangleClaw, server-side |

A read-only Master in `bypassPermissions` is coherent — it edits its own `memory/` without nagging and still cannot touch the fleet. A `write` Master in `default` is equally coherent. The comment now says what the code does.

## Stored is not resolved, and both travel

Reconciled in `_masterRuntime` — the one place that already resolves engine and enforcement — because the settings modal and the launching session must not be able to disagree. That is the lockstep hazard the function's own docstring names.

- A mode the effective engine cannot honor degrades to `default` **at launch**.
- It is **not** flattened at rest: it stays stored, stays selected in the picker, and is labelled as unavailable alongside what will actually run. Switching engines and back restores the operator's choice.
- `validateMasterPatch` therefore validates by **name**, against the union of every installed engine's modes rather than whichever engine is resolved right now — otherwise the setting's validity would depend on unrelated state. What it refuses is a mode no engine defines, which is a typo rather than a preference.

The picker renders only what the server says the engine offers, never a list the frontend derived for itself (the third-source-of-truth failure #768 names), and an engine offering nothing yields an honest sentence rather than an empty select. `write` + `bypassPermissions` is called out where it is chosen — #756's bar is that it be selectable but never reachable unnoticed.

## Test plan

- Suite **6242 pass / 0 fail / 1 skipped** (+18 from the 6224 baseline at `2fd859b`).
- **Eleven mutations run**, all red, all green on restore: mode not passed to the launch command; reconcile removed; stored mode ignored; status reporting stored-as-resolved; `launchMode` not settable; unknown mode accepted; `launchMode` dropped from the stored value; modes re-derived in the frontend; stranded mode dropped; a mode guessed when no picker exists; the dangerous combination left unremarked.
- New `test/master-launch-mode.test.js` **lifts and runs** the real `renderMasterSettingsBody` and `saveMasterSettings` rather than regex-matching source — the existing master-settings suite is source-pinned (backlog TST-6L2P), and a source pin cannot tell a rendered option from a string that merely appears in the file.
- Backend assertions pin the **CLI flags** that reach the launch command, not the argument handed to a spy: the engine profile is what turns a mode id into `--permission-mode acceptEdits`, so a test stopping at the call boundary would pass even if the mode never reached the CLI.
- Two existing assertions widened for the new normalized field — both were "the master block has exactly these keys", not relaxed checks.
- `public/` work done in a git worktree, per the live-install rule. No `CACHE_NAME` bump.

## Not in scope

**#768 stays open.** Three of its five controls have no Master-side API (Upload and Medusa have no route, Kill no endpoint) and access level is blocked on #755. Plan for it: `.tangleclaw/plans/768-master-control-bar.md`.

Fixes #756