### PR TITLE
Declare the prompt placeholder attribute per engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ All notable changes to TangleClaw are documented in this file.
 
   Verified against the live panes it was built from: three sessions holding suggestions moved from `no-bare-prompt` to `at-prompt`, while a session with genuinely typed text stayed refused. `lib/tmux.js`, `lib/medusa-wake.js`, `test/medusa-wake.test.js`, `test/tmux.test.js`.
 
+- **The placeholder rule was Claude's rule, so antigravity sessions stayed unwakeable (#1105).** #1103 taught the wake gate that a prompt-line placeholder is not operator input, but it recognised only SGR 2 (faint) — how Claude Code dims its inline suggestion. Antigravity greys its mode banner (`Accept-edits mode: …`) with SGR 90 instead, so the gate still read it as typed input and refused. Found by auditing all four gates against live panes on both engines after #1103 shipped; the fix generalised from one engine, which is the same mistake in a new place.
+
+  `placeholderSgr` is now declared per engine — `[2]` for Claude, `[90]` for antigravity — rather than shared. A shared set would pass one engine and silently fail the other, and accepting the wrong attribute is not a cosmetic error: it means treating real operator input as a placeholder and typing over it. Both directions are pinned by tests.
+
+  `_cells` now tracks the full SGR attribute set per column instead of a single faint flag, with the resets that actually end a span: `0` clears everything, `22` clears intensity, `39` restores the default foreground, and a new colour replaces the old rather than stacking. Without that last pair a grey span would never end.
+
+  What makes this safe rather than a guess is the control capture: **genuinely typed antigravity input carries no styling at all**. Treating a colour as "not real input" without evidence that real input is never rendered in it would have been reckless — that capture is the reason the rule is defensible, and it is pinned as a fixture. New fixtures use `` escapes rather than raw control bytes, since the raw form is invisible in every viewer and that invisibility is part of how the Claude-only assumption survived review. `lib/medusa-wake.js`, `test/medusa-wake.test.js`.
+
 ### Internal
 - **The #818 Switchboard train's plan is archived, and its live verification is on the record (#1097, #1098).** `818-switchboard-truth.md` moved to `.tangleclaw/plans/archive/` now that it shipped as `5.13.0` — archived rather than deleted so the rationale survives, and out of the active listing so a future session cannot read closed work as ready.
 

--- a/lib/medusa-wake.js
+++ b/lib/medusa-wake.js
@@ -95,12 +95,23 @@ const TMUX_TAIL_LINES = 15;
 const ENGINE_WAKE_PROFILES = {
   // Claude Code (T2 spike, 2026-07-11): `esc to interrupt` in the status line
   // iff busy; a busy turn hides the bare `❯`, so no positive idle marker needed.
-  claude: { busyMarker: 'esc to interrupt', promptRe: /^\s*❯\s*$/, promptGlyph: '❯', idleMarker: null },
+  // `placeholderSgr` is how this engine renders text the operator did NOT type
+  // (#1105): Claude Code dims its inline suggestion with SGR 2 (faint).
+  claude: {
+    busyMarker: 'esc to interrupt', promptRe: /^\s*❯\s*$/, promptGlyph: '❯',
+    placeholderSgr: [2], idleMarker: null
+  },
   // antigravity / Gemini CLI (#560 spike, 2026-07-14): status flips to
   // `esc to cancel` (from `? for shortcuts`) while a spinner shows "Generating…"
   // — but the bare `>` input line is STILL rendered mid-turn, so `? for
   // shortcuts` is required as the positive at-rest signal.
-  antigravity: { busyMarker: 'esc to cancel', promptRe: /^\s*>\s*$/, promptGlyph: '>', idleMarker: '? for shortcuts' }
+  // antigravity greys its mode banner ("Accept-edits mode: …") with SGR 90
+  // (bright black) rather than dimming it — a different attribute for the same
+  // idea, which is why `placeholderSgr` is declared per engine and not shared.
+  antigravity: {
+    busyMarker: 'esc to cancel', promptRe: /^\s*>\s*$/, promptGlyph: '>',
+    placeholderSgr: [90], idleMarker: '? for shortcuts'
+  }
 };
 
 // CSI escape sequences + bare CR (same construction as wrap-sentinel.js:
