### PR TITLE
Fix: bare /openclaw-direct/<connId> 404s its own app bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **`/openclaw-direct/<connId>` without a trailing slash 404'd its own app bundle, and the failure surfaced as a browser-extension warning from another repo (#1012).** The bare form served the OpenClaw Control UI index, whose script tag is relative — `src="./assets/index-DUOiCYMK.js"`. From a base with no trailing slash the browser resolves that to `/openclaw-direct/assets/...`, where the proxy reads path segment 2 as the connection id, looks up a connection literally named `assets`, misses, and 404s the bundle.
+
+  The page then renders with no `openclaw-app` custom element ever registering, and OpenClaw's own error card blames "a browser extension or early content script" — a misdiagnosis three layers from the cause, in a repo that cannot see TangleClaw's routing. The bare form now 301s to the canonical slashed URL, query string preserved, so relative assets resolve from any entry point rather than only from the `/chat` sub-path today's UI happens to use.
+
+  Guards pin the redirect, the query-string carry, that a sub-path still proxies rather than redirecting (redirecting `/chat` would loop the UI's own frame src), that an unknown connection still 404s ahead of the redirect, and — the reason the redirect exists — that the unslashed asset path is genuinely broken. Mutation-verified: removing the branch reds two of them rather than leaving them vacuously green.
+
+  This is the deterministic half of #1012. The reported blocker's other half — a tunnel that drops mid-load leaves the UI on "starting tunnel" with no honest terminal state — remains open there.
+
 ## [5.11.1] - 2026-08-19
 
 ### Fixed

--- a/server.js
+++ b/server.js
@@ -5517,6 +5517,21 @@ async function handleRequest(req, res) {
       if (!resolved) {
         return errorResponse(res, 404, 'OpenClaw connection not found', 'NOT_FOUND');
       }
+      // #1012 — the bare `/openclaw-direct/<connId>` form serves the Control UI
+      // index, whose script tag is RELATIVE (`src="./assets/index-*.js"`). From a
+      // base with no trailing slash the browser resolves that to
+      // `/openclaw-direct/assets/...`, where `parts[2]` above reads "assets" as the
+      // connection id, misses, and 404s the bundle. The page then renders but the
+      // `openclaw-app` component never registers, and OpenClaw's own error card
+      // blames a browser extension — a misdiagnosis three layers from the cause.
+      // Redirect to the canonical slashed form so relative assets resolve from any
+      // entry point (a link, a bookmark, a hand-typed URL), not just from the
+      // `/chat` sub-path today's UI happens to use.
+      if (parts.length === 3) {
+        const query = req.url.includes('?') ? '?' + req.url.split('?').slice(1).join('?') : '';
+        res.writeHead(301, { Location: pathname + '/' + query });
+        return res.end();
+      }
       const subPath = parts.slice(3).join('/');
       const targetPath = '/' + subPath + (req.url.includes('?') ? '?' + req.url.split('?')[1] : '');
 

--- a/test/openclaw-direct-trailing-slash.test.js
+++ b/test/openclaw-direct-trailing-slash.test.js
@@ -1,0 +1,145 @@
+'use strict';
+
+/*
+ * #1012 — `/openclaw-direct/<connId>` with no trailing slash served the Control
+ * UI index directly. That index's script tag is RELATIVE:
+ *
+ *     <script type="module" crossorigin src="./assets/index-DUOiCYMK.js">
+ *
+ * From a base with no trailing slash the browser resolves that to
+ * `/openclaw-direct/assets/index-*.js`, where the proxy reads path segment 2 as
+ * the connection id — so it looks up a connection literally named "assets",
+ * misses, and 404s the bundle. The page renders, the `openclaw-app` web
+ * component never registers, and OpenClaw's own error card blames a browser
+ * extension: a misdiagnosis three layers from the cause.
+ *
+ * The fix redirects the bare form to the canonical slashed one. The guard below
+ * pins the redirect AND the reason it exists — that the unslashed asset path is
+ * genuinely broken — so deleting the redirect fails a test that explains itself.
+ *
+ * Verified by mutation: dropping the `parts.length === 3` branch from server.js
+ * turns the redirect assertions red rather than leaving them vacuously green.
+ */
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { PassThrough } = require('node:stream');
+const { setLevel } = require('../lib/logger');
+const store = require('../lib/store');
+const { handleRequest } = require('../server');
+
+setLevel('error');
+
+/**
+ * Minimal res double that captures status and headers.
+ * @returns {{statusCode:number, headers:object, body:string, writeHead:Function, end:Function}}
+ */
+function mockRes() {
+  return {
+    statusCode: 0,
+    headers: {},
+    body: '',
+    writeHead(status, headers) {
+      this.statusCode = status;
+      this.headers = headers || {};
+    },
+    end(chunk) { if (chunk != null) this.body = String(chunk); },
+    // The sub-path case pipes a real proxy response into this double, so it has
+    // to be writable-shaped. No-ops are enough — the assertions read statusCode.
+    on() { return this; },
+    once() { return this; },
+    emit() { return false; },
+    write() { return true; },
+    setHeader() {},
+    getHeader() { return undefined; }
+  };
+}
+
+/**
+ * Drive a GET through the real request handler.
+ * @param {string} url - Raw request target.
+ * @returns {Promise<object>} The mock res after handling.
+ */
+async function get(url) {
+  const req = { url, method: 'GET', headers: { host: 'localhost:3102' }, on() {} };
+  const res = mockRes();
+  await handleRequest(req, res);
+  return res;
+}
+
+describe('/openclaw-direct/<connId> redirects to the slashed form (#1012)', () => {
+  let tmpDir;
+  let connId;
+
+  before(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tc-oc-slash-'));
+    store._setBasePath(tmpDir);
+    store.init();
+    const conn = store.openclawConnections.create({
+      name: 'SlashTest',
+      host: '10.0.0.9',
+      sshUser: 'admin',
+      sshKeyPath: '~/.ssh/id_rsa'
+    });
+    connId = conn.id;
+  });
+
+  after(() => {
+    store.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('301s the bare form to the canonical trailing-slash URL', async () => {
+    const res = await get(`/openclaw-direct/${connId}`);
+    assert.equal(res.statusCode, 301, 'bare form must redirect, not serve the index');
+    assert.equal(
+      res.headers.Location, `/openclaw-direct/${connId}/`,
+      'must point at the slashed form so relative ./assets/* resolve under the connId'
+    );
+  });
+
+  it('preserves the query string across the redirect', async () => {
+    const res = await get(`/openclaw-direct/${connId}?session=main&x=1`);
+    assert.equal(res.statusCode, 301);
+    assert.equal(
+      res.headers.Location, `/openclaw-direct/${connId}/?session=main&x=1`,
+      'a dropped query would silently change which session the UI opens'
+    );
+  });
+
+  it('does NOT redirect a sub-path — those proxy through untouched', async () => {
+    // A sub-path reaches the real proxy, which pipes the request body, so this
+    // one needs a stream-shaped req. The tunnel port is dead in test, so the
+    // proxy errors out to 502 — which is the point: it PROXIED rather than
+    // redirected. Redirecting `/chat` would loop the UI's own frame src.
+    const req = new PassThrough();
+    req.url = `/openclaw-direct/${connId}/chat?session=main`;
+    req.method = 'GET';
+    req.headers = { host: 'localhost:3102' };
+    const res = mockRes();
+    await handleRequest(req, res);
+    req.end();
+    for (let i = 0; i < 100 && res.statusCode === 0; i++) {
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    assert.notEqual(res.statusCode, 0, 'the proxy must answer, otherwise this asserts nothing');
+    assert.notEqual(res.statusCode, 301, '/chat is the path the UI actually uses; redirecting it would loop');
+  });
+
+  it('an unknown connection still 404s rather than redirecting into a dead end', async () => {
+    const res = await get('/openclaw-direct/no-such-connection');
+    assert.equal(res.statusCode, 404, 'redirect must not outrank the connection check');
+    assert.match(res.body, /NOT_FOUND/);
+  });
+
+  it('the unslashed asset path a bare base produces is genuinely broken — the reason this redirect exists', async () => {
+    const res = await get('/openclaw-direct/assets/index-DUOiCYMK.js');
+    assert.equal(
+      res.statusCode, 404,
+      'if this ever stops 404ing, the resolve-by-segment-2 hazard changed and this guard needs rereading'
+    );
+  });
+});


### PR DESCRIPTION
## What

Redirects `/openclaw-direct/<connId>` (no trailing slash) to `/openclaw-direct/<connId>/` with a 301, query string preserved. Adds `test/openclaw-direct-trailing-slash.test.js`.

Fixes the deterministic half of #1012.

## Why

The bare form served the OpenClaw Control UI index, whose script tag is **relative**:

```html
<script type="module" crossorigin src="./assets/index-DUOiCYMK.js">
```

From a base with no trailing slash the browser resolves that to `/openclaw-direct/assets/index-*.js`. The proxy reads path segment 2 as the connection id, so it looks up a connection literally named `assets`, misses, and 404s the bundle.

The page then renders with `openclaw-app` never registering — and OpenClaw's own error card blames *"a browser extension or early content script"*. That text is not ours (`grep` finds it nowhere in `public/`, `lib/`, `server.js`, `data/`); it ships in the OpenClaw bundle, which cannot see TangleClaw's routing. So a TC path bug surfaced to the operator as a browser problem, three layers from the cause.

Today's UI dodges it because `public/openclaw-view.js:93` points the frame at `/openclaw-direct/<id>/chat`, whose base ends in a path segment. Any link, bookmark, redirect, or future caller landing on the bare form got the broken page — latent, not live.

Verified against the running server before and after:

| URL | Before | After |
|---|---|---|
| `/openclaw-direct/<id>` | 200 (index with dead assets) | 301 → `/openclaw-direct/<id>/` |
| `/openclaw-direct/assets/index-*.js` | 404 | 404 (unchanged — that's the hazard) |
| `/openclaw-direct/<id>/chat` | 200 | 200 (unchanged) |

## Test plan

Five guards in the new file, all green; full suite green (`node --test 'test/*.test.js'`, the CI command), 0 failures.

They pin the redirect, the query-string carry (a dropped query silently changes which session the UI opens), that a **sub-path still proxies** rather than redirecting — redirecting `/chat` would loop the UI's own frame src — that an unknown connection still 404s *ahead of* the redirect, and that the unslashed asset path is genuinely broken, which is the reason the redirect exists.

**Mutation-verified.** Replacing `parts.length === 3` with `false` turns 2 of the 5 red rather than leaving them vacuously green.

## Not in scope

The reported blocker's other half — a tunnel dropping mid-load leaves the UI on "starting tunnel" with no honest terminal state — stays open on #1012. `tunnel-monitor` auto-heals the drop, so it needs a repro to fix properly.

The misdiagnosing error card is OpenClaw's; that has been handed to the OpenClaw side over the switchboard and acknowledged.