### PR TITLE
Mark the #996 plan complete

### DIFF
--- a/.tangleclaw/plans/996-master-medusa.md
+++ b/.tangleclaw/plans/996-master-medusa.md
@@ -1,8 +1,8 @@
 # Plan — #996: Wire Medusa to the Master
 
-**Issue:** [#996](https://github.com/Jason-Vaughan/TangleClaw/issues/996) (OPEN, verified 2026-08-21) · **Milestone:** Master Control (#829)
+**Issue:** [#996](https://github.com/Jason-Vaughan/TangleClaw/issues/996) (CLOSED 2026-08-21 by #1081 — this plan is complete; archive candidate) · **Milestone:** Master Control (#829)
 **Predecessors:** #768 (control bar, Medusa slot shipped as a labelled placeholder) · #755/#968 (access level, server-enforced) · MED-2K9P (session switchboard v1)
-**Status:** chunk 1 SHIPPED 2026-08-21 as #1079 (`6b05c52`), live on the operator's install (Master listening as `project-master-1ad424e1`); chunk 2 BUILT 2026-08-21 (branch `feat/996-master-medusa-bar`). Chunk boxes are in `## Status` at the bottom.
+**Status:** chunk 1 SHIPPED 2026-08-21 as #1079 (`6b05c52`), live on the operator's install (Master listening as `project-master-1ad424e1`); chunk 2 SHIPPED 2026-08-21 as #1081 (`d39f87f`), **verified live in Chrome on both surfaces** (dashboard Master panel + session drawer: gold heads lit, label "on, listening"). #996 CLOSED. Chunk boxes are in `## Status` at the bottom.
 
 ## Why this slipped
 


### PR DESCRIPTION
## What
Plan status: chunk 2 shipped as #1081 and verified live in Chrome on the dashboard Master panel and the session drawer; #996 closed. Plan is an archive candidate.

## Why
Plan Status is what the next session believes. Doc-only.

## Test plan
- [x] Doc-only.