### PR TITLE
Ask tmux where the cursor is instead of reading the prompt line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ All notable changes to TangleClaw are documented in this file.
 
   The hazard #783 identified is unchanged and still guarded: with a subagent focused the busy marker moves into the agent block, so `esc to interrupt` is absent and a bare prompt is rendered — which is why the gate sits above the prompt checks. Regression fixtures are verbatim live captures of all four states, and reverting the regex turns exactly the two new guards red. `lib/medusa-wake.js`, `test/medusa-wake.test.js`.
 
+- **The wake gate counted an inline suggestion as operator input, so an idle session with an empty composer was never woken (#1103).** The sibling defect to #1101, in the next gate along. Claude Code offers a likely next prompt *because* a session is at rest, and draws it on the prompt line — so once the escape sequences were stripped, a pending suggestion was indistinguishable from typed text and `promptRe` returned `no-bare-prompt`. As soon as #1101 shipped, this became the top blocker: 3 of 5 undelivered participants, the Project Master among them.
+
+  The fix stops inferring input from rendered characters and asks tmux where the cursor is. `tmux.cursorInfo` reports `cursor_x`/`cursor_y` and re-reads that one row with `-e` so styling survives; the composer is empty when nothing non-blank sits between the prompt glyph and the cursor, **and** everything to the cursor's right is blank or faint. Both halves are load-bearing — the first catches ordinary typing, the second catches an operator who typed and then pressed Home, where the cursor alone would report an empty composer and the nudge would paste over real input.
+
+  Cursor position was chosen over matching the faint attribute because it is a terminal property rather than an application one: it survives a suggestion long enough to wrap, needs no per-engine colour knowledge, and does not depend on rendering that Claude Code has already changed once between builds. Faintness is still consulted, but only to classify text the cursor has already placed to its right. A pane that cannot report a cursor falls back to the previous text check rather than losing its nudge, and a cursor that is not on a prompt line at all returns "undecidable" rather than "at rest" — guessing rest is the failure this module exists to prevent.
+
+  Verified against the live panes it was built from: three sessions holding suggestions moved from `no-bare-prompt` to `at-prompt`, while a session with genuinely typed text stayed refused. `lib/tmux.js`, `lib/medusa-wake.js`, `test/medusa-wake.test.js`, `test/tmux.test.js`.
+
 ### Internal
 - **The #818 Switchboard train's plan is archived, and its live verification is on the record (#1097, #1098).** `818-switchboard-truth.md` moved to `.tangleclaw/plans/archive/` now that it shipped as `5.13.0` — archived rather than deleted so the rationale survives, and out of the active listing so a future session cannot read closed work as ready.
 

--- a/lib/medusa-wake.js
+++ b/lib/medusa-wake.js
@@ -95,12 +95,12 @@ const TMUX_TAIL_LINES = 15;
 const ENGINE_WAKE_PROFILES = {
   // Claude Code (T2 spike, 2026-07-11): `esc to interrupt` in the status line
   // iff busy; a busy turn hides the bare `❯`, so no positive idle marker needed.
-  claude: { busyMarker: 'esc to interrupt', promptRe: /^\s*❯\s*$/, idleMarker: null },
+  claude: { busyMarker: 'esc to interrupt', promptRe: /^\s*❯\s*$/, promptGlyph: '❯', idleMarker: null },
   // antigravity / Gemini CLI (#560 spike, 2026-07-14): status flips to
   // `esc to cancel` (from `? for shortcuts`) while a spinner shows "Generating…"
   // — but the bare `>` input line is STILL rendered mid-turn, so `? for
   // shortcuts` is required as the positive at-rest signal.
-  antigravity: { busyMarker: 'esc to cancel', promptRe: /^\s*>\s*$/, idleMarker: '? for shortcuts' }
+  antigravity: { busyMarker: 'esc to cancel', promptRe: /^\s*>\s*$/, promptGlyph: '>', idleMarker: '? for shortcuts' }
 };
 
 // CSI escape sequences + bare CR (same construction as wrap-sentinel.js:
@@ -113,7 +113,7 @@ let _timer = null;
 
 /**
  * Per-session monitor state.
- * @type {Map<number, {idleTicks: number, lastNudgedKey: string|null, skipLogged: boolean, configWarnLogged: boolean}>}
+ * @type {Map<number, {idleTicks: number, lastNudgedKey: string|null, skipLogged: boolean, configWarnLogged: boolean, cursorWarnLogged: boolean}>}
  */
 const _sessions = new Map();
 
@@ -169,6 +169,98 @@ function _strip(text) {
 const _FLEET_RE = /^[ \t]*◯[ \t]+\S/m;
 
 /**
+ * Split a raw pane line into visible cells, carrying each cell's faint flag.
+ *
+ * Faintness is the whole point: a TUI draws an inline suggestion faint and real
+ * input at normal intensity, so it is the only thing in the rendered line that
+ * separates "the operator typed this" from "the editor is offering this".
+ * SGR 2 sets faint; SGR 22 clears it specifically and SGR 0 clears everything,
+ * and a bare `ESC[m` is an alias for `ESC[0m`.
+ *
+ * Cell indices line up with tmux's `cursor_x` because both count visible
+ * columns, so a cursor column can be used to index the returned array.
+ *
+ * @param {string} line - One raw pane line, escape sequences retained.
+ * @returns {Array<{ch: string, faint: boolean}>} One entry per visible column.
+ */
+function _cells(line) {
+  const out = [];
+  let faint = false;
+  const src = String(line == null ? '' : line);
+  // eslint-disable-next-line no-control-regex
+  const sgr = /\[([0-9;:]*)m/y;
+  // eslint-disable-next-line no-control-regex
+  const other = /\[[0-9;:?]*[ -/]*[@-~]|[()][AB0-2]|\r/y;
+
+  for (let i = 0; i < src.length;) {
+    sgr.lastIndex = i;
+    const m = sgr.exec(src);
+    if (m) {
+      // An empty parameter list (`ESC[m`) means reset, same as `ESC[0m`.
+      const params = m[1] === '' ? ['0'] : m[1].split(';');
+      for (const p of params) {
+        if (p === '2') faint = true;
+        else if (p === '0' || p === '22') faint = false;
+      }
+      i = sgr.lastIndex;
+      continue;
+    }
+    other.lastIndex = i;
+    if (other.exec(src)) { i = other.lastIndex; continue; }
+    out.push({ ch: src[i], faint });
+    i += 1;
+  }
+  return out;
+}
+
+/** @type {RegExp} Blank cell: ordinary space, or the NBSP a prompt pads with. */
+const _BLANK_RE = /[\s ]/;
+
+/**
+ * Has the operator typed anything into the composer?
+ *
+ * Answered from the cursor rather than from the rendered text, because the two
+ * disagree exactly when it matters (#1103): a pending inline suggestion draws
+ * a full sentence on the prompt line while the composer is still empty, so any
+ * check that reads the line as characters concludes the operator is mid-input
+ * and refuses to nudge a session that is in fact at rest.
+ *
+ * Both sides of the cursor are checked, and each catches a case the other
+ * cannot:
+ *
+ *   - **Before the cursor** must be blank. Typed text pushes the cursor to its
+ *     right, so anything non-blank there is real input.
+ *   - **After the cursor** must be blank or faint. Without this, an operator who
+ *     typed and then pressed Home would sit at the first input column with
+ *     their text intact to the right, and the cursor check alone would read the
+ *     pane as empty and paste over it.
+ *
+ * @param {{x: number, line: string}} cursor - Cursor column and its raw line.
+ * @param {{promptGlyph: string}} profile - The engine's detection profile.
+ * @returns {boolean|null} `true` if the composer is empty, `false` if it holds
+ *   typed input, `null` if the cursor is not on a prompt line at all — a
+ *   dialog, a menu, or a scrolled pane, where the caller must not infer rest.
+ */
+function _composerEmpty(cursor, profile) {
+  if (!cursor || !profile || !profile.promptGlyph) return null;
+  const cells = _cells(cursor.line);
+  const glyph = cells.findIndex((c) => c.ch === profile.promptGlyph);
+  // No prompt glyph on the cursor's line: not the composer. Undecidable here,
+  // never "empty" — guessing rest is the failure this module exists to avoid.
+  if (glyph === -1) return null;
+  if (!Number.isInteger(cursor.x) || cursor.x <= glyph) return null;
+  // Anything typed sits between the glyph and the cursor.
+  for (let i = glyph + 1; i < cursor.x && i < cells.length; i++) {
+    if (!_BLANK_RE.test(cells[i].ch)) return false;
+  }
+  // Anything to the right must be the suggestion (faint) or padding.
+  for (let i = cursor.x; i < cells.length; i++) {
+    if (!cells[i].faint && !_BLANK_RE.test(cells[i].ch)) return false;
+  }
+  return true;
+}
+
+/**
  * Judge a captured pane tail against an engine profile: is the session safe to
  * type into right now?
  *
@@ -179,14 +271,18 @@ const _FLEET_RE = /^[ \t]*◯[ \t]+\S/m;
  * engine whose prompt persists mid-turn, and any dialog/menu that drops the
  * at-rest hint); no bare `promptRe` line → `no-bare-prompt`; else idle.
  * @param {string[]} lines - Pane tail lines (raw, may carry ANSI).
- * @param {{busyMarker: string, promptRe: RegExp, idleMarker: (string|null)}} profile
+ * @param {{busyMarker: string, promptRe: RegExp, promptGlyph: string, idleMarker: (string|null)}} profile
  *   - The engine's detection profile (from `ENGINE_WAKE_PROFILES`).
+ * @param {{x: number, line: string}} [cursor] - Cursor column and its raw line
+ *   (`tmux.cursorInfo`). Omit it and the prompt check falls back to reading the
+ *   rendered line, which cannot distinguish an inline suggestion from typed
+ *   input (#1103).
  * @returns {{idle: boolean, reason: string}} `idle` true only when the busy
  *   marker is absent, any required idle marker is present, AND a bare prompt
  *   line is present; `reason` is one of
  *   `turn-in-flight` | `not-at-rest` | `no-bare-prompt` | `at-prompt`.
  */
-function _assessPane(lines, profile) {
+function _assessPane(lines, profile, cursor) {
   const text = _strip((lines || []).join('\n'));
   if (text.includes(profile.busyMarker)) return { idle: false, reason: 'turn-in-flight' };
   // A running subagent fleet makes the pane unsafe to type into, so this gate
@@ -197,6 +293,15 @@ function _assessPane(lines, profile) {
   if (profile.idleMarker && !text.includes(profile.idleMarker)) {
     return { idle: false, reason: 'not-at-rest' };
   }
+  // Cursor first when it is available, because it answers the question the
+  // rendered text only approximates (#1103): a pending inline suggestion draws
+  // a sentence on the prompt line that the text check cannot tell from typed
+  // input. `null` means the cursor is not on a prompt line at all, which is not
+  // evidence of rest — fall through to the text check rather than assume.
+  const composerEmpty = _composerEmpty(cursor, profile);
+  if (composerEmpty === true) return { idle: true, reason: 'at-prompt' };
+  if (composerEmpty === false) return { idle: false, reason: 'no-bare-prompt' };
+
   const hasBarePrompt = text.split('\n').some((l) => profile.promptRe.test(l));
   if (!hasBarePrompt) return { idle: false, reason: 'no-bare-prompt' };
   return { idle: true, reason: 'at-prompt' };
@@ -288,7 +393,7 @@ function _scanSession(session) {
   const sessionId = session.id;
   let st = _sessions.get(sessionId);
   if (!st) {
-    st = { idleTicks: 0, lastNudgedKey: null, skipLogged: false, configWarnLogged: false, lastRecorded: null };
+    st = { idleTicks: 0, lastNudgedKey: null, skipLogged: false, configWarnLogged: false, cursorWarnLogged: false, lastRecorded: null };
     _sessions.set(sessionId, st);
   }
 
@@ -449,7 +554,21 @@ function _scanSession(session) {
     record('skipped', 'none', 'pane-capture-failed');
     return;
   }
-  const verdict = _assessPane(cap.lines || [], profile);
+  // Best-effort: a pane that cannot report a cursor still gets judged, just by
+  // the weaker text check. Never fatal — a nudge must not be lost to a tmux
+  // query that failed while the pane itself captured fine.
+  let cursor = null;
+  try {
+    cursor = _internal.cursorInfo(session.tmuxSession);
+  } catch (err) {
+    if (!st.cursorWarnLogged) {
+      st.cursorWarnLogged = true;
+      log.warn('medusa-wake: cursor probe failed — falling back to the text prompt check', {
+        sessionId, error: err.message
+      });
+    }
+  }
+  const verdict = _assessPane(cap.lines || [], profile, cursor);
   if (!verdict.idle) {
     st.idleTicks = 0;
     record('skipped', 'none', `pane-${verdict.reason}`);
@@ -570,6 +689,7 @@ const _internal = {
   getStatus: (sessionId) => require('./medusa').getStatus(sessionId),
   getMessages: (sessionId) => require('./medusa').getMessages(sessionId),
   capturePane: (session, options) => require('./tmux').capturePane(session, options),
+  cursorInfo: (session) => require('./tmux').cursorInfo(session),
   injectCommand: (projectName, command, options) => require('./sessions').injectCommand(projectName, command, options),
   // The Master's two seams, lazy like the rest so requiring this module never
   // pulls `lib/master.js` (and its store/engine graph) in behind it.
@@ -586,6 +706,8 @@ module.exports = {
   ENGINE_WAKE_PROFILES,
   IDLE_TICKS_REQUIRED,
   _assessPane,
+  _cells,
+  _composerEmpty,
   _nudgeLine,
   _nudgeLineFor,
   _internal

--- a/lib/tmux.js
+++ b/lib/tmux.js
@@ -706,6 +706,45 @@ function capturePane(session, options = {}) {
 }
 
 /**
+ * Where the cursor sits in a pane, plus the one line it sits on with styling
+ * intact.
+ *
+ * Both halves answer a question `capturePane` structurally cannot (#1103):
+ * whether the operator has typed anything. A TUI that offers an inline
+ * suggestion draws it on the prompt line, so the rendered text is identical to
+ * typed input — but the cursor stays at the first input column, and the
+ * suggestion is drawn faint. `capturePane` omits `-e`, so tmux strips the SGR
+ * attributes and the distinction is gone before any caller sees it.
+ *
+ * The line is addressed by `cursor_y` rather than by searching the capture:
+ * `-S y -E y` is pane-relative and 0-indexed from the top of the visible pane,
+ * which is the same origin `cursor_y` uses, so the two cannot disagree about
+ * which line is meant.
+ *
+ * @param {string} session - Session name.
+ * @returns {{x: number, y: number, line: string}|null} Cursor column and row
+ *   (0-indexed) and the raw line with escape sequences retained, or `null` if
+ *   tmux reported a position that could not be parsed.
+ * @throws {Error} If the session does not exist.
+ */
+function cursorInfo(session) {
+  if (!hasSession(session)) {
+    throw new Error(`tmux session "${session}" does not exist`);
+  }
+
+  const pos = _exec(`tmux display-message -p -t ${_target(session)} '#{cursor_x},#{cursor_y}'`);
+  const [rawX, rawY] = String(pos).split(',');
+  const x = Number.parseInt(rawX, 10);
+  const y = Number.parseInt(rawY, 10);
+  // Not an error: a pane in an odd state can report an empty or partial
+  // position, and a caller must be able to fall back rather than guess.
+  if (!Number.isInteger(x) || !Number.isInteger(y)) return null;
+
+  const line = _exec(`tmux capture-pane -e -p -t ${_target(session)} -S ${y} -E ${y}`);
+  return { x, y, line: String(line) };
+}
+
+/**
  * Set tmux mouse mode on or off for a session.
  * @param {string} session - Session name
  * @param {boolean} on - Whether to enable mouse mode
@@ -902,6 +941,7 @@ module.exports = {
   sendRawKey,
   isAlternateScreen,
   capturePane,
+  cursorInfo,
   setMouse,
   unsetMouse,
   getMouse,

--- a/test/medusa-wake.test.js
+++ b/test/medusa-wake.test.js
@@ -116,6 +116,9 @@ function installWorld(overrides = {}) {
     status: { state: 'listening', workspaceId: 'proj-a-abc123', unread: 1, lastError: null },
     inbox: [{ id: 'm1', from: 'peer', message: 'hello' }],
     pane: IDLE_PANE,
+    // #1103. `null` means "no cursor captured", so the prompt verdict comes from
+    // `pane` alone and every pre-existing test keeps its original meaning.
+    cursor: null,
     injected: [],
     injectResult: { ok: true, error: null },
     // The Master's seams (#996). `null` = no Master to scan, which keeps every
@@ -139,6 +142,12 @@ function installWorld(overrides = {}) {
   wake._internal.getStatus = () => world.status;
   wake._internal.getMessages = () => world.inbox;
   wake._internal.capturePane = () => ({ lines: world.pane });
+  // Stubbed for isolation, not convenience: fixture session names collide with
+  // real ones on a developer box (`tangleclaw-master` is live here), so an
+  // unstubbed cursor probe reads the operator's actual pane and the verdict
+  // changes with whatever they happen to have typed. `world.cursor` is null by
+  // default, which exercises the text-check fallback.
+  wake._internal.cursorInfo = () => world.cursor;
   wake._internal.injectCommand = (projectName, command, options) => {
     world.injected.push({ projectName, command, options });
     return world.injectResult;
@@ -199,6 +208,116 @@ const AGENTS_FINISHED_PANE = [
   '  TangleClaw (main) | Opus 5 (1M context) | 77% left',
   '  ⏵⏵ bypass permissions on (shift+tab to cycle) · /tasks to see subagents · ← 2 agents'
 ];
+
+/**
+ * Live captures from 2026-08-21 (#1103), escapes retained because stripping
+ * them is the defect. ` ` is the NBSP a Claude Code prompt pads with, and
+ * `[2m` is SGR 2 (faint) — the attribute that marks an inline suggestion.
+ *
+ * The two lines render almost identically in a terminal. Only the faintness and
+ * the cursor column separate "the editor is offering this" from "the operator
+ * typed this", and the cursor column is the one a text check cannot see.
+ */
+const SUGGESTION_LINE =
+  '❯ [2madd case law to the reading list too, then branch and PR[0m';
+const SUGGESTION_CURSOR = { x: 2, line: SUGGESTION_LINE };
+
+const TYPED_LINE = '❯ can you check why tilt-claw isn\'t responding?';
+const TYPED_CURSOR = { x: 47, line: TYPED_LINE };
+
+/** The pane body around either line; the prompt line itself is not bare. */
+const PANE_WITH_PROMPT_TEXT = [
+  '  Churned for 17s',
+  '',
+  '❯ can you check why tilt-claw isn\'t responding?',
+  '  master | Opus 5 (1M context) | 95% left',
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)'
+];
+
+describe('medusa-wake — _composerEmpty (cursor-based input detection, #1103)', () => {
+  it('reads a pending inline suggestion as an empty composer', () => {
+    assert.equal(wake._composerEmpty(SUGGESTION_CURSOR, CLAUDE), true);
+  });
+
+  it('reads genuinely typed input as a non-empty composer', () => {
+    assert.equal(wake._composerEmpty(TYPED_CURSOR, CLAUDE), false);
+  });
+
+  it('refuses typed text even when the cursor was moved back to the prompt column', () => {
+    // Home-key case: the cursor alone would say "empty". The text to its right
+    // is at normal intensity, so it is real input and must not be typed over.
+    assert.equal(wake._composerEmpty({ x: 2, line: TYPED_LINE }, CLAUDE), false);
+  });
+
+  it('returns null when the cursor line carries no prompt glyph', () => {
+    // A dialog or scrolled pane is undecidable here — never "empty", because
+    // guessing rest is the failure this module exists to prevent.
+    assert.equal(wake._composerEmpty({ x: 2, line: '  no glyph here' }, CLAUDE), null);
+  });
+
+  it('refuses rather than guesses when a transcript line happens to contain the glyph', () => {
+    // Not `null`: the glyph is present, so this reads as a prompt line holding
+    // text, and the verdict is the conservative one. Erring toward refusing a
+    // nudge is the correct direction — the opposite error types into a pane
+    // that is not at rest.
+    assert.equal(wake._composerEmpty({ x: 4, line: '  ❯ some transcript text' }, CLAUDE), false);
+  });
+
+  it('returns null when no cursor was captured', () => {
+    assert.equal(wake._composerEmpty(null, CLAUDE), null);
+  });
+
+  it('carries faintness across an SGR reset and a specific un-faint', () => {
+    // `ESC[22m` clears faint alone; `ESC[0m` and a bare `ESC[m` clear everything.
+    const cells = wake._cells('[2mab[22mc[2md[me');
+    assert.deepEqual(cells.map((c) => c.ch).join(''), 'abcde');
+    assert.deepEqual(cells.map((c) => c.faint), [true, true, false, true, false]);
+  });
+
+  it('indexes cells by visible column, ignoring escape sequences', () => {
+    // cursor_x counts visible columns, so the mapping must survive styling.
+    const cells = wake._cells(SUGGESTION_LINE);
+    assert.equal(cells[0].ch, '❯');
+    assert.equal(cells[2].ch, 'a', 'column 2 is the first input position');
+    assert.equal(cells[2].faint, true);
+  });
+});
+
+describe('medusa-wake — _assessPane with cursor (#1103)', () => {
+  it('judges a pane idle when its prompt line holds only a suggestion', () => {
+    // The regression. Without the cursor this same pane reads `no-bare-prompt`,
+    // because the suggestion is indistinguishable from typed input once the
+    // escape sequences are stripped.
+    const withSuggestion = PANE_WITH_PROMPT_TEXT.slice();
+    withSuggestion[2] = 'add case law to the reading list too, then branch and PR';
+    assert.deepEqual(wake._assessPane(withSuggestion, CLAUDE),
+      { idle: false, reason: 'no-bare-prompt' });
+    assert.deepEqual(wake._assessPane(withSuggestion, CLAUDE, SUGGESTION_CURSOR),
+      { idle: true, reason: 'at-prompt' });
+  });
+
+  it('still refuses a pane whose composer really holds typed input', () => {
+    assert.deepEqual(wake._assessPane(PANE_WITH_PROMPT_TEXT, CLAUDE, TYPED_CURSOR),
+      { idle: false, reason: 'no-bare-prompt' });
+  });
+
+  it('falls back to the text check when the cursor is unavailable', () => {
+    // A failed cursor probe must not cost a nudge that the text check can judge.
+    assert.deepEqual(wake._assessPane(IDLE_PANE, CLAUDE, null),
+      { idle: true, reason: 'at-prompt' });
+    assert.deepEqual(wake._assessPane(PANE_WITH_PROMPT_TEXT, CLAUDE, null),
+      { idle: false, reason: 'no-bare-prompt' });
+  });
+
+  it('lets the busy and fleet gates win over an empty composer', () => {
+    // Gate order matters: a suggestion can be pending while a turn is in
+    // flight, and an empty composer is not permission to interrupt one.
+    const busy = BUSY_PANE.concat(['  ⏵⏵ bypass permissions on (shift+tab to cycle)']);
+    assert.equal(wake._assessPane(busy, CLAUDE, SUGGESTION_CURSOR).reason, 'turn-in-flight');
+    const fleet = ['  ⏺ main', '  ◯ general-purpose  doing a thing   4s', '❯ '];
+    assert.equal(wake._assessPane(fleet, CLAUDE, SUGGESTION_CURSOR).reason, 'agents-running');
+  });
+});
 
 describe('medusa-wake — _assessPane (Claude idle policy, pinned byte-for-byte)', () => {
   it('refuses a pane with a running subagent, even though it reads at-prompt (#783)', () => {

--- a/test/tmux.test.js
+++ b/test/tmux.test.js
@@ -337,6 +337,15 @@ describe('tmux', () => {
     });
   });
 
+  describe('cursorInfo - error cases (#1103)', () => {
+    it('should throw for non-existent session', () => {
+      assert.throws(
+        () => tmux.cursorInfo('__nonexistent_test_session__'),
+        /does not exist/
+      );
+    });
+  });
+
   describe('setMouse - error cases', () => {
     it('should throw for non-existent session', () => {
       assert.throws(
@@ -995,13 +1004,14 @@ describe('tmux', () => {
 
       // An exact floor, not a lower bound: a site DISAPPEARING is as much a
       // regression as one losing its wrapper, and `>=` would wave that through.
-      // 22 since `_clearPromptLine` gained a `send-keys C-u` site: injection
-      // clears the prompt before pasting, because paste-buffer appends and the
-      // Enter would otherwise submit the operator's unsent draft along with the
-      // payload. Bumping this number is the acknowledgement the tripwire asks
-      // for — it fired correctly, and the `_target` loop below already confirmed
-      // the new site is wrapped.
-      assert.equal(targets.length, 22, `expected 22 -t sites in lib/tmux.js, found ${targets.length}`);
+      // 24 since `cursorInfo` gained two sites (#1103): a `display-message`
+      // reading `cursor_x`/`cursor_y`, and a `capture-pane -e` re-reading just
+      // the cursor's own row with styling intact — the pair that tells a pending
+      // inline suggestion from text the operator actually typed. Bumping this
+      // number is the acknowledgement the tripwire asks for — it fired
+      // correctly, and the `_target` loop below already confirmed both new sites
+      // are wrapped.
+      assert.equal(targets.length, 24, `expected 24 -t sites in lib/tmux.js, found ${targets.length}`);
       for (const expr of targets) {
         assert.match(
           expr,


### PR DESCRIPTION
## What

The bare-prompt gate counted Claude Code's **inline suggestion** as operator input. The gate now asks tmux where the cursor is instead of reading the rendered prompt line.

## Why

The suggestion is offered *because* a session is at rest, and it is drawn on the prompt line — so once `_strip` removed the escape sequences it was indistinguishable from typed text, and `promptRe` returned `no-bare-prompt`. This is the sibling defect to #1101, one gate along: as soon as that fix shipped, this became the top blocker at **3 of 5** undelivered participants, the Project Master among them.

Both live cases, escapes retained:

```
suggestion pending:  ❯ ESC[2madd case law to the reading list too, then branch and PR ESC[0m   cursor_x=2
typed by operator:   ❯ can you check why tilt-claw isn't responding?                            cursor_x=47
```

They render almost identically. Only the faintness and the cursor column differ — and `capturePane` omits `-e`, so the faintness never reached the gate at all.

## How

`tmux.cursorInfo` reports `cursor_x`/`cursor_y` and re-reads that one row with `-e`. The composer is empty when nothing non-blank sits between the prompt glyph and the cursor, **and** everything to the cursor's right is blank or faint.

Both halves earn their place: the first catches ordinary typing; the second catches an operator who typed and then pressed **Home**, where the cursor alone reports an empty composer and the nudge would paste over real input.

Cursor position was chosen over matching `ESC[2m` because it is a *terminal* property rather than an application one — it survives a suggestion long enough to wrap, needs no per-engine colour knowledge, and does not depend on rendering that Claude Code has already changed once between builds (`2.1.179` and `2.1.238` differ). Faintness is still consulted, but only to classify text the cursor has already placed to its right.

Degrading rather than failing: a pane that cannot report a cursor falls back to the previous text check rather than losing its nudge, and a cursor that is not on a prompt line returns *undecidable* rather than *at rest* — guessing rest is the failure this module exists to prevent.

## Test plan

Verified against the live panes it was built from:

```
OpenClaw-Genesis   x=2    was=no-bare-prompt   now=at-prompt
TiLT-Claw          x=2    was=no-bare-prompt   now=at-prompt
TangleBrain        x=2    was=no-bare-prompt   now=at-prompt
tangleclaw-master  x=47   was=no-bare-prompt   now=no-bare-prompt   (real typed input, correctly refused)
```

- Full suite green: exit 0, **6692 passing**, zero `not ok`.
- **Mutations**, each asserted to have applied before running: ignoring the cursor reds the #1103 regression guard; dropping the faint check reds the Home-key guard.
- Fixtures are verbatim live captures with escape sequences retained — stripping them is the defect, so a pre-stripped fixture could not test it.

## Two things worth a reviewer's attention

**A real isolation gap this change exposed.** The Master tests use the fixture session name `tangleclaw-master`, which collides with a live session on a developer box — so an unstubbed cursor probe read the operator's actual pane and the verdict moved with whatever they had typed. `installWorld` now stubs the seam, defaulting to no cursor so every pre-existing test keeps its original meaning.

**The `-t` routing tripwire in `test/tmux.test.js` fired correctly** at the two new sites. Both are `_target()`-wrapped (the per-site loop confirms it); the exact count is bumped from 22 to 24 with the reason recorded inline, which is the acknowledgement that guard asks for.

Fixes #1103