@@ -185,8 +196,29 @@ const _FLEET_RE = /^[ \t]*◯[ \t]+\S/m;
  */
 function _cells(line) {
   const out = [];
-  let faint = false;
+  /** @type {Set<number>} SGR attributes in force at the current column. */
+  const active = new Set();
   const src = String(line == null ? '' : line);
+
+  /**
+   * Apply one SGR parameter to `active`. Only the resets that actually end a
+   * placeholder span are modelled; every other attribute is simply recorded, so
+   * a profile can name whichever one its engine uses.
+   * @param {number} n - The SGR parameter.
+   * @returns {void}
+   */
+  const apply = (n) => {
+    if (n === 0) { active.clear(); return; }                       // reset all
+    if (n === 22) { active.delete(1); active.delete(2); return; }  // normal intensity
+    const isFg = (a) => (a >= 30 && a <= 37) || (a >= 90 && a <= 97);
+    // 39 restores the default foreground; a new colour replaces the old one
+    // rather than stacking, so both clear whatever colour was in force.
+    if (n === 39 || isFg(n)) {
+      for (const a of [...active]) if (isFg(a)) active.delete(a);
+      if (n === 39) return;
+    }
+    active.add(n);
+  };
   // eslint-disable-next-line no-control-regex
   const sgr = /\[([0-9;:]*)m/y;
   // eslint-disable-next-line no-control-regex
@@ -199,18 +231,40 @@ function _cells(line) {
       // An empty parameter list (`ESC[m`) means reset, same as `ESC[0m`.
       const params = m[1] === '' ? ['0'] : m[1].split(';');
       for (const p of params) {
-        if (p === '2') faint = true;
-        else if (p === '0' || p === '22') faint = false;
+        const n = Number.parseInt(p, 10);
+        if (Number.isInteger(n)) apply(n);
       }
       i = sgr.lastIndex;
       continue;
     }
     other.lastIndex = i;
     if (other.exec(src)) { i = other.lastIndex; continue; }
-    out.push({ ch: src[i], faint });
+    out.push({ ch: src[i], sgr: new Set(active) });
     i += 1;
   }
   return out;
+}
+
+/**
+ * Is this cell styled the way its engine styles a prompt placeholder?
+ *
+ * Per-engine rather than one shared rule, because the two engines express the
+ * same idea with different attributes and neither should inherit the other's
+ * assumption (#1105): Claude Code dims its inline suggestion with SGR 2, while
+ * antigravity greys its mode banner with SGR 90. Verified against live captures
+ * of both — and, importantly, of genuinely typed input in both, which carries no
+ * styling at all. That last check is what makes this safe: treating a colour as
+ * "not real input" would be reckless without evidence that real input is never
+ * rendered in it.
+ *
+ * @param {{sgr: Set<number>}} cell - One cell from `_cells`.
+ * @param {number[]} codes - The engine's `placeholderSgr` attributes.
+ * @returns {boolean} True when any of the engine's attributes is in force.
+ */
+function _isPlaceholder(cell, codes) {
+  if (!cell || !codes) return false;
+  for (const c of codes) if (cell.sgr.has(c)) return true;
+  return false;
 }
 
 /** @type {RegExp} Blank cell: ordinary space, or the NBSP a prompt pads with. */
@@ -230,13 +284,14 @@ const _BLANK_RE = /[\s ]/;
  *
  *   - **Before the cursor** must be blank. Typed text pushes the cursor to its
  *     right, so anything non-blank there is real input.
- *   - **After the cursor** must be blank or faint. Without this, an operator who
- *     typed and then pressed Home would sit at the first input column with
- *     their text intact to the right, and the cursor check alone would read the
- *     pane as empty and paste over it.
+ *   - **After the cursor** must be blank or placeholder-styled. Without this, an
+ *     operator who typed and then pressed Home would sit at the first input
+ *     column with their text intact to the right, and the cursor check alone
+ *     would read the pane as empty and paste over it.
  *
  * @param {{x: number, line: string}} cursor - Cursor column and its raw line.
