### PR TITLE
Release a dead session's Medusa listener, so peers stop messaging a ghost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to TangleClaw are documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- **A session that simply died kept its Medusa listener, so peers were messaging a ghost (#1000).** Two of the three end paths — an explicit kill and a wrap teardown — released the session's Medusa presence. The third, the branch where `getSessionStatus` observes that the pane is gone, persisted `markCrashed` and released nothing. The listener kept its WebSocket open, so the dead workspace stayed in the roster reporting `connected: true` alongside the live one, four seconds apart in `lastSeen` and indistinguishable from it.
+
+  **The leak is worse than a stale record, because the listener is a live consumer.** A peer addressing the dead workspace got `{"status":"received"}` from the hub and the message was filed into an inbox no agent would ever read — a delivery that genuinely succeeded, to nobody. Nothing reported a problem, and the peer that had restarted no longer had the context to notice it never heard from you. Hit live: a long re-orientation brief was acknowledged as received and never arrived.
+
+  The fix is one call beside `markCrashed`, on the principle that the branch persisting "this session has ended" is the one that must release what it held. The guard asserts the **real effect** — that the listener is actually off — rather than that a function was called, since a spy would still pass if the call were wired to something that released nothing. Verified by mutation: removing the call fails it.
+
+  Until an install picks this up, resolve a peer's workspace id from `GET /api/sessions/:project/medusa/status` immediately before sending. The roster is not authoritative.
+
 - Fixed the Settings modal rendering behind the Master drawer by defining a unified `z-index` scale for both the session and dashboard views (#985).
 
 ## [5.10.0] - 2026-08-19

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -1622,6 +1622,21 @@ function getSessionStatus(projectName) {
       // tmux died unexpectedly — mark as crashed so frontend detects session end
       store.sessions.markCrashed(active.id, 'tmux session died');
       clearIdleCache(active.tmuxSession);
+      // Release the Medusa presence too (#1000). The other two end paths — an
+      // explicit kill and a wrap teardown — already do this; a session that
+      // simply died did not, so its listener kept its WebSocket open and its
+      // workspace stayed in the roster reporting `connected: true`.
+      //
+      // That is worse than a stale record: the leaked listener is a LIVE
+      // consumer. A peer addressing the dead workspace gets `{"status":
+      // "received"}` back from the hub and the message is filed into an inbox
+      // no agent will ever read — a delivery that genuinely succeeded, to a
+      // ghost. Nothing anywhere reports a problem, and the peer that restarted
+      // has lost its context and cannot tell you it never heard from you.
+      //
+      // Sits beside `markCrashed` deliberately: the same branch that persists
+      // "this session has ended" is the one that must release what it held.
+      _teardownMedusa(project, active);
       log.warn('Active session tmux died', { project: projectName, session: active.id });
       // Fall through to wrapping/lastSession checks below
     } else {

--- a/test/session-status-unknown.test.js
+++ b/test/session-status-unknown.test.js
@@ -69,6 +69,31 @@ function withProbe(verdict, fn) {
   }
 }
 
+
+/**
+ * Minimal WebSocket double for the leak guard: the listener only ever attaches
+ * handlers, sends frames, and closes. Nothing here reaches a network.
+ */
+class FakeWS {
+  /** @param {string} url - Requested URL. */
+  constructor(url) {
+    this.url = url;
+    this.readyState = 1;
+    /** @type {string[]} */
+    this.sent = [];
+    this._h = Object.create(null);
+  }
+
+  /** @param {string} t - Event type. @param {Function} h - Handler. @returns {void} */
+  addEventListener(t, h) { (this._h[t] || (this._h[t] = [])).push(h); }
+
+  /** @param {string} d - Serialized frame. @returns {void} */
+  send(d) { this.sent.push(d); }
+
+  /** @returns {void} */
+  close() { this.readyState = 3; }
+}
+
 const UNREACHABLE = { live: false, answered: false, cause: 'read-timed-out' };
 const ALIVE = { live: true, answered: true, cause: null };
 const GONE = { live: false, answered: true, cause: null };
@@ -113,6 +138,47 @@ describe('an active session whose pane could not be reached (#907)', () => {
         'a REACHED pane produces a real reading — this must not become "always unknown"');
     } finally {
       store.sessions.kill(session.id, 'test cleanup');
+    }
+  });
+
+  it('releases the session\'s Medusa presence when the pane is gone (#1000)', () => {
+    // The leak: `markCrashed` persisted "this session has ended" while its
+    // Medusa listener kept its WebSocket open, so the dead workspace stayed in
+    // the roster reporting `connected: true`. That is worse than a stale
+    // record — the leaked listener is a LIVE consumer, so a peer addressing it
+    // gets `{"status":"received"}` back and the message is filed into an inbox
+    // no agent will ever read. A delivery that genuinely succeeded, to a ghost.
+    //
+    // Asserted on the real effect (the listener is actually off) rather than on
+    // "forgetSession was called", because a spy would still pass if the call
+    // were wired to something that did not release anything.
+    //
+    // THE MUTATION THIS CATCHES: removing the `_teardownMedusa(project, active)`
+    // call from the crashed branch of `getSessionStatus`.
+    const medusa = require('../lib/medusa');
+    const session = store.sessions.start({
+      projectId, engineId: 'claude', tmuxSession: 'tc-unknown-medusa'
+    });
+    const sid = String(session.id);
+    try {
+      medusa.startSession({
+        projectPath: path.join(projectsDir, 'unknown-status'),
+        sessionId: sid,
+        name: 'Leak Guard',
+        wsFactory: (u) => new FakeWS(u)
+      });
+      assert.notEqual(medusa.getStatus(sid).state, 'off',
+        'precondition: the listener must actually be running, or the assertion below is vacuous');
+
+      withProbe(GONE, () => sessions.getSessionStatus('unknown-status'));
+
+      assert.equal(medusa.getStatus(sid).state, 'off',
+        'a session whose pane died must not keep a live Medusa listener holding its workspace open');
+    } finally {
+      medusa.forgetSession({ projectPath: path.join(projectsDir, 'unknown-status'), sessionId: sid });
+      if (store.sessions.get(session.id).status === 'active') {
+        store.sessions.kill(session.id, 'test cleanup');
+      }
     }
   });
 


