### PR TITLE
feat: declare UI wrap vs clear decision logic

### DIFF
--- a/data/hooks/sessionstart-prime.sh
+++ b/data/hooks/sessionstart-prime.sh
@@ -15,4 +15,14 @@ if [ -n "${CLAUDE_PROJECT_DIR:-}" ] && [ -f "$PRIME_FILE" ] && [ -r "$PRIME_FILE
   # readability check and cat — the script still exits 0 silently.
   cat "$PRIME_FILE" || true
 fi
+
+WRAP_ADVISORY="${CLAUDE_PROJECT_DIR:-}/.tangleclaw/ui-wrap-advisory.md"
+if [ -n "${CLAUDE_PROJECT_DIR:-}" ] && [ -f "$WRAP_ADVISORY" ] && [ -r "$WRAP_ADVISORY" ]; then
+  # Inject the UI Wrap advisory decision heuristic
+  echo ""
+  echo "---"
+  echo ""
+  cat "$WRAP_ADVISORY" || true
+fi
+
 exit 0

--- a/lib/engines.js
+++ b/lib/engines.js
@@ -1808,6 +1808,20 @@ function _buildBaselineHooks(projConfig, engineProfile, ruleShardCount = 0) {
  * @returns {{written: boolean, skipped: boolean, skipReason: string|null, drifted: boolean, configFilePath: string|null, error: string|null}}
  */
 function writeEngineConfig(engineId, projectPath, projectConfig, engineProfile) {
+  // Always declare UI wrap availability for the platform before returning.
+  const uiWrapAdvisoryPath = path.join(projectPath, '.tangleclaw', 'ui-wrap-advisory.md');
+  const advisoryContent = `**Platform Capability: UI Wrap**
+TangleClaw provides a "Session Wrap" UI button. At a chunk-close or stopping place, intelligently decide whether to recommend \`/clear\` or "UI Wrap":
+- Recommend **UI Wrap** if the work represents a completed milestone, requires a version bump, needs changelog entries, or needs a continuity record.
+- Recommend **\`/clear\`** if you just need to drop context mid-task (e.g., memory is getting full) but aren't ready to run the full wrap protocol.
+When signaling the stopping place, explicitly state which one the operator should use and why.`;
+  try {
+    if (!fs.existsSync(path.join(projectPath, '.tangleclaw'))) {
+      fs.mkdirSync(path.join(projectPath, '.tangleclaw'), { recursive: true });
+    }
+    fs.writeFileSync(uiWrapAdvisoryPath, advisoryContent, 'utf8');
+  } catch (err) { /* ignore */ }
+
   // Defer to the Prawduct V2 Claude Code plugin when it governs this project
   // (#330 hybrid). The plugin owns CLAUDE.md (a thin PRAWDUCT:ANCHOR file);
   // regenerating here would destructively clobber it on every launch/boot/PATCH.


### PR DESCRIPTION
Resolves #972. Injects an advisory from TangleClaw into the session start context so agents can intelligently recommend UI Wrap vs `/clear`.