- * @param {{promptGlyph: string}} profile - The engine's detection profile.
+ * @param {{promptGlyph: string, placeholderSgr: number[]}} profile - The
+ *   engine's detection profile.
  * @returns {boolean|null} `true` if the composer is empty, `false` if it holds
  *   typed input, `null` if the cursor is not on a prompt line at all — a
  *   dialog, a menu, or a scrolled pane, where the caller must not infer rest.
@@ -255,7 +310,7 @@ function _composerEmpty(cursor, profile) {
   }
   // Anything to the right must be the suggestion (faint) or padding.
   for (let i = cursor.x; i < cells.length; i++) {
-    if (!cells[i].faint && !_BLANK_RE.test(cells[i].ch)) return false;
+    if (!_isPlaceholder(cells[i], profile.placeholderSgr) && !_BLANK_RE.test(cells[i].ch)) return false;
   }
   return true;
 }

--- a/test/medusa-wake.test.js
+++ b/test/medusa-wake.test.js
@@ -271,7 +271,7 @@ describe('medusa-wake — _composerEmpty (cursor-based input detection, #1103)',
     // `ESC[22m` clears faint alone; `ESC[0m` and a bare `ESC[m` clear everything.
     const cells = wake._cells('[2mab[22mc[2md[me');
     assert.deepEqual(cells.map((c) => c.ch).join(''), 'abcde');
-    assert.deepEqual(cells.map((c) => c.faint), [true, true, false, true, false]);
+    assert.deepEqual(cells.map((c) => c.sgr.has(2)), [true, true, false, true, false]);
   });
 
   it('indexes cells by visible column, ignoring escape sequences', () => {
@@ -279,7 +279,61 @@ describe('medusa-wake — _composerEmpty (cursor-based input detection, #1103)',
     const cells = wake._cells(SUGGESTION_LINE);
     assert.equal(cells[0].ch, '❯');
     assert.equal(cells[2].ch, 'a', 'column 2 is the first input position');
-    assert.equal(cells[2].faint, true);
+    assert.equal(cells[2].sgr.has(2), true);
+  });
+
+  it('ends a colour span on the default-foreground reset, not only on a full reset', () => {
+    // SGR 39 restores the default foreground, which is how antigravity closes
+    // its grey placeholder, and a new colour replaces the old rather than
+    // stacking — without both, the first span would never end.
+    const cells = wake._cells('[90mab[39mc[90md[31me');
+    assert.equal(cells.map((c) => c.ch).join(''), 'abcde');
+    assert.deepEqual(cells.map((c) => c.sgr.has(90)), [true, true, false, true, false]);
+  });
+});
+
+/**
+ * Live antigravity captures from 2026-08-21 (#1105). Written with ``
+ * escapes rather than raw control bytes: the raw form is invisible in every
+ * viewer, which is how the Claude-only assumption survived review in the first
+ * place.
+ *
+ * `AG_TYPED_LINE` is the control that makes this approach safe — genuinely
+ * typed antigravity input carries NO styling at all. Without that capture,
+ * treating a colour as "not real input" would be a guess.
+ */
+const AG_PLACEHOLDER_LINE =
+  '[94m>[39m [90mAccept-edits mode: file edits auto-approved (shift+tab to cycle)[39m';
+const AG_TYPED_LINE = '[94m>[39m Hello there';
+
+describe('medusa-wake — placeholder styling is declared per engine (#1105)', () => {
+  const AG = wake.ENGINE_WAKE_PROFILES.antigravity;
+
+  it('reads the antigravity grey placeholder as an empty composer', () => {
+    // The regression: antigravity greys with SGR 90 while Claude dims with
+    // SGR 2, so the faint-only rule refused this pane and the session, which
+    // was idle, was never woken.
+    assert.equal(wake._composerEmpty({ x: 2, line: AG_PLACEHOLDER_LINE }, AG), true);
+  });
+
+  it('reads genuinely typed antigravity input as a non-empty composer', () => {
+    assert.equal(wake._composerEmpty({ x: 13, line: AG_TYPED_LINE }, AG), false);
+  });
+
+  it('refuses typed antigravity input with the cursor moved back to the prompt column', () => {
+    assert.equal(wake._composerEmpty({ x: 2, line: AG_TYPED_LINE }, AG), false);
+  });
+
+  it('does not let either engine inherit the other\'s placeholder attribute', () => {
+    // Both directions: a shared rule would pass one engine and silently fail
+    // the other. Accepting the wrong attribute means treating real operator
+    // input as a placeholder and typing over it.
+    assert.equal(wake._composerEmpty({ x: 2, line: AG_PLACEHOLDER_LINE.replace('>', '❯') }, CLAUDE), false,
+      'SGR 90 is not Claude\'s placeholder marker');
+    assert.equal(wake._composerEmpty({ x: 2, line: SUGGESTION_LINE.replace('❯', '>') }, AG), false,
+      'SGR 2 is not antigravity\'s placeholder marker');
+    assert.deepEqual(CLAUDE.placeholderSgr, [2]);
+    assert.deepEqual(AG.placeholderSgr, [90]);
   });
 });
 


