### PR TITLE
Compare the identity mtime with a tolerance, so the guard stops scoring the host's clock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -441,6 +441,22 @@ All notable changes to TangleClaw are documented in this file.
 
 ### Internal
 
+- **The identity-mtime guard stopped comparing filesystem timestamps exactly (#974).** It scored the
+  host's clock plumbing rather than the contract, and it had `main` red from #970 onward:
+  `utimesSync` hands the kernel a float of *seconds*, so a millisecond value that float cannot
+  represent comes back off by a fraction — ext4 stored `1787039343102` and returned
+  `1787039343101.999`, while a 2000-value probe on APFS drifts on none of them. Green on the
+  developer's machine, red in CI, with the code under test running identically in both.
+
+  **The tolerance costs the assertion nothing**, which is why it is the fix rather than a weakening:
+  the mutation the guard exists to catch is reverting `_writeIfChanged` to an unconditional
+  `writeFileSync`, which sets the mtime to *now* — 60s from the recorded value by construction. That
+  mutation was run and the guard failed on it by 60001 ms. Sub-millisecond and sixty seconds are not
+  close together.
+
+  Third guard in this repo found scoring host plumbing instead of its own merits, after #969 (stderr
+  that never reaches the assertion) and #957 (a threadpool assertion that fails under machine load).
+
 - **A refusal guard in the plugin-migration suite stopped depending on how Node formats an error
   (#969).** It matched Python's `ValueError` text, which only reaches the assertion when a child
   process's stderr is appended to the thrown error — a property of the Node build, not of the code

--- a/test/master.test.js
+++ b/test/master.test.js
@@ -776,8 +776,21 @@ describe('readMasterIdentityFreshness — has the RUNNING Master read this? (#96
     fs.utimesSync(master.masterIdentityPath(home), past, past);
 
     master.refreshMasterIdentity({ home, enginesLib: { resolveDefaultEngine: () => 'claude', reconcileLaunchMode: () => 'default' } });
-    assert.equal(fs.statSync(master.masterIdentityPath(home)).mtimeMs, past.getTime(),
-      'an ensure that changes nothing must not touch the identity mtime');
+    // Compared with a tolerance rather than exactly, because an exact comparison
+    // scores the host's clock plumbing instead of the contract. `utimesSync`
+    // hands the kernel a float of SECONDS, and a millisecond value that is not
+    // representable in that float comes back off by a fraction: ext4 stored
+    // 1787039343102 and returned 1787039343101.999, so CI went red on Linux
+    // while macOS — where the same 2000-value probe drifts on none of them —
+    // stayed green. The code under test never ran differently.
+    //
+    // The tolerance costs the assertion nothing. The mutation it exists to catch
+    // is an unconditional `writeFileSync`, which sets the mtime to NOW — 60s
+    // from `past` by construction above. Sub-millisecond and sixty seconds are
+    // not close together, so the guard still fails the moment the write returns.
+    const rewritten = fs.statSync(master.masterIdentityPath(home)).mtimeMs;
+    assert.ok(Math.abs(rewritten - past.getTime()) < 2,
+      `an ensure that changes nothing must not touch the identity mtime (got ${rewritten}, expected ~${past.getTime()})`);
   });
 
   it('a read that failed on a LIVE session is unknown, not "no such session"', () => {


### PR DESCRIPTION
## What

`test/master.test.js` → `an identity rewritten with IDENTICAL content does not become stale` now compares the mtime with a tolerance instead of exactly. Test-only; no product code changed.

Fixes #974.

## Why

`main` has been red since 7cc2bd0 (#970) and PR #971 was inheriting the failure.

```
an ensure that changes nothing must not touch the identity mtime
+ actual   1787039343101.999
- expected 1787039343102
```

`fs.utimesSync` hands the kernel a float of **seconds**, so a millisecond value that is not representable in that float round-trips off by a fraction. ext4 stored `1787039343102` and returned `1787039343101.999`. A 2000-value probe on darwin/APFS drifts on none of them — which is why this is green on the developer machine and red in CI, with the code under test running identically in both.

The assertion was measuring the filesystem, not the contract.

## Why this is a fix and not a weakened test

The mutation the guard exists to catch is reverting `_writeIfChanged` to an unconditional `writeFileSync`, which sets the mtime to **now** — 60s from the recorded value by construction. Sub-millisecond and sixty seconds are not close together, so a 2 ms tolerance removes nothing.

That is not an argument, it was run:

```
# mutation applied to lib/master.js: `if (false) return false;`
not ok 6 - an identity rewritten with IDENTICAL content does not become stale
  error: 'an ensure that changes nothing must not touch the identity mtime
          (got 1787076675839.312, expected ~1787076615838)'
# fail 1

# mutation reverted
# pass 132 / # fail 0
```

The guard failed on the mutation by 60001 ms.

## Test plan

- `node --test test/master.test.js` — 132 pass, 0 fail
- Mutation run above: guard goes red under an unconditional write, green when reverted
- CI on this branch is the real check, since the defect only reproduces on Linux

## Note

Third guard found scoring host plumbing rather than its own merits, after #969 (stderr that never reaches the assertion) and #957 (a threadpool assertion that fails under machine load). Not proposing a sweep here — flagging the pattern.