### PR TITLE
feat(master): add Launch button to control bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **Added a Launch button to the Master control bar (#995).**
+  The Master control bar now supports launching a fresh Master session directly, replacing the less-discoverable drawer-reopen workflow. The Launch button is mutually exclusive with Kill and driven by the existing liveness probe, ensuring accurate presentation even when tmux is unresponsive.
+
 ### Fixed
 - Fixed the Settings modal rendering behind the Master drawer by defining a unified `z-index` scale for both the session and dashboard views (#985).
 

--- a/public/api-helper.js
+++ b/public/api-helper.js
@@ -2208,6 +2208,8 @@
       <button class="banner-btn" id="${p}SettingsBtn"
               aria-label="Master settings" title="Master settings">&#9881;</button>
       ${pend('Wrap', 'banner-btn btn-wrap', 'Wrap')}
+      <button type="button" class="banner-btn btn-launch hidden" id="${p}LaunchBtn"
+              title="Start a fresh Master session. Its memory/ files survive; the conversation does not.">Launch</button>
       <button type="button" class="banner-btn btn-kill" id="${p}KillBtn"
               title="Stop the Master session. Its memory/ files survive; the conversation does not.">Kill</button>
       <span class="master-bar-error" id="${p}Error" role="status" hidden></span>
@@ -2278,6 +2280,8 @@
         const seg = el(spec.suffix);
         if (seg) seg.addEventListener('click', () => flip(spec.level));
       }
+      const launch = el('LaunchBtn');
+      if (launch && deps.onRetry) launch.addEventListener('click', deps.onRetry);
       const kill = el('KillBtn');
       if (kill) kill.addEventListener('click', killMaster);
       // Establish the resting state in CODE rather than leaning on the markup's
@@ -2312,6 +2316,18 @@
       if (t && text !== undefined) t.textContent = text;
       const retry = el('RetryBtn');
       if (retry) retry.classList.toggle('hidden', !showRetry);
+
+      const kill = el('KillBtn');
+      const launch = el('LaunchBtn');
+      if (kill && launch) {
+        if (status === 'down') {
+          kill.classList.add('hidden');
+          launch.classList.remove('hidden');
+        } else if (status === 'live' || status === '') {
+          kill.classList.remove('hidden');
+          launch.classList.add('hidden');
+        }
+      }
     }
 
     /**
@@ -2654,6 +2670,8 @@
       // stopping a Master whose status could not be read is still meaningful.
       const kill = el('KillBtn');
       if (kill) kill.disabled = on;
+      const launch = el('LaunchBtn');
+      if (launch) launch.disabled = on;
     }
 
     /**

--- a/public/shared-controls.css
+++ b/public/shared-controls.css
@@ -203,6 +203,14 @@
   background: var(--danger-dark);
   color: #fff;
 }
+.banner-btn.btn-launch {
+  color: var(--primary);
+  border-color: var(--primary-dark);
+}
+.banner-btn.btn-launch:active {
+  background: var(--primary-dark);
+  color: #fff;
+}
 .banner-btn:disabled {
   opacity: 0.4;
   pointer-events: none;

--- a/test/master-control-bar.test.js
+++ b/test/master-control-bar.test.js
@@ -1303,6 +1303,34 @@ describe('#755 both surfaces drive the live toggle, and neither grows a timer', 
     assert.doesNotMatch(m[0], /aria-disabled/);
   });
 
+  it('the Launch button ships as a real control, hidden by default, with correct title', () => {
+    const markup = G.tcMasterControlBarMarkup('masterPanel', {});
+    const m = /<button[^>]*id="masterPanelLaunchBtn"[^>]*>/.exec(markup);
+    assert.ok(m, 'Launch must render as a real button');
+    assert.match(m[0], /hidden/, 'Launch must be hidden by default');
+    assert.match(m[0], /title="Start a fresh Master session\. Its memory\/ files survive; the conversation does not\."/, 'Must specify fresh conversation');
+  });
+
+  it('toggles Launch and Kill visibility mutually exclusively based on status', () => {
+    const { doc, ids } = makeDocument(['root']);
+    withIdParsingInnerHTML(ids.root, doc);
+    const bar = G.tcCreateMasterControlBar({ doc, rootId: 'root', prefix: 'masterPanel' });
+    bar.mount();
+    const el = (s) => doc.getElementById('masterPanel' + s);
+
+    bar.setStatus('live');
+    assert.equal(el('LaunchBtn').classList.contains('hidden'), true, 'Launch hidden when live');
+    assert.equal(el('KillBtn').classList.contains('hidden'), false, 'Kill shown when live');
+
+    bar.setStatus('down');
+    assert.equal(el('LaunchBtn').classList.contains('hidden'), false, 'Launch shown when down');
+    assert.equal(el('KillBtn').classList.contains('hidden'), true, 'Kill hidden when down');
+
+    bar.setStatus('');
+    assert.equal(el('LaunchBtn').classList.contains('hidden'), true, 'Launch hidden when unknown');
+    assert.equal(el('KillBtn').classList.contains('hidden'), false, 'Kill shown when unknown');
+  });
+
   it('the segments meet the touch-target minimum the mobile Direction binds', () => {
     // `nonfunctional-requirements.md` § Direction: "Interactive elements are
     // ≥44×44px", ratified, no exception covering this surface — the bar renders

--- a/test/master-control-bar.test.js
+++ b/test/master-control-bar.test.js
@@ -1327,8 +1327,33 @@ describe('#755 both surfaces drive the live toggle, and neither grows a timer', 
     assert.equal(el('KillBtn').classList.contains('hidden'), true, 'Kill hidden when down');
 
     bar.setStatus('');
+    // Rationale for unknown state:
+    // Showing Kill on an unknown state is the safer default. The kill route (#968) 
+    // refuses safely with MASTER_LIVENESS_UNKNOWN, whereas showing Launch on an 
+    // unknown state risks spawning a second Master over one that could just be wedged.
     assert.equal(el('LaunchBtn').classList.contains('hidden'), true, 'Launch hidden when unknown');
     assert.equal(el('KillBtn').classList.contains('hidden'), false, 'Kill shown when unknown');
+  });
+
+  it('wires the Launch button to deps.onRetry only if provided', () => {
+    let fired = 0;
+    const { doc: doc1, ids: ids1 } = makeDocument(['root1']);
+    withIdParsingInnerHTML(ids1.root1, doc1);
+    const bar1 = G.tcCreateMasterControlBar({ 
+      doc: doc1, rootId: 'root1', prefix: 'masterPanel', onRetry: () => fired++ 
+    });
+    bar1.mount();
+    doc1.getElementById('masterPanelLaunchBtn').dispatch('click');
+    assert.equal(fired, 1, 'Launch button must invoke deps.onRetry when provided');
+
+    const { doc: doc2, ids: ids2 } = makeDocument(['root2']);
+    withIdParsingInnerHTML(ids2.root2, doc2);
+    const bar2 = G.tcCreateMasterControlBar({ 
+      doc: doc2, rootId: 'root2', prefix: 'masterPanel2' 
+    });
+    bar2.mount();
+    assert.doesNotThrow(() => doc2.getElementById('masterPanel2LaunchBtn').dispatch('click'), 
+      'Launch button must not crash when clicked without deps.onRetry');
   });
 
   it('the segments meet the touch-target minimum the mobile Direction binds', () => {


### PR DESCRIPTION
Resolves #995.

Adds a mutually exclusive Launch button to the Master control bar. It shares the same liveness probe as the Kill button, directly replacing the previous 'reopen drawer' workflow for restarting a Master. 

The liveness probe differentiates between 'live', 'down', and 'unknown' (e.g. MASTER_LIVENESS_UNKNOWN). The visibility toggle intentionally groups the 'unknown' state with 'live' (showing Kill, hiding Launch) rather than 'down'. Showing Kill on an unknown state is the safer default, as the kill route gracefully handles MASTER_LIVENESS_UNKNOWN, whereas showing Launch risks spawning a second Master over one that might simply be wedged.