### PR TITLE
docs(plan): compose the v5.13.0 Switchboard train (#818)

### DIFF
--- a/.tangleclaw/plans/818-switchboard-truth.md
+++ b/.tangleclaw/plans/818-switchboard-truth.md
@@ -1,0 +1,188 @@
+# v5.13.0 — The Switchboard Tells The Truth
+
+**Tracking issue:** [#818](https://github.com/Jason-Vaughan/TangleClaw/issues/818) (rollup) · **Milestone:** Session Switchboard
+**Composed:** 2026-08-21 · **Status:** roster ratified, no car started
+**Hosted mirror:** https://claude.ai/code/artifact/097ad1cb-6325-4b8c-b547-5a0e97bc259c (updated in place)
+
+---
+
+## Why this train, and why now
+
+**This is an un-honored release gate, not new work.** #818 opens with an operator ruling dated
+2026-07-31: *"a working Switchboard is a **v5 release requirement**, not post-v5 polish."*
+v5.0.0 shipped 2026-08-13 without it. Twelve minor releases have gone out since.
+
+**The blocker has moved to our side of the wire.** #818's proposed cut named seven issues — five in
+TangleClaw, two in Medusa. The Medusa half is **done**:
+
+| Issue | State | Closed |
+|---|---|---|
+| Medusa#25 — `medusa_hook` to a nonexistent workspace returns success | CLOSED | 2026-08-15 |
+| Medusa#22 — presence ≠ deliverability; broadcast delivers 0/N | CLOSED | 2026-08-15 |
+| Medusa#31 — three disjoint ID namespaces | CLOSED | 2026-08-15 |
+
+`Jason-Vaughan/Medusa` has **zero open issues**. The bus was fixed six days ago. TangleClaw's six
+integration issues have not been touched since early August. "Who drives the Medusa half" — #818's
+third open follow-up — is answered: nobody needs to.
+
+**We just put the Master on this channel.** v5.12.0 (#996, both chunks) made the Project Master a
+switchboard participant — the one session with a fleet-wide view now rides a bus with no delivery
+guarantee. Every car below makes that shipped feature more true.
+
+**A third-party report is sitting on the subsystem.** #1075 (GURULifeline, 2026-08-21) reports the
+roster endpoint returning `502 BRIDGE_UNREACHABLE`. It does **not** reproduce here — a live probe of
+`GET /api/sessions/Medusa/medusa/roster` returned 200 with a full workspace list. Off-train and
+tracked; see "Open questions".
+
+## The completion test
+
+**This train is done when operator project rule #5 can be deleted.**
+
+That rule is a six-step manual procedure the operator wrote because the channel lies. Its own text
+names the exit condition: *"Until #791/#792/#785/#784 land, treat the following as the procedure
+rather than as improvisation."* Each step maps to a car:
+
+| Rule #5 step | Retired by |
+|---|---|
+| 1. Keep your own watermark (`read` is advisory) | Car 1 (#784) |
+| 2. Verify delivery, never assume it (peek at the peer's pane) | Car 2 (#792, #791) |
+| 3. Then inject, but check the prompt first (draft-clobber) | Car 1 (#812) |
+| 4. tmux targets must be exact | Car 3 (#1025 addressing) |
+| 5. Consent is not optional | stays — a norm, not a defect |
+| 6. Instruct the peer to verify rather than recall | stays — a norm, not a defect |
+
+Steps 5–6 are genuine collaboration norms and survive as a shorter rule. Steps 1–4 are workarounds
+for defects and go away with them. **The deliverable is the rule shrinking, and it is externally
+checkable** — a property this subsystem otherwise lacks, since its whole failure mode is looking
+fine from one side.
+
+---
+
+## The cars
+
+### Car 1 — Stop the bleeding, and give the inbox a lifecycle
+**#812 · #784 · #785**
+
+`#812` rides first because it is the only car that can **destroy operator work** and it is
+independent of everything else. `lib/tmux.js:529#sendKeys` pastes via `load-buffer`/`paste-buffer -p`
+and then fires `Enter` unconditionally — with no read of what is already at the prompt. tmux
+*appends*, so injecting onto a half-typed line submits the operator's text with our payload glued on.
+Verified against the tree 2026-08-21: there is no prompt check anywhere in the function.
+
+`#784`/`#785` are the foundation the rest of the train assumes: that **"handled" is a real state**.
+Verified against the tree:
+
+- `lib/medusa-listener.js:93` — `this.inbox = []`, in-memory, capped at 500, not persisted.
+- `lib/medusa-listener.js:169#markRead` — mutates `this.unread` (a scalar) and the
+  `_unackedIds`/`_ackAwaiting` sets that drive Hub ACKs. **Not one line writes to a message object.**
+- `lib/medusa.js:195#getMessages` — returns `listener.inbox.slice()` raw.
+
+So `read` comes back `None` because the field is never created. The ACK path is correct; TangleClaw
+then keeps its own untouched copy forever and every reader re-derives "is this new?" from scratch.
+
+**Design fork, already scoped in #784 and to be settled before code:**
+
+1. **Stamp** — add a real per-message `read`/`handledAt`, set it in `markRead`, let `GET` filter or
+   expose it. Backwards-compatible; keeps history in the inbox; every consumer must still opt into
+   filtering.
+2. **Clear on delivery** — remove ACKed messages from `this.inbox`. Simpler contract, no flag to get
+   wrong, makes the common bug structurally impossible.
+
+Operator leans (2) — *"once a message is properly delivered it should be cleared from the switchboard
+right?"* — and it is the stronger design. **Blocking dependency to resolve first:**
+`lib/medusa.js:505#getLoops` iterates `listener.inbox` to re-learn loop ids from messages tagged
+`loopId`. Clearing the inbox removes that history. Loop state needs a home that is not the inbox
+before (2) can be committed to. Cost that out as step one of this car.
+
+### Car 2 — Delivery is receipted, not assumed
+**#792 · #791 · #934**
+
+The sender must learn whether the session was actually told. Today `{"status":"received"}` from the
+hub means the *hub* has it — the peer may never have been woken, and the operator becomes the
+transport. `#934` belongs here rather than with the UI cars: notifications not clearing is a missing
+ACK, which is the same lifecycle question as the receipt.
+
+Per #818, a **TangleClaw-side receipt is an acceptable shape** — the guarantee is testable from here
+alone and does not require touching Medusa's architecture.
+
+### Car 3 — Injection reaches the right reader
+**#783 · #1025 · #998**
+
+Three ways a nudge lands on the wrong reader: a focused **subagent** absorbs it (`#783`, false-idle
+read with no agent-focus gate); **any** running agent in a session can pick up mail meant for the
+session (`#1025`, no addressing); and the shared-doc watcher nudges **the session that wrote the
+file** (`#998`, a self-inflicted wake loop into a live pane).
+
+### Car 4 — Identity survives a restart
+**#1023**
+
+A peer restart rotates its ephemeral workspace id and sends hard-fail `SEND_REJECTED`. **#996 already
+solved this for the Master** by pinning the workspace id to its home directory through the existing
+registry (`<home>/.tangleclaw/medusa/registry.json`) — kill → ensure yields the same id. Check whether
+that technique generalizes to project sessions before designing anything new.
+
+### Car 5 — The surfaces stop lying
+**#836 · #820 · #556**
+
+Listeners outlive their sessions and the roster reports dead sessions as `connected` (`#836`) — the
+same class of lie as Medusa#22, on our side. The Medusa control renders on every session page
+regardless of `medusaEnabled`, because the flag gates autostart and not the surface (`#820`). The
+live-loop glow overrides mark-state filters, so blue on gold reads green (`#556`).
+
+### Car 6 — The channel teaches itself, and the rule comes down
+**#912 · #1020 · #904** → **delete project rule #5 steps 1–4**
+
+The wake nudge omits the reply obligation, so initiators hang silently (`#912`). It points at a
+"project guide" that never states the base URL — dangling for every plugin-governed project
+(`#1020`). And generated project rules never mention the switchboard at all, so sessions cannot use
+infrastructure they were never told exists (`#904`).
+
+`#904` is the exact counterpart of the completion test: **the workaround leaves the operator's
+hand-written rules, and the capability enters the generated ones.** Engine-agnostic rule applies
+directly — the generated text must interpolate each engine's own config filename, never `CLAUDE.md`.
+
+---
+
+## Explicitly not on this train
+
+**All switchboard automation: #801 · #979 · #1040 · #1041 · #1042 · #1043.** #818 gates these on the
+delivery guarantee, and they are the fastest way to make the train never leave. Auto-inject built on
+a channel that drops messages automates the lie.
+
+**Also off:** #810 (always-on steward session class), #868 (stranded wrap discoverability), #1084
+(shared-doc broadcast reaches the Master — a feature, and #818's cut says features wait), #1075
+(does not reproduce).
+
+---
+
+## Verification stance — read this before scoring any car
+
+**This subsystem's entire failure mode is that it looks correct from one side.** A green suite is not
+evidence a message arrived. Per `reference_live_verification_traps` and
+`feedback_wait_conditions_must_be_falsifiable`:
+
+- Cars 1–2 are not done on a unit suite. **The bar is a real two-session round trip** against the
+  Medusa session (`feedback_switchboard_test_target` — Medusa is the sanctioned target; any other
+  live session means ask first and wait).
+- `pgrep` never matches in-process agents and mtime fires on unrelated writes. Any wait condition
+  used to score a round trip must be falsifiable — name the mutation that turns it red.
+- Never `2>/dev/null` in a wait condition: it turns "broken" into "not yet".
+
+## Open questions for the operator
+
+1. **#784's design fork** — stamp vs clear-on-delivery. Recommendation: clear-on-delivery, *after*
+   `getLoops` gets a home for loop state that is not the inbox. Needs a ruling before car 1 codes.
+2. **#1075 (GURULifeline)** — does not reproduce; roster returns 200 here. Reply asking whether it
+   was transient or persists on his install? Third-party reports are the only place several defect
+   classes are observable at all (`project_field_installer_elliot`), and the batched-release model
+   has no fast lane for them yet (`project_post_v5_release_cadence`).
+3. **Does #818 close with this train, or stay open** for the deferred automation half?
+
+## Status
+
+- [ ] Car 1 — Stop the bleeding, and give the inbox a lifecycle (#812, #784, #785)
+- [ ] Car 2 — Delivery is receipted, not assumed (#792, #791, #934)
+- [ ] Car 3 — Injection reaches the right reader (#783, #1025, #998)
+- [ ] Car 4 — Identity survives a restart (#1023)
+- [ ] Car 5 — The surfaces stop lying (#836, #820, #556)
+- [ ] Car 6 — The channel teaches itself, and the rule comes down (#912, #1020, #904)


### PR DESCRIPTION
## What

Adds `.tangleclaw/plans/818-switchboard-truth.md` — the composed **v5.13.0 release train, "The Switchboard Tells The Truth."** Plan only; no runtime change.

Six dependency-ordered cars, 16 issues, tracked on #818 and the `Session Switchboard` milestone.

## Why

Composing a train rather than shipping the next available fix, per the post-v5 cadence ("a complete train with cars, sorted").

The finding that picked this train over Master Control: **#818's Medusa half is already done.** M#25, M#22 and M#31 all closed 2026-08-15 and `Jason-Vaughan/Medusa` now has zero open issues — so the delivery guarantee the operator made a **v5 release requirement** on 2026-07-31, and which v5 shipped without, is blocked entirely on TangleClaw's six integration issues. Those have not been touched since early August. #818's third open follow-up ("who drives the Medusa half") no longer needs an owner.

Reinforcing: v5.12.0 (#996) just made the Project Master a participant on that same channel.

## The completion test

**The train is done when operator project rule #5 can be deleted.** That rule is a six-step manual workaround naming its own exit condition — *"Until #791/#792/#785/#784 land, treat the following as the procedure."* Steps 1–4 map to cars 1–3; steps 5–6 are collaboration norms and survive as a shorter rule. This subsystem otherwise has no externally checkable done-condition, since its whole failure mode is looking correct from one side.

## Test plan

Plan document only — no code, no CHANGELOG entry (matching the #1082 precedent for plan-only PRs).

Verified against the tree at `92fe09c` rather than inferred from the issue bodies:
- `lib/medusa-listener.js:169#markRead` mutates `unread`/`_unackedIds`/`_ackAwaiting` only, never a message object.
- `lib/medusa.js:195#getMessages` returns `listener.inbox.slice()` raw — the `read` field is never created.
- `lib/medusa.js:505#getLoops` iterates `listener.inbox`, which is the blocking dependency for clear-on-delivery.
- `lib/tmux.js:529#sendKeys` pastes then fires `Enter` with no read of the prompt.
- Medusa issue states confirmed via `gh issue view -R Jason-Vaughan/Medusa`.

## Also in this change (repo state, not files)

Milestone hygiene — the cluster read as 15 open when it was 22. #1025, #1023, #1020, #998, #934, #912 and #1075 assigned to `Session Switchboard`; #791, #836, #934, #912, #1075 and #801 labelled.

Refs #818
