### PR TITLE
chore: set merge=union on .prawduct/change-log.md

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.prawduct/change-log.md merge=union


### PR DESCRIPTION
## What
Adds `.gitattributes` with `.prawduct/change-log.md merge=union`.

## Why
Flagged by the prawduct 3.4.0 doctor's new change-log merge-attribute check. Every branch prepends its change-log entry to the same first lines, so merging an advanced base conflicts there every time; the built-in git `union` merge driver keeps both sides' entries automatically instead.

## Test plan
- [x] `git check-attr merge -- .prawduct/change-log.md` confirmed unspecified before this change