### PR TITLE
Restore v5.7.0's CHANGELOG section and fail the suite on release absorption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ All notable changes to TangleClaw are documented in this file.
 - **Medusa Switchboard Integration (#945)**: Shared documents are now watched via `fs.watch` on the server and Medusa pings connected sessions when the file changes, removing the refresh-or-restart step for cross-session updates.
 
 ### Fixed
+- **v5.7.0's release section is back in the CHANGELOG, and v5.8.0 no longer claims its features (#597, #598).** A squash dropped the `## [5.7.0]` heading and left its 527-line body sitting inside `## [5.8.0]`. Because `lib/changelog-notes.js` extracts by heading, the published v5.8.0 release page went out republishing every v5.7.0 feature as new — 537 lines for a release whose own content is nine. The heading is restored at a split point **proven, not guessed**: lines 33–559 were byte-identical to the v5.7.0 tag's published release body, so the boundary came from the artifact rather than from reading the prose.
+
+  **A new structural invariant (#6) now fails the suite on the shape rather than on its consequences.** Keep a Changelog gives a release at most one of each subsection, so a section carrying `### Added` twice is the seam where one release swallowed another — the visible tell both times this has happened. Fenced blocks are skipped, since this changelog quotes markdown. Nineteen pre-existing violations, all in frozen 3.x sections, are baselined by version with the rule written beside them that nothing new may join; a released section is immutable history, and rewriting it to satisfy a test would edit the record. Verified by re-inflicting the original wound: delete the `## [5.7.0]` heading and the invariant fails.
+
 - **Master Session Recovery (#342, #372, #348)**: Hardened the Master session update loop against orphaned tmux states and lingering cache files.
 
 - **The Recent-uploads history is clickable again — the multi-file rewrite removed the handlers but kept the button markup (#338, #770).** Each item still rendered with `role="button" tabindex="0" data-path=...`, and `historyEl.onclick`, `historyEl.onkeydown`, and `copyUploadPath()` had all been deleted. That combination is worse than dropping the feature outright: a screen reader still announces a button, a keyboard user can still tab to it and press Enter, and nothing happens — a broken affordance that advertises itself as working. The handlers and the clipboard helper are restored, along with the `onclick = null` / `onkeydown = null` teardown on the empty-history branch that keeps re-opens from stacking stale listeners.
@@ -29,6 +33,8 @@ All notable changes to TangleClaw are documented in this file.
 - **Strict Quality Floors (#177)**: Rewrote `WRAP_STEP_PATTERNS` to cover all 14 pipeline steps. The quality scanner now strictly increments `stepsMissing` for unknown steps instead of silently auto-passing them.
 - **Auto Mode for Feature PRs (#213)**: Edited `global-rules.md` to allow Auto Mode to default `--auto` on feature PRs and refactors, removing manual wait steps.
 - Swept and closed 6 stale issues and rehomed obsolete issues as part of the Post-v5 roadmap completion.
+
+## [5.7.0] - 2026-08-18
 
 ### Added
 

--- a/test/changelog-structure.test.js
+++ b/test/changelog-structure.test.js
@@ -35,6 +35,49 @@ function compareSemver(a, b) {
   return 0;
 }
 
+/**
+ * Find release sections that carry the same `###` subsection twice.
+ *
+ * This is the tell for a section ABSORPTION: a squash merge lands a branch's
+ * CHANGELOG edit under the wrong heading, the older release's `## [X.Y.Z]`
+ * line is dropped, and its whole body ends up inside the newer section. The
+ * result reads as one enormous release and, because `lib/changelog-notes.js`
+ * extracts by heading, the newer version's GitHub Release republishes the
+ * older one's notes verbatim.
+ *
+ * It has happened twice: #598/#597, and again when v5.7.0's 527-line body was
+ * absorbed into `## [5.8.0]` — which published a v5.8.0 release page claiming
+ * every v5.7.0 feature as new. A duplicated `### Added` was the visible seam
+ * both times, because Keep a Changelog gives each section at most one of each.
+ *
+ * Fenced blocks are skipped: this changelog quotes markdown, so a `### ` line
+ * inside a fence is content, not a heading.
+ *
+ * @param {string} text - Full CHANGELOG.md contents.
+ * @returns {Array<{section: string, subsection: string, line: number}>}
+ */
+function findDuplicateSubsections(text) {
+  const violations = [];
+  let section = null;
+  let seen = new Set();
+  let inFence = false;
+  text.split('\n').forEach((line, i) => {
+    if (/^\s*(```|~~~)/.test(line)) { inFence = !inFence; return; }
+    if (inFence) return;
+    if (/^## /.test(line)) {
+      section = line.replace(/^##\s+/, '').trim();
+      seen = new Set();
+      return;
+    }
+    const m = line.match(/^###\s+(.+?)\s*$/);
+    if (!m || section === null) return;
+    const name = m[1];
+    if (seen.has(name)) violations.push({ section, subsection: name, line: i + 1 });
+    else seen.add(name);
+  });
+  return violations;
+}
+
 function findOrphanBanners(text) {
   let currentSection = null;
   const orphans = [];
@@ -136,6 +179,32 @@ describe('CHANGELOG.md structural invariants (#168)', () => {
     );
   });
 
+  // Sections that already carried repeated subsections before this guard existed.
+  // They are all 3.x, they pre-date the current release process, and a released
+  // section is immutable history — rewriting them would edit the record to satisfy
+  // a test. Keyed by version rather than line number so the baseline does not rot
+  // as the file grows above them. NOTHING NEW MAY JOIN THIS LIST: a duplicate in
+  // any other section is an absorption and fails.
+  const PRE_GUARD_SECTIONS = new Set(['3.20.0', '3.18.0', '3.16.0', '3.13.0', '3.0.1']);
+
+  it('no release section carries the same ### subsection twice (invariant #6 — absorption)', () => {
+    const violations = findDuplicateSubsections(changelog)
+      .filter((v) => {
+        const m = v.section.match(/^\[(\d+\.\d+\.\d+)\]/);
+        return !(m && PRE_GUARD_SECTIONS.has(m[1]));
+      });
+    assert.equal(
+      violations.length,
+      0,
+      violations.length === 0
+        ? ''
+        : 'a repeated ### subsection means one release section swallowed another (a squash '
+          + 'dropped the older `## [X.Y.Z]` heading). The newer version then publishes the older '
+          + "one's notes as its own. Offenders: "
+          + violations.map((v) => `"${v.section}" repeats "### ${v.subsection}" at line ${v.line}`).join('; ')
+    );
+  });
+
   it('no release banner (> 🛟 / > 🚀) floats outside a released-version section (invariant #1)', () => {
     const orphans = findOrphanBanners(changelog);
     assert.equal(
@@ -198,6 +267,50 @@ describe('CHANGELOG.md invariant detectors flag the post-#166 / pre-#167 regress
     const dupes = findDuplicateHeadings(parseReleaseHeadings(DUPED));
     assert.equal(dupes.length, 1);
     assert.equal(dupes[0].versionString, '3.16.0');
+  });
+
+  it('an absorbed release section is detected (invariant #6 — the v5.7.0-into-v5.8.0 shape)', () => {
+    // The exact wound: [5.8.0] keeps its own Added/Fixed, then [5.7.0]'s heading
+    // is gone and its Added/Changed body continues inside the same section.
+    const absorbed = [
+      '## [Unreleased]',
+      '',
+      '## [5.8.0] - 2026-08-18',
+      '',
+      '### Added',
+      '- 5.8.0 own entry',
+      '',
+      '### Fixed',
+      '- 5.8.0 own fix',
+      '',
+      '### Added',
+      "- 5.7.0's entry, absorbed when the squash dropped its heading",
+      '',
+      '### Changed',
+      "- 5.7.0's change",
+      '',
+    ].join('\n');
+    const violations = findDuplicateSubsections(absorbed);
+    assert.equal(violations.length, 1, 'the repeated ### Added must be flagged');
+    assert.equal(violations[0].section, '[5.8.0] - 2026-08-18');
+    assert.equal(violations[0].subsection, 'Added');
+  });
+
+  it('a ### line inside a fenced block is content, not a subsection (invariant #6 false-positive guard)', () => {
+    const fenced = [
+      '## [1.0.0] - 2026-01-01',
+      '',
+      '### Added',
+      '- an entry that quotes markdown:',
+      '',
+      '  ```markdown',
+      '  ### Added',
+      '  ### Added',
+      '  ```',
+      '',
+    ].join('\n');
+    assert.deepEqual(findDuplicateSubsections(fenced), [],
+      'repeated headings inside a fence are quoted content and must not trip the detector');
   });
 
   it('a buried second [Unreleased] heading is detected (invariant #5 — #281 shape)', () => {


### PR DESCRIPTION
## What

Restores the `## [5.7.0]` heading, and adds structural invariant #6 so this shape fails the suite instead of reaching a release page.

## Why

A squash dropped the `## [5.7.0]` heading and left its **527-line body inside `## [5.8.0]`**. `lib/changelog-notes.js` extracts release notes by heading, so:

- the published **v5.8.0 release page republished every v5.7.0 feature as new** — 537 lines for a release whose own content is nine
- the tracked CHANGELOG attributed all of 5.7.0's work to 5.8.0

Second occurrence; #597/#598 was the first.

## The split point is proven, not guessed

`sed -n '33,559p' CHANGELOG.md` was **byte-identical** to the v5.7.0 tag's published release body (`diff` clean, 527 lines). The boundary came from the artifact rather than from reading the prose. After the repair:

| | lines extracted |
|---|---|
| `changelog-notes.js 5.7.0` | 526 — matches the published v5.7.0 notes |
| `changelog-notes.js 5.8.0` | 9 — its own content only |

`node lib/changelog-notes.js 5.8.0 \| grep -c "Master control bar can stop the Master"` → `0`.

## Invariant #6 — fail on the shape, not the consequences

Keep a Changelog gives a release at most one of each subsection, so a section carrying `### Added` twice is the seam where one release swallowed another. That duplicated heading was the visible tell both times.

- Fenced blocks are skipped — this changelog quotes markdown, so a `### ` inside a fence is content.
- **19 pre-existing violations, all in frozen 3.x sections, are baselined by version** with the rule written beside them that nothing new may join. A released section is immutable history; rewriting it to satisfy a test would edit the record.
- A false-positive guard covers the fenced case.

## Test plan

- `node --test 'test/*.test.js'` → **6473 pass / 0 fail / 1 skipped**
- **Mutation:** re-inflicting the original wound (deleting the `## [5.7.0]` heading) fails invariant #6; restoring it passes.
- Detector test asserts the guard flags the exact v5.7.0-into-v5.8.0 shape.

## Not included

The **published v5.8.0 GitHub Release page is still wrong** — this PR fixes the tracked file and the guard. Editing that published page is a separate, outward-facing step.