### PR TITLE
Fix: Settings modal renders behind Master drawer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Fixed the Settings modal rendering behind the Master drawer by defining a unified `z-index` scale for both the session and dashboard views (#985).
+
 ## [5.10.0] - 2026-08-19
 
 ### Added

--- a/public/session.css
+++ b/public/session.css
@@ -31,8 +31,8 @@
   /* Z-Index Scale */
   --z-drawer-backdrop: 290;
   --z-drawer: 300;
-  --z-toast: 400;
-  --z-modal-backdrop: 450;
+  --z-modal-backdrop: 400;
+  --z-toast: 450;
   --z-unreachable: 500;
 }
 

--- a/public/session.css
+++ b/public/session.css
@@ -27,6 +27,13 @@
   --radius-card: 10px;
   --radius-modal: 12px;
   --radius-pill: 14px;
+  
+  /* Z-Index Scale */
+  --z-drawer-backdrop: 290;
+  --z-drawer: 300;
+  --z-toast: 400;
+  --z-modal-backdrop: 450;
+  --z-unreachable: 500;
 }
 
 /* ── Light Theme ── */
@@ -825,7 +832,7 @@ body {
   position: fixed;
   inset: 0;
   background: rgba(0,0,0,0.5);
-  z-index: 290;
+  z-index: var(--z-drawer-backdrop);
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.3s;
@@ -839,7 +846,7 @@ body {
   bottom: 0;
   left: 0;
   right: 0;
-  z-index: 300;
+  z-index: var(--z-drawer);
   background: var(--card-bg);
   border: 1px solid var(--elevated-bg);
   border-radius: var(--radius-modal) var(--radius-modal) 0 0;
@@ -945,7 +952,7 @@ body {
   bottom: 0;
   left: 0;
   right: 0;
-  z-index: 300;
+  z-index: var(--z-drawer);
   background: var(--card-bg);
   border: 1px solid var(--elevated-bg);
   border-radius: var(--radius-modal) var(--radius-modal) 0 0;
@@ -1011,7 +1018,7 @@ body {
   position: fixed;
   inset: 0;
   background: rgba(0,0,0,0.7);
-  z-index: 200;
+  z-index: var(--z-modal-backdrop);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1530,7 +1537,7 @@ body {
   bottom: 0;
   left: 0;
   right: 0;
-  z-index: 300;
+  z-index: var(--z-drawer);
   background: var(--card-bg);
   border: 1px solid var(--elevated-bg);
   border-radius: var(--radius-modal) var(--radius-modal) 0 0;
@@ -1724,7 +1731,7 @@ body {
   bottom: 0;
   left: 0;
   right: 0;
-  z-index: 300;
+  z-index: var(--z-drawer);
   background: var(--card-bg);
   border: 1px solid var(--elevated-bg);
   border-radius: var(--radius-modal) var(--radius-modal) 0 0;

--- a/public/style.css
+++ b/public/style.css
@@ -31,8 +31,8 @@
   /* Z-Index Scale */
   --z-drawer-backdrop: 290;
   --z-drawer: 300;
-  --z-toast: 400;
-  --z-modal-backdrop: 450;
+  --z-modal-backdrop: 400;
+  --z-toast: 450;
   --z-unreachable: 500;
 }
 

--- a/public/style.css
+++ b/public/style.css
@@ -27,6 +27,13 @@
   --radius-card: 10px;
   --radius-modal: 12px;
   --radius-pill: 14px;
+  
+  /* Z-Index Scale */
+  --z-drawer-backdrop: 290;
+  --z-drawer: 300;
+  --z-toast: 400;
+  --z-modal-backdrop: 450;
+  --z-unreachable: 500;
 }
 
 /* ── Light Theme ── */
@@ -1897,7 +1904,7 @@ body {
 .unreachable-state {
   position: fixed;
   inset: 0;
-  z-index: 500;
+  z-index: var(--z-unreachable);
   display: none;
   align-items: center;
   justify-content: center;
@@ -1930,7 +1937,7 @@ body {
   top: 0;
   left: 0;
   right: 0;
-  z-index: 400;
+  z-index: var(--z-toast);
   padding: calc(env(safe-area-inset-top, 0px) + 10px) 16px 10px;
   font-size: 13px;
   font-weight: 600;
@@ -1947,7 +1954,7 @@ body {
   position: fixed;
   inset: 0;
   background: rgba(0,0,0,0.7);
-  z-index: 200;
+  z-index: var(--z-modal-backdrop);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/test/z-index-scale.test.js
+++ b/test/z-index-scale.test.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+/**
+ * Parses the z-index scale from a CSS file.
+ * Returns a Map of variable names to numeric values.
+ */
+function extractZScale(filePath) {
+  const content = fs.readFileSync(filePath, 'utf8');
+  // Match lines like: --z-drawer: 300;
+  const regex = /--z-([a-zA-Z0-9-]+):\s*(\d+);/g;
+  const scale = new Map();
+  let match;
+  while ((match = regex.exec(content)) !== null) {
+    scale.set(match[1], parseInt(match[2], 10));
+  }
+  return scale;
+}
+
+describe('z-index scales', () => {
+  it('enforces the exact ordering: drawer-backdrop < drawer < modal-backdrop < toast < unreachable', () => {
+    const styleCssPath = path.join(__dirname, '..', 'public', 'style.css');
+    const sessionCssPath = path.join(__dirname, '..', 'public', 'session.css');
+    
+    const styleScale = extractZScale(styleCssPath);
+    const sessionScale = extractZScale(sessionCssPath);
+    
+    assert.equal(styleScale.size, 5, `Expected 5 variables in style.css, found ${styleScale.size}`);
+    assert.equal(sessionScale.size, 5, `Expected 5 variables in session.css, found ${sessionScale.size}`);
+    
+    const expectedKeys = ['drawer-backdrop', 'drawer', 'modal-backdrop', 'toast', 'unreachable'];
+    for (const key of expectedKeys) {
+      assert.ok(styleScale.has(key), `style.css is missing --z-${key}`);
+      assert.ok(sessionScale.has(key), `session.css is missing --z-${key}`);
+      assert.equal(styleScale.get(key), sessionScale.get(key), `--z-${key} mismatch between files`);
+    }
+
+    const db = styleScale.get('drawer-backdrop');
+    const d = styleScale.get('drawer');
+    const mb = styleScale.get('modal-backdrop');
+    const t = styleScale.get('toast');
+    const u = styleScale.get('unreachable');
+    
+    assert.ok(db < d, `drawer-backdrop (${db}) should be < drawer (${d})`);
+    assert.ok(d < mb, `drawer (${d}) should be < modal-backdrop (${mb})`);
+    assert.ok(mb < t, `modal-backdrop (${mb}) should be < toast (${t})`);
+    assert.ok(t < u, `toast (${t}) should be < unreachable (${u})`);
+  });
+});


### PR DESCRIPTION
Fixes #985

**What changed:**
Defined a unified CSS variable scale for z-indexes in `:root` of both `public/style.css` and `public/session.css`. Replaced hardcoded z-index values with variables to ensure consistency across the dashboard and session pages. The scale explicitly places toast messages above modal backdrops.

**Why:**
The Master drawer had a z-index of 300, while the Settings modal backdrop had a z-index of 200. This caused the Settings modal to render behind the Master drawer when opened from it. Furthermore, toast messages were mistakenly placed behind modals in the initial fix attempt. This PR restores toast visibility over modals and adds a source-scanning test to prevent drift.

**Test plan:**
Added a source-scanning test (`test/z-index-scale.test.js`) to assert the exact ordering: `drawer-backdrop < drawer < modal-backdrop < toast < unreachable` and that both CSS files stay synchronized. 
Verified the guard fails correctly when ordering is violated.

**Evidence of guard working:**
```
not ok 1 - enforces the exact ordering: drawer-backdrop < drawer < modal-backdrop < toast < unreachable
  ---
  error: 'modal-backdrop (450) should be < toast (400)'
  expected: true
  actual: false
  operator: '=='
```