### PR DESCRIPTION
## What

Adds the missing `_teardownMedusa()` call to the third session-end path — the branch where `getSessionStatus` observes that the pane is gone.

Fixes #1000.

## Why

`lib/sessions.js` had a teardown helper whose own JSDoc named the gap:

> Called from both end paths — **explicit kill and wrap teardown**.

Two paths. Neither is *"the tmux session died on its own."* So an abruptly-dead session kept its listener, and its WebSocket stayed open:

```
roster:  tangleclaw-roadmap-ee19d89e  connected=True  lastSeen=04:13:12Z   ← dead
roster:  tangleclaw-roadmap-3d5f988e  connected=True  lastSeen=04:13:16Z   ← live
```

Four seconds apart, both `connected: true`, indistinguishable.

## The leak is worse than a stale record

A leaked listener is a **live consumer**. A peer addressing the dead workspace gets:

```json
{"status":"received","id":"ffaab9f7-…","to":"tangleclaw-roadmap-ee19d89e"}
```

`received` means the *hub* accepted it. The message is then filed into an inbox no agent will ever read — a delivery that genuinely succeeded, to nobody. Nothing anywhere reports a problem, and the peer that restarted has lost its context and cannot tell you it never heard from you.

Hit live tonight: a long re-orientation brief was acknowledged as `received` and never arrived. It was only caught because a human noticed it hadn't shown up.

Severity scales with the abrupt-death rate, which today was 13 sessions.

## The fix

One call, placed beside `markCrashed` — the branch that persists *"this session has ended"* is the one that must release what it held.

## Test plan

- `node --test 'test/*.test.js'` → **6483 pass / 0 fail / 1 skipped**
- New guard in `test/session-status-unknown.test.js`, which already drives `getSessionStatus` with an injected `GONE` probe.

The guard asserts the **real effect** — `medusa.getStatus(sid).state === 'off'` — rather than that `forgetSession` was called. A spy would still pass if the call were wired to something that released nothing.

It also asserts the listener was running *before* the probe, so it cannot pass vacuously against a listener that was never started.

**Mutation:** removing `_teardownMedusa(project, active)` fails it —

```
not ok 3 - releases the session's Medusa presence when the pane is gone (#1000)
    a session whose pane died must not keep a live Medusa listener holding its workspace open
```

## Until this ships

Resolve a peer's workspace id from `GET /api/sessions/:project/medusa/status` immediately before sending. The roster is not authoritative.