### PR TITLE
Fix the wake gate reading an at-rest hint as a running fleet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to TangleClaw are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **The wake gate read an at-rest affordance as a running fleet, so any idle Claude session stopped waking (#1101).** `_FLEET_RE` matched `← N agents` in the status line. That text is the "press ← to view agents" hint on the **empty-composer** row — it renders *because* the session is at rest, and clears the instant a character is typed. Keying the gate on it inverted the gate: an idle session read `agents-running`, and never recovered, because an idle composer never fills on its own. The comment claimed the cost was "a delayed nudge that the next tick retries"; the retry could not succeed, so the cost was the wake itself.
+
+  Measured, not inferred, across four live states of one session: the hint is present at rest, present while an agent runs, and present after it finishes — and its count never moved, reading `2` with nothing dispatched, `2` with one agent running, and `2` once it completed. It tracks liveness in neither direction. The observed blast radius was six of six Claude sessions, including the Project Master, which made the switchboard's **return** path fail unattended: a reply reaches the initiator's inbox and nothing announces it. One session sat on an undelivered message for 31 minutes and was nudged within seconds of a single space being typed into its pane.
+
+  The gate now keys on Claude Code's **agent block** — the rows rendered above the composer while a fleet is live, which appear when it starts and clear when the last agent finishes. It matches the *unfocused* row (`◯`), because the glyphs mark focus rather than liveness: #783's capture had the agent focused (`◯ main` / `⏺ prawduct-critic`) and the 2026-08-21 capture had main focused (`⏺ main` / `◯ general-purpose`), so keying on `◯` works from either side. `⏺` would be wrong — Claude Code uses it for ordinary transcript lines too. The match is anchored at line start, because the tail is 15 lines of arbitrary transcript rather than a status line, and an unanchored scan let a session block its own nudge merely by *mentioning* agents in its output.
+
+  The hazard #783 identified is unchanged and still guarded: with a subagent focused the busy marker moves into the agent block, so `esc to interrupt` is absent and a bare prompt is rendered — which is why the gate sits above the prompt checks. Regression fixtures are verbatim live captures of all four states, and reverting the regex turns exactly the two new guards red. `lib/medusa-wake.js`, `test/medusa-wake.test.js`.
+
 ## [5.13.0] - 2026-08-21
 
 ### Added

--- a/lib/medusa-wake.js
+++ b/lib/medusa-wake.js
@@ -127,17 +127,46 @@ function _strip(text) {
 }
 
 /**
- * @type {RegExp} The running-subagent-fleet indicator in a Claude Code pane's
- * status line, from the live capture in #783: `⏵⏵ bypass permissions … · ← 1 agent`.
+ * @type {RegExp} The running-subagent-fleet indicator: an unfocused row of
+ * Claude Code's agent block, rendered directly above the composer while a fleet
+ * is live. The block appears when the fleet starts and clears when the last
+ * agent finishes, so a block row is present iff agents are actually running.
  *
- * Deliberately broader than "a subagent currently has focus". Focus can change
- * between the capture and the paste, and only one live capture of the
- * multi-agent render exists — inferring the focused-main variant from it would
- * be the guessing this module forbids for engine markers. Refusing while ANY
- * agent runs costs a delayed nudge that the next tick retries; the failure it
- * prevents is a reviewer acting on someone else's mail mid-review.
+ * The glyphs mark FOCUS, not liveness — `⏺` is the focused entry and `◯` the
+ * unfocused one, which is why the two live captures disagree about which name
+ * carries which:
+ *
+ *   #783 (agent focused):   `◯ main` / `⏺ prawduct-critic  Composing …  7m 20s`
+ *   2026-08-21 (main focused): `⏺ main` / `◯ general-purpose  Find lib …  4s`
+ *
+ * Keying on `◯` therefore works from either side: the block lists `main` plus
+ * every agent, so whenever it renders at least one row is unfocused. Matching
+ * `⏺` instead would be wrong — Claude Code uses it for ordinary transcript
+ * lines too (`⏺ Agent "…" finished`, `⏺ Running 1 shell command…`).
+ *
+ * Anchored at line start, because an unanchored scan matches the glyph anywhere
+ * in ordinary terminal output — the pane tail is 15 lines of arbitrary content,
+ * not a status line.
+ *
+ * NOT the `← N agents` text in the status line, which this gate used until it
+ * was measured. That is the "press ← to view agents" affordance on the
+ * empty-composer hint row: it renders because the input box is EMPTY, which is
+ * the at-rest state this monitor exists to act on, and it clears the instant any
+ * character is typed. Keying the gate on it inverted the gate — idle sessions
+ * read busy, and never recovered, because an idle composer never fills on its
+ * own. Measured across four live states (at rest / at rest with the hint cleared
+ * / agent running / agent finished): the hint is present in three of them and
+ * the count does not track live agents in either direction.
+ *
+ * The hazard #783 identified is real and this still guards it: with a subagent
+ * focused the busy marker MOVES into the agent block, so `esc to interrupt` is
+ * absent and a bare prompt IS rendered — a session minutes into a turn reads
+ * `at-prompt`, and the two-tick debounce confirms the false read rather than
+ * rejecting it, because the state is stable. Second, the paste buffer targets
+ * whichever view holds focus, so the nudge would land in the subagent's
+ * composer — telling a reviewer mid-review to act on someone else's mail.
  */
-const _FLEET_RE = /←\s*\d+\s*agents?\b/;
+const _FLEET_RE = /^[ \t]*◯[ \t]+\S/m;
 
 /**
  * Judge a captured pane tail against an engine profile: is the session safe to
@@ -160,17 +189,10 @@ const _FLEET_RE = /←\s*\d+\s*agents?\b/;
 function _assessPane(lines, profile) {
   const text = _strip((lines || []).join('\n'));
   if (text.includes(profile.busyMarker)) return { idle: false, reason: 'turn-in-flight' };
-  // A running subagent fleet makes the pane unsafe to type into for two
-  // independent reasons, so this gate sits above the prompt checks rather than
-  // beside them (#783). First, the busy marker MOVES: with a subagent focused
-  // the turn indicator lives in the agent block below the status line, so
-  // `esc to interrupt` is absent and the bare prompt IS rendered — a session
-  // seven minutes into a turn reads `at-prompt`, and the two-tick debounce
-  // confirms the false read instead of rejecting it, because the state is
-  // stable for minutes. Second, paste-buffer targets whichever view holds
-  // focus, so the nudge lands in the subagent's composer — and the nudge tells
-  // its reader to fetch and act on Medusa mail, which a reviewer mid-review
-  // must not do.
+  // A running subagent fleet makes the pane unsafe to type into, so this gate
+  // sits above the prompt checks rather than beside them (#783) — see
+  // `_FLEET_RE` for why the agent block is the signal and the status-line
+  // `← N agents` hint is not.
   if (_FLEET_RE.test(text)) return { idle: false, reason: 'agents-running' };
   if (profile.idleMarker && !text.includes(profile.idleMarker)) {
     return { idle: false, reason: 'not-at-rest' };

--- a/test/medusa-wake.test.js
+++ b/test/medusa-wake.test.js
@@ -169,6 +169,37 @@ const SUBAGENT_FOCUSED_PANE = [
   '  ⏺ prawduct-critic  Composing reviewer.json critic partial   7m 20s · ↓ 133.2k tokens'
 ];
 
+/**
+ * Live captures from 2026-08-21, taken while diagnosing #1101 across four real
+ * states of one session. They are the evidence that `← N agents` is an at-rest
+ * affordance rather than a fleet indicator: it is present in three of the four,
+ * including both states where nothing is running, and its count never changed —
+ * it read `2` with no agent dispatched, `2` with one running, and `2` after it
+ * finished.
+ */
+const AT_REST_WITH_AGENTS_HINT = [
+  '  ...which is why the wake was refused.',
+  '',
+  '❯ ',
+  '  TiLT Claw (main) | Opus 5 (1M context) | 62% left',
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← 2 agents'
+];
+
+const AGENT_RUNNING_PANE = [
+  '❯ ',
+  '  TangleClaw (main) | Opus 5 (1M context) | 77% left',
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← 2 agents',
+  '',
+  '  ⏺ main',
+  '  ◯ general-purpose  Find lib files lacking tests                    4s'
+];
+
+const AGENTS_FINISHED_PANE = [
+  '❯ ',
+  '  TangleClaw (main) | Opus 5 (1M context) | 77% left',
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle) · /tasks to see subagents · ← 2 agents'
+];
+
 describe('medusa-wake — _assessPane (Claude idle policy, pinned byte-for-byte)', () => {
   it('refuses a pane with a running subagent, even though it reads at-prompt (#783)', () => {
     // The regression this gate exists for. Both of the old policy's signals say
@@ -195,6 +226,46 @@ describe('medusa-wake — _assessPane (Claude idle policy, pinned byte-for-byte)
   it('does not mistake ordinary pane text for a fleet indicator', () => {
     const chatter = ['I asked 2 agents about it earlier', '❯'];
     assert.deepEqual(wake._assessPane(chatter, CLAUDE), { idle: true, reason: 'at-prompt' });
+  });
+
+  it('judges an at-rest pane idle even though the status line offers `← N agents` (#1101)', () => {
+    // The bug this fixture exists for. `← N agents` is the "press ← to view
+    // agents" affordance on the EMPTY-composer hint row — it renders because the
+    // session is at rest, and clears the moment a character is typed. Reading it
+    // as a fleet inverted the gate: idle sessions read busy and never recovered,
+    // because an idle composer never fills on its own.
+    assert.ok(!AT_REST_WITH_AGENTS_HINT.join('\n').includes('esc to interrupt'),
+      'fixture precondition: no busy marker');
+    assert.ok(!/^[ \t]*[◯⏺][ \t]+\S/m.test(AT_REST_WITH_AGENTS_HINT.join('\n')),
+      'fixture precondition: no agent block is rendered');
+    assert.deepEqual(wake._assessPane(AT_REST_WITH_AGENTS_HINT, CLAUDE), { idle: true, reason: 'at-prompt' });
+  });
+
+  it('judges a pane idle once its fleet has finished, while the hint persists (#1101)', () => {
+    // Captured immediately after the last agent completed: the agent block has
+    // cleared, but the hint row still advertises the count — and has gained
+    // `/tasks to see subagents`. Nothing about either text tracks liveness.
+    assert.ok(AGENTS_FINISHED_PANE.join('\n').includes('← 2 agents'),
+      'fixture precondition: the hint really does persist after completion');
+    assert.deepEqual(wake._assessPane(AGENTS_FINISHED_PANE, CLAUDE), { idle: true, reason: 'at-prompt' });
+  });
+
+  it('refuses a pane whose agent block is live, captured with main focused (#1101)', () => {
+    // The other side of #783's capture: there the agent held focus (`◯ main` /
+    // `⏺ prawduct-critic`), here main does (`⏺ main` / `◯ general-purpose`).
+    // The gate must fire from either side, so it keys on the unfocused row.
+    assert.ok(!AGENT_RUNNING_PANE.join('\n').includes('esc to interrupt'),
+      'fixture precondition: the busy marker is absent while the agent runs');
+    assert.ok(AGENT_RUNNING_PANE.some((l) => /^\s*❯\s*$/.test(l)),
+      'fixture precondition: a bare prompt is rendered while the agent runs');
+    assert.deepEqual(wake._assessPane(AGENT_RUNNING_PANE, CLAUDE), { idle: false, reason: 'agents-running' });
+  });
+
+  it('ignores the agent glyph when it is not at the start of a line', () => {
+    // The tail is 15 lines of arbitrary transcript, not a status line, so an
+    // unanchored scan would let ordinary output block a nudge indefinitely.
+    const quoting = ['  the other pane showed ◯ general-purpose in its block', '❯'];
+    assert.deepEqual(wake._assessPane(quoting, CLAUDE), { idle: true, reason: 'at-prompt' });
   });
 
   it('judges a bare-prompt pane with no busy marker idle', () => {


### PR DESCRIPTION
## What

The wake gate keyed on `← N agents` in the status line. That is the "press ← to view agents" affordance on the **empty-composer** hint row — it renders *because* the session is at rest, and clears the instant any character is typed. The gate now keys on Claude Code's **agent block** instead, which appears when a fleet starts and clears when the last agent finishes.

## Why

The gate was inverted. An idle session read `agents-running`, and never recovered, because an idle composer never fills on its own. The code comment claimed the cost was "a delayed nudge that the next tick retries" — the retry could not succeed, so the cost was the wake itself.

Measured across four live states of one session rather than inferred:

| State | agent block | `← N agents` | correct | before |
|---|---|---|---|---|
| At rest | — | present | idle | **busy** ✗ |
| At rest, hint cleared by a keystroke | — | absent | idle | idle ✓ |
| Agent running | present | present | busy | busy ✓ |
| Agent finished | — | present | idle | **busy** ✗ |

The count never moved either: `2` with nothing dispatched, `2` with one agent running, `2` once it completed. It tracks liveness in neither direction.

Six of six Claude sessions were affected, including the Project Master — which made the switchboard's **return** path fail unattended, since a reply lands in the initiator's inbox and nothing announces it. One session sat on an undelivered message for 31 minutes and was nudged within seconds of a single space being typed into its pane:

```
tilt-claw-2bceca03  nudged   -                    17:23:30
tilt-claw-2bceca03  skipped  pane-agents-running  16:52:28
```

## How

Match the **unfocused** row of the agent block. The glyphs mark focus, not liveness, which is why the two live captures disagree about which name carries which:

```
#783        (agent focused):  ◯ main  /  ⏺ prawduct-critic  Composing …  7m 20s
2026-08-21  (main focused):   ⏺ main  /  ◯ general-purpose  Find lib …   4s
```

The block lists `main` plus every agent, so whenever it renders at least one row is unfocused — keying on `◯` works from either side. `⏺` would be wrong: Claude Code uses it for ordinary transcript lines (`⏺ Agent "…" finished`, `⏺ Running 1 shell command…`).

Anchored at line start. The tail is 15 lines of arbitrary transcript, not a status line, and the previous unanchored scan let a session block its own nudge merely by *mentioning* agents in its output — demonstrated in a new guard.

The hazard #783 identified is unchanged and still guarded: with a subagent focused the busy marker moves into the agent block, so `esc to interrupt` is absent while a bare prompt *is* rendered. That is why this gate stays above the prompt checks.

## Test plan

- Three new fixtures are verbatim live captures (at rest with the hint, agent running, agent finished); the existing #783 fixture is untouched and still passes.
- Full suite green: exit 0, 6679 passing, zero `not ok`.
- **Mutation:** restoring the old regex turns exactly the two new #1101 guards red (exit 1), with the anchor asserted before the write so a mutation that failed to apply cannot masquerade as one that survived.

Fixes #1101
