### PR TITLE
Fix the Wrap button: it called a function that does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **The Wrap button was inert: it spun forever, opened an empty drawer, and could not be cancelled.** `public/session.js` called `startWrapSse()`, which is defined nowhere — #185 shipped the SERVER half of live wrap progress (`GET /wrap/stream`, the registry hooks the runner feeds) and no client was ever written. The call sat between the optimistic UI and the POST, so a ReferenceError fired *after* the spinner appeared and an empty drawer opened, and *before* the wrap request went out. The pipeline never started, and because the throw skipped the `finally`, `wrapInFlight` stayed `true` and Cancel remained permanently disabled.
+
+  **`node --check` passes on an undefined call** — it is a runtime error, not a syntax one — so the whole suite stayed green while the product's session-ending path was broken. It shipped in v5.11.0 and broke the first wrap attempted after it.
+
+  Restored to the honest blocking behaviour: the drawer opens when the POST returns its `pipelineResult`. The optimistic open should re-land *with* a real `EventSource` client, not before one — an empty drawer with nothing feeding it is worse than a drawer that arrives late.
+
+  A guard now scans the wrap-confirm path and fails when it calls anything undefined. It is scoped to that path rather than the whole file on purpose: a whole-file scan produces false positives from prose and browser globals, and a guard nobody trusts gets deleted. Verified both ways — re-adding `startWrapSse()` fails it, and breaking the extraction fails a separate vacuity assertion rather than silently passing on zero calls.
+
 ## [5.11.0] - 2026-08-19
 
 ### Added

