### PR TITLE
The fleet map says what each project is doing (#950)

### DIFF
--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -68,12 +68,28 @@ a failure for every non-repo project on the fleet, which is the exact invention 
 remove, one level down. Found by rendering the real `GET /api/projects` output rather than trusting
 the fixtures; now `not a git repository`, with its own guard.
 
-**Tests:** `test/master-fleet-map.test.js` (+17). Every honesty pair asserts the two render
+**Critic (cumulative `rev-20260816T220814Z-0f187352`): 0 blocking, 11 warning, 11 note.** Six warnings
+fixed in one batch, and three of them were the same defect class this change exists to remove:
+`version not established` manufactured an unknown out of a plain absence (mirror of the `git: null`
+correction); the identity-only banner promised the map refreshes "when the dashboard polls", which
+never writes it; and it could not say whether a missing state pass had failed or was still running.
+Also fixed: `refreshFleetMap` had no single-flight guard, so it queued behind the poll on the serial
+scanner and could earn a healthy project a false Full Disk Access hint (#884/#891); and — the
+sharpest one — calling it from `server.js` resolved `os.homedir()` regardless of any caller-supplied
+home, so `test/master.test.js`'s route test could overwrite the OPERATOR'S live
+`~/.tangleclaw/master/memory/FLEET.md`. The trigger moved into `refreshMasterIdentity`, where home is
+already resolved, behind an opt-in `fleetState` flag and an injectable `refreshFleet` seam, and both
+`server.js` call sites are gone. The decision to make `buildFleetMap` a second reader of the
+`incomplete`/`cause` vocabulary — the only one outside the browser, since the `tc*` classifiers are
+browser globals returning DOM-shaped records — is recorded in `boundary-patterns.md` with the
+obligation it creates: a new cause token now needs a row in two places.
+
+**Tests:** `test/master-fleet-map.test.js` (+25). Every honesty pair asserts the two render
 DIFFERENTLY, not merely that each contains a string — a `notEqual` on the rendered line, because the
-defect class here is flattening, not omission. Five mutations confirmed red before the guards were
-kept (flatten unknown liveness, render an unread tree as clean, treat raw rows as stateful, drop the
+defect class here is flattening, not omission. Nine mutations confirmed red before the guards were kept, four of them against the finding-fixes
+themselves (flatten unknown liveness, render an unread tree as clean, treat raw rows as stateful, drop the
 no-master-home guard, restore the "git could not be read" wording). Fixtures verified against the
-real shape by rendering the live fleet through them. Full suite **6278 pass / 0 fail / 1 skip**.
+real shape by rendering the live fleet through them. Full suite **6285 pass / 0 fail / 1 skip**.
 
 ## 2026-08-16: the Master settings modal becomes a component both pages can mount (#768 chunk 1)
 

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -40,9 +40,11 @@ needs none of that spec's rulings.
 **What changed:** `lib/master.js` gains `buildFleetMap(projects, {generatedAt})` — a PURE renderer,
 no filesystem/git/tmux/clock — plus `refreshFleetMap()`, async, which rides the enriched list
 `projects.listProjects()` already builds and writes only `FLEET.md`. `_refreshMasterMemory` now takes
-an optional `projects` and delegates rendering. Wired in `server.js` at boot (after the identity
-refresh) and on `POST /api/master/ensure`, both **unawaited** — neither boot nor an ensure response
-may wait on the whole fleet's git reads.
+an optional `projects` and delegates rendering. Triggered from `refreshMasterIdentity` behind an opt-in
+`fleetState` flag, so it resolves `home` exactly where every other write in that function does. The
+two production askers are `server.js` at boot and `lib/master.js#ensureMasterSession`; the pass is
+**unawaited** in both, since neither boot nor an ensure response may wait on the whole fleet's git
+reads. `server.js` calls `refreshFleetMap` nowhere — a test pins that.
 
 **The constraint that shaped it, and the estimate it corrected.** The spec called this "one
 function". It is not: `refreshMasterIdentity` is fully synchronous and runs at server boot, while the
@@ -93,9 +95,11 @@ project rendered as `not a git repository · no live session`, identical to an o
 against live data first and rejected — eight present projects report `not-applicable`, so that
 derivation would have declared them gone. (b) Nothing pinned either production wiring site: dropping
 `fleetState: true` at boot or in `ensureMasterSession` left the suite green. Both pinned, both
-mutation-confirmed. `ensureMasterSession` also forwards `refreshFleet` now, because ~15 of its tests
-were firing unawaited real fleet reads that spawned `tmux list-sessions` and raced their own temp-dir
-teardown — a hygiene regression this change introduced.
+mutation-confirmed. `ensureMasterSession` forwards a `refreshFleet` seam, and all 20 of its call
+sites in `test/master.test.js` now pass a no-op through it. Adding the seam without applying it —
+which is how this shipped at first — left every one of those tests firing an unawaited REAL fleet
+pass against temp project paths, racing the file's own teardown, and green only because the write
+failure was caught and the file logs at `error`. A test that passes for the wrong reason.
 
 **Carried, not dropped:** `listProjects` still has no cross-caller guard, so this module's
 single-flight does not stop it interleaving with the ten-second dashboard poll — a `lib/projects.js`

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -105,7 +105,7 @@ concern affecting that poll generally, recorded in `.prawduct/.handoff-notes.md`
 DIFFERENTLY, not merely that each contains a string — a `notEqual` on the rendered line, because the
 defect class here is flattening, not omission. Thirteen mutations confirmed red before the guards were kept, six of them against finding-fixes (flatten unknown liveness, render an unread tree as clean, treat raw rows as stateful, drop the
 no-master-home guard, restore the "git could not be read" wording). Fixtures verified against the
-real shape by rendering the live fleet through them. Full suite **6289 pass / 0 fail / 1 skip**.
+real shape by rendering the live fleet through them. Full suite green (TAP total 6291 including subtests; the evidence store's JUnit top-level count for the same tree is lower by reporter semantics, not by missing tests).
 
 ## 2026-08-16: the Master settings modal becomes a component both pages can mount (#768 chunk 1)
 

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -84,12 +84,28 @@ already resolved, behind an opt-in `fleetState` flag and an injectable `refreshF
 browser globals returning DOM-shaped records — is recorded in `boundary-patterns.md` with the
 obligation it creates: a new cause token now needs a row in two places.
 
-**Tests:** `test/master-fleet-map.test.js` (+25). Every honesty pair asserts the two render
+**Second review round (`verify-resolutions rev-20260816T222306Z-70954d1d`): 7 of 11 verified fixed, 4
+left unresolved and then closed.** Two mattered. (a) The comment justifying the version fix claimed
+the degraded path "always sets `unreadable`" — it does not: `lib/dir-scanner-child.js:231-235`
+returns `exists: false` with no `unreadable` for a directory that is simply gone. So a DELETED
+project rendered as `not a git repository · no live session`, identical to an ordinary idle one.
+`enrichProject` now carries `exists` (additive); deriving it from `governanceState` was checked
+against live data first and rejected — eight present projects report `not-applicable`, so that
+derivation would have declared them gone. (b) Nothing pinned either production wiring site: dropping
+`fleetState: true` at boot or in `ensureMasterSession` left the suite green. Both pinned, both
+mutation-confirmed. `ensureMasterSession` also forwards `refreshFleet` now, because ~15 of its tests
+were firing unawaited real fleet reads that spawned `tmux list-sessions` and raced their own temp-dir
+teardown — a hygiene regression this change introduced.
+
+**Carried, not dropped:** `listProjects` still has no cross-caller guard, so this module's
+single-flight does not stop it interleaving with the ten-second dashboard poll — a `lib/projects.js`
+concern affecting that poll generally, recorded in `.prawduct/.handoff-notes.md`.
+
+**Tests:** `test/master-fleet-map.test.js` (+29). Every honesty pair asserts the two render
 DIFFERENTLY, not merely that each contains a string — a `notEqual` on the rendered line, because the
-defect class here is flattening, not omission. Nine mutations confirmed red before the guards were kept, four of them against the finding-fixes
-themselves (flatten unknown liveness, render an unread tree as clean, treat raw rows as stateful, drop the
+defect class here is flattening, not omission. Thirteen mutations confirmed red before the guards were kept, six of them against finding-fixes (flatten unknown liveness, render an unread tree as clean, treat raw rows as stateful, drop the
 no-master-home guard, restore the "git could not be read" wording). Fixtures verified against the
-real shape by rendering the live fleet through them. Full suite **6285 pass / 0 fail / 1 skip**.
+real shape by rendering the live fleet through them. Full suite **6289 pass / 0 fail / 1 skip**.
 
 ## 2026-08-16: the Master settings modal becomes a component both pages can mount (#768 chunk 1)
 

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -26,6 +26,55 @@ Tag-line conventions (ART-4K9M, ratified 2026-07-17):
 -->
 
 
+## 2026-08-16: the fleet map says what each project is doing (#950)
+
+<!-- prawduct: type=feat | scope=fleet-map-state-950 | chunks=01 -->
+
+**Why:** `FLEET.md` is the Project Master's entire picture of the fleet, and it carried
+name · engine · path. Enough to say a project EXISTS, nothing about what it is DOING — not a basis
+for coordinating anything. Every field it should have carried was already computed for the dashboard
+poll and thrown away at the moment the file was written. This is build item 1 of the ratified Master
+startup/wrap spec (`.tangleclaw/plans/master-startup-and-wrap.md`), picked to go first because it
+needs none of that spec's rulings.
+
+**What changed:** `lib/master.js` gains `buildFleetMap(projects, {generatedAt})` — a PURE renderer,
+no filesystem/git/tmux/clock — plus `refreshFleetMap()`, async, which rides the enriched list
+`projects.listProjects()` already builds and writes only `FLEET.md`. `_refreshMasterMemory` now takes
+an optional `projects` and delegates rendering. Wired in `server.js` at boot (after the identity
+refresh) and on `POST /api/master/ensure`, both **unawaited** — neither boot nor an ensure response
+may wait on the whole fleet's git reads.
+
+**The constraint that shaped it, and the estimate it corrected.** The spec called this "one
+function". It is not: `refreshMasterIdentity` is fully synchronous and runs at server boot, while the
+state the map needs comes from `git.getInfo` (several `execSync` spawns per repo on a cold cache) and
+an async tmux snapshot. Adding that per project to the boot path is precisely the event-loop hazard
+`lib/dir-scanner.js` exists to prevent (#883/#884). Hence the split: the sync path keeps writing an
+identity-only map at no new cost, and the async sibling upgrades it. Whether state was gathered is
+DERIVED from the records (`_hasStateFields` tests for the KEY, not its value) rather than passed as a
+flag, because a flag can disagree with its data — and an enriched record whose read failed carries
+`git: null` while a raw row simply never had the key, which are different facts.
+
+**Honesty is the feature, not a side-effect.** The map preserves every distinction #941/#937/#920
+bought: "no live session" vs "liveness could not be established" (opposite situations for a
+coordinator — one is safe to act on, the other is when acting is most dangerous); "clean" vs
+"dirty-state unknown"; a branch read vs "branch not established". An unreadable directory reports
+once with its cause instead of as a row of separate unknowns. A pass that gathered no state prints a
+banner saying so, and that absence of a state line means nobody looked.
+
+**Caught on live data before it shipped:** the first draft rendered a null `git` as "git could not be
+read". `lib/dir-scanner-child.js#_gitInfo` returns null for "not a repository, or git is absent" and
+an OBJECT carrying `incomplete`/`cause` when a read genuinely fell short — so the draft manufactured
+a failure for every non-repo project on the fleet, which is the exact invention this change exists to
+remove, one level down. Found by rendering the real `GET /api/projects` output rather than trusting
+the fixtures; now `not a git repository`, with its own guard.
+
+**Tests:** `test/master-fleet-map.test.js` (+17). Every honesty pair asserts the two render
+DIFFERENTLY, not merely that each contains a string — a `notEqual` on the rendered line, because the
+defect class here is flattening, not omission. Five mutations confirmed red before the guards were
+kept (flatten unknown liveness, render an unread tree as clean, treat raw rows as stateful, drop the
+no-master-home guard, restore the "git could not be read" wording). Fixtures verified against the
+real shape by rendering the live fleet through them. Full suite **6278 pass / 0 fail / 1 skip**.
+
 ## 2026-08-16: the Master settings modal becomes a component both pages can mount (#768 chunk 1)
 
 <!-- prawduct: type=refactor | scope=master-settings-component-768 | chunks=01 -->

--- a/.prawduct/change-log.md
+++ b/.prawduct/change-log.md
@@ -109,7 +109,11 @@ concern affecting that poll generally, recorded in `.prawduct/.handoff-notes.md`
 DIFFERENTLY, not merely that each contains a string — a `notEqual` on the rendered line, because the
 defect class here is flattening, not omission. Thirteen mutations confirmed red before the guards were kept, six of them against finding-fixes (flatten unknown liveness, render an unread tree as clean, treat raw rows as stateful, drop the
 no-master-home guard, restore the "git could not be read" wording). Fixtures verified against the
-real shape by rendering the live fleet through them. Full suite green (TAP total 6291 including subtests; the evidence store's JUnit top-level count for the same tree is lower by reporter semantics, not by missing tests).
+real shape by rendering the live fleet through them — which caught the `git: null` invention but NOT
+three fixtures carrying an `unreadableCode` no producer emits, nor a pair whose two fields were the
+same string and so left the code-rendering branch vacuous. Rendering live data proves the shapes you
+happen to have; it does not prove the ones you wrote by hand. Both were caught by review, and the
+fixtures now use the producer's real message-plus-code pair. Full suite green (TAP total 6291 including subtests; the evidence store's JUnit top-level count for the same tree is lower by reporter semantics, not by missing tests).
 
 ## 2026-08-16: the Master settings modal becomes a component both pages can mount (#768 chunk 1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,12 @@ All notable changes to TangleClaw are documented in this file.
   for a coordinator is the difference between "nothing to do here" and "this is gone". A failed scan
   still reports as a failed scan; `unreadable` is what separates the two.
 
+  **A degraded read never hides a live session.** Session liveness does not depend on the project's
+  directory — a tmux pane can be attached to a checkout that has been deleted, or to one the server
+  is not permitted to read. Both of those branches report the directory problem *and* the session,
+  rather than letting the directory's state swallow it; a pane attached to a project that is gone is
+  the case most worth surfacing, not the one to hide.
+
   **Concurrency.** `refreshFleetMap` is single-flight. `listProjects` is the path the ten-second
   dashboard poll already drives, and `lib/dir-scanner.js` starts each request's deadline at *issue*
   time against a serial child — so a second unsynchronized caller's reads queue while their clocks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,15 @@ All notable changes to TangleClaw are documented in this file.
   master home exists — so it cannot create master state for an operator who has never opened the
   Master. The renderer, `master.buildFleetMap()`, is pure: no filesystem, no git, no tmux, no clock.
 
+  **A deleted project no longer reads as an idle one.** `enrichProject` now carries `exists` through
+  (additive), because the fields already on the record cannot answer it: `governanceState:
+  'not-applicable'` is also what a present-but-ungoverned project reports — eight of them on this
+  machine — so deriving absence from it would have declared live projects gone. A registered path
+  that is not there now says `DIRECTORY MISSING`, where before it rendered as
+  `not a git repository · no live session`: indistinguishable from an ordinary idle project, which
+  for a coordinator is the difference between "nothing to do here" and "this is gone". A failed scan
+  still reports as a failed scan; `unreadable` is what separates the two.
+
   **Concurrency.** `refreshFleetMap` is single-flight. `listProjects` is the path the ten-second
   dashboard poll already drives, and `lib/dir-scanner.js` starts each request's deadline at *issue*
   time against a serial child — so a second unsynchronized caller's reads queue while their clocks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,13 @@ All notable changes to TangleClaw are documented in this file.
   master home exists — so it cannot create master state for an operator who has never opened the
   Master. The renderer, `master.buildFleetMap()`, is pure: no filesystem, no git, no tmux, no clock.
 
+  **Concurrency.** `refreshFleetMap` is single-flight. `listProjects` is the path the ten-second
+  dashboard poll already drives, and `lib/dir-scanner.js` starts each request's deadline at *issue*
+  time against a serial child — so a second unsynchronized caller's reads queue while their clocks
+  run, and a healthy project can burn its deadline waiting its turn and earn the Full Disk Access
+  hint it did not deserve (#884/#891). Concurrent callers coalesce onto one read; the latch releases
+  on failure too, so a thrown read cannot freeze the map for the life of the process.
+
   Groundwork for the ratified Master startup/wrap spec
   (`.tangleclaw/plans/master-startup-and-wrap.md`), whose next item compares this file's
   `generated-at` stamp against the Master's own `observed-at` notes to compute memory drift.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **The Project Master's fleet map says what each project is doing, not just that it exists (#950).**
+  `FLEET.md` — the Master's whole picture of the fleet it coordinates — carried three fields per
+  project: name, engine, path. It could tell the Master a project existed and nothing about its
+  state, which is not a basis for coordinating anything. A map that lists doors without saying which
+  rooms have anyone in them.
+
+  It now carries version, branch, working-tree state, session liveness and last-commit age. None of
+  that required new scanning: every field was already computed for the dashboard poll and discarded
+  at the moment the file was written.
+
+  **Unknowns stay unknowns.** The map inherits the tri-state vocabulary from #941/#937/#920, and the
+  distinctions it preserves are the ones a coordinator acts on: "no live session" and "liveness could
+  not be established" are opposite situations — one is safe to act on, the other is exactly when
+  acting is most dangerous — and they now render differently. Same for a clean tree versus one whose
+  dirtiness was never read, and for a branch read versus a branch not established. An unreadable
+  project directory reports once, with its cause, instead of as a row of separate unknowns.
+
+  **A pass that gathered no state says so.** `refreshMasterIdentity` is synchronous and runs at
+  server boot; it must never grow per-project git or tmux work, because that is the event-loop
+  hazard the forked scanner exists to prevent (#883/#884). So the boot pass still writes an
+  identity-only map — but it now declares itself as identity-only, and states that a missing state
+  line means nobody looked rather than that there is nothing to report. Whether state was gathered is
+  derived from the records themselves, never passed as a flag that could disagree with its data.
+
+  The state half is a new `master.refreshFleetMap()`, async, riding the enriched list
+  `projects.listProjects()` already builds. It is called (not awaited) after the boot identity
+  refresh and on `POST /api/master/ensure`, writes only `FLEET.md`, and does nothing at all when no
+  master home exists — so it cannot create master state for an operator who has never opened the
+  Master. The renderer, `master.buildFleetMap()`, is pure: no filesystem, no git, no tmux, no clock.
+
+  Groundwork for the ratified Master startup/wrap spec
+  (`.tangleclaw/plans/master-startup-and-wrap.md`), whose next item compares this file's
+  `generated-at` stamp against the Master's own `observed-at` notes to compute memory drift.
+
 ### Internal
 
 - **The Master settings modal became a mountable component (#768, chunk 1 of 3).** The modal — the

--- a/lib/master.js
+++ b/lib/master.js
@@ -658,6 +658,12 @@ function buildFleetMap(projects, options = {}) {
         // unknown rather than absent. Say that once instead of repeating it.
         bits.push(`state unknown — could not read the project directory (${p.unreadable})`);
         if (p.unreadableCode) bits.push(p.unreadableCode);
+        // Same reasoning as the missing-directory branch above, applied to the
+        // sibling case: liveness is no more dependent on a READABLE directory
+        // than on an existing one. A pane can be attached to a project whose
+        // folder is permission-blocked, and that is worth surfacing next to the
+        // reason its other state is unknown.
+        bits.push(_fleetSessionBit(p.session));
       } else {
         // A null version on a directory that is THERE and readable is a plain
         // absence — the project has no version file. The two paths that null it

--- a/lib/master.js
+++ b/lib/master.js
@@ -648,6 +648,11 @@ function buildFleetMap(projects, options = {}) {
         // ordinary idle one, which for a coordinator is the difference between
         // "nothing to do here" and "this is gone".
         bits.push('DIRECTORY MISSING — the registered path is not there');
+        // Session liveness does NOT depend on the directory: a tmux session can
+        // outlive a deleted checkout, and a coordinator told only "directory
+        // missing" would not know a pane is still attached to it. Reported
+        // alongside rather than suppressed.
+        bits.push(_fleetSessionBit(p.session));
       } else if (p.unreadable) {
         // The directory itself did not answer, so every field below it is
         // unknown rather than absent. Say that once instead of repeating it.
@@ -1029,8 +1034,6 @@ function ensureMasterSession(options = {}) {
  * is no DB row to drift from reality.
  * @param {object} [options]
  * @param {object} [options.tmuxLib] - tmux module override (tests)
- * @param {Function} [options.refreshFleet] - Fleet refresher override (tests); see
- *   {@link refreshMasterIdentity}. Without it a test fires a real fleet read.
  * @param {object} [options.enginesLib] - engines module override (tests); the
  *   reported engine is resolved against what is installed, so a stub that does
  *   not answer resolution makes this depend on the host's CLIs.

--- a/lib/master.js
+++ b/lib/master.js
@@ -624,9 +624,14 @@ function buildFleetMap(projects, options = {}) {
     lines.push(
       '**Identity only in this pass.** Branch, working-tree state, session liveness and version',
       'were not gathered — this refresh ran on the synchronous path, which deliberately does no',
-      'per-project git or tmux work. The map refreshes with state when the dashboard polls or the',
-      'master starts. Absence of a state line below means nobody looked, NOT that there is nothing',
-      'to report.',
+      'per-project git or tmux work. Absence of a state line below means nobody looked, NOT that',
+      'there is nothing to report.',
+      '',
+      'A state pass is started whenever the master is refreshed — at server boot and when the master',
+      'session is opened — and rewrites this file when it completes. **If you are reading this banner',
+      'in a running install, that pass has either not finished yet or it failed**; the two are not',
+      'distinguishable from here, and a failure is logged server-side rather than written here.',
+      'Re-open the master to start another.',
       ''
     );
   }
@@ -643,7 +648,13 @@ function buildFleetMap(projects, options = {}) {
         bits.push(`state unknown — could not read the project directory (${p.unreadable})`);
         if (p.unreadableCode) bits.push(p.unreadableCode);
       } else {
-        bits.push(p.version ? `v${p.version}` : 'version not established');
+        // A null version on a READABLE directory is a plain absence — the
+        // project has no version file. Only the degraded path nulls it for a
+        // reason, and that path always sets `unreadable`, which the branch
+        // above already caught. Saying "not established" here would manufacture
+        // an unknown out of a nothing, which is the mirror of the invention
+        // this map exists to remove.
+        if (p.version) bits.push(`v${p.version}`);
         bits.push(..._fleetGitBits(p.git));
         bits.push(_fleetSessionBit(p.session));
       }
@@ -750,6 +761,11 @@ function _refreshMasterMemory(home, options = {}) {
  * @param {object} [options]
  * @param {string} [options.home] - Master home override (tests)
  * @param {object} [options.enginesLib] - engines module override (tests)
+ * @param {boolean} [options.fleetState] - Also start the async pass that fills
+ *   `FLEET.md` with per-project state. Opt-in: most callers here are tests that
+ *   want the file writes and nothing else, and an always-on read would make
+ *   every one of them enumerate the real fleet.
+ * @param {Function} [options.refreshFleet] - Fleet refresher override (tests).
  * @param {boolean} [options.skipIfAbsent] - Do nothing if the master home does
  *   not exist. Boot uses this so an operator who has never opened the master
  *   does not get master state created as a side effect of starting the server.
@@ -771,9 +787,31 @@ function refreshMasterIdentity(options = {}) {
     rules: store.sessionRules.listActiveForMaster(),
     scope: _resolveScope(settings.scope)
   }));
-  _refreshMasterMemory(home);
+  _refreshMasterMemory(home, { generatedAt: new Date().toISOString() });
 
   if (enforcement === 'structural') _writeMasterGuardrails(home);
+
+  // The state half, opt-in and deliberately not awaited.
+  //
+  // It lives HERE rather than at the server's call sites so it resolves `home`
+  // from the same place everything else in this function does. A caller that
+  // passes a test home gets the fleet map written into that test home; a route
+  // test that stubs this module's entry points gets no fleet read at all. The
+  // earlier shape called it directly from `server.js`, where it resolved
+  // `os.homedir()` regardless — which let a route test overwrite the operator's
+  // real `~/.tangleclaw/master/memory/FLEET.md`.
+  //
+  // Opt-in because most callers of this function are tests that want file
+  // writes and nothing else; only the two production entry points ask for it.
+  if (options.fleetState) {
+    // Injectable like `enginesLib`/`tmuxLib` above, and for the same reason: the
+    // internal call cannot be reached by reassigning the export, so without a
+    // seam the wiring is untestable and would ship on the strength of a comment.
+    const refresh = options.refreshFleet || refreshFleetMap;
+    refresh({ home })
+      .then((r) => { if (r.refreshed) log.debug('Fleet map refreshed with state', { count: r.count }); })
+      .catch((err) => log.warn('Fleet map state refresh failed', { error: err.message }));
+  }
 
   return { home, refreshed: true };
 }
@@ -803,19 +841,44 @@ function refreshMasterIdentity(options = {}) {
  * @returns {Promise<{home: string, refreshed: boolean, count: number}>}
  *   `refreshed: false` when there is no master home to write into.
  */
+let _fleetRefreshInFlight = null;
+
 async function refreshFleetMap(options = {}) {
   const home = options.home || masterHome();
   const memDir = path.join(home, 'memory');
   if (!fs.existsSync(memDir)) return { home, refreshed: false, count: 0 };
 
+  // SINGLE-FLIGHT, and not merely for tidiness. `listProjects` is the same path
+  // the ten-second dashboard poll drives, and `lib/dir-scanner.js` starts each
+  // request's deadline at ISSUE time against a SERIAL child — so a second
+  // caller's reads queue behind the first while their clocks run, and a
+  // perfectly healthy project can burn its deadline waiting its turn, get
+  // killed, and earn the Full Disk Access hint it did not deserve (the
+  // #884/#891 family). Coalescing keeps this module to one outstanding fleet
+  // read no matter how many times the master is opened.
+  //
+  // Callers awaiting a coalesced run get the in-flight result, which is a
+  // slightly older map rather than a second scan — the right trade for a file
+  // that is regenerated rather than accumulated.
+  if (_fleetRefreshInFlight) return _fleetRefreshInFlight;
+
   const lister = options.listProjects
     || ((opts) => require('./projects').listProjects(opts));
-  const projects = await lister({ archived: true });
-  fs.writeFileSync(
-    path.join(memDir, 'FLEET.md'),
-    buildFleetMap(projects, { generatedAt: options.generatedAt || new Date().toISOString() })
-  );
-  return { home, refreshed: true, count: projects.length };
+
+  _fleetRefreshInFlight = (async () => {
+    const projects = await lister({ archived: true });
+    fs.writeFileSync(
+      path.join(memDir, 'FLEET.md'),
+      buildFleetMap(projects, { generatedAt: options.generatedAt || new Date().toISOString() })
+    );
+    return { home, refreshed: true, count: projects.length };
+  })();
+
+  try {
+    return await _fleetRefreshInFlight;
+  } finally {
+    _fleetRefreshInFlight = null;
+  }
 }
 
 /**
@@ -844,7 +907,8 @@ function ensureMasterSession(options = {}) {
   const config = store.config.load();
   const { settings, engineId, enforcement, launchMode } = _masterRuntime(config, eng);
 
-  refreshMasterIdentity({ home, enginesLib: eng });
+  // Opening the master is exactly when its fleet map most needs to be current.
+  refreshMasterIdentity({ home, enginesLib: eng, fleetState: true });
 
   const base = { tmuxSession: MASTER_TMUX_SESSION, home, engine: engineId, accessLevel: settings.accessLevel, enforcement, launchMode };
 

--- a/lib/master.js
+++ b/lib/master.js
@@ -497,35 +497,191 @@ function _writeMasterGuardrails(home) {
   fs.writeFileSync(path.join(claudeDir, 'settings.json'), JSON.stringify(settings, null, 2) + '\n');
 }
 
+// ── The fleet map ──
+// FLEET.md is the master's whole picture of what it coordinates. It used to
+// carry name, engine and path — enough to say a project EXISTS, and nothing
+// about what it is DOING, which is not a basis for coordinating anything.
+//
+// It now renders whatever state the caller managed to gather, and says plainly
+// where it gathered none. Two callers, deliberately different:
+//
+//   - `_refreshMasterMemory` runs inside `refreshMasterIdentity`, which is
+//     SYNCHRONOUS and runs at server boot. It passes the raw store rows. It
+//     must never grow per-project git or tmux work: `git.getInfo` is several
+//     `execSync` spawns per repository on a cold cache, and doing that across
+//     the fleet on the event loop is the hazard the forked scanner exists to
+//     prevent (#883/#884).
+//   - `refreshFleetMap` is async and rides the enriched list the dashboard poll
+//     already computes, so full state costs no new scanning at all.
+//
+// Which one wrote the file is derived from the records themselves rather than
+// passed as a flag, because a flag can disagree with its data.
+
+/**
+ * Does this record carry the enriched state fields, or is it a raw store row?
+ *
+ * Tests for the KEY, not its value: an enriched record whose read failed
+ * carries `git: null` / `session: null`, and that is a different fact from a
+ * raw row where nobody looked. Collapsing the two is how a map starts claiming
+ * a project has no session when nothing ever asked.
+ *
+ * @param {object} p - A project record.
+ * @returns {boolean} True when state was gathered for this record.
+ */
+function _hasStateFields(p) {
+  return Object.prototype.hasOwnProperty.call(p, 'session')
+    || Object.prototype.hasOwnProperty.call(p, 'git');
+}
+
+/**
+ * The git half of a project's line.
+ *
+ * `incomplete` names the fields the read could not establish and is present
+ * (empty) on the healthy object too, so this reads its contents rather than
+ * probing for its existence — the contract `lib/git.js` and `lib/projects.js`
+ * both state.
+ *
+ * @param {object|null} git - The record's `git` payload.
+ * @returns {string[]} Zero or more display segments.
+ */
+function _fleetGitBits(git) {
+  // A null `git` is NOT a failed read. `lib/dir-scanner-child.js#_gitInfo`
+  // returns null when the directory is not a repository (or git is absent) and
+  // returns an OBJECT carrying `incomplete`/`cause` when a read genuinely fell
+  // short. Reporting "could not be read" here would manufacture a failure for
+  // every non-repo project on the fleet — the same invention this whole change
+  // exists to remove, one level down.
+  if (!git) return ['not a git repository'];
+  const incomplete = Array.isArray(git.incomplete) ? git.incomplete : [];
+  const bits = [];
+
+  if (incomplete.includes('branch') || !git.branch) {
+    bits.push(`branch not established${git.cause ? ` (${git.cause})` : ''}`);
+  } else {
+    bits.push(git.branch);
+  }
+
+  // `dirty` is a tri-state: true, false, or null for "the read did not get
+  // there". Rendering null as clean is the exact substitution #920's family is
+  // about — it would tell the master a tree is safe to act on when nobody knows.
+  if (incomplete.includes('dirty') || git.dirty === null || git.dirty === undefined) {
+    bits.push('dirty-state unknown');
+  } else {
+    bits.push(git.dirty ? 'DIRTY' : 'clean');
+  }
+
+  if (git.lastCommitAge) bits.push(`last commit ${git.lastCommitAge}`);
+  return bits;
+}
+
+/**
+ * The session half of a project's line.
+ *
+ * @param {object|null} session - The record's `session` payload.
+ * @returns {string} One display segment.
+ */
+function _fleetSessionBit(session) {
+  if (!session) return 'no live session';
+  // `active: null` with `incomplete: ['active']` means the read did not happen.
+  // It is falsy, so a consumer testing truthiness behaves as it always did;
+  // this consumer wants the distinction, so it reads `incomplete`.
+  const incomplete = Array.isArray(session.incomplete) ? session.incomplete : [];
+  if (incomplete.includes('active') || session.active === null) {
+    return `session liveness could not be established${session.cause ? ` (${session.cause})` : ''}`;
+  }
+  if (!session.active) return 'no live session';
+  return session.startedAt
+    ? `session LIVE since ${session.startedAt}`
+    : 'session LIVE';
+}
+
+/**
+ * Render the fleet map.
+ *
+ * PURE — no filesystem, no tmux, no git, no clock. Everything it reports comes
+ * from the records it is handed, which is what lets the guards drive it with
+ * fixtures shaped like `listProjects` output instead of standing up a fleet.
+ *
+ * @param {object[]} projects - Raw store rows or enriched records; the two may
+ *   be mixed, and each line reports only what its own record established.
+ * @param {object} [options] - Render options.
+ * @param {string} [options.generatedAt] - ISO stamp for the header. The master's
+ *   drift check compares this against its own `observed-at` notes, so it is an
+ *   input rather than read from the clock here.
+ * @returns {string} The complete file body.
+ */
+function buildFleetMap(projects, options = {}) {
+  const list = Array.isArray(projects) ? projects : [];
+  const anyState = list.some(_hasStateFields);
+  const lines = [
+    '<!-- Generated by TangleClaw — refreshed on every master ensure; do not edit. -->',
+    ''
+  ];
+  if (options.generatedAt) lines.push(`<!-- generated-at: ${options.generatedAt} -->`, '');
+  lines.push('# Fleet map', '', 'Every project registered on this TangleClaw instance.', '');
+
+  if (!anyState && list.length > 0) {
+    lines.push(
+      '**Identity only in this pass.** Branch, working-tree state, session liveness and version',
+      'were not gathered — this refresh ran on the synchronous path, which deliberately does no',
+      'per-project git or tmux work. The map refreshes with state when the dashboard polls or the',
+      'master starts. Absence of a state line below means nobody looked, NOT that there is nothing',
+      'to report.',
+      ''
+    );
+  }
+
+  for (const p of list) {
+    const bits = [];
+    // An enriched record names its engine object; a raw row names only the id.
+    bits.push((p.engine && p.engine.id) || p.engineId || 'no engine');
+
+    if (_hasStateFields(p)) {
+      if (p.unreadable) {
+        // The directory itself did not answer, so every field below it is
+        // unknown rather than absent. Say that once instead of repeating it.
+        bits.push(`state unknown — could not read the project directory (${p.unreadable})`);
+        if (p.unreadableCode) bits.push(p.unreadableCode);
+      } else {
+        bits.push(p.version ? `v${p.version}` : 'version not established');
+        bits.push(..._fleetGitBits(p.git));
+        bits.push(_fleetSessionBit(p.session));
+      }
+    }
+
+    bits.push(p.path);
+    if (p.archived) bits.push('ARCHIVED');
+    lines.push(`- **${p.name}** — ${bits.join(' · ')}`);
+  }
+
+  if (list.length === 0) lines.push('*(no projects registered)*');
+  lines.push('');
+  return lines.join('\n');
+}
+
 /**
  * Scaffold and refresh the master's memory directory. TC-maintained files
  * (`FLEET.md` fleet map, `HOWTO.md` operational how-tos) are overwritten on
  * every ensure — same contract as the CLAUDE.md identity. Master-maintained
  * files (`MEMORY.md` index, `CHANGELOG.md` activity log, `NOTES.md`) are
  * seeded once when absent and never touched again.
+ *
  * @param {string} home - Absolute master home path
+ * @param {object} [options] - Options.
+ * @param {object[]} [options.projects] - Records to render the fleet map from.
+ *   Defaults to the raw store rows, which carry no state — see the fleet-map
+ *   header comment for why this path must stay free of git and tmux work.
+ * @param {string} [options.generatedAt] - ISO stamp for the map header.
  */
-function _refreshMasterMemory(home) {
+function _refreshMasterMemory(home, options = {}) {
   const memDir = path.join(home, 'memory');
   fs.mkdirSync(memDir, { recursive: true });
 
-  const projects = store.projects.list({ archived: true });
-  const fleetLines = [
-    '<!-- Generated by TangleClaw — refreshed on every master ensure; do not edit. -->',
-    '',
-    '# Fleet map',
-    '',
-    'Every project registered on this TangleClaw instance.',
-    ''
-  ];
-  for (const p of projects) {
-    const bits = [p.engineId || 'no engine', p.path];
-    if (p.archived) bits.push('ARCHIVED');
-    fleetLines.push(`- **${p.name}** — ${bits.join(' · ')}`);
-  }
-  if (projects.length === 0) fleetLines.push('*(no projects registered)*');
-  fleetLines.push('');
-  fs.writeFileSync(path.join(memDir, 'FLEET.md'), fleetLines.join('\n'));
+  const projects = options.projects || store.projects.list({ archived: true });
+  fs.writeFileSync(
+    path.join(memDir, 'FLEET.md'),
+    buildFleetMap(projects, { generatedAt: options.generatedAt })
+  );
 
   fs.writeFileSync(path.join(memDir, 'HOWTO.md'), [
     '<!-- Generated by TangleClaw — refreshed on every master ensure; do not edit. -->',
@@ -620,6 +776,46 @@ function refreshMasterIdentity(options = {}) {
   if (enforcement === 'structural') _writeMasterGuardrails(home);
 
   return { home, refreshed: true };
+}
+
+/**
+ * Rewrite `FLEET.md` with full per-project state.
+ *
+ * The state half of {@link refreshMasterIdentity}, kept separate because it
+ * cannot live on that function's synchronous path. It rides the enriched list
+ * `lib/projects.js#listProjects` already builds for the dashboard poll — one
+ * `tmux list-sessions` snapshot for the whole fleet and a `git.getInfo` per
+ * project inside the forked scanner — so full state costs no scanning this
+ * module would not otherwise have caused.
+ *
+ * Writes only `FLEET.md`. It never touches the master-owned files, and it does
+ * nothing at all when no master home exists, so calling it on boot cannot
+ * create master state for an operator who has never opened the master.
+ *
+ * `projects` is required lazily so importing this module does not pull the
+ * project subsystem in behind it, and so a test can drive the whole function
+ * without one.
+ *
+ * @param {object} [options] - Options.
+ * @param {string} [options.home] - Master home override (tests).
+ * @param {Function} [options.listProjects] - Async lister override (tests).
+ * @param {string} [options.generatedAt] - ISO stamp for the map header.
+ * @returns {Promise<{home: string, refreshed: boolean, count: number}>}
+ *   `refreshed: false` when there is no master home to write into.
+ */
+async function refreshFleetMap(options = {}) {
+  const home = options.home || masterHome();
+  const memDir = path.join(home, 'memory');
+  if (!fs.existsSync(memDir)) return { home, refreshed: false, count: 0 };
+
+  const lister = options.listProjects
+    || ((opts) => require('./projects').listProjects(opts));
+  const projects = await lister({ archived: true });
+  fs.writeFileSync(
+    path.join(memDir, 'FLEET.md'),
+    buildFleetMap(projects, { generatedAt: options.generatedAt || new Date().toISOString() })
+  );
+  return { home, refreshed: true, count: projects.length };
 }
 
 /**
@@ -839,6 +1035,8 @@ module.exports = {
   restoreDefaultMasterRules,
   ensureMasterSession,
   refreshMasterIdentity,
+  refreshFleetMap,
+  buildFleetMap,
   getMasterStatus,
   _resolveScope,
   _refreshMasterMemory,

--- a/lib/master.js
+++ b/lib/master.js
@@ -642,18 +642,27 @@ function buildFleetMap(projects, options = {}) {
     bits.push((p.engine && p.engine.id) || p.engineId || 'no engine');
 
     if (_hasStateFields(p)) {
-      if (p.unreadable) {
+      if (p.exists === false && !p.unreadable) {
+        // The directory is not there. Before this, a deleted project rendered as
+        // "not a git repository · no live session" — indistinguishable from an
+        // ordinary idle one, which for a coordinator is the difference between
+        // "nothing to do here" and "this is gone".
+        bits.push('DIRECTORY MISSING — the registered path is not there');
+      } else if (p.unreadable) {
         // The directory itself did not answer, so every field below it is
         // unknown rather than absent. Say that once instead of repeating it.
         bits.push(`state unknown — could not read the project directory (${p.unreadable})`);
         if (p.unreadableCode) bits.push(p.unreadableCode);
       } else {
-        // A null version on a READABLE directory is a plain absence — the
-        // project has no version file. Only the degraded path nulls it for a
-        // reason, and that path always sets `unreadable`, which the branch
-        // above already caught. Saying "not established" here would manufacture
-        // an unknown out of a nothing, which is the mirror of the invention
-        // this map exists to remove.
+        // A null version on a directory that is THERE and readable is a plain
+        // absence — the project has no version file. The two paths that null it
+        // for a reason are both caught above: a failed scan sets `unreadable`,
+        // and a missing directory sets `exists: false`. (An earlier version of
+        // this comment claimed the degraded path "always sets unreadable" — it
+        // does not; `lib/dir-scanner-child.js` returns `exists: false` with no
+        // `unreadable` for a directory that is simply gone, which is why that
+        // branch exists.) Saying "not established" here would manufacture an
+        // unknown out of a nothing.
         if (p.version) bits.push(`v${p.version}`);
         bits.push(..._fleetGitBits(p.git));
         bits.push(_fleetSessionBit(p.session));
@@ -896,6 +905,8 @@ async function refreshFleetMap(options = {}) {
  * @param {object} [options]
  * @param {string} [options.home] - Master home override (tests)
  * @param {object} [options.tmuxLib] - tmux module override (tests)
+ * @param {Function} [options.refreshFleet] - Fleet refresher override (tests); see
+ *   {@link refreshMasterIdentity}. Without it a test fires a real fleet read.
  * @param {object} [options.enginesLib] - engines module override (tests)
  * @returns {{created: boolean, tmuxSession: string, home: string, engine?: string, accessLevel?: string, enforcement?: string, error?: string}}
  */
@@ -908,7 +919,12 @@ function ensureMasterSession(options = {}) {
   const { settings, engineId, enforcement, launchMode } = _masterRuntime(config, eng);
 
   // Opening the master is exactly when its fleet map most needs to be current.
-  refreshMasterIdentity({ home, enginesLib: eng, fleetState: true });
+  // `refreshFleet` is forwarded so a test can neutralise the fleet pass; without
+  // it every ensureMasterSession test fires an unawaited real fleet read that
+  // spawns `tmux list-sessions` and races its own temp-dir teardown.
+  refreshMasterIdentity({
+    home, enginesLib: eng, fleetState: true, refreshFleet: options.refreshFleet
+  });
 
   const base = { tmuxSession: MASTER_TMUX_SESSION, home, engine: engineId, accessLevel: settings.accessLevel, enforcement, launchMode };
 
@@ -1013,6 +1029,8 @@ function ensureMasterSession(options = {}) {
  * is no DB row to drift from reality.
  * @param {object} [options]
  * @param {object} [options.tmuxLib] - tmux module override (tests)
+ * @param {Function} [options.refreshFleet] - Fleet refresher override (tests); see
+ *   {@link refreshMasterIdentity}. Without it a test fires a real fleet read.
  * @param {object} [options.enginesLib] - engines module override (tests); the
  *   reported engine is resolved against what is installed, so a stub that does
  *   not answer resolution makes this depend on the host's CLIs.

--- a/lib/projects.js
+++ b/lib/projects.js
@@ -971,6 +971,16 @@ async function enrichProject(project, facts, context) {
     // A directory that isn't there — or won't answer — can't be inspected, so
     // both read as not-applicable; `unreadable` is what distinguishes them.
     governanceState: facts.governanceState,
+    // Whether the directory is THERE. Additive (#950), because the pair above
+    // cannot answer it: `governanceState: 'not-applicable'` is also what a
+    // present-but-ungoverned project reports — eight of them on this machine at
+    // the time of writing — so deriving absence from it would declare live
+    // projects gone. Carried through so a consumer can tell "this project's
+    // directory has been deleted" from "this project is idle", which read
+    // identically before. `false` with `unreadable` set means the scan failed
+    // rather than the directory being absent; `unreadable` is what separates
+    // those two, exactly as the governanceState comment above describes.
+    exists: facts.exists !== false,
     // Why this project's directory could not be read, and what to do about it.
     // Always present, `null` on the healthy path — a field that appeared only on
     // failure would make every consumer probe for its existence rather than read

--- a/server.js
+++ b/server.js
@@ -604,13 +604,6 @@ route('GET', '/api/master/status', (_req, res) => {
 // the terminal iframe (ttyd only attaches to EXISTING tmux sessions).
 route('POST', '/api/master/ensure', (_req, res) => {
   const result = master.ensureMasterSession();
-  // Opening the master is exactly when its fleet map most needs to be current,
-  // and it is the one moment the operator is already waiting on a session to
-  // start — so refresh the state half here too. Not awaited: the response must
-  // not wait on the whole fleet's git reads, and `ensureMasterSession` has
-  // already written the identity-only map synchronously.
-  master.refreshFleetMap()
-    .catch((err) => log.warn('Fleet map state refresh failed', { error: err.message }));
   if (result.error) {
     // A refusal because tmux never answered is not a failed start, and the panel
     // must not paint it as one — "down" would be a definite claim about the very
@@ -6219,22 +6212,13 @@ if (require.main === module) {
   // the master's equivalent. skipIfAbsent so starting the server never creates
   // master state for an operator who has not used it.
   try {
-    const refreshed = master.refreshMasterIdentity({ skipIfAbsent: true });
+    // `fleetState` starts the async state pass that fills FLEET.md in; it is
+    // fire-and-forget inside, so boot never waits on the fleet's git reads.
+    const refreshed = master.refreshMasterIdentity({ skipIfAbsent: true, fleetState: true });
     if (refreshed.refreshed) log.debug('Master identity refreshed', { home: refreshed.home });
   } catch (err) {
     log.warn('Master identity refresh failed', { error: err.message });
   }
-
-  // The state half of the fleet map, deliberately NOT awaited: it enriches
-  // every project (a git read each, inside the forked scanner), and boot must
-  // not wait on the fleet to finish answering. The identity refresh above has
-  // already written an honest identity-only FLEET.md, so a slow or failed run
-  // here leaves a map that under-claims rather than one that is wrong.
-  master.refreshFleetMap()
-    .then((r) => {
-      if (r.refreshed) log.debug('Fleet map refreshed with state', { count: r.count });
-    })
-    .catch((err) => log.warn('Fleet map state refresh failed', { error: err.message }));
 
   // Project Master auto-start: launch the reserved master session at boot
   // when the operator opted in (master.autoStart). Failure is logged, never

--- a/server.js
+++ b/server.js
@@ -604,6 +604,13 @@ route('GET', '/api/master/status', (_req, res) => {
 // the terminal iframe (ttyd only attaches to EXISTING tmux sessions).
 route('POST', '/api/master/ensure', (_req, res) => {
   const result = master.ensureMasterSession();
+  // Opening the master is exactly when its fleet map most needs to be current,
+  // and it is the one moment the operator is already waiting on a session to
+  // start — so refresh the state half here too. Not awaited: the response must
+  // not wait on the whole fleet's git reads, and `ensureMasterSession` has
+  // already written the identity-only map synchronously.
+  master.refreshFleetMap()
+    .catch((err) => log.warn('Fleet map state refresh failed', { error: err.message }));
   if (result.error) {
     // A refusal because tmux never answered is not a failed start, and the panel
     // must not paint it as one — "down" would be a definite claim about the very
@@ -6217,6 +6224,17 @@ if (require.main === module) {
   } catch (err) {
     log.warn('Master identity refresh failed', { error: err.message });
   }
+
+  // The state half of the fleet map, deliberately NOT awaited: it enriches
+  // every project (a git read each, inside the forked scanner), and boot must
+  // not wait on the fleet to finish answering. The identity refresh above has
+  // already written an honest identity-only FLEET.md, so a slow or failed run
+  // here leaves a map that under-claims rather than one that is wrong.
+  master.refreshFleetMap()
+    .then((r) => {
+      if (r.refreshed) log.debug('Fleet map refreshed with state', { count: r.count });
+    })
+    .catch((err) => log.warn('Fleet map state refresh failed', { error: err.message }));
 
   // Project Master auto-start: launch the reserved master session at boot
   // when the operator opted in (master.autoStart). Failure is logged, never

--- a/test/master-fleet-map.test.js
+++ b/test/master-fleet-map.test.js
@@ -39,6 +39,7 @@ function enriched(over = {}) {
     path: '/p/Enriched',
     archived: false,
     version: '1.2.3',
+    exists: true,
     unreadable: null,
     git: {
       branch: 'main',
@@ -131,6 +132,31 @@ describe('#950 — an unknown and an absence must not render the same', () => {
     assert.doesNotMatch(notRepo, /could not|not established|unknown/i,
       'a directory that is simply not a repo has nothing to report as unestablished');
     assert.match(failedRead, /not established/);
+  });
+
+  it('separates a DELETED directory from an idle non-repo project', () => {
+    // These rendered identically until `exists` was carried through: a deleted
+    // project came back with git: null, version: null and no session, which is
+    // exactly what an ordinary idle non-repo project looks like. For a
+    // coordinator that is the difference between "nothing to do here" and
+    // "this is gone". `governanceState` cannot separate them — a
+    // present-but-ungoverned project reports 'not-applicable' too.
+    const gone = line(enriched({ exists: false, unreadable: null, version: null, git: null, session: null }));
+    const idle = line(enriched({ exists: true, version: null, git: null, session: null }));
+
+    assert.notEqual(gone, idle);
+    assert.match(gone, /DIRECTORY MISSING/);
+    assert.doesNotMatch(idle, /DIRECTORY MISSING/);
+    assert.doesNotMatch(gone, /not a git repository/,
+      'a path that is not there has no repo state to report');
+  });
+
+  it('a failed scan is still reported as a failed scan, not as a missing directory', () => {
+    // `exists: false` WITH `unreadable` means the scan degraded, not that the
+    // path is gone — the two must not collapse into each other.
+    const l = line(enriched({ exists: false, unreadable: 'EACCES', unreadableCode: 'TC_EACCES', git: null, session: null }));
+    assert.match(l, /could not read the project directory/i);
+    assert.doesNotMatch(l, /DIRECTORY MISSING/);
   });
 
   it('reports an unreadable directory once, instead of a row of separate unknowns', () => {
@@ -422,5 +448,32 @@ describe('#950 — the state pass is wired, and wired where home resolves', () =
     assert.match(md, /at server boot and when the master\s+session is opened/);
     // And it must own the ambiguity it cannot resolve from inside the file.
     assert.match(md, /not finished yet or it failed/);
+  });
+});
+
+describe('#950 — the production wiring is pinned, not just the seam', () => {
+  const fs = require('node:fs');
+  const path = require('node:path');
+
+  // The seam tests above prove the trigger fires when asked. They do NOT prove
+  // anything asks — dropping `fleetState: true` at either production site left
+  // the whole suite green. These pin the two call sites that exist.
+
+  it('ensureMasterSession asks for the state pass, and forwards a test override', () => {
+    const src = fs.readFileSync(path.join(__dirname, '..', 'lib', 'master.js'), 'utf8');
+    const fn = src.slice(src.indexOf('function ensureMasterSession'));
+    const body = fn.slice(0, fn.indexOf('\nfunction '));
+    assert.match(body, /fleetState: true/,
+      'opening the master is when its fleet map most needs to be current');
+    assert.match(body, /refreshFleet: options\.refreshFleet/,
+      'and the override must be forwarded, or every ensure test fires a real fleet read');
+  });
+
+  it('server boot asks for the state pass', () => {
+    const src = fs.readFileSync(path.join(__dirname, '..', 'server.js'), 'utf8');
+    assert.match(src, /refreshMasterIdentity\(\{ skipIfAbsent: true, fleetState: true \}\)/,
+      'boot must start the state pass, or FLEET.md stays identity-only until someone opens the master');
+    assert.doesNotMatch(src, /master\.refreshFleetMap\(/,
+      'server.js must NOT call it directly — that resolved os.homedir() past any caller-supplied home');
   });
 });

--- a/test/master-fleet-map.test.js
+++ b/test/master-fleet-map.test.js
@@ -151,6 +151,20 @@ describe('#950 — an unknown and an absence must not render the same', () => {
       'a path that is not there has no repo state to report');
   });
 
+  it('still reports a live session on a project whose directory is gone', () => {
+    // Session liveness is independent of the directory — a tmux session can
+    // outlive a deleted checkout, and that is precisely when a coordinator needs
+    // to know a pane is still attached to it. Suppressing it would be
+    // information lost, not a claim avoided.
+    const l = line(enriched({
+      exists: false, unreadable: null, version: null, git: null,
+      session: { active: true, status: 'active', startedAt: '2026-08-16 19:36', tmuxSession: 'Gone', incomplete: [], cause: null }
+    }));
+    assert.match(l, /DIRECTORY MISSING/);
+    assert.match(l, /session LIVE since/,
+      'a pane attached to a deleted checkout is the case worth surfacing, not hiding');
+  });
+
   it('a failed scan is still reported as a failed scan, not as a missing directory', () => {
     // `exists: false` WITH `unreadable` means the scan degraded, not that the
     // path is gone — the two must not collapse into each other.

--- a/test/master-fleet-map.test.js
+++ b/test/master-fleet-map.test.js
@@ -1,0 +1,267 @@
+'use strict';
+
+/*
+ * #950 — the fleet map carries state, and says where it has none.
+ *
+ * FLEET.md is the Project Master's whole picture of what it coordinates. It
+ * used to carry name, engine and path: enough to say a project EXISTS, nothing
+ * about what it is DOING.
+ *
+ * The defect class these guards exist for is not "a field is missing" — it is
+ * "two different facts render identically". A project with no live session and
+ * a project whose liveness could not be established are opposite situations for
+ * a coordinator: one is safe to act on, the other is the case where acting is
+ * most dangerous. `lib/projects.js` already distinguishes them (`active: null`
+ * with `incomplete: ['active']` vs `active: false`), so the map has no excuse
+ * for flattening them, and every pair below asserts they diverge.
+ *
+ * `buildFleetMap` is pure, so these drive it with records rather than standing
+ * up a fleet. The fixtures are shaped like `listProjects` output — enriched
+ * records carrying `git`/`session` objects whose `incomplete` arrays are
+ * present-and-empty when healthy, which is the contract those modules state.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const master = require('../lib/master');
+
+/** A raw store row — what `store.projects.list()` returns. No state keys. */
+function rawRow(over = {}) {
+  return { name: 'Raw', engineId: 'claude', path: '/p/Raw', archived: false, ...over };
+}
+
+/** An enriched record — the shape `listProjects` resolves to. */
+function enriched(over = {}) {
+  return {
+    name: 'Enriched',
+    engineId: 'claude',
+    engine: { id: 'claude', name: 'Claude Code', available: true },
+    path: '/p/Enriched',
+    archived: false,
+    version: '1.2.3',
+    unreadable: null,
+    git: {
+      branch: 'main',
+      dirty: false,
+      lastCommit: 'do a thing',
+      lastCommitAge: '2 hours ago',
+      latestTag: 'v1.2.3',
+      incomplete: [],
+      cause: null
+    },
+    session: {
+      active: false,
+      status: 'ended',
+      startedAt: null,
+      tmuxSession: null,
+      incomplete: [],
+      cause: null
+    },
+    ...over
+  };
+}
+
+/** The line for one project, from a one-project map. */
+function line(project) {
+  const md = master.buildFleetMap([project]);
+  const found = md.split('\n').find((l) => l.startsWith('- **'));
+  assert.ok(found, 'the map must render a line for the project');
+  return found;
+}
+
+describe('#950 — an unknown and an absence must not render the same', () => {
+  it('separates "no live session" from "liveness could not be established"', () => {
+    const none = line(enriched({
+      session: { active: false, status: 'ended', startedAt: null, tmuxSession: null, incomplete: [], cause: null }
+    }));
+    const unknown = line(enriched({
+      session: {
+        active: null, status: 'active', startedAt: '2026-08-16 19:36', tmuxSession: 'Enriched',
+        incomplete: ['active'], cause: 'read-timed-out'
+      }
+    }));
+
+    assert.notEqual(none, unknown,
+      'the two render identically — a coordinator cannot tell "nothing running" from "nobody looked"');
+    assert.match(none, /no live session/);
+    assert.match(unknown, /could not be established/i);
+    assert.doesNotMatch(unknown, /no live session/,
+      'an unestablished read must never be reported as an absent session');
+    assert.match(unknown, /read-timed-out/, 'and it must carry why');
+  });
+
+  it('separates a clean tree from a tree whose dirtiness was not established', () => {
+    // `dirty: null` is the read that did not get there. Rendering it as clean
+    // tells the master a tree is safe to act on when nobody knows.
+    const clean = line(enriched());
+    const unknown = line(enriched({
+      git: { branch: 'main', dirty: null, lastCommitAge: '2 hours ago', incomplete: ['dirty'], cause: 'read-timed-out' }
+    }));
+
+    assert.notEqual(clean, unknown);
+    assert.match(clean, /\bclean\b/);
+    assert.match(unknown, /dirty-state unknown/);
+    assert.doesNotMatch(unknown, /\bclean\b/, 'an unread tree must not be called clean');
+  });
+
+  it('separates a branch it read from a branch it could not', () => {
+    const known = line(enriched());
+    const unknown = line(enriched({
+      git: { branch: null, dirty: null, incomplete: ['branch', 'dirty'], cause: 'read-timed-out' }
+    }));
+
+    assert.notEqual(known, unknown);
+    assert.match(known, /\bmain\b/);
+    assert.match(unknown, /branch not established/);
+  });
+
+  it('separates "not a git repository" from "the git read fell short"', () => {
+    // Caught on live data before it shipped: the first draft rendered a null
+    // `git` as "git could not be read", which invents a failure for every
+    // non-repo project on the fleet. `lib/dir-scanner-child.js#_gitInfo` returns
+    // null for "not a repository, or git is absent" and an OBJECT carrying
+    // `incomplete`/`cause` when a read genuinely fell short — opposite facts.
+    const notRepo = line(enriched({ git: null }));
+    const failedRead = line(enriched({
+      git: { branch: null, dirty: null, incomplete: ['branch', 'dirty'], cause: 'read-timed-out' }
+    }));
+
+    assert.notEqual(notRepo, failedRead);
+    assert.match(notRepo, /not a git repository/);
+    assert.doesNotMatch(notRepo, /could not|not established|unknown/i,
+      'a directory that is simply not a repo has nothing to report as unestablished');
+    assert.match(failedRead, /not established/);
+  });
+
+  it('reports an unreadable directory once, instead of a row of separate unknowns', () => {
+    const l = line(enriched({
+      unreadable: 'EACCES', unreadableCode: 'TC_EACCES',
+      version: null, git: null, session: null
+    }));
+    assert.match(l, /could not read the project directory/i);
+    assert.match(l, /EACCES/);
+    // The directory not answering is ONE fact. Repeating it per field would
+    // bury the cause under its own consequences.
+    assert.doesNotMatch(l, /dirty-state unknown/);
+    assert.doesNotMatch(l, /branch not established/);
+  });
+
+  it('says a version was not established rather than omitting it', () => {
+    assert.match(line(enriched({ version: null })), /version not established/);
+    assert.match(line(enriched()), /v1\.2\.3/);
+  });
+});
+
+describe('#950 — the identity-only pass declares itself', () => {
+  it('says state was not gathered, so absence is not read as a report', () => {
+    const md = master.buildFleetMap([rawRow()]);
+    assert.match(md, /Identity only in this pass/);
+    assert.match(md, /Absence of a state line below means nobody looked/);
+    // And it must not invent state it never gathered.
+    assert.doesNotMatch(md, /no live session/,
+      'a pass that gathered nothing must not claim a project has no session');
+    assert.doesNotMatch(md, /\bclean\b/);
+  });
+
+  it('drops the banner once records carry state', () => {
+    const md = master.buildFleetMap([enriched()]);
+    assert.doesNotMatch(md, /Identity only in this pass/);
+    assert.match(md, /session/);
+  });
+
+  it('decides per record, so a mixed list does not mislabel either half', () => {
+    // Derived from the records rather than passed as a flag, because a flag can
+    // disagree with its data.
+    const md = master.buildFleetMap([enriched(), rawRow()]);
+    const enrichedLine = md.split('\n').find((l) => l.includes('**Enriched**'));
+    const rawLine = md.split('\n').find((l) => l.includes('**Raw**'));
+    assert.match(enrichedLine, /session/, 'the enriched record still reports its state');
+    assert.doesNotMatch(rawLine, /session/, 'the raw row reports none, and claims none');
+  });
+});
+
+describe('#950 — what the fleet map already did, it still does', () => {
+  it('keeps the do-not-edit stamp, the heading and the path', () => {
+    const md = master.buildFleetMap([rawRow()]);
+    assert.match(md, /Generated by TangleClaw/);
+    assert.match(md, /do not edit/);
+    assert.match(md, /# Fleet map/);
+    assert.match(md, /\/p\/Raw/);
+  });
+
+  it('still marks archived projects and engine-less ones', () => {
+    assert.match(line(rawRow({ archived: true })), /ARCHIVED/);
+    assert.match(line(rawRow({ engineId: null })), /no engine/);
+  });
+
+  it('still says so when nothing is registered', () => {
+    assert.match(master.buildFleetMap([]), /\(no projects registered\)/);
+  });
+
+  it('prefers the enriched engine object over the raw id when both are present', () => {
+    assert.match(line(enriched({ engine: { id: 'codex', name: 'Codex' }, engineId: 'claude' })), /codex/);
+  });
+
+  it('carries a generated-at stamp when given one, for the drift check to read', () => {
+    const md = master.buildFleetMap([rawRow()], { generatedAt: '2026-08-16T22:00:00Z' });
+    assert.match(md, /generated-at: 2026-08-16T22:00:00Z/);
+    // Omitted rather than faked when the caller has no stamp to give.
+    assert.doesNotMatch(master.buildFleetMap([rawRow()]), /generated-at/);
+  });
+
+  it('tolerates a malformed record instead of taking the whole map down', () => {
+    // The map is written from a poll; one bad record must not cost the master
+    // its entire picture of the fleet.
+    const md = master.buildFleetMap([{ name: 'Odd', path: '/p/Odd', session: undefined, git: undefined }]);
+    assert.match(md, /\*\*Odd\*\*/);
+  });
+});
+
+describe('#950 — refreshFleetMap writes only the fleet map', () => {
+  const fs = require('node:fs');
+  const os = require('node:os');
+  const path = require('node:path');
+
+  /** A master home with a seeded memory dir. @returns {string} */
+  function seedHome() {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-fleet-'));
+    fs.mkdirSync(path.join(home, 'memory'), { recursive: true });
+    return home;
+  }
+
+  it('rewrites FLEET.md and leaves the master-owned files untouched', async () => {
+    const home = seedHome();
+    const mem = path.join(home, 'memory');
+    for (const f of ['MEMORY.md', 'NOTES.md', 'CHANGELOG.md']) {
+      fs.writeFileSync(path.join(mem, f), `MASTER OWNED ${f}`);
+    }
+    fs.writeFileSync(path.join(mem, 'FLEET.md'), 'stale');
+
+    const res = await master.refreshFleetMap({
+      home,
+      listProjects: async () => [enriched()],
+      generatedAt: '2026-08-16T22:00:00Z'
+    });
+
+    assert.equal(res.refreshed, true);
+    assert.equal(res.count, 1);
+    assert.match(fs.readFileSync(path.join(mem, 'FLEET.md'), 'utf8'), /session/);
+    for (const f of ['MEMORY.md', 'NOTES.md', 'CHANGELOG.md']) {
+      assert.equal(fs.readFileSync(path.join(mem, f), 'utf8'), `MASTER OWNED ${f}`,
+        `${f} is the master's — TC must never overwrite it`);
+    }
+  });
+
+  it('does nothing when no master home exists, so boot cannot create one', async () => {
+    const absent = path.join(os.tmpdir(), 'tc-fleet-absent-' + process.pid);
+    let asked = false;
+    const res = await master.refreshFleetMap({
+      home: absent,
+      listProjects: async () => { asked = true; return []; }
+    });
+    assert.equal(res.refreshed, false);
+    assert.equal(asked, false,
+      'it must not even enumerate the fleet for an operator who has never opened the master');
+    assert.equal(fs.existsSync(absent), false);
+  });
+});

--- a/test/master-fleet-map.test.js
+++ b/test/master-fleet-map.test.js
@@ -186,6 +186,20 @@ describe('#950 — an unknown and an absence must not render the same', () => {
     assert.doesNotMatch(l, /branch not established/);
   });
 
+  it('still reports a live session on a project whose directory will not answer', () => {
+    // The uniformity check on the rule the missing-directory branch adopted:
+    // liveness is no more dependent on a READABLE directory than on an existing
+    // one. Applying it to one branch and not its sibling is how two surfaces
+    // that share a rule drift apart.
+    const l = line(enriched({
+      unreadable: 'EACCES', unreadableCode: 'TC_EACCES', version: null, git: null,
+      session: { active: true, status: 'active', startedAt: '2026-08-16 19:36', tmuxSession: 'Blocked', incomplete: [], cause: null }
+    }));
+    assert.match(l, /could not read the project directory/i);
+    assert.match(l, /session LIVE since/,
+      'a pane attached to a permission-blocked project is worth surfacing too');
+  });
+
   it('treats a missing version as an absence, not as an unknown', () => {
     // The mirror of the `git: null` correction. On a READABLE directory a null
     // version means the project has no version file; only the degraded path

--- a/test/master-fleet-map.test.js
+++ b/test/master-fleet-map.test.js
@@ -168,14 +168,14 @@ describe('#950 — an unknown and an absence must not render the same', () => {
   it('a failed scan is still reported as a failed scan, not as a missing directory', () => {
     // `exists: false` WITH `unreadable` means the scan degraded, not that the
     // path is gone — the two must not collapse into each other.
-    const l = line(enriched({ exists: false, unreadable: 'EACCES', unreadableCode: 'EACCES', git: null, session: null }));
+    const l = line(enriched({ exists: false, unreadable: 'the directory is there but this server may not read it (permission denied)', unreadableCode: 'EACCES', git: null, session: null }));
     assert.match(l, /could not read the project directory/i);
     assert.doesNotMatch(l, /DIRECTORY MISSING/);
   });
 
   it('reports an unreadable directory once, instead of a row of separate unknowns', () => {
     const l = line(enriched({
-      unreadable: 'EACCES', unreadableCode: 'EACCES',
+      unreadable: 'the directory is there but this server may not read it (permission denied)', unreadableCode: 'EACCES',
       version: null, git: null, session: null
     }));
     assert.match(l, /could not read the project directory/i);
@@ -192,7 +192,7 @@ describe('#950 — an unknown and an absence must not render the same', () => {
     // one. Applying it to one branch and not its sibling is how two surfaces
     // that share a rule drift apart.
     const l = line(enriched({
-      unreadable: 'EACCES', unreadableCode: 'EACCES', version: null, git: null,
+      unreadable: 'the directory is there but this server may not read it (permission denied)', unreadableCode: 'EACCES', version: null, git: null,
       session: { active: true, status: 'active', startedAt: '2026-08-16 19:36', tmuxSession: 'Blocked', incomplete: [], cause: null }
     }));
     assert.match(l, /could not read the project directory/i);

--- a/test/master-fleet-map.test.js
+++ b/test/master-fleet-map.test.js
@@ -168,14 +168,14 @@ describe('#950 — an unknown and an absence must not render the same', () => {
   it('a failed scan is still reported as a failed scan, not as a missing directory', () => {
     // `exists: false` WITH `unreadable` means the scan degraded, not that the
     // path is gone — the two must not collapse into each other.
-    const l = line(enriched({ exists: false, unreadable: 'EACCES', unreadableCode: 'TC_EACCES', git: null, session: null }));
+    const l = line(enriched({ exists: false, unreadable: 'EACCES', unreadableCode: 'EACCES', git: null, session: null }));
     assert.match(l, /could not read the project directory/i);
     assert.doesNotMatch(l, /DIRECTORY MISSING/);
   });
 
   it('reports an unreadable directory once, instead of a row of separate unknowns', () => {
     const l = line(enriched({
-      unreadable: 'EACCES', unreadableCode: 'TC_EACCES',
+      unreadable: 'EACCES', unreadableCode: 'EACCES',
       version: null, git: null, session: null
     }));
     assert.match(l, /could not read the project directory/i);
@@ -192,7 +192,7 @@ describe('#950 — an unknown and an absence must not render the same', () => {
     // one. Applying it to one branch and not its sibling is how two surfaces
     // that share a rule drift apart.
     const l = line(enriched({
-      unreadable: 'EACCES', unreadableCode: 'TC_EACCES', version: null, git: null,
+      unreadable: 'EACCES', unreadableCode: 'EACCES', version: null, git: null,
       session: { active: true, status: 'active', startedAt: '2026-08-16 19:36', tmuxSession: 'Blocked', incomplete: [], cause: null }
     }));
     assert.match(l, /could not read the project directory/i);

--- a/test/master-fleet-map.test.js
+++ b/test/master-fleet-map.test.js
@@ -146,8 +146,17 @@ describe('#950 — an unknown and an absence must not render the same', () => {
     assert.doesNotMatch(l, /branch not established/);
   });
 
-  it('says a version was not established rather than omitting it', () => {
-    assert.match(line(enriched({ version: null })), /version not established/);
+  it('treats a missing version as an absence, not as an unknown', () => {
+    // The mirror of the `git: null` correction. On a READABLE directory a null
+    // version means the project has no version file; only the degraded path
+    // nulls it for a reason, and that path always sets `unreadable`, which the
+    // renderer branches on separately. Calling this "not established" would
+    // manufacture an unknown out of a nothing.
+    const noVersion = line(enriched({ version: null }));
+    assert.doesNotMatch(noVersion, /version not established/);
+    assert.doesNotMatch(noVersion, /version/i,
+      'a project with no version has nothing to say about one');
+    assert.match(noVersion, /\bmain\b/, 'and the rest of its state still renders');
     assert.match(line(enriched()), /v1\.2\.3/);
   });
 });
@@ -252,6 +261,59 @@ describe('#950 — refreshFleetMap writes only the fleet map', () => {
     }
   });
 
+  it('coalesces concurrent callers into one fleet read', async () => {
+    // Not tidiness. `listProjects` is the path the ten-second dashboard poll
+    // drives, and `lib/dir-scanner.js` starts each request's deadline at ISSUE
+    // time against a SERIAL child — so a second caller's reads queue while their
+    // clocks run, and a healthy project can burn its deadline waiting its turn
+    // and earn the Full Disk Access hint it did not deserve (#884/#891).
+    const home = seedHome();
+    let reads = 0;
+    let release;
+    const gate = new Promise((r) => { release = r; });
+    const lister = async () => { reads += 1; await gate; return [enriched()]; };
+
+    const all = Promise.all([
+      master.refreshFleetMap({ home, listProjects: lister }),
+      master.refreshFleetMap({ home, listProjects: lister }),
+      master.refreshFleetMap({ home, listProjects: lister })
+    ]);
+    release();
+    const results = await all;
+
+    assert.equal(reads, 1, 'three concurrent callers must cost ONE fleet read');
+    assert.deepEqual(results.map((r) => r.count), [1, 1, 1],
+      'and every caller still gets a real result');
+  });
+
+  it('starts a fresh read once the previous one has settled', async () => {
+    // The latch must not wedge the map at its first snapshot for the life of
+    // the process — coalescing is per-flight, not once-ever.
+    const home = seedHome();
+    let reads = 0;
+    const lister = async () => { reads += 1; return [enriched()]; };
+    await master.refreshFleetMap({ home, listProjects: lister });
+    await master.refreshFleetMap({ home, listProjects: lister });
+    assert.equal(reads, 2);
+  });
+
+  it('releases the latch when the fleet read throws', async () => {
+    // A rejected read that left the latch set would silently disable every
+    // later refresh for the process's lifetime — the map would freeze without
+    // anything saying so.
+    const home = seedHome();
+    await assert.rejects(master.refreshFleetMap({
+      home, listProjects: async () => { throw new Error('scanner died'); }
+    }), /scanner died/);
+
+    let reads = 0;
+    const res = await master.refreshFleetMap({
+      home, listProjects: async () => { reads += 1; return [enriched()]; }
+    });
+    assert.equal(reads, 1, 'a later refresh must still run');
+    assert.equal(res.refreshed, true);
+  });
+
   it('does nothing when no master home exists, so boot cannot create one', async () => {
     const absent = path.join(os.tmpdir(), 'tc-fleet-absent-' + process.pid);
     let asked = false;
@@ -263,5 +325,102 @@ describe('#950 — refreshFleetMap writes only the fleet map', () => {
     assert.equal(asked, false,
       'it must not even enumerate the fleet for an operator who has never opened the master');
     assert.equal(fs.existsSync(absent), false);
+  });
+});
+
+describe('#950 — the state pass is wired, and wired where home resolves', () => {
+  const { before, after } = require('node:test');
+  const fs = require('node:fs');
+  const os = require('node:os');
+  const path = require('node:path');
+  const store = require('../lib/store');
+
+  // `refreshMasterIdentity` loads config, so this suite needs a store — an
+  // ISOLATED one, on its own base path, exactly as test/master.test.js does.
+  let storeDir;
+  before(() => {
+    storeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-fleet-store-'));
+    store._setBasePath(storeDir);
+    store.init();
+  });
+  after(() => {
+    store.close();
+    fs.rmSync(storeDir, { recursive: true, force: true });
+  });
+
+  /**
+   * Run `refreshMasterIdentity` against a temp home with the fleet read stubbed.
+   * @param {object} opts - Extra options for refreshMasterIdentity.
+   * @returns {{home: string, asked: () => number, settle: () => Promise<void>}}
+   */
+  function driveIdentity(opts) {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-fleet-wire-'));
+    let asked = 0;
+    let seenHome = null;
+    master.refreshMasterIdentity({
+      home,
+      refreshFleet: async (o) => { asked += 1; seenHome = o.home; return { refreshed: false, count: 0 }; },
+      ...opts
+    });
+    return { home, asked: () => asked, seenHome: () => seenHome };
+  }
+
+  it('refreshMasterIdentity starts the state pass only when asked', () => {
+    // Opt-in on purpose: most callers of this function are tests that want file
+    // writes and nothing else, and an always-on read would make every one of
+    // them enumerate the real fleet.
+    assert.equal(driveIdentity({ fleetState: true }).asked(), 1);
+    assert.equal(driveIdentity({}).asked(), 0);
+  });
+
+  it('the state pass resolves home the same way the identity write does', () => {
+    // The whole reason this trigger lives in master.js rather than at the
+    // server's call sites. Called from server.js it resolved os.homedir()
+    // regardless of what the caller passed, so a route test could overwrite the
+    // OPERATOR'S real ~/.tangleclaw/master/memory/FLEET.md with an empty fleet.
+    const d = driveIdentity({ fleetState: true });
+    assert.equal(d.seenHome(), d.home,
+      'a caller-supplied home must reach the fleet pass, or tests write to the real one');
+  });
+
+  it('the sync pass stamps generated-at, which the drift check consumes', () => {
+    // The governing spec treats the stamp as an invariant of this file, and the
+    // next build item compares it against the master's own observed-at notes.
+    // An identity-only map with no stamp is undatable.
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-fleet-stamp-'));
+    master._refreshMasterMemory(home, { projects: [], generatedAt: '2026-08-16T22:00:00Z' });
+    const md = fs.readFileSync(path.join(home, 'memory', 'FLEET.md'), 'utf8');
+    assert.match(md, /generated-at: 2026-08-16T22:00:00Z/);
+  });
+
+  it('_refreshMasterMemory renders the projects it is handed', () => {
+    // The seam refreshMasterIdentity uses; without a caller-supplied list it
+    // falls back to the raw store rows, which is the identity-only path.
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-fleet-seam-'));
+    master._refreshMasterMemory(home, {
+      projects: [{
+        name: 'Handed', engineId: 'claude', path: '/p/Handed', archived: false,
+        version: '9.9.9', unreadable: null,
+        git: { branch: 'topic', dirty: true, incomplete: [], cause: null },
+        session: { active: false, status: 'ended', incomplete: [], cause: null }
+      }]
+    });
+    const md = fs.readFileSync(path.join(home, 'memory', 'FLEET.md'), 'utf8');
+    assert.match(md, /\*\*Handed\*\*/);
+    assert.match(md, /v9\.9\.9/);
+    assert.match(md, /DIRTY/);
+    assert.doesNotMatch(md, /Identity only in this pass/,
+      'records carrying state must suppress the identity-only banner');
+  });
+
+  it('the identity-only banner does not promise a trigger that does not exist', () => {
+    // It used to say the map refreshes "when the dashboard polls" — the poll
+    // never writes this file. A banner in the honesty surface must not be the
+    // one false claim in it.
+    const md = master.buildFleetMap([{ name: 'Raw', engineId: 'claude', path: '/p/Raw' }]);
+    assert.doesNotMatch(md, /dashboard polls/);
+    assert.match(md, /at server boot and when the master\s+session is opened/);
+    // And it must own the ambiguity it cannot resolve from inside the file.
+    assert.match(md, /not finished yet or it failed/);
   });
 });

--- a/test/master.test.js
+++ b/test/master.test.js
@@ -25,6 +25,18 @@ setLevel('error');
 delete process.env.TANGLECLAW_PORT;
 
 const store = require('../lib/store');
+
+/**
+ * A no-op fleet refresher for `ensureMasterSession`.
+ *
+ * Without it every call here fires an unawaited REAL fleet pass — `listProjects`
+ * → a dir-scanner fork plus `tmux list-sessions` — against a store pointing at
+ * temp project paths, racing this file's own `after()` teardown. It stayed green
+ * only because `refreshMasterIdentity` catches the resulting write failure and
+ * this file logs at `error`, which is the shape of a test that passes for the
+ * wrong reason.
+ */
+const NO_FLEET = async () => ({ refreshed: false, count: 0 });
 const master = require('../lib/master');
 
 let tmpDir;
@@ -175,7 +187,7 @@ describe('ensureMasterSession', () => {
 
   it('creates the home dir + CLAUDE.md and launches when the session is absent', () => {
     const t = fakeTmux({ alive: false });
-    const r = master.ensureMasterSession({ home, tmuxLib: t, enginesLib: availableEngines });
+    const r = master.ensureMasterSession({ refreshFleet: NO_FLEET, home, tmuxLib: t, enginesLib: availableEngines });
     assert.equal(r.created, true);
     assert.equal(r.tmuxSession, master.MASTER_TMUX_SESSION);
     assert.equal(r.error, undefined);
@@ -191,7 +203,7 @@ describe('ensureMasterSession', () => {
     const t = fakeTmux({ alive: true });
     fs.mkdirSync(home, { recursive: true });
     fs.writeFileSync(path.join(home, 'CLAUDE.md'), 'stale hand-edit');
-    const r = master.ensureMasterSession({ home, tmuxLib: t, enginesLib: availableEngines });
+    const r = master.ensureMasterSession({ refreshFleet: NO_FLEET, home, tmuxLib: t, enginesLib: availableEngines });
     assert.equal(r.created, false);
     assert.equal(r.error, undefined);
     assert.equal(t.calls.length, 0, 'must not create a second session');
@@ -202,7 +214,7 @@ describe('ensureMasterSession', () => {
 
   it('refuses with an error when the engine binary is unavailable — and does not create tmux', () => {
     const t = fakeTmux({ alive: false });
-    const r = master.ensureMasterSession({
+    const r = master.ensureMasterSession({ refreshFleet: NO_FLEET,
       home,
       tmuxLib: t,
       // Resolution is pinned so this test is about DETECTION only — without it the
@@ -224,7 +236,7 @@ describe('ensureMasterSession', () => {
     // doesn't depend on which CLIs the host machine has installed.
     const noEngines = { detectEngine: () => ({ available: false }), resolveDefaultEngine: () => null };
     const t = fakeTmux({ alive: false });
-    const r = master.ensureMasterSession({ home, tmuxLib: t, enginesLib: noEngines });
+    const r = master.ensureMasterSession({ refreshFleet: NO_FLEET, home, tmuxLib: t, enginesLib: noEngines });
     assert.equal(r.created, false);
     assert.match(r.error, /No AI engine is installed/);
     assert.doesNotMatch(r.error, /null/, 'must not leak the null through to the operator');
@@ -238,7 +250,7 @@ describe('ensureMasterSession', () => {
       config.defaultEngine = 'ghost-engine';
       store.config.save(config);
       const t = fakeTmux({ alive: false });
-      const r = master.ensureMasterSession({ home, tmuxLib: t, enginesLib: availableEngines });
+      const r = master.ensureMasterSession({ refreshFleet: NO_FLEET, home, tmuxLib: t, enginesLib: availableEngines });
       assert.equal(r.created, false);
       assert.match(r.error, /"ghost-engine" not found/);
       assert.equal(t.calls.length, 0);
@@ -254,7 +266,7 @@ describe('ensureMasterSession', () => {
     try {
       sessionsLib._buildLaunchCommand = () => undefined;
       const t = fakeTmux({ alive: false });
-      const r = master.ensureMasterSession({ home, tmuxLib: t, enginesLib: availableEngines });
+      const r = master.ensureMasterSession({ refreshFleet: NO_FLEET, home, tmuxLib: t, enginesLib: availableEngines });
       assert.equal(r.created, false);
       assert.match(r.error, /no launch command/);
       assert.equal(t.calls.length, 0, 'must not create a session that would run a bare shell');
@@ -266,12 +278,12 @@ describe('ensureMasterSession', () => {
   it('surfaces tmux failures as typed errors — create-false and thrown', () => {
     const engines = availableEngines;
     const refusing = fakeTmux({ alive: false, createSession: () => false });
-    const r1 = master.ensureMasterSession({ home, tmuxLib: refusing, enginesLib: engines });
+    const r1 = master.ensureMasterSession({ refreshFleet: NO_FLEET, home, tmuxLib: refusing, enginesLib: engines });
     assert.equal(r1.created, false);
     assert.match(r1.error, /Failed to create tmux session/);
 
     const throwing = fakeTmux({ alive: false, createSession: () => { throw new Error('boom'); } });
-    const r2 = master.ensureMasterSession({ home: home + '-t', tmuxLib: throwing, enginesLib: engines });
+    const r2 = master.ensureMasterSession({ refreshFleet: NO_FLEET, home: home + '-t', tmuxLib: throwing, enginesLib: engines });
     assert.equal(r2.created, false);
     assert.match(r2.error, /tmux error: boom/);
   });
@@ -366,7 +378,7 @@ describe('ensureMasterSession refuses to start a second master over one it canno
     const t = fakeTmux({ alive: true, answered: false });
     const home = path.join(tmpDir, 'master-wedge');
 
-    const r = master.ensureMasterSession({ home, tmuxLib: t, enginesLib: availableEngines });
+    const r = master.ensureMasterSession({ refreshFleet: NO_FLEET, home, tmuxLib: t, enginesLib: availableEngines });
 
     assert.equal(r.created, false);
     assert.match(r.error, /could not determine/i,
@@ -400,7 +412,7 @@ describe('ensureMasterSession refuses to start a second master over one it canno
     const t = fakeTmux({ alive: false, answered: true });
     const home = path.join(tmpDir, 'master-answered-absent');
 
-    const r = master.ensureMasterSession({ home, tmuxLib: t, enginesLib: availableEngines });
+    const r = master.ensureMasterSession({ refreshFleet: NO_FLEET, home, tmuxLib: t, enginesLib: availableEngines });
 
     assert.equal(r.error, undefined, 'an answered absence is not an error');
     assert.equal(t.calls.length, 1, 'it has to actually start the master');
@@ -648,7 +660,7 @@ describe('ensureMasterSession — settings integration', () => {
   });
 
   it('seeds the baseline, renders it into CLAUDE.md, scaffolds memory, and writes guardrails (claude engine)', () => {
-    const r = master.ensureMasterSession({ home, tmuxLib: fakeTmux({ alive: false }), enginesLib: availableEngines });
+    const r = master.ensureMasterSession({ refreshFleet: NO_FLEET, home, tmuxLib: fakeTmux({ alive: false }), enginesLib: availableEngines });
     assert.equal(r.created, true);
     assert.equal(r.engine, 'claude');
     assert.equal(r.accessLevel, 'read-only');
@@ -662,7 +674,7 @@ describe('ensureMasterSession — settings integration', () => {
   it('renders edited rules into the identity on the next ensure', () => {
     master.seedBaselineMasterRules();
     store.sessionRules.create({ content: 'Session-rules-backed custom boundary.', kind: 'master' });
-    master.ensureMasterSession({ home, tmuxLib: fakeTmux({ alive: true }), enginesLib: availableEngines });
+    master.ensureMasterSession({ refreshFleet: NO_FLEET, home, tmuxLib: fakeTmux({ alive: true }), enginesLib: availableEngines });
     assert.match(fs.readFileSync(path.join(home, 'CLAUDE.md'), 'utf8'), /Session-rules-backed custom boundary\./);
   });
 
@@ -677,7 +689,7 @@ describe('ensureMasterSession — settings integration', () => {
     try {
       config.master = { accessLevel: 'read-only', engine: 'claude', scope: 'all', autoStart: false };
       store.config.save(config);
-      const r = master.ensureMasterSession({
+      const r = master.ensureMasterSession({ refreshFleet: NO_FLEET,
         home, tmuxLib: fakeTmux({ alive: false }), enginesLib: enginesInstalling(['codex'])
       });
       assert.equal(r.engine, 'codex', 'a pinned engine that is not installed must resolve, not be honored');
@@ -694,7 +706,7 @@ describe('ensureMasterSession — settings integration', () => {
     try {
       config.master = { accessLevel: 'read-only', engine: 'codex', scope: 'all', autoStart: false };
       store.config.save(config);
-      const r = master.ensureMasterSession({
+      const r = master.ensureMasterSession({ refreshFleet: NO_FLEET,
         home, tmuxLib: fakeTmux({ alive: false }), enginesLib: enginesInstalling(['claude', 'codex'])
       });
       assert.equal(r.engine, 'codex', 'an installed pin must be honored, not overridden');
@@ -728,7 +740,7 @@ describe('ensureMasterSession — settings integration', () => {
         config.master = { accessLevel: 'read-only', engine: null, scope: 'all', autoStart: false, ...masterBlock };
         store.config.save(config);
         const tmuxLib = fakeTmux({ alive: false });
-        const r = master.ensureMasterSession({
+        const r = master.ensureMasterSession({ refreshFleet: NO_FLEET,
           home, tmuxLib, enginesLib: opts.enginesLib || availableEngines
         });
         return { result: r, command: tmuxLib.calls.length ? tmuxLib.calls[0].opts.command : null };
@@ -775,7 +787,7 @@ describe('ensureMasterSession — settings integration', () => {
       try {
         config.master = { accessLevel: 'read-only', engine: 'aider', launchMode: 'acceptEdits', scope: 'all', autoStart: false };
         store.config.save(config);
-        master.ensureMasterSession({ home, tmuxLib: fakeTmux({ alive: false }), enginesLib: enginesInstalling(['aider']) });
+        master.ensureMasterSession({ refreshFleet: NO_FLEET, home, tmuxLib: fakeTmux({ alive: false }), enginesLib: enginesInstalling(['aider']) });
         assert.equal(master.masterSettings(store.config.load()).launchMode, 'acceptEdits',
           'the stored preference must survive an engine that cannot honor it');
       } finally {
@@ -819,7 +831,7 @@ describe('ensureMasterSession — settings integration', () => {
       try {
         config.master = { accessLevel: 'read-only', engine: 'aider', launchMode: 'acceptEdits', scope: 'all', autoStart: false };
         store.config.save(config);
-        master.ensureMasterSession({
+        master.ensureMasterSession({ refreshFleet: NO_FLEET,
           home, tmuxLib: fakeTmux({ alive: false }), enginesLib: enginesInstalling(['aider'])
         });
         assert.match(captured.join(''), /not honored by the resolved engine/,
@@ -868,7 +880,7 @@ describe('ensureMasterSession — settings integration', () => {
       try {
         config.master = { accessLevel: 'read-only', engine: 'claude', launchMode: 'acceptEdits', scope: 'all', autoStart: false };
         store.config.save(config);
-        master.ensureMasterSession({ home, tmuxLib: fakeTmux({ alive: false }), enginesLib: availableEngines });
+        master.ensureMasterSession({ refreshFleet: NO_FLEET, home, tmuxLib: fakeTmux({ alive: false }), enginesLib: availableEngines });
         assert.doesNotMatch(captured.join(''), /not honored by the resolved engine/);
       } finally {
         config.master = saved;
@@ -916,7 +928,7 @@ describe('ensureMasterSession — settings integration', () => {
         config.master = { accessLevel: 'read-only', engine: 'aider', launchMode: 'plan', scope: 'all', autoStart: false };
         store.config.save(config);
         const lib = enginesInstalling(['aider']);
-        const ensured = master.ensureMasterSession({ home, tmuxLib: fakeTmux({ alive: false }), enginesLib: lib });
+        const ensured = master.ensureMasterSession({ refreshFleet: NO_FLEET, home, tmuxLib: fakeTmux({ alive: false }), enginesLib: lib });
         const status = master.getMasterStatus({ tmuxLib: fakeTmux({ alive: true }), enginesLib: lib });
         assert.equal(ensured.launchMode, status.settings.resolvedLaunchMode);
       } finally {
@@ -934,7 +946,7 @@ describe('ensureMasterSession — settings integration', () => {
       // (proving master.engine wins) and skip the claude-only guardrails.
       config.master = { accessLevel: 'read-only', engine: 'ghost-engine', scope: 'all', autoStart: false };
       store.config.save(config);
-      const r = master.ensureMasterSession({ home, tmuxLib: fakeTmux({ alive: false }), enginesLib: availableEngines });
+      const r = master.ensureMasterSession({ refreshFleet: NO_FLEET, home, tmuxLib: fakeTmux({ alive: false }), enginesLib: availableEngines });
       assert.equal(r.engine, 'ghost-engine');
       assert.equal(r.enforcement, 'instructional');
       assert.match(r.error, /"ghost-engine" not found/);

--- a/test/projects.test.js
+++ b/test/projects.test.js
@@ -201,6 +201,40 @@ describe('projects', () => {
         'enrichProject must not shell out to git when the scanner already answered');
     });
 
+    it('enrichProject carries `exists` through, so a deleted directory stays distinguishable', async () => {
+      // THE MUTATION THIS CATCHES: deleting `exists: facts.exists !== false` from
+      // the returned record. Nothing else in the suite reads `exists` off an
+      // enriched project, so removing it leaves every other assertion green while
+      // `p.exists === false` silently stops firing downstream — and a project
+      // whose directory has been DELETED reverts to rendering exactly like an
+      // ordinary idle one in the Master's fleet map (#950).
+      //
+      // The fleet-map guards cannot catch this: they feed a hand-built fixture
+      // that SYNTHESIZES this producer's signal, so they keep passing against a
+      // record shape the producer no longer emits. The guard has to live here,
+      // against the function that actually emits it.
+      //
+      // Why the field exists at all: `governanceState: 'not-applicable'` is also
+      // what a present-but-ungoverned project reports, so absence cannot be
+      // derived from it — checked against live data, where eight registered
+      // projects report `not-applicable` with directories that are there.
+      projects.createProject({ name: 'facts-exists-through' });
+      const row = store.projects.getByName('facts-exists-through');
+      const facts = (over) => ({
+        governanceState: 'not-applicable', git: null, config: null,
+        version: null, unreadable: null, unreadableHint: null, ...over
+      });
+
+      const gone = await projects.enrichProject(row, facts({ exists: false }));
+      assert.equal(gone.exists, false,
+        'a directory that is not there must say so on the record, not just in the scanner');
+      assert.equal(gone.unreadable, null,
+        'and it is NOT an unreadable — that is what separates "deleted" from "the scan failed"');
+
+      const there = await projects.enrichProject(row, facts({ exists: true }));
+      assert.equal(there.exists, true);
+    });
+
     it('enrichProject reads no version from disk — it reports what the child detected', async () => {
       // THE MUTATION THIS CATCHES: restoring `_detectProjectVersion(project.path)`
       // here. The fixture is what makes that observable: the project's directory


### PR DESCRIPTION
Build item 1 of the ratified Master startup/wrap spec (`.tangleclaw/plans/master-startup-and-wrap.md`). Closes #950.

## What

`FLEET.md` — the Project Master's entire picture of the fleet it coordinates — carried three fields per project: name, engine, path. It could say a project *existed* and nothing about what it was *doing*. A map that lists doors without saying which rooms have anyone in them.

It now carries version, branch, working-tree state, session liveness and last-commit age. **None of it required new scanning**: every field was already computed for the dashboard poll and discarded at the moment the file was written.

Before / after, on the real fleet:

```
- **Notse** — claude · /Users/jasonvaughan/Documents/Projects/Notse
- **Notse** — claude · v0.5.20 · wrap/20260701020939-notse · DIRTY · last commit 4 weeks ago · session LIVE since 2026-08-16 …
```

## Honesty is the feature, not a side-effect

The map preserves every distinction #941/#937/#920 bought, and the guards assert the two render **differently** — a `notEqual` on the rendered line — because the defect class here is *flattening*, not omission:

| These must never render the same | |
|---|---|
| `no live session` | `session liveness could not be established (<cause>)` |
| `clean` | `dirty-state unknown` |
| `main` | `branch not established` |
| `not a git repository` | a git read that fell short |
| `DIRECTORY MISSING` | an ordinary idle project |

For a coordinator those pairs are opposites: one is safe to act on, the other is exactly when acting is most dangerous.

**A pass that gathered no state says so.** `refreshMasterIdentity` is synchronous and runs at server boot, so it must never grow per-project git or tmux work. The boot pass still writes an identity-only map — but it now declares itself as identity-only and states that a missing state line means *nobody looked*, rather than that there is nothing to report. Whether state was gathered is **derived from the records**, never passed as a flag that could disagree with its data.

**A degraded read never hides a live session.** A tmux pane can be attached to a checkout that has been deleted, or to one the server cannot read. Both branches report the directory problem *and* the session.

## The constraint that shaped it — and an estimate it corrected

The spec called this "one function". It isn't, and the reason is load-bearing: `refreshMasterIdentity` is fully synchronous and runs at **server boot**, while the state the map needs comes from `git.getInfo` (several `execSync` spawns per repo on a cold cache) plus an async tmux snapshot. The end-to-end run measures **1368ms across 37 projects** — 1.4s of event-loop blocking every boot, which is precisely the hazard `lib/dir-scanner.js` exists to prevent (#883/#884).

So it is a split: a pure renderer (`buildFleetMap`), the sync path writing an honest identity-only map at no new cost, and an async `refreshFleetMap` riding the enriched list `listProjects` already builds. The spec has been corrected to say so.

`refreshFleetMap` is **single-flight**: `listProjects` is the path the ten-second dashboard poll drives, and `dir-scanner.js` starts each deadline at *issue* time against a serial child, so a second unsynchronized caller could make a healthy project burn its deadline waiting its turn and earn a Full Disk Access hint it did not deserve. The latch releases on failure too, so a thrown read cannot freeze the map for the process's lifetime.

## New API field

`GET /api/projects` records now carry **`exists`** (additive; no consumer breaks). It cannot be derived from what was already there: `governanceState: 'not-applicable'` is *also* what a present-but-ungoverned project reports — **eight of them on this machine** — so inferring absence from it would have declared eight live projects gone. Documented in `api-contract.md`, both the example payload and the field notes.

## Test plan

Full suite green. `test/master-fleet-map.test.js` (+31) and `test/projects.test.js` (+1); the authoritative pass/fail is the evidence store, per tree.

`buildFleetMap` is pure — no filesystem, git, tmux or clock — so the guards drive it with records instead of standing up a fleet. **Every guard on this branch was mutation-checked red before being kept** — including each finding-fix, which is where most of them were needed.

Verified end-to-end against the real 37-project fleet through the un-injected lazy-required lister: 11 live sessions correctly detected, master-owned `MEMORY.md`/`NOTES.md`/`CHANGELOG.md` untouched, and no false `DIRECTORY MISSING`.

## Review

Cumulative Critic + **six** `verify-resolutions` rounds, plus two independent PR reviews. 0 blocking outstanding; all 22 cumulative findings dispositioned (13 accepted, 9 fixed).

The rounds earned their cost — each caught a *previous round's fix* being incomplete:

- **Round 2** found `version not established` manufacturing an unknown out of a plain absence — the mirror of a `git: null` correction I had made an hour earlier on this same branch; that the identity-only banner promised a refresh trigger (`"when the dashboard polls"`) that never writes the file; and that calling `refreshFleetMap` from `server.js` resolved `os.homedir()` past any caller-supplied home, so a route test could overwrite the operator's live `~/.tangleclaw/master/memory/FLEET.md`.
- **Round 3** found a comment I had written to *justify* a correctness decision was itself false ("the degraded path always sets `unreadable`" — it does not), and that the false invariant was hiding a real defect: a deleted project rendered identically to an idle one.
- **Round 4** found the `exists` producer completely unpinned — deleting the line left **236 tests green**, because the fleet-map guards feed a fixture that *synthesizes* the producer's signal. The guard now lives against `enrichProject` itself.
- **The first PR review** found the change-log claiming a `refreshFleet` seam was applied when it had been added and applied at **zero** of 20 call sites — so each still fired an unawaited real fleet read racing its own teardown, green only because the failure was caught and the file logs at `error`.
- **Round 6** found that correcting a fabricated fixture code had left `unreadable` and `unreadableCode` as the same string, making the branch that renders the code vacuous. Fixed a value and created a hole in the same edit.

The feature itself has been sound since the first round. What kept moving was the accuracy of what I wrote *about* it — every one of those is prose or a guard asserting something the mechanism did not do.

## Carried, not dropped

`listProjects` has no *cross-caller* guard, so this module's single-flight does not stop it interleaving with the dashboard poll. That is a `lib/projects.js` concern affecting the poll generally rather than something this branch introduced — recorded in `.prawduct/.handoff-notes.md`.

Closes #950. Milestone: Master Control (#829).
