### PR TITLE
fix: Medusa POST /read supports message-specific stamping

### DIFF
--- a/lib/medusa-listener.js
+++ b/lib/medusa-listener.js
@@ -160,19 +160,28 @@ class MedusaListener extends EventEmitter {
   }
 
   /**
-   * Mark the inbox as read (resets the unread counter; keeps the messages) and
-   * ACK every read message to the Hub (TC#547) so it is dropped from the durable
-   * queue and never redelivered on reconnect/restart. Ids stay in the awaiting
-   * set until the Hub confirms (`ack_response`); unconfirmed ids are re-flushed
-   * on the next (re)`registered` handshake, so a lost ACK frame degrades to a
-   * redundant retry, never a re-flood the operator has to re-read.
+   * Mark the inbox as read. If `ids` is provided, marks only those specific messages
+   * as read and ACKs them; if omitted, marks all unread messages as read (resets
+   * the unread counter).
+   * @param {string[]} [ids] - Array of envelope ids to mark read.
    * @returns {void}
    */
-  markRead() {
-    this.unread = 0;
-    if (this._unackedIds.length > 0) {
-      for (const id of this._unackedIds) this._ackAwaiting.add(id);
-      this._unackedIds = [];
+  markRead(ids) {
+    if (ids && Array.isArray(ids)) {
+      for (const id of ids) {
+        const idx = this._unackedIds.indexOf(id);
+        if (idx !== -1) {
+          this._unackedIds.splice(idx, 1);
+          this._ackAwaiting.add(id);
+          this.unread = Math.max(0, this.unread - 1);
+        }
+      }
+    } else {
+      this.unread = 0;
+      if (this._unackedIds.length > 0) {
+        for (const id of this._unackedIds) this._ackAwaiting.add(id);
+        this._unackedIds = [];
+      }
     }
     this._flushAcks();
   }

--- a/lib/medusa.js
+++ b/lib/medusa.js
@@ -198,11 +198,12 @@ function getMessages(sessionId) {
 /**
  * Mark a session's inbox as read (resets the unread badge). No-op if none.
  * @param {string|number} sessionId - The TC session id.
+ * @param {string[]} [ids] - Specific message ids to mark as read. If omitted, marks all read.
  * @returns {void}
  */
-function markRead(sessionId) {
+function markRead(sessionId, ids) {
   const listener = listeners.get(String(sessionId));
-  if (listener) listener.markRead();
+  if (listener) listener.markRead(ids);
 }
 
 /**

--- a/server.js
+++ b/server.js
@@ -3438,14 +3438,14 @@ route('GET', '/api/sessions/:project/medusa/messages', (req, res, params) => {
 // POST /api/sessions/:project/medusa/read — mark this session's inbox read,
 // clearing the unread badge (MED-2K9P Chunk 02). Fired when the operator opens
 // the read panel. Idempotent; a session with no listener is a safe no-op.
-route('POST', '/api/sessions/:project/medusa/read', (_req, res, params) => {
+route('POST', '/api/sessions/:project/medusa/read', (_req, res, params, body) => {
   const project = store.projects.getByName(params.project);
   if (!project) {
     return errorResponse(res, 404, `Project "${params.project}" not found`, 'NOT_FOUND');
   }
   const active = store.sessions.getActive(project.id);
   const sessionId = active ? active.id : null;
-  if (sessionId != null) medusa.markRead(sessionId);
+  if (sessionId != null) medusa.markRead(sessionId, body && body.ids);
   jsonResponse(res, 200, medusa.getStatus(sessionId));
 });
 


### PR DESCRIPTION
Resolves #837. \n\nAllows API callers to ACK specific envelope IDs by passing `{ ids: [...] }` in the POST body. If omitted, it falls back to the previous behavior of marking the entire inbox as read (which preserves compatibility with the UI's "Mark Read" button).