--- a/public/session.js
+++ b/public/session.js
@@ -3285,16 +3285,23 @@ async function confirmWrap() {
   const postStartedAt = Date.now();
 
   // V1 and V2 both enter the wrapping state immediately (#771).
-  // The V2 POST blocks for the full duration of the wrap. This state
-  // is the only visible indication the pipeline is running until the
-  // SSE stream paints the drawer (#185).
+  // The V2 POST blocks for the full duration of the wrap, so this state is the
+  // only visible indication the pipeline is running until the POST returns.
   sessionState.wrapping = true;
   showWrappingState();
 
-  // #185: Open drawer empty and stream progress via SSE immediately
-  currentWrapPipelineResult = { results: [] };
-  openWrapDrawer(currentWrapPipelineResult, pw);
-  startWrapSse();
+  // #185 shipped the SERVER half of live wrap progress — GET /wrap/stream, and
+  // the registry hooks the runner feeds — but no client was ever written. This
+  // called `startWrapSse()`, which is defined nowhere, so it threw a
+  // ReferenceError HERE: after the spinner was shown and an empty drawer was
+  // opened, and BEFORE the POST below. The wrap never started, and because the
+  // throw skipped the `finally`, `wrapInFlight` stayed true and Cancel was
+  // permanently disabled. `node --check` passes on it, so CI stayed green.
+  //
+  // Restored to the honest blocking behaviour: the drawer opens when the POST
+  // returns a pipelineResult. Re-land the optimistic open together with a real
+  // EventSource client, not before it — an empty drawer with no stream feeding
+  // it is worse than a drawer that arrives late.
 
   try {
     const data = await apiMutate(

--- a/test/wrap-confirm-calls-defined.test.js
+++ b/test/wrap-confirm-calls-defined.test.js
@@ -1,0 +1,92 @@
+'use strict';
+
+/*
+ * The wrap-confirm path must not call a function that does not exist.
+ *
+ * #185 shipped the SERVER half of live wrap progress and left a call to
+ * `startWrapSse()` in `public/session.js` with no definition anywhere. At
+ * runtime that threw a ReferenceError positioned exactly between the optimistic
+ * UI and the POST:
+ *
+ *     sessionState.wrapping = true;
+ *     showWrappingState();          // spinner appears
+ *     openWrapDrawer({results: []}) // drawer opens EMPTY
+ *     startWrapSse();               // THROWS
+ *     try { await apiMutate(.../wrap, 'POST') }   // never reached
+ *     finally { wrapInFlight = false; }           // never runs
+ *
+ * So the wrap never started, the drawer never filled, and Cancel stayed
+ * permanently disabled because the throw skipped the `finally`. It shipped in
+ * v5.11.0 and broke the first wrap attempted after it.
+ *
+ * `node --check` passes on an undefined call — it is a runtime error, not a
+ * syntax one — so CI was green throughout. This guard is the thing that would
+ * have caught it.
+ *
+ * Deliberately scoped to the wrap-confirm path rather than the whole file: a
+ * whole-file scan produces false positives from prose and browser globals, and
+ * a guard nobody trusts gets deleted. This surface is ~9 calls and exact.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const PUBLIC = path.join(__dirname, '..', 'public');
+
+/** @param {string} t - Source. @returns {string} Source with comments removed. */
+function stripComments(t) {
+  return t.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+}
+
+/**
+ * Names defined in a file: function declarations, assignments, and the
+ * `global.x = x` exports `api-helper.js` uses to publish shared helpers.
+ * @param {string} t - Source.
+ * @returns {Set<string>}
+ */
+function definedNames(t) {
+  const out = new Set();
+  const re = /(?:function\s+([A-Za-z_$][\w$]*)|(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=|global\.([A-Za-z_$][\w$]*)\s*=)/g;
+  for (const m of t.matchAll(re)) out.add(m[1] || m[2] || m[3]);
+  return out;
+}
+
+// Language keywords and platform builtins that read as calls to the scanner.
+const NOT_FUNCTIONS = new Set(['if', 'for', 'while', 'switch', 'catch', 'return', 'typeof', 'encodeURIComponent']);
+
+describe('the wrap-confirm path calls only functions that exist', () => {
+  const session = fs.readFileSync(path.join(PUBLIC, 'session.js'), 'utf8');
+  const helper = fs.readFileSync(path.join(PUBLIC, 'api-helper.js'), 'utf8');
+
+  // The confirm handler, from the in-flight latch to the `finally` that clears it.
+  const start = session.indexOf('  wrapInFlight = true;');
+  const end = session.indexOf('    wrapInFlight = false;', start);
+
+  it('the wrap-confirm path is still locatable (the scan has something to read)', () => {
+    // Without this the extraction could silently yield an empty string and the
+    // assertion below would pass on zero calls — green, and measuring nothing.
+    assert.ok(start !== -1, 'could not find the wrap-confirm in-flight latch in session.js');
+    assert.ok(end > start, 'could not find the finally that clears wrapInFlight');
+  });
+
+  it('every function it calls is defined in session.js or api-helper.js', () => {
+    const body = stripComments(session.slice(start, end));
+    const called = [...new Set(
+      [...body.matchAll(/(?:^|[^\w$.])([a-z][\w$]*)\s*\(/g)].map((m) => m[1])
+    )].filter((n) => !NOT_FUNCTIONS.has(n));
+
+    assert.ok(called.length >= 5,
+      `expected the wrap path to call several helpers, found ${called.length} — the extraction is probably wrong`);
+
+    const defined = new Set([...definedNames(stripComments(session)), ...definedNames(stripComments(helper))]);
+    const missing = called.filter((n) => !defined.has(n));
+
+    assert.deepEqual(missing, [],
+      `the wrap-confirm path calls ${missing.join(', ')}, which nothing defines. At runtime this `
+      + 'throws a ReferenceError mid-handler: the optimistic UI above it has already run, the POST '
+      + 'below it never fires, and the `finally` that clears wrapInFlight is skipped — so the wrap '
+      + 'never starts and Cancel stays disabled. `node --check` will not catch it.');
+  });
+});


### PR DESCRIPTION
## What

`public/session.js` called `startWrapSse()`. **Nothing defines it** — one call site, zero definitions.

```
$ grep -rn "startWrapSse" public/
  public/session.js:3297:  startWrapSse();
```

## Why it broke exactly the way it did

#185 shipped the **server** half of live wrap progress — `GET /api/sessions/:project/wrap/stream`, plus the `wrapRunRegistry` hooks `_triggerWrapV2` feeds. No client was ever written; `grep -rn "wrap/stream\|EventSource" public/*.js` returns nothing.

The call's *position* is the whole failure:

```js
sessionState.wrapping = true;
showWrappingState();               // ← spinner appears
openWrapDrawer({ results: [] }, pw); // ← drawer opens EMPTY
startWrapSse();                      // ← ReferenceError
try {
  await apiMutate(`.../wrap`, 'POST'); // ← never reached
} finally {
  wrapInFlight = false;                // ← never runs
}
```

Reported symptoms map one-to-one: **spins forever** (spinner shown, nothing clears it), **drawer never fills** (opened empty, no stream), **cannot cancel** (`wrapInFlight` never released because the throw skipped the `finally`).

Confirmed against the server: no `POST .../wrap` in the log at all, and `/wrap/status` reports `running: false` — the pipeline genuinely never started.

## Why CI did not catch it

**`node --check` passes on a call to an undefined function.** It is a runtime `ReferenceError`, not a syntax error. The full suite was green through v5.9.0, v5.10.0 and v5.11.0 while the product's session-ending path was broken.

## The fix

Restored to the honest blocking behaviour — the drawer opens when the POST returns its `pipelineResult`. The optimistic open should re-land **together with** a real `EventSource` client, not before one: an empty drawer with nothing feeding it is worse than a drawer that arrives late.

The now-stale comment promising the SSE stream would paint the drawer is corrected too.

## The guard

`test/wrap-confirm-calls-defined.test.js` scans the wrap-confirm path and fails when it calls anything neither `session.js` nor `api-helper.js` defines.

Scoped to that path rather than the whole file **on purpose**: a whole-file scan produced 17 hits, mostly prose and browser globals. A guard nobody trusts gets deleted. This surface is ~9 calls and exact.

| Mutation | Result |
|---|---|
| re-add `startWrapSse()` | **fails** — names it, and explains the ReferenceError's position |
| break the extraction anchor | **fails** the separate vacuity assertion, rather than passing on zero calls |

## Test plan

- `node --test 'test/*.test.js'` → **6491 pass / 0 fail / 1 skipped**
- Both mutations above
- Server state confirms the diagnosis: drawer requested and acked at `05:04:27`, no `POST .../wrap` ever logged

## Follow-up

The SSE client half of #185 is still unwritten. Filing separately — the server endpoint and registry hooks are live and unconsumed.