### PR TITLE
chore: add missing prawduct session-file gitignore entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ logs/
 # no plugin reference, TC will generate a CLAUDE.md rather than leave it alone.
 # That coupling is issue #833; revisit this line when #833 is decided.
 CLAUDE.md
+
+# Prawduct session files
+.prawduct/.critic-partials-archive/


### PR DESCRIPTION
## What
Adds `.prawduct/.critic-partials-archive/` to `.gitignore`, the one session-file entry missing from prawduct's gitignore contract.

## Why
Flagged by the `gitignore-contract-drift` advisory. Verified against the plugin's actual `GITIGNORE_ENTRIES`/`RETIRED_GITIGNORE_ENTRIES` constants line-by-line — all 21 required entries now present, no retired entries.

## Test plan
- [x] Diffed `.gitignore` against `lib/core.py` contract constants directly