### PR DESCRIPTION
## What

The prompt-line placeholder rule from #1103 recognised only **SGR 2 (faint)** — how Claude Code dims its inline suggestion. Antigravity greys its mode banner with **SGR 90** instead, so the gate still counted it as operator input and refused to nudge an idle session. `placeholderSgr` is now declared per engine.

## Why

Found by auditing all four gates against live panes on both engine profiles after #1103 shipped — the audit that produced #1105 and #1106. The #1103 fix generalised from a single engine, which is the same mistake as #1101 and #1103 in a new place, and it left `JasonVaughanComPortfolio` refused all day for text nobody had typed.

The two renderings, captured live:

```
placeholder (composer empty):  ESC[94m>ESC[39m ESC[90mAccept-edits mode: file edits auto-approved…ESC[39m   cursor_x=2
typed by the operator:         ESC[94m>ESC[39m Hello there                                                  cursor_x=13
```

## How

`placeholderSgr` is `[2]` for Claude and `[90]` for antigravity, declared per engine rather than shared. A shared set would pass one engine and silently fail the other — and accepting the wrong attribute is not cosmetic: it means treating **real operator input as a placeholder and typing over it**. Both directions are pinned by tests.

`_cells` now tracks the full SGR attribute set per column instead of one faint flag, modelling the resets that actually end a span: `0` clears everything, `22` clears intensity, `39` restores the default foreground, and a new colour replaces the old rather than stacking. Without that last pair a grey span never ends.

**What makes this a rule and not a guess:** genuinely typed antigravity input carries *no styling at all*. Treating a colour as "not real input" without evidence that real input is never rendered in it would have been reckless — the operator typed into a live session specifically to produce that control capture, and it is pinned as a fixture.

New fixtures use `` escapes rather than raw control bytes. The raw form is invisible in every viewer, and that invisibility is part of how the Claude-only assumption survived review in the first place.

## Test plan

Verified against the live panes it was built from:

```
antigravity placeholder, cursor at prompt col : true   (empty)
antigravity typed input,  cursor past it      : false
antigravity typed input,  cursor moved Home   : false
antigravity placeholder judged as Claude      : false  (SGR 90 is not Claude's marker)
Claude suggestion judged as antigravity       : false  (SGR 2 is not antigravity's marker)
```

- Full suite green: exit 0, **6697 passing**, zero `not ok`.
- **Three mutations**, each asserted to have applied before running: giving antigravity Claude's attribute, sharing one set across both engines, and dropping the `39` reset — each reds the guard that covers it.

## Note for the reviewer

This is the third fix in the same family today (#1101 → #1103 → #1105), and all three were the same error: reading a surface that a TUI renders *because* a session is at rest as evidence that it is busy. #1106 tracks the fourth gate, where the Claude profile has no at-rest marker at all and its stated justification is measurably untrue.

Fixes #